### PR TITLE
New record: Muon paired-head groups (-10 steps, -.4s)

### DIFF
--- a/records/track_1_short/2026-04-08_PairedHeadMuon/README.md
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/README.md
@@ -1,2 +1,17 @@
-# Paired head muon
+# Paired head Muon groups
 
+Treat each paired-head in K and V as its own Muon group, reducing loss/step and allowing us to reduce step count by 10 and still meet 3.28 loss target.
+
+
+```bash
+                 Runs  Steps   Time μ   Time σ  Time +/-   Time p   Loss μ   Loss σ  Loss +/-   Loss p
+  baseline-1490     4   1490  93.0205   0.1629    0.0000      nan   3.2782   0.0010   -0.0018    0.0187
+  baseline-1480     8   1480  92.5491   0.0588   -0.4714   0.0040   3.2800   0.0017    0.0000    0.5000
+        this PR     8   1480  92.6259   0.2129   -0.3946   0.0038   3.2788   0.0009   -0.0012    0.0029
+```
+
+Previously, Muon treated each of Q, K, V, O as one `(hdim, hdim)` group per layer, lumping all heads together within each group. Given heads often specialize, it seemed intuitive that treating each *head* as its own Muon group would further improve optimization. I split K/V into per-**head-pair** groups (because of paired head attention in some layers). This gives each head pair its own independent polar decomposition. Treating each head-pair in K and V as its own Muon group improved loss per step while increasing time/step by ~.1% (this overhead can probably be reduced, splitting Muon groups further should reduce flops).
+
+Now, we can reach the target loss in 10 less steps, saving ~0.4s. If we reduce the baseline by 10 steps without adding the per-head-pair Muon groups, the loss does not meet the target.
+
+**Note on timing:** not sure why my 8xh100 is so slow -- ~8% slower per step for the baseline. However, given that the speedup comes from reducing steps, I think this will hold in a more controlled setup.

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/README.md
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/README.md
@@ -1,0 +1,2 @@
+# Paired head muon
+

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline0-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline0-1480.txt
@@ -1,0 +1,4447 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:20:41 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   41C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   36C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   41C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   36C    P0            127W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   37C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   38C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   67C    P0            153W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          321139      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          321140      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          321141      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          321142      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          321143      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          321144      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          321145      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          321146      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8285 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:89ms step_avg:89.18ms
+step:2/1480 train_time:117ms step_avg:58.40ms
+step:3/1480 train_time:137ms step_avg:45.80ms
+step:4/1480 train_time:161ms step_avg:40.25ms
+step:5/1480 train_time:182ms step_avg:36.47ms
+step:6/1480 train_time:217ms step_avg:36.25ms
+step:7/1480 train_time:245ms step_avg:34.98ms
+step:8/1480 train_time:280ms step_avg:35.02ms
+step:9/1480 train_time:308ms step_avg:34.18ms
+step:10/1480 train_time:342ms step_avg:34.24ms
+step:11/1480 train_time:371ms step_avg:33.69ms
+step:12/1480 train_time:406ms step_avg:33.82ms
+step:13/1480 train_time:434ms step_avg:33.36ms
+step:14/1480 train_time:469ms step_avg:33.50ms
+step:15/1480 train_time:497ms step_avg:33.13ms
+step:16/1480 train_time:533ms step_avg:33.29ms
+step:17/1480 train_time:560ms step_avg:32.96ms
+step:18/1480 train_time:596ms step_avg:33.10ms
+step:19/1480 train_time:623ms step_avg:32.81ms
+step:20/1480 train_time:659ms step_avg:32.94ms
+step:21/1480 train_time:687ms step_avg:32.73ms
+step:22/1480 train_time:722ms step_avg:32.83ms
+step:23/1480 train_time:751ms step_avg:32.64ms
+step:24/1480 train_time:786ms step_avg:32.74ms
+step:25/1480 train_time:814ms step_avg:32.56ms
+step:26/1480 train_time:852ms step_avg:32.78ms
+step:27/1480 train_time:884ms step_avg:32.73ms
+step:28/1480 train_time:922ms step_avg:32.95ms
+step:29/1480 train_time:953ms step_avg:32.88ms
+step:30/1480 train_time:991ms step_avg:33.04ms
+step:31/1480 train_time:1021ms step_avg:32.95ms
+step:32/1480 train_time:1060ms step_avg:33.12ms
+step:33/1480 train_time:1091ms step_avg:33.06ms
+step:34/1480 train_time:1129ms step_avg:33.20ms
+step:35/1480 train_time:1159ms step_avg:33.11ms
+step:36/1480 train_time:1197ms step_avg:33.26ms
+step:37/1480 train_time:1228ms step_avg:33.20ms
+step:38/1480 train_time:1265ms step_avg:33.28ms
+step:39/1480 train_time:1292ms step_avg:33.14ms
+step:40/1480 train_time:1327ms step_avg:33.18ms
+step:41/1480 train_time:1355ms step_avg:33.05ms
+step:42/1480 train_time:1390ms step_avg:33.09ms
+step:43/1480 train_time:1418ms step_avg:32.97ms
+step:44/1480 train_time:1453ms step_avg:33.03ms
+step:45/1480 train_time:1481ms step_avg:32.91ms
+step:46/1480 train_time:1516ms step_avg:32.95ms
+step:47/1480 train_time:1543ms step_avg:32.84ms
+step:48/1480 train_time:1580ms step_avg:32.92ms
+step:49/1480 train_time:1609ms step_avg:32.83ms
+step:50/1480 train_time:1646ms step_avg:32.93ms
+step:51/1480 train_time:1677ms step_avg:32.88ms
+step:52/1480 train_time:1715ms step_avg:32.98ms
+step:53/1480 train_time:1745ms step_avg:32.92ms
+step:54/1480 train_time:1782ms step_avg:33.01ms
+step:55/1480 train_time:1813ms step_avg:32.96ms
+step:56/1480 train_time:1851ms step_avg:33.05ms
+step:57/1480 train_time:1881ms step_avg:33.00ms
+step:58/1480 train_time:1919ms step_avg:33.08ms
+step:59/1480 train_time:1949ms step_avg:33.04ms
+step:60/1480 train_time:1986ms step_avg:33.10ms
+step:61/1480 train_time:2016ms step_avg:33.05ms
+step:62/1480 train_time:2054ms step_avg:33.13ms
+step:63/1480 train_time:2084ms step_avg:33.07ms
+step:64/1480 train_time:2121ms step_avg:33.14ms
+step:65/1480 train_time:2152ms step_avg:33.10ms
+step:66/1480 train_time:2188ms step_avg:33.15ms
+step:67/1480 train_time:2218ms step_avg:33.10ms
+step:68/1480 train_time:2255ms step_avg:33.17ms
+step:69/1480 train_time:2285ms step_avg:33.11ms
+step:70/1480 train_time:2322ms step_avg:33.17ms
+step:71/1480 train_time:2352ms step_avg:33.13ms
+step:72/1480 train_time:2389ms step_avg:33.18ms
+step:73/1480 train_time:2418ms step_avg:33.13ms
+step:74/1480 train_time:2455ms step_avg:33.18ms
+step:75/1480 train_time:2485ms step_avg:33.13ms
+step:76/1480 train_time:2522ms step_avg:33.18ms
+step:77/1480 train_time:2552ms step_avg:33.14ms
+step:78/1480 train_time:2588ms step_avg:33.19ms
+step:79/1480 train_time:2618ms step_avg:33.14ms
+step:80/1480 train_time:2656ms step_avg:33.20ms
+step:81/1480 train_time:2685ms step_avg:33.15ms
+step:82/1480 train_time:2720ms step_avg:33.17ms
+step:83/1480 train_time:2748ms step_avg:33.11ms
+step:84/1480 train_time:2783ms step_avg:33.13ms
+step:85/1480 train_time:2811ms step_avg:33.07ms
+step:86/1480 train_time:2846ms step_avg:33.09ms
+step:87/1480 train_time:2874ms step_avg:33.03ms
+step:88/1480 train_time:2911ms step_avg:33.08ms
+step:89/1480 train_time:2941ms step_avg:33.04ms
+step:90/1480 train_time:2979ms step_avg:33.10ms
+step:91/1480 train_time:3009ms step_avg:33.07ms
+step:92/1480 train_time:3046ms step_avg:33.11ms
+step:93/1480 train_time:3076ms step_avg:33.08ms
+step:94/1480 train_time:3114ms step_avg:33.13ms
+step:95/1480 train_time:3144ms step_avg:33.09ms
+step:96/1480 train_time:3181ms step_avg:33.13ms
+step:97/1480 train_time:3211ms step_avg:33.10ms
+step:98/1480 train_time:3248ms step_avg:33.14ms
+step:99/1480 train_time:3278ms step_avg:33.11ms
+step:100/1480 train_time:3316ms step_avg:33.16ms
+step:101/1480 train_time:3345ms step_avg:33.12ms
+step:102/1480 train_time:3382ms step_avg:33.15ms
+step:103/1480 train_time:3412ms step_avg:33.13ms
+step:104/1480 train_time:3449ms step_avg:33.16ms
+step:105/1480 train_time:3479ms step_avg:33.13ms
+step:106/1480 train_time:3516ms step_avg:33.17ms
+step:107/1480 train_time:3546ms step_avg:33.14ms
+step:108/1480 train_time:3583ms step_avg:33.17ms
+step:109/1480 train_time:3612ms step_avg:33.14ms
+step:110/1480 train_time:3649ms step_avg:33.17ms
+step:111/1480 train_time:3679ms step_avg:33.14ms
+step:112/1480 train_time:3716ms step_avg:33.18ms
+step:113/1480 train_time:3745ms step_avg:33.15ms
+step:114/1480 train_time:3782ms step_avg:33.17ms
+step:115/1480 train_time:3812ms step_avg:33.15ms
+step:116/1480 train_time:3848ms step_avg:33.17ms
+step:117/1480 train_time:3878ms step_avg:33.14ms
+step:118/1480 train_time:3915ms step_avg:33.18ms
+step:119/1480 train_time:3943ms step_avg:33.14ms
+step:120/1480 train_time:3980ms step_avg:33.17ms
+step:121/1480 train_time:4010ms step_avg:33.14ms
+step:122/1480 train_time:4046ms step_avg:33.16ms
+step:123/1480 train_time:4076ms step_avg:33.13ms
+step:124/1480 train_time:4113ms step_avg:33.17ms
+step:125/1480 train_time:4141ms step_avg:33.13ms
+step:126/1480 train_time:4178ms step_avg:33.16ms
+step:127/1480 train_time:4208ms step_avg:33.13ms
+step:128/1480 train_time:4243ms step_avg:33.15ms
+step:129/1480 train_time:4273ms step_avg:33.13ms
+step:130/1480 train_time:4310ms step_avg:33.16ms
+step:131/1480 train_time:4338ms step_avg:33.12ms
+step:132/1480 train_time:4375ms step_avg:33.15ms
+step:133/1480 train_time:4404ms step_avg:33.11ms
+step:134/1480 train_time:4440ms step_avg:33.13ms
+step:135/1480 train_time:4470ms step_avg:33.11ms
+step:136/1480 train_time:4505ms step_avg:33.13ms
+step:137/1480 train_time:4535ms step_avg:33.10ms
+step:138/1480 train_time:4571ms step_avg:33.12ms
+step:139/1480 train_time:4600ms step_avg:33.09ms
+step:140/1480 train_time:4637ms step_avg:33.12ms
+step:141/1480 train_time:4666ms step_avg:33.09ms
+step:142/1480 train_time:4702ms step_avg:33.11ms
+step:143/1480 train_time:4731ms step_avg:33.09ms
+step:144/1480 train_time:4767ms step_avg:33.11ms
+step:145/1480 train_time:4796ms step_avg:33.08ms
+step:146/1480 train_time:4832ms step_avg:33.10ms
+step:147/1480 train_time:4861ms step_avg:33.07ms
+step:148/1480 train_time:4898ms step_avg:33.09ms
+step:149/1480 train_time:4926ms step_avg:33.06ms
+step:150/1480 train_time:4962ms step_avg:33.08ms
+step:151/1480 train_time:4991ms step_avg:33.05ms
+step:152/1480 train_time:5029ms step_avg:33.08ms
+step:153/1480 train_time:5056ms step_avg:33.05ms
+step:154/1480 train_time:5092ms step_avg:33.06ms
+step:155/1480 train_time:5121ms step_avg:33.04ms
+step:156/1480 train_time:5157ms step_avg:33.06ms
+step:157/1480 train_time:5187ms step_avg:33.04ms
+step:158/1480 train_time:5222ms step_avg:33.05ms
+step:159/1480 train_time:5252ms step_avg:33.03ms
+step:160/1480 train_time:5288ms step_avg:33.05ms
+step:161/1480 train_time:5317ms step_avg:33.02ms
+step:162/1480 train_time:5354ms step_avg:33.05ms
+step:163/1480 train_time:5383ms step_avg:33.02ms
+step:164/1480 train_time:5419ms step_avg:33.05ms
+step:165/1480 train_time:5449ms step_avg:33.02ms
+step:166/1480 train_time:5485ms step_avg:33.04ms
+step:167/1480 train_time:5515ms step_avg:33.02ms
+step:168/1480 train_time:5552ms step_avg:33.05ms
+step:169/1480 train_time:5581ms step_avg:33.02ms
+step:170/1480 train_time:5618ms step_avg:33.05ms
+step:171/1480 train_time:5647ms step_avg:33.03ms
+step:172/1480 train_time:5683ms step_avg:33.04ms
+step:173/1480 train_time:5713ms step_avg:33.02ms
+step:174/1480 train_time:5748ms step_avg:33.04ms
+step:175/1480 train_time:5778ms step_avg:33.02ms
+step:176/1480 train_time:5815ms step_avg:33.04ms
+step:177/1480 train_time:5844ms step_avg:33.02ms
+step:178/1480 train_time:5880ms step_avg:33.03ms
+step:179/1480 train_time:5910ms step_avg:33.02ms
+step:180/1480 train_time:5946ms step_avg:33.03ms
+step:181/1480 train_time:5976ms step_avg:33.02ms
+step:182/1480 train_time:6014ms step_avg:33.04ms
+step:183/1480 train_time:6042ms step_avg:33.01ms
+step:184/1480 train_time:6079ms step_avg:33.04ms
+step:185/1480 train_time:6108ms step_avg:33.02ms
+step:186/1480 train_time:6144ms step_avg:33.03ms
+step:187/1480 train_time:6173ms step_avg:33.01ms
+step:188/1480 train_time:6210ms step_avg:33.03ms
+step:189/1480 train_time:6239ms step_avg:33.01ms
+step:190/1480 train_time:6275ms step_avg:33.03ms
+step:191/1480 train_time:6304ms step_avg:33.01ms
+step:192/1480 train_time:6340ms step_avg:33.02ms
+step:193/1480 train_time:6370ms step_avg:33.01ms
+step:194/1480 train_time:6406ms step_avg:33.02ms
+step:195/1480 train_time:6435ms step_avg:33.00ms
+step:196/1480 train_time:6472ms step_avg:33.02ms
+step:197/1480 train_time:6501ms step_avg:33.00ms
+step:198/1480 train_time:6537ms step_avg:33.02ms
+step:199/1480 train_time:6567ms step_avg:33.00ms
+step:200/1480 train_time:6603ms step_avg:33.01ms
+step:201/1480 train_time:6632ms step_avg:33.00ms
+step:202/1480 train_time:6668ms step_avg:33.01ms
+step:203/1480 train_time:6697ms step_avg:32.99ms
+step:204/1480 train_time:6733ms step_avg:33.01ms
+step:205/1480 train_time:6762ms step_avg:32.98ms
+step:206/1480 train_time:6798ms step_avg:33.00ms
+step:207/1480 train_time:6828ms step_avg:32.98ms
+step:208/1480 train_time:6863ms step_avg:33.00ms
+step:209/1480 train_time:6893ms step_avg:32.98ms
+step:210/1480 train_time:6929ms step_avg:32.99ms
+step:211/1480 train_time:6957ms step_avg:32.97ms
+step:212/1480 train_time:6994ms step_avg:32.99ms
+step:213/1480 train_time:7023ms step_avg:32.97ms
+step:214/1480 train_time:7060ms step_avg:32.99ms
+step:215/1480 train_time:7090ms step_avg:32.98ms
+step:216/1480 train_time:7126ms step_avg:32.99ms
+step:217/1480 train_time:7156ms step_avg:32.98ms
+step:218/1480 train_time:7193ms step_avg:33.00ms
+step:219/1480 train_time:7222ms step_avg:32.98ms
+step:220/1480 train_time:7259ms step_avg:32.99ms
+step:221/1480 train_time:7289ms step_avg:32.98ms
+step:222/1480 train_time:7325ms step_avg:33.00ms
+step:223/1480 train_time:7355ms step_avg:32.98ms
+step:224/1480 train_time:7391ms step_avg:33.00ms
+step:225/1480 train_time:7420ms step_avg:32.98ms
+step:226/1480 train_time:7458ms step_avg:33.00ms
+step:227/1480 train_time:7488ms step_avg:32.99ms
+step:228/1480 train_time:7524ms step_avg:33.00ms
+step:229/1480 train_time:7554ms step_avg:32.99ms
+step:230/1480 train_time:7590ms step_avg:33.00ms
+step:231/1480 train_time:7619ms step_avg:32.98ms
+step:232/1480 train_time:7657ms step_avg:33.00ms
+step:233/1480 train_time:7686ms step_avg:32.99ms
+step:234/1480 train_time:7723ms step_avg:33.00ms
+step:235/1480 train_time:7753ms step_avg:32.99ms
+step:236/1480 train_time:7789ms step_avg:33.00ms
+step:237/1480 train_time:7818ms step_avg:32.99ms
+step:238/1480 train_time:7855ms step_avg:33.01ms
+step:239/1480 train_time:7885ms step_avg:32.99ms
+step:240/1480 train_time:7921ms step_avg:33.01ms
+step:241/1480 train_time:7951ms step_avg:32.99ms
+step:242/1480 train_time:7988ms step_avg:33.01ms
+step:243/1480 train_time:8017ms step_avg:32.99ms
+step:244/1480 train_time:8054ms step_avg:33.01ms
+step:245/1480 train_time:8084ms step_avg:33.00ms
+step:246/1480 train_time:8121ms step_avg:33.01ms
+step:247/1480 train_time:8151ms step_avg:33.00ms
+step:248/1480 train_time:8187ms step_avg:33.01ms
+step:249/1480 train_time:8216ms step_avg:33.00ms
+step:250/1480 train_time:8253ms step_avg:33.01ms
+step:250/1480 val_loss:4.5211 train_time:8299ms step_avg:33.20ms
+step:251/1480 train_time:8317ms step_avg:33.14ms
+step:252/1480 train_time:8337ms step_avg:33.08ms
+step:253/1480 train_time:8353ms step_avg:33.01ms
+step:254/1480 train_time:8387ms step_avg:33.02ms
+step:255/1480 train_time:8416ms step_avg:33.00ms
+step:256/1480 train_time:8451ms step_avg:33.01ms
+step:257/1480 train_time:8480ms step_avg:33.00ms
+step:258/1480 train_time:8516ms step_avg:33.01ms
+step:259/1480 train_time:8544ms step_avg:32.99ms
+step:260/1480 train_time:8580ms step_avg:33.00ms
+step:261/1480 train_time:8609ms step_avg:32.98ms
+step:262/1480 train_time:8645ms step_avg:33.00ms
+step:263/1480 train_time:8674ms step_avg:32.98ms
+step:264/1480 train_time:8711ms step_avg:32.99ms
+step:265/1480 train_time:8739ms step_avg:32.98ms
+step:266/1480 train_time:8776ms step_avg:32.99ms
+step:267/1480 train_time:8805ms step_avg:32.98ms
+step:268/1480 train_time:8842ms step_avg:32.99ms
+step:269/1480 train_time:8870ms step_avg:32.98ms
+step:270/1480 train_time:8907ms step_avg:32.99ms
+step:271/1480 train_time:8937ms step_avg:32.98ms
+step:272/1480 train_time:8973ms step_avg:32.99ms
+step:273/1480 train_time:9003ms step_avg:32.98ms
+step:274/1480 train_time:9039ms step_avg:32.99ms
+step:275/1480 train_time:9068ms step_avg:32.98ms
+step:276/1480 train_time:9105ms step_avg:32.99ms
+step:277/1480 train_time:9135ms step_avg:32.98ms
+step:278/1480 train_time:9171ms step_avg:32.99ms
+step:279/1480 train_time:9201ms step_avg:32.98ms
+step:280/1480 train_time:9237ms step_avg:32.99ms
+step:281/1480 train_time:9266ms step_avg:32.98ms
+step:282/1480 train_time:9303ms step_avg:32.99ms
+step:283/1480 train_time:9332ms step_avg:32.98ms
+step:284/1480 train_time:9369ms step_avg:32.99ms
+step:285/1480 train_time:9399ms step_avg:32.98ms
+step:286/1480 train_time:9435ms step_avg:32.99ms
+step:287/1480 train_time:9464ms step_avg:32.98ms
+step:288/1480 train_time:9501ms step_avg:32.99ms
+step:289/1480 train_time:9530ms step_avg:32.98ms
+step:290/1480 train_time:9567ms step_avg:32.99ms
+step:291/1480 train_time:9597ms step_avg:32.98ms
+step:292/1480 train_time:9632ms step_avg:32.99ms
+step:293/1480 train_time:9662ms step_avg:32.98ms
+step:294/1480 train_time:9699ms step_avg:32.99ms
+step:295/1480 train_time:9728ms step_avg:32.98ms
+step:296/1480 train_time:9765ms step_avg:32.99ms
+step:297/1480 train_time:9795ms step_avg:32.98ms
+step:298/1480 train_time:9831ms step_avg:32.99ms
+step:299/1480 train_time:9860ms step_avg:32.98ms
+step:300/1480 train_time:9897ms step_avg:32.99ms
+step:301/1480 train_time:9926ms step_avg:32.98ms
+step:302/1480 train_time:9964ms step_avg:32.99ms
+step:303/1480 train_time:9993ms step_avg:32.98ms
+step:304/1480 train_time:10029ms step_avg:32.99ms
+step:305/1480 train_time:10058ms step_avg:32.98ms
+step:306/1480 train_time:10095ms step_avg:32.99ms
+step:307/1480 train_time:10124ms step_avg:32.98ms
+step:308/1480 train_time:10161ms step_avg:32.99ms
+step:309/1480 train_time:10190ms step_avg:32.98ms
+step:310/1480 train_time:10226ms step_avg:32.99ms
+step:311/1480 train_time:10257ms step_avg:32.98ms
+step:312/1480 train_time:10295ms step_avg:33.00ms
+step:313/1480 train_time:10325ms step_avg:32.99ms
+step:314/1480 train_time:10364ms step_avg:33.00ms
+step:315/1480 train_time:10394ms step_avg:33.00ms
+step:316/1480 train_time:10431ms step_avg:33.01ms
+step:317/1480 train_time:10462ms step_avg:33.00ms
+step:318/1480 train_time:10500ms step_avg:33.02ms
+step:319/1480 train_time:10530ms step_avg:33.01ms
+step:320/1480 train_time:10567ms step_avg:33.02ms
+step:321/1480 train_time:10598ms step_avg:33.02ms
+step:322/1480 train_time:10635ms step_avg:33.03ms
+step:323/1480 train_time:10665ms step_avg:33.02ms
+step:324/1480 train_time:10703ms step_avg:33.03ms
+step:325/1480 train_time:10733ms step_avg:33.02ms
+step:326/1480 train_time:10770ms step_avg:33.04ms
+step:327/1480 train_time:10800ms step_avg:33.03ms
+step:328/1480 train_time:10838ms step_avg:33.04ms
+step:329/1480 train_time:10867ms step_avg:33.03ms
+step:330/1480 train_time:10905ms step_avg:33.04ms
+step:331/1480 train_time:10935ms step_avg:33.04ms
+step:332/1480 train_time:10972ms step_avg:33.05ms
+step:333/1480 train_time:11002ms step_avg:33.04ms
+step:334/1480 train_time:11039ms step_avg:33.05ms
+step:335/1480 train_time:11069ms step_avg:33.04ms
+step:336/1480 train_time:11106ms step_avg:33.05ms
+step:337/1480 train_time:11136ms step_avg:33.04ms
+step:338/1480 train_time:11172ms step_avg:33.05ms
+step:339/1480 train_time:11202ms step_avg:33.04ms
+step:340/1480 train_time:11239ms step_avg:33.06ms
+step:341/1480 train_time:11268ms step_avg:33.04ms
+step:342/1480 train_time:11305ms step_avg:33.06ms
+step:343/1480 train_time:11335ms step_avg:33.05ms
+step:344/1480 train_time:11371ms step_avg:33.06ms
+step:345/1480 train_time:11401ms step_avg:33.05ms
+step:346/1480 train_time:11438ms step_avg:33.06ms
+step:347/1480 train_time:11467ms step_avg:33.05ms
+step:348/1480 train_time:11504ms step_avg:33.06ms
+step:349/1480 train_time:11534ms step_avg:33.05ms
+step:350/1480 train_time:11570ms step_avg:33.06ms
+step:351/1480 train_time:11600ms step_avg:33.05ms
+step:352/1480 train_time:11637ms step_avg:33.06ms
+step:353/1480 train_time:11666ms step_avg:33.05ms
+step:354/1480 train_time:11703ms step_avg:33.06ms
+step:355/1480 train_time:11733ms step_avg:33.05ms
+step:356/1480 train_time:11769ms step_avg:33.06ms
+step:357/1480 train_time:11799ms step_avg:33.05ms
+step:358/1480 train_time:11836ms step_avg:33.06ms
+step:359/1480 train_time:11865ms step_avg:33.05ms
+step:360/1480 train_time:11902ms step_avg:33.06ms
+step:361/1480 train_time:11931ms step_avg:33.05ms
+step:362/1480 train_time:11968ms step_avg:33.06ms
+step:363/1480 train_time:11997ms step_avg:33.05ms
+step:364/1480 train_time:12034ms step_avg:33.06ms
+step:365/1480 train_time:12063ms step_avg:33.05ms
+step:366/1480 train_time:12100ms step_avg:33.06ms
+step:367/1480 train_time:12129ms step_avg:33.05ms
+step:368/1480 train_time:12166ms step_avg:33.06ms
+step:369/1480 train_time:12196ms step_avg:33.05ms
+step:370/1480 train_time:12232ms step_avg:33.06ms
+step:371/1480 train_time:12262ms step_avg:33.05ms
+step:372/1480 train_time:12299ms step_avg:33.06ms
+step:373/1480 train_time:12329ms step_avg:33.05ms
+step:374/1480 train_time:12365ms step_avg:33.06ms
+step:375/1480 train_time:12395ms step_avg:33.05ms
+step:376/1480 train_time:12431ms step_avg:33.06ms
+step:377/1480 train_time:12461ms step_avg:33.05ms
+step:378/1480 train_time:12498ms step_avg:33.06ms
+step:379/1480 train_time:12527ms step_avg:33.05ms
+step:380/1480 train_time:12564ms step_avg:33.06ms
+step:381/1480 train_time:12594ms step_avg:33.05ms
+step:382/1480 train_time:12630ms step_avg:33.06ms
+step:383/1480 train_time:12660ms step_avg:33.05ms
+step:384/1480 train_time:12697ms step_avg:33.06ms
+step:385/1480 train_time:12726ms step_avg:33.05ms
+step:386/1480 train_time:12763ms step_avg:33.06ms
+step:387/1480 train_time:12793ms step_avg:33.06ms
+step:388/1480 train_time:12829ms step_avg:33.06ms
+step:389/1480 train_time:12858ms step_avg:33.06ms
+step:390/1480 train_time:12895ms step_avg:33.06ms
+step:391/1480 train_time:12924ms step_avg:33.05ms
+step:392/1480 train_time:12961ms step_avg:33.06ms
+step:393/1480 train_time:12990ms step_avg:33.05ms
+step:394/1480 train_time:13026ms step_avg:33.06ms
+step:395/1480 train_time:13056ms step_avg:33.05ms
+step:396/1480 train_time:13092ms step_avg:33.06ms
+step:397/1480 train_time:13124ms step_avg:33.06ms
+step:398/1480 train_time:13163ms step_avg:33.07ms
+step:399/1480 train_time:13194ms step_avg:33.07ms
+step:400/1480 train_time:13232ms step_avg:33.08ms
+step:401/1480 train_time:13262ms step_avg:33.07ms
+step:402/1480 train_time:13300ms step_avg:33.08ms
+step:403/1480 train_time:13330ms step_avg:33.08ms
+step:404/1480 train_time:13367ms step_avg:33.09ms
+step:405/1480 train_time:13398ms step_avg:33.08ms
+step:406/1480 train_time:13436ms step_avg:33.09ms
+step:407/1480 train_time:13466ms step_avg:33.08ms
+step:408/1480 train_time:13503ms step_avg:33.10ms
+step:409/1480 train_time:13533ms step_avg:33.09ms
+step:410/1480 train_time:13571ms step_avg:33.10ms
+step:411/1480 train_time:13601ms step_avg:33.09ms
+step:412/1480 train_time:13637ms step_avg:33.10ms
+step:413/1480 train_time:13667ms step_avg:33.09ms
+step:414/1480 train_time:13705ms step_avg:33.10ms
+step:415/1480 train_time:13735ms step_avg:33.10ms
+step:416/1480 train_time:13773ms step_avg:33.11ms
+step:417/1480 train_time:13802ms step_avg:33.10ms
+step:418/1480 train_time:13839ms step_avg:33.11ms
+step:419/1480 train_time:13869ms step_avg:33.10ms
+step:420/1480 train_time:13907ms step_avg:33.11ms
+step:421/1480 train_time:13937ms step_avg:33.10ms
+step:422/1480 train_time:13975ms step_avg:33.12ms
+step:423/1480 train_time:14005ms step_avg:33.11ms
+step:424/1480 train_time:14042ms step_avg:33.12ms
+step:425/1480 train_time:14072ms step_avg:33.11ms
+step:426/1480 train_time:14110ms step_avg:33.12ms
+step:427/1480 train_time:14140ms step_avg:33.12ms
+step:428/1480 train_time:14178ms step_avg:33.13ms
+step:429/1480 train_time:14208ms step_avg:33.12ms
+step:430/1480 train_time:14246ms step_avg:33.13ms
+step:431/1480 train_time:14277ms step_avg:33.12ms
+step:432/1480 train_time:14314ms step_avg:33.13ms
+step:433/1480 train_time:14344ms step_avg:33.13ms
+step:434/1480 train_time:14382ms step_avg:33.14ms
+step:435/1480 train_time:14411ms step_avg:33.13ms
+step:436/1480 train_time:14448ms step_avg:33.14ms
+step:437/1480 train_time:14479ms step_avg:33.13ms
+step:438/1480 train_time:14516ms step_avg:33.14ms
+step:439/1480 train_time:14546ms step_avg:33.13ms
+step:440/1480 train_time:14584ms step_avg:33.14ms
+step:441/1480 train_time:14613ms step_avg:33.14ms
+step:442/1480 train_time:14650ms step_avg:33.14ms
+step:443/1480 train_time:14680ms step_avg:33.14ms
+step:444/1480 train_time:14718ms step_avg:33.15ms
+step:445/1480 train_time:14748ms step_avg:33.14ms
+step:446/1480 train_time:14785ms step_avg:33.15ms
+step:447/1480 train_time:14815ms step_avg:33.14ms
+step:448/1480 train_time:14851ms step_avg:33.15ms
+step:449/1480 train_time:14881ms step_avg:33.14ms
+step:450/1480 train_time:14919ms step_avg:33.15ms
+step:451/1480 train_time:14950ms step_avg:33.15ms
+step:452/1480 train_time:14986ms step_avg:33.16ms
+step:453/1480 train_time:15016ms step_avg:33.15ms
+step:454/1480 train_time:15053ms step_avg:33.16ms
+step:455/1480 train_time:15082ms step_avg:33.15ms
+step:456/1480 train_time:15120ms step_avg:33.16ms
+step:457/1480 train_time:15149ms step_avg:33.15ms
+step:458/1480 train_time:15187ms step_avg:33.16ms
+step:459/1480 train_time:15216ms step_avg:33.15ms
+step:460/1480 train_time:15253ms step_avg:33.16ms
+step:461/1480 train_time:15283ms step_avg:33.15ms
+step:462/1480 train_time:15320ms step_avg:33.16ms
+step:463/1480 train_time:15349ms step_avg:33.15ms
+step:464/1480 train_time:15384ms step_avg:33.16ms
+step:465/1480 train_time:15412ms step_avg:33.14ms
+step:466/1480 train_time:15449ms step_avg:33.15ms
+step:467/1480 train_time:15479ms step_avg:33.15ms
+step:468/1480 train_time:15516ms step_avg:33.15ms
+step:469/1480 train_time:15548ms step_avg:33.15ms
+step:470/1480 train_time:15589ms step_avg:33.17ms
+step:471/1480 train_time:15622ms step_avg:33.17ms
+step:472/1480 train_time:15661ms step_avg:33.18ms
+step:473/1480 train_time:15691ms step_avg:33.17ms
+step:474/1480 train_time:15729ms step_avg:33.18ms
+step:475/1480 train_time:15760ms step_avg:33.18ms
+step:476/1480 train_time:15795ms step_avg:33.18ms
+step:477/1480 train_time:15823ms step_avg:33.17ms
+step:478/1480 train_time:15858ms step_avg:33.18ms
+step:479/1480 train_time:15889ms step_avg:33.17ms
+step:480/1480 train_time:15928ms step_avg:33.18ms
+step:481/1480 train_time:15961ms step_avg:33.18ms
+step:482/1480 train_time:16021ms step_avg:33.24ms
+step:483/1480 train_time:16081ms step_avg:33.29ms
+step:484/1480 train_time:16143ms step_avg:33.35ms
+step:485/1480 train_time:16201ms step_avg:33.40ms
+step:486/1480 train_time:16266ms step_avg:33.47ms
+step:487/1480 train_time:16325ms step_avg:33.52ms
+step:488/1480 train_time:16390ms step_avg:33.59ms
+step:489/1480 train_time:16449ms step_avg:33.64ms
+step:490/1480 train_time:16514ms step_avg:33.70ms
+step:491/1480 train_time:16573ms step_avg:33.75ms
+step:492/1480 train_time:16638ms step_avg:33.82ms
+step:493/1480 train_time:16697ms step_avg:33.87ms
+step:494/1480 train_time:16762ms step_avg:33.93ms
+step:495/1480 train_time:16821ms step_avg:33.98ms
+step:496/1480 train_time:16886ms step_avg:34.04ms
+step:497/1480 train_time:16944ms step_avg:34.09ms
+step:498/1480 train_time:17009ms step_avg:34.16ms
+step:499/1480 train_time:17069ms step_avg:34.21ms
+step:500/1480 train_time:17134ms step_avg:34.27ms
+step:500/1480 val_loss:4.2151 train_time:17215ms step_avg:34.43ms
+step:501/1480 train_time:17234ms step_avg:34.40ms
+step:502/1480 train_time:17257ms step_avg:34.38ms
+step:503/1480 train_time:17315ms step_avg:34.42ms
+step:504/1480 train_time:17381ms step_avg:34.49ms
+step:505/1480 train_time:17443ms step_avg:34.54ms
+step:506/1480 train_time:17509ms step_avg:34.60ms
+step:507/1480 train_time:17568ms step_avg:34.65ms
+step:508/1480 train_time:17634ms step_avg:34.71ms
+step:509/1480 train_time:17694ms step_avg:34.76ms
+step:510/1480 train_time:17760ms step_avg:34.82ms
+step:511/1480 train_time:17818ms step_avg:34.87ms
+step:512/1480 train_time:17883ms step_avg:34.93ms
+step:513/1480 train_time:17943ms step_avg:34.98ms
+step:514/1480 train_time:18008ms step_avg:35.04ms
+step:515/1480 train_time:18065ms step_avg:35.08ms
+step:516/1480 train_time:18124ms step_avg:35.12ms
+step:517/1480 train_time:18181ms step_avg:35.17ms
+step:518/1480 train_time:18247ms step_avg:35.23ms
+step:519/1480 train_time:18304ms step_avg:35.27ms
+step:520/1480 train_time:18366ms step_avg:35.32ms
+step:521/1480 train_time:18423ms step_avg:35.36ms
+step:522/1480 train_time:18487ms step_avg:35.42ms
+step:523/1480 train_time:18546ms step_avg:35.46ms
+step:524/1480 train_time:18610ms step_avg:35.52ms
+step:525/1480 train_time:18669ms step_avg:35.56ms
+step:526/1480 train_time:18732ms step_avg:35.61ms
+step:527/1480 train_time:18790ms step_avg:35.66ms
+step:528/1480 train_time:18854ms step_avg:35.71ms
+step:529/1480 train_time:18913ms step_avg:35.75ms
+step:530/1480 train_time:18978ms step_avg:35.81ms
+step:531/1480 train_time:19034ms step_avg:35.85ms
+step:532/1480 train_time:19099ms step_avg:35.90ms
+step:533/1480 train_time:19156ms step_avg:35.94ms
+step:534/1480 train_time:19220ms step_avg:35.99ms
+step:535/1480 train_time:19280ms step_avg:36.04ms
+step:536/1480 train_time:19353ms step_avg:36.11ms
+step:537/1480 train_time:19417ms step_avg:36.16ms
+step:538/1480 train_time:19486ms step_avg:36.22ms
+step:539/1480 train_time:19550ms step_avg:36.27ms
+step:540/1480 train_time:19621ms step_avg:36.34ms
+step:541/1480 train_time:19682ms step_avg:36.38ms
+step:542/1480 train_time:19742ms step_avg:36.42ms
+step:543/1480 train_time:19796ms step_avg:36.46ms
+step:544/1480 train_time:19855ms step_avg:36.50ms
+step:545/1480 train_time:19911ms step_avg:36.53ms
+step:546/1480 train_time:19976ms step_avg:36.59ms
+step:547/1480 train_time:20039ms step_avg:36.63ms
+step:548/1480 train_time:20107ms step_avg:36.69ms
+step:549/1480 train_time:20168ms step_avg:36.74ms
+step:550/1480 train_time:20235ms step_avg:36.79ms
+step:551/1480 train_time:20294ms step_avg:36.83ms
+step:552/1480 train_time:20359ms step_avg:36.88ms
+step:553/1480 train_time:20417ms step_avg:36.92ms
+step:554/1480 train_time:20481ms step_avg:36.97ms
+step:555/1480 train_time:20539ms step_avg:37.01ms
+step:556/1480 train_time:20604ms step_avg:37.06ms
+step:557/1480 train_time:20663ms step_avg:37.10ms
+step:558/1480 train_time:20728ms step_avg:37.15ms
+step:559/1480 train_time:20786ms step_avg:37.18ms
+step:560/1480 train_time:20850ms step_avg:37.23ms
+step:561/1480 train_time:20910ms step_avg:37.27ms
+step:562/1480 train_time:20974ms step_avg:37.32ms
+step:563/1480 train_time:21033ms step_avg:37.36ms
+step:564/1480 train_time:21098ms step_avg:37.41ms
+step:565/1480 train_time:21156ms step_avg:37.44ms
+step:566/1480 train_time:21221ms step_avg:37.49ms
+step:567/1480 train_time:21278ms step_avg:37.53ms
+step:568/1480 train_time:21342ms step_avg:37.57ms
+step:569/1480 train_time:21401ms step_avg:37.61ms
+step:570/1480 train_time:21465ms step_avg:37.66ms
+step:571/1480 train_time:21523ms step_avg:37.69ms
+step:572/1480 train_time:21587ms step_avg:37.74ms
+step:573/1480 train_time:21646ms step_avg:37.78ms
+step:574/1480 train_time:21711ms step_avg:37.82ms
+step:575/1480 train_time:21769ms step_avg:37.86ms
+step:576/1480 train_time:21834ms step_avg:37.91ms
+step:577/1480 train_time:21892ms step_avg:37.94ms
+step:578/1480 train_time:21957ms step_avg:37.99ms
+step:579/1480 train_time:22014ms step_avg:38.02ms
+step:580/1480 train_time:22078ms step_avg:38.07ms
+step:581/1480 train_time:22136ms step_avg:38.10ms
+step:582/1480 train_time:22200ms step_avg:38.14ms
+step:583/1480 train_time:22257ms step_avg:38.18ms
+step:584/1480 train_time:22321ms step_avg:38.22ms
+step:585/1480 train_time:22378ms step_avg:38.25ms
+step:586/1480 train_time:22440ms step_avg:38.29ms
+step:587/1480 train_time:22497ms step_avg:38.33ms
+step:588/1480 train_time:22561ms step_avg:38.37ms
+step:589/1480 train_time:22620ms step_avg:38.40ms
+step:590/1480 train_time:22687ms step_avg:38.45ms
+step:591/1480 train_time:22748ms step_avg:38.49ms
+step:592/1480 train_time:22813ms step_avg:38.54ms
+step:593/1480 train_time:22872ms step_avg:38.57ms
+step:594/1480 train_time:22938ms step_avg:38.62ms
+step:595/1480 train_time:22996ms step_avg:38.65ms
+step:596/1480 train_time:23062ms step_avg:38.69ms
+step:597/1480 train_time:23120ms step_avg:38.73ms
+step:598/1480 train_time:23185ms step_avg:38.77ms
+step:599/1480 train_time:23244ms step_avg:38.80ms
+step:600/1480 train_time:23310ms step_avg:38.85ms
+step:601/1480 train_time:23369ms step_avg:38.88ms
+step:602/1480 train_time:23434ms step_avg:38.93ms
+step:603/1480 train_time:23492ms step_avg:38.96ms
+step:604/1480 train_time:23557ms step_avg:39.00ms
+step:605/1480 train_time:23615ms step_avg:39.03ms
+step:606/1480 train_time:23679ms step_avg:39.07ms
+step:607/1480 train_time:23736ms step_avg:39.10ms
+step:608/1480 train_time:23801ms step_avg:39.15ms
+step:609/1480 train_time:23859ms step_avg:39.18ms
+step:610/1480 train_time:23922ms step_avg:39.22ms
+step:611/1480 train_time:23981ms step_avg:39.25ms
+step:612/1480 train_time:24044ms step_avg:39.29ms
+step:613/1480 train_time:24103ms step_avg:39.32ms
+step:614/1480 train_time:24167ms step_avg:39.36ms
+step:615/1480 train_time:24225ms step_avg:39.39ms
+step:616/1480 train_time:24291ms step_avg:39.43ms
+step:617/1480 train_time:24351ms step_avg:39.47ms
+step:618/1480 train_time:24416ms step_avg:39.51ms
+step:619/1480 train_time:24473ms step_avg:39.54ms
+step:620/1480 train_time:24537ms step_avg:39.58ms
+step:621/1480 train_time:24595ms step_avg:39.60ms
+step:622/1480 train_time:24659ms step_avg:39.64ms
+step:623/1480 train_time:24716ms step_avg:39.67ms
+step:624/1480 train_time:24779ms step_avg:39.71ms
+step:625/1480 train_time:24836ms step_avg:39.74ms
+step:626/1480 train_time:24900ms step_avg:39.78ms
+step:627/1480 train_time:24957ms step_avg:39.80ms
+step:628/1480 train_time:25021ms step_avg:39.84ms
+step:629/1480 train_time:25079ms step_avg:39.87ms
+step:630/1480 train_time:25144ms step_avg:39.91ms
+step:631/1480 train_time:25204ms step_avg:39.94ms
+step:632/1480 train_time:25270ms step_avg:39.98ms
+step:633/1480 train_time:25329ms step_avg:40.01ms
+step:634/1480 train_time:25395ms step_avg:40.05ms
+step:635/1480 train_time:25454ms step_avg:40.09ms
+step:636/1480 train_time:25519ms step_avg:40.12ms
+step:637/1480 train_time:25577ms step_avg:40.15ms
+step:638/1480 train_time:25642ms step_avg:40.19ms
+step:639/1480 train_time:25701ms step_avg:40.22ms
+step:640/1480 train_time:25765ms step_avg:40.26ms
+step:641/1480 train_time:25824ms step_avg:40.29ms
+step:642/1480 train_time:25889ms step_avg:40.33ms
+step:643/1480 train_time:25948ms step_avg:40.35ms
+step:644/1480 train_time:26013ms step_avg:40.39ms
+step:645/1480 train_time:26072ms step_avg:40.42ms
+step:646/1480 train_time:26137ms step_avg:40.46ms
+step:647/1480 train_time:26195ms step_avg:40.49ms
+step:648/1480 train_time:26260ms step_avg:40.52ms
+step:649/1480 train_time:26318ms step_avg:40.55ms
+step:650/1480 train_time:26381ms step_avg:40.59ms
+step:651/1480 train_time:26439ms step_avg:40.61ms
+step:652/1480 train_time:26504ms step_avg:40.65ms
+step:653/1480 train_time:26563ms step_avg:40.68ms
+step:654/1480 train_time:26629ms step_avg:40.72ms
+step:655/1480 train_time:26688ms step_avg:40.75ms
+step:656/1480 train_time:26753ms step_avg:40.78ms
+step:657/1480 train_time:26812ms step_avg:40.81ms
+step:658/1480 train_time:26877ms step_avg:40.85ms
+step:659/1480 train_time:26934ms step_avg:40.87ms
+step:660/1480 train_time:26998ms step_avg:40.91ms
+step:661/1480 train_time:27056ms step_avg:40.93ms
+step:662/1480 train_time:27120ms step_avg:40.97ms
+step:663/1480 train_time:27177ms step_avg:40.99ms
+step:664/1480 train_time:27240ms step_avg:41.02ms
+step:665/1480 train_time:27296ms step_avg:41.05ms
+step:666/1480 train_time:27360ms step_avg:41.08ms
+step:667/1480 train_time:27418ms step_avg:41.11ms
+step:668/1480 train_time:27481ms step_avg:41.14ms
+step:669/1480 train_time:27539ms step_avg:41.16ms
+step:670/1480 train_time:27602ms step_avg:41.20ms
+step:671/1480 train_time:27662ms step_avg:41.22ms
+step:672/1480 train_time:27728ms step_avg:41.26ms
+step:673/1480 train_time:27786ms step_avg:41.29ms
+step:674/1480 train_time:27850ms step_avg:41.32ms
+step:675/1480 train_time:27909ms step_avg:41.35ms
+step:676/1480 train_time:27973ms step_avg:41.38ms
+step:677/1480 train_time:28032ms step_avg:41.41ms
+step:678/1480 train_time:28096ms step_avg:41.44ms
+step:679/1480 train_time:28154ms step_avg:41.46ms
+step:680/1480 train_time:28218ms step_avg:41.50ms
+step:681/1480 train_time:28274ms step_avg:41.52ms
+step:682/1480 train_time:28337ms step_avg:41.55ms
+step:683/1480 train_time:28395ms step_avg:41.57ms
+step:684/1480 train_time:28458ms step_avg:41.60ms
+step:685/1480 train_time:28514ms step_avg:41.63ms
+step:686/1480 train_time:28577ms step_avg:41.66ms
+step:687/1480 train_time:28634ms step_avg:41.68ms
+step:688/1480 train_time:28698ms step_avg:41.71ms
+step:689/1480 train_time:28755ms step_avg:41.73ms
+step:690/1480 train_time:28818ms step_avg:41.77ms
+step:691/1480 train_time:28875ms step_avg:41.79ms
+step:692/1480 train_time:28938ms step_avg:41.82ms
+step:693/1480 train_time:28996ms step_avg:41.84ms
+step:694/1480 train_time:29059ms step_avg:41.87ms
+step:695/1480 train_time:29119ms step_avg:41.90ms
+step:696/1480 train_time:29190ms step_avg:41.94ms
+step:697/1480 train_time:29256ms step_avg:41.97ms
+step:698/1480 train_time:29324ms step_avg:42.01ms
+step:699/1480 train_time:29387ms step_avg:42.04ms
+step:700/1480 train_time:29457ms step_avg:42.08ms
+step:701/1480 train_time:29520ms step_avg:42.11ms
+step:702/1480 train_time:29589ms step_avg:42.15ms
+step:703/1480 train_time:29653ms step_avg:42.18ms
+step:704/1480 train_time:29723ms step_avg:42.22ms
+step:705/1480 train_time:29778ms step_avg:42.24ms
+step:706/1480 train_time:29836ms step_avg:42.26ms
+step:707/1480 train_time:29891ms step_avg:42.28ms
+step:708/1480 train_time:29954ms step_avg:42.31ms
+step:709/1480 train_time:30010ms step_avg:42.33ms
+step:710/1480 train_time:30072ms step_avg:42.36ms
+step:711/1480 train_time:30131ms step_avg:42.38ms
+step:712/1480 train_time:30198ms step_avg:42.41ms
+step:713/1480 train_time:30258ms step_avg:42.44ms
+step:714/1480 train_time:30322ms step_avg:42.47ms
+step:715/1480 train_time:30380ms step_avg:42.49ms
+step:716/1480 train_time:30444ms step_avg:42.52ms
+step:717/1480 train_time:30504ms step_avg:42.54ms
+step:718/1480 train_time:30568ms step_avg:42.57ms
+step:719/1480 train_time:30626ms step_avg:42.60ms
+step:720/1480 train_time:30692ms step_avg:42.63ms
+step:721/1480 train_time:30753ms step_avg:42.65ms
+step:722/1480 train_time:30817ms step_avg:42.68ms
+step:723/1480 train_time:30874ms step_avg:42.70ms
+step:724/1480 train_time:30938ms step_avg:42.73ms
+step:725/1480 train_time:30995ms step_avg:42.75ms
+step:726/1480 train_time:31059ms step_avg:42.78ms
+step:727/1480 train_time:31117ms step_avg:42.80ms
+step:728/1480 train_time:31180ms step_avg:42.83ms
+step:729/1480 train_time:31238ms step_avg:42.85ms
+step:730/1480 train_time:31302ms step_avg:42.88ms
+step:731/1480 train_time:31360ms step_avg:42.90ms
+step:732/1480 train_time:31423ms step_avg:42.93ms
+step:733/1480 train_time:31481ms step_avg:42.95ms
+step:734/1480 train_time:31545ms step_avg:42.98ms
+step:735/1480 train_time:31604ms step_avg:43.00ms
+step:736/1480 train_time:31666ms step_avg:43.02ms
+step:737/1480 train_time:31724ms step_avg:43.04ms
+step:738/1480 train_time:31787ms step_avg:43.07ms
+step:739/1480 train_time:31845ms step_avg:43.09ms
+step:740/1480 train_time:31908ms step_avg:43.12ms
+step:741/1480 train_time:31966ms step_avg:43.14ms
+step:742/1480 train_time:32033ms step_avg:43.17ms
+step:743/1480 train_time:32094ms step_avg:43.19ms
+step:744/1480 train_time:32161ms step_avg:43.23ms
+step:745/1480 train_time:32219ms step_avg:43.25ms
+step:746/1480 train_time:32286ms step_avg:43.28ms
+step:747/1480 train_time:32348ms step_avg:43.30ms
+step:748/1480 train_time:32415ms step_avg:43.34ms
+step:749/1480 train_time:32474ms step_avg:43.36ms
+step:750/1480 train_time:32540ms step_avg:43.39ms
+step:750/1480 val_loss:3.8111 train_time:32616ms step_avg:43.49ms
+step:751/1480 train_time:32634ms step_avg:43.45ms
+step:752/1480 train_time:32657ms step_avg:43.43ms
+step:753/1480 train_time:32714ms step_avg:43.44ms
+step:754/1480 train_time:32780ms step_avg:43.47ms
+step:755/1480 train_time:32837ms step_avg:43.49ms
+step:756/1480 train_time:32902ms step_avg:43.52ms
+step:757/1480 train_time:32961ms step_avg:43.54ms
+step:758/1480 train_time:33026ms step_avg:43.57ms
+step:759/1480 train_time:33085ms step_avg:43.59ms
+step:760/1480 train_time:33150ms step_avg:43.62ms
+step:761/1480 train_time:33210ms step_avg:43.64ms
+step:762/1480 train_time:33273ms step_avg:43.67ms
+step:763/1480 train_time:33331ms step_avg:43.68ms
+step:764/1480 train_time:33394ms step_avg:43.71ms
+step:765/1480 train_time:33451ms step_avg:43.73ms
+step:766/1480 train_time:33514ms step_avg:43.75ms
+step:767/1480 train_time:33572ms step_avg:43.77ms
+step:768/1480 train_time:33634ms step_avg:43.79ms
+step:769/1480 train_time:33691ms step_avg:43.81ms
+step:770/1480 train_time:33754ms step_avg:43.84ms
+step:771/1480 train_time:33812ms step_avg:43.85ms
+step:772/1480 train_time:33875ms step_avg:43.88ms
+step:773/1480 train_time:33932ms step_avg:43.90ms
+step:774/1480 train_time:33995ms step_avg:43.92ms
+step:775/1480 train_time:34052ms step_avg:43.94ms
+step:776/1480 train_time:34116ms step_avg:43.96ms
+step:777/1480 train_time:34173ms step_avg:43.98ms
+step:778/1480 train_time:34236ms step_avg:44.00ms
+step:779/1480 train_time:34293ms step_avg:44.02ms
+step:780/1480 train_time:34359ms step_avg:44.05ms
+step:781/1480 train_time:34421ms step_avg:44.07ms
+step:782/1480 train_time:34493ms step_avg:44.11ms
+step:783/1480 train_time:34556ms step_avg:44.13ms
+step:784/1480 train_time:34625ms step_avg:44.16ms
+step:785/1480 train_time:34688ms step_avg:44.19ms
+step:786/1480 train_time:34758ms step_avg:44.22ms
+step:787/1480 train_time:34819ms step_avg:44.24ms
+step:788/1480 train_time:34878ms step_avg:44.26ms
+step:789/1480 train_time:34932ms step_avg:44.27ms
+step:790/1480 train_time:34993ms step_avg:44.29ms
+step:791/1480 train_time:35052ms step_avg:44.31ms
+step:792/1480 train_time:35118ms step_avg:44.34ms
+step:793/1480 train_time:35187ms step_avg:44.37ms
+step:794/1480 train_time:35255ms step_avg:44.40ms
+step:795/1480 train_time:35315ms step_avg:44.42ms
+step:796/1480 train_time:35379ms step_avg:44.45ms
+step:797/1480 train_time:35436ms step_avg:44.46ms
+step:798/1480 train_time:35502ms step_avg:44.49ms
+step:799/1480 train_time:35562ms step_avg:44.51ms
+step:800/1480 train_time:35628ms step_avg:44.53ms
+step:801/1480 train_time:35686ms step_avg:44.55ms
+step:802/1480 train_time:35751ms step_avg:44.58ms
+step:803/1480 train_time:35810ms step_avg:44.59ms
+step:804/1480 train_time:35874ms step_avg:44.62ms
+step:805/1480 train_time:35932ms step_avg:44.64ms
+step:806/1480 train_time:35996ms step_avg:44.66ms
+step:807/1480 train_time:36054ms step_avg:44.68ms
+step:808/1480 train_time:36118ms step_avg:44.70ms
+step:809/1480 train_time:36176ms step_avg:44.72ms
+step:810/1480 train_time:36240ms step_avg:44.74ms
+step:811/1480 train_time:36297ms step_avg:44.76ms
+step:812/1480 train_time:36360ms step_avg:44.78ms
+step:813/1480 train_time:36418ms step_avg:44.80ms
+step:814/1480 train_time:36481ms step_avg:44.82ms
+step:815/1480 train_time:36539ms step_avg:44.83ms
+step:816/1480 train_time:36602ms step_avg:44.86ms
+step:817/1480 train_time:36662ms step_avg:44.87ms
+step:818/1480 train_time:36726ms step_avg:44.90ms
+step:819/1480 train_time:36784ms step_avg:44.91ms
+step:820/1480 train_time:36849ms step_avg:44.94ms
+step:821/1480 train_time:36910ms step_avg:44.96ms
+step:822/1480 train_time:36975ms step_avg:44.98ms
+step:823/1480 train_time:37033ms step_avg:45.00ms
+step:824/1480 train_time:37096ms step_avg:45.02ms
+step:825/1480 train_time:37154ms step_avg:45.04ms
+step:826/1480 train_time:37218ms step_avg:45.06ms
+step:827/1480 train_time:37276ms step_avg:45.07ms
+step:828/1480 train_time:37340ms step_avg:45.10ms
+step:829/1480 train_time:37397ms step_avg:45.11ms
+step:830/1480 train_time:37461ms step_avg:45.13ms
+step:831/1480 train_time:37519ms step_avg:45.15ms
+step:832/1480 train_time:37582ms step_avg:45.17ms
+step:833/1480 train_time:37640ms step_avg:45.19ms
+step:834/1480 train_time:37704ms step_avg:45.21ms
+step:835/1480 train_time:37764ms step_avg:45.23ms
+step:836/1480 train_time:37830ms step_avg:45.25ms
+step:837/1480 train_time:37890ms step_avg:45.27ms
+step:838/1480 train_time:37957ms step_avg:45.29ms
+step:839/1480 train_time:38016ms step_avg:45.31ms
+step:840/1480 train_time:38083ms step_avg:45.34ms
+step:841/1480 train_time:38142ms step_avg:45.35ms
+step:842/1480 train_time:38209ms step_avg:45.38ms
+step:843/1480 train_time:38269ms step_avg:45.40ms
+step:844/1480 train_time:38335ms step_avg:45.42ms
+step:845/1480 train_time:38394ms step_avg:45.44ms
+step:846/1480 train_time:38460ms step_avg:45.46ms
+step:847/1480 train_time:38519ms step_avg:45.48ms
+step:848/1480 train_time:38584ms step_avg:45.50ms
+step:849/1480 train_time:38644ms step_avg:45.52ms
+step:850/1480 train_time:38710ms step_avg:45.54ms
+step:851/1480 train_time:38770ms step_avg:45.56ms
+step:852/1480 train_time:38835ms step_avg:45.58ms
+step:853/1480 train_time:38893ms step_avg:45.60ms
+step:854/1480 train_time:38958ms step_avg:45.62ms
+step:855/1480 train_time:39016ms step_avg:45.63ms
+step:856/1480 train_time:39081ms step_avg:45.66ms
+step:857/1480 train_time:39139ms step_avg:45.67ms
+step:858/1480 train_time:39203ms step_avg:45.69ms
+step:859/1480 train_time:39262ms step_avg:45.71ms
+step:860/1480 train_time:39327ms step_avg:45.73ms
+step:861/1480 train_time:39385ms step_avg:45.74ms
+step:862/1480 train_time:39450ms step_avg:45.77ms
+step:863/1480 train_time:39509ms step_avg:45.78ms
+step:864/1480 train_time:39573ms step_avg:45.80ms
+step:865/1480 train_time:39632ms step_avg:45.82ms
+step:866/1480 train_time:39697ms step_avg:45.84ms
+step:867/1480 train_time:39752ms step_avg:45.85ms
+step:868/1480 train_time:39814ms step_avg:45.87ms
+step:869/1480 train_time:39873ms step_avg:45.88ms
+step:870/1480 train_time:39940ms step_avg:45.91ms
+step:871/1480 train_time:39996ms step_avg:45.92ms
+step:872/1480 train_time:40060ms step_avg:45.94ms
+step:873/1480 train_time:40117ms step_avg:45.95ms
+step:874/1480 train_time:40181ms step_avg:45.97ms
+step:875/1480 train_time:40238ms step_avg:45.99ms
+step:876/1480 train_time:40302ms step_avg:46.01ms
+step:877/1480 train_time:40364ms step_avg:46.03ms
+step:878/1480 train_time:40433ms step_avg:46.05ms
+step:879/1480 train_time:40495ms step_avg:46.07ms
+step:880/1480 train_time:40563ms step_avg:46.09ms
+step:881/1480 train_time:40626ms step_avg:46.11ms
+step:882/1480 train_time:40693ms step_avg:46.14ms
+step:883/1480 train_time:40754ms step_avg:46.15ms
+step:884/1480 train_time:40822ms step_avg:46.18ms
+step:885/1480 train_time:40883ms step_avg:46.20ms
+step:886/1480 train_time:40951ms step_avg:46.22ms
+step:887/1480 train_time:41013ms step_avg:46.24ms
+step:888/1480 train_time:41080ms step_avg:46.26ms
+step:889/1480 train_time:41141ms step_avg:46.28ms
+step:890/1480 train_time:41208ms step_avg:46.30ms
+step:891/1480 train_time:41262ms step_avg:46.31ms
+step:892/1480 train_time:41321ms step_avg:46.32ms
+step:893/1480 train_time:41378ms step_avg:46.34ms
+step:894/1480 train_time:41438ms step_avg:46.35ms
+step:895/1480 train_time:41496ms step_avg:46.36ms
+step:896/1480 train_time:41561ms step_avg:46.39ms
+step:897/1480 train_time:41617ms step_avg:46.40ms
+step:898/1480 train_time:41681ms step_avg:46.42ms
+step:899/1480 train_time:41742ms step_avg:46.43ms
+step:900/1480 train_time:41806ms step_avg:46.45ms
+step:901/1480 train_time:41867ms step_avg:46.47ms
+step:902/1480 train_time:41931ms step_avg:46.49ms
+step:903/1480 train_time:41989ms step_avg:46.50ms
+step:904/1480 train_time:42051ms step_avg:46.52ms
+step:905/1480 train_time:42110ms step_avg:46.53ms
+step:906/1480 train_time:42176ms step_avg:46.55ms
+step:907/1480 train_time:42235ms step_avg:46.57ms
+step:908/1480 train_time:42300ms step_avg:46.59ms
+step:909/1480 train_time:42359ms step_avg:46.60ms
+step:910/1480 train_time:42425ms step_avg:46.62ms
+step:911/1480 train_time:42485ms step_avg:46.64ms
+step:912/1480 train_time:42551ms step_avg:46.66ms
+step:913/1480 train_time:42611ms step_avg:46.67ms
+step:914/1480 train_time:42677ms step_avg:46.69ms
+step:915/1480 train_time:42736ms step_avg:46.71ms
+step:916/1480 train_time:42801ms step_avg:46.73ms
+step:917/1480 train_time:42860ms step_avg:46.74ms
+step:918/1480 train_time:42926ms step_avg:46.76ms
+step:919/1480 train_time:42986ms step_avg:46.77ms
+step:920/1480 train_time:43052ms step_avg:46.80ms
+step:921/1480 train_time:43111ms step_avg:46.81ms
+step:922/1480 train_time:43177ms step_avg:46.83ms
+step:923/1480 train_time:43235ms step_avg:46.84ms
+step:924/1480 train_time:43300ms step_avg:46.86ms
+step:925/1480 train_time:43359ms step_avg:46.87ms
+step:926/1480 train_time:43424ms step_avg:46.89ms
+step:927/1480 train_time:43484ms step_avg:46.91ms
+step:928/1480 train_time:43550ms step_avg:46.93ms
+step:929/1480 train_time:43609ms step_avg:46.94ms
+step:930/1480 train_time:43675ms step_avg:46.96ms
+step:931/1480 train_time:43732ms step_avg:46.97ms
+step:932/1480 train_time:43796ms step_avg:46.99ms
+step:933/1480 train_time:43851ms step_avg:47.00ms
+step:934/1480 train_time:43912ms step_avg:47.02ms
+step:935/1480 train_time:43972ms step_avg:47.03ms
+step:936/1480 train_time:44039ms step_avg:47.05ms
+step:937/1480 train_time:44096ms step_avg:47.06ms
+step:938/1480 train_time:44160ms step_avg:47.08ms
+step:939/1480 train_time:44218ms step_avg:47.09ms
+step:940/1480 train_time:44283ms step_avg:47.11ms
+step:941/1480 train_time:44342ms step_avg:47.12ms
+step:942/1480 train_time:44408ms step_avg:47.14ms
+step:943/1480 train_time:44467ms step_avg:47.16ms
+step:944/1480 train_time:44532ms step_avg:47.17ms
+step:945/1480 train_time:44590ms step_avg:47.19ms
+step:946/1480 train_time:44656ms step_avg:47.21ms
+step:947/1480 train_time:44717ms step_avg:47.22ms
+step:948/1480 train_time:44781ms step_avg:47.24ms
+step:949/1480 train_time:44842ms step_avg:47.25ms
+step:950/1480 train_time:44908ms step_avg:47.27ms
+step:951/1480 train_time:44968ms step_avg:47.28ms
+step:952/1480 train_time:45033ms step_avg:47.30ms
+step:953/1480 train_time:45092ms step_avg:47.32ms
+step:954/1480 train_time:45158ms step_avg:47.34ms
+step:955/1480 train_time:45216ms step_avg:47.35ms
+step:956/1480 train_time:45281ms step_avg:47.36ms
+step:957/1480 train_time:45339ms step_avg:47.38ms
+step:958/1480 train_time:45404ms step_avg:47.39ms
+step:959/1480 train_time:45464ms step_avg:47.41ms
+step:960/1480 train_time:45529ms step_avg:47.43ms
+step:961/1480 train_time:45591ms step_avg:47.44ms
+step:962/1480 train_time:45680ms step_avg:47.48ms
+step:963/1480 train_time:45769ms step_avg:47.53ms
+step:964/1480 train_time:45863ms step_avg:47.58ms
+step:965/1480 train_time:45944ms step_avg:47.61ms
+step:966/1480 train_time:46035ms step_avg:47.65ms
+step:967/1480 train_time:46122ms step_avg:47.70ms
+step:968/1480 train_time:46217ms step_avg:47.74ms
+step:969/1480 train_time:46306ms step_avg:47.79ms
+step:970/1480 train_time:46401ms step_avg:47.84ms
+step:971/1480 train_time:46488ms step_avg:47.88ms
+step:972/1480 train_time:46580ms step_avg:47.92ms
+step:973/1480 train_time:46667ms step_avg:47.96ms
+step:974/1480 train_time:46760ms step_avg:48.01ms
+step:975/1480 train_time:46849ms step_avg:48.05ms
+step:976/1480 train_time:46944ms step_avg:48.10ms
+step:977/1480 train_time:47034ms step_avg:48.14ms
+step:978/1480 train_time:47129ms step_avg:48.19ms
+step:979/1480 train_time:47216ms step_avg:48.23ms
+step:980/1480 train_time:47312ms step_avg:48.28ms
+step:981/1480 train_time:47401ms step_avg:48.32ms
+step:982/1480 train_time:47496ms step_avg:48.37ms
+step:983/1480 train_time:47584ms step_avg:48.41ms
+step:984/1480 train_time:47678ms step_avg:48.45ms
+step:985/1480 train_time:47767ms step_avg:48.49ms
+step:986/1480 train_time:47862ms step_avg:48.54ms
+step:987/1480 train_time:47949ms step_avg:48.58ms
+step:988/1480 train_time:48042ms step_avg:48.63ms
+step:989/1480 train_time:48130ms step_avg:48.67ms
+step:990/1480 train_time:48223ms step_avg:48.71ms
+step:991/1480 train_time:48309ms step_avg:48.75ms
+step:992/1480 train_time:48402ms step_avg:48.79ms
+step:993/1480 train_time:48490ms step_avg:48.83ms
+step:994/1480 train_time:48582ms step_avg:48.88ms
+step:995/1480 train_time:48670ms step_avg:48.91ms
+step:996/1480 train_time:48763ms step_avg:48.96ms
+step:997/1480 train_time:48850ms step_avg:49.00ms
+step:998/1480 train_time:48943ms step_avg:49.04ms
+step:999/1480 train_time:49030ms step_avg:49.08ms
+step:1000/1480 train_time:49124ms step_avg:49.12ms
+step:1000/1480 val_loss:3.5098 train_time:49241ms step_avg:49.24ms
+step:1001/1480 train_time:49260ms step_avg:49.21ms
+step:1002/1480 train_time:49303ms step_avg:49.20ms
+step:1003/1480 train_time:49390ms step_avg:49.24ms
+step:1004/1480 train_time:49486ms step_avg:49.29ms
+step:1005/1480 train_time:49572ms step_avg:49.32ms
+step:1006/1480 train_time:49665ms step_avg:49.37ms
+step:1007/1480 train_time:49751ms step_avg:49.41ms
+step:1008/1480 train_time:49842ms step_avg:49.45ms
+step:1009/1480 train_time:49928ms step_avg:49.48ms
+step:1010/1480 train_time:50019ms step_avg:49.52ms
+step:1011/1480 train_time:50104ms step_avg:49.56ms
+step:1012/1480 train_time:50196ms step_avg:49.60ms
+step:1013/1480 train_time:50283ms step_avg:49.64ms
+step:1014/1480 train_time:50377ms step_avg:49.68ms
+step:1015/1480 train_time:50464ms step_avg:49.72ms
+step:1016/1480 train_time:50558ms step_avg:49.76ms
+step:1017/1480 train_time:50645ms step_avg:49.80ms
+step:1018/1480 train_time:50739ms step_avg:49.84ms
+step:1019/1480 train_time:50825ms step_avg:49.88ms
+step:1020/1480 train_time:50918ms step_avg:49.92ms
+step:1021/1480 train_time:51005ms step_avg:49.96ms
+step:1022/1480 train_time:51099ms step_avg:50.00ms
+step:1023/1480 train_time:51184ms step_avg:50.03ms
+step:1024/1480 train_time:51277ms step_avg:50.08ms
+step:1025/1480 train_time:51360ms step_avg:50.11ms
+step:1026/1480 train_time:51450ms step_avg:50.15ms
+step:1027/1480 train_time:51534ms step_avg:50.18ms
+step:1028/1480 train_time:51628ms step_avg:50.22ms
+step:1029/1480 train_time:51714ms step_avg:50.26ms
+step:1030/1480 train_time:51807ms step_avg:50.30ms
+step:1031/1480 train_time:51894ms step_avg:50.33ms
+step:1032/1480 train_time:51986ms step_avg:50.37ms
+step:1033/1480 train_time:52072ms step_avg:50.41ms
+step:1034/1480 train_time:52163ms step_avg:50.45ms
+step:1035/1480 train_time:52250ms step_avg:50.48ms
+step:1036/1480 train_time:52341ms step_avg:50.52ms
+step:1037/1480 train_time:52427ms step_avg:50.56ms
+step:1038/1480 train_time:52516ms step_avg:50.59ms
+step:1039/1480 train_time:52603ms step_avg:50.63ms
+step:1040/1480 train_time:52696ms step_avg:50.67ms
+step:1041/1480 train_time:52780ms step_avg:50.70ms
+step:1042/1480 train_time:52875ms step_avg:50.74ms
+step:1043/1480 train_time:52965ms step_avg:50.78ms
+step:1044/1480 train_time:53060ms step_avg:50.82ms
+step:1045/1480 train_time:53149ms step_avg:50.86ms
+step:1046/1480 train_time:53245ms step_avg:50.90ms
+step:1047/1480 train_time:53335ms step_avg:50.94ms
+step:1048/1480 train_time:53431ms step_avg:50.98ms
+step:1049/1480 train_time:53520ms step_avg:51.02ms
+step:1050/1480 train_time:53617ms step_avg:51.06ms
+step:1051/1480 train_time:53699ms step_avg:51.09ms
+step:1052/1480 train_time:53788ms step_avg:51.13ms
+step:1053/1480 train_time:53873ms step_avg:51.16ms
+step:1054/1480 train_time:53964ms step_avg:51.20ms
+step:1055/1480 train_time:54049ms step_avg:51.23ms
+step:1056/1480 train_time:54140ms step_avg:51.27ms
+step:1057/1480 train_time:54228ms step_avg:51.30ms
+step:1058/1480 train_time:54321ms step_avg:51.34ms
+step:1059/1480 train_time:54410ms step_avg:51.38ms
+step:1060/1480 train_time:54504ms step_avg:51.42ms
+step:1061/1480 train_time:54594ms step_avg:51.46ms
+step:1062/1480 train_time:54689ms step_avg:51.50ms
+step:1063/1480 train_time:54779ms step_avg:51.53ms
+step:1064/1480 train_time:54874ms step_avg:51.57ms
+step:1065/1480 train_time:54964ms step_avg:51.61ms
+step:1066/1480 train_time:55059ms step_avg:51.65ms
+step:1067/1480 train_time:55147ms step_avg:51.68ms
+step:1068/1480 train_time:55242ms step_avg:51.72ms
+step:1069/1480 train_time:55330ms step_avg:51.76ms
+step:1070/1480 train_time:55424ms step_avg:51.80ms
+step:1071/1480 train_time:55513ms step_avg:51.83ms
+step:1072/1480 train_time:55607ms step_avg:51.87ms
+step:1073/1480 train_time:55693ms step_avg:51.90ms
+step:1074/1480 train_time:55787ms step_avg:51.94ms
+step:1075/1480 train_time:55876ms step_avg:51.98ms
+step:1076/1480 train_time:55969ms step_avg:52.02ms
+step:1077/1480 train_time:56056ms step_avg:52.05ms
+step:1078/1480 train_time:56150ms step_avg:52.09ms
+step:1079/1480 train_time:56237ms step_avg:52.12ms
+step:1080/1480 train_time:56332ms step_avg:52.16ms
+step:1081/1480 train_time:56419ms step_avg:52.19ms
+step:1082/1480 train_time:56513ms step_avg:52.23ms
+step:1083/1480 train_time:56600ms step_avg:52.26ms
+step:1084/1480 train_time:56692ms step_avg:52.30ms
+step:1085/1480 train_time:56778ms step_avg:52.33ms
+step:1086/1480 train_time:56869ms step_avg:52.37ms
+step:1087/1480 train_time:56956ms step_avg:52.40ms
+step:1088/1480 train_time:57047ms step_avg:52.43ms
+step:1089/1480 train_time:57134ms step_avg:52.46ms
+step:1090/1480 train_time:57225ms step_avg:52.50ms
+step:1091/1480 train_time:57312ms step_avg:52.53ms
+step:1092/1480 train_time:57402ms step_avg:52.57ms
+step:1093/1480 train_time:57488ms step_avg:52.60ms
+step:1094/1480 train_time:57580ms step_avg:52.63ms
+step:1095/1480 train_time:57666ms step_avg:52.66ms
+step:1096/1480 train_time:57758ms step_avg:52.70ms
+step:1097/1480 train_time:57843ms step_avg:52.73ms
+step:1098/1480 train_time:57935ms step_avg:52.76ms
+step:1099/1480 train_time:58019ms step_avg:52.79ms
+step:1100/1480 train_time:58110ms step_avg:52.83ms
+step:1101/1480 train_time:58195ms step_avg:52.86ms
+step:1102/1480 train_time:58284ms step_avg:52.89ms
+step:1103/1480 train_time:58369ms step_avg:52.92ms
+step:1104/1480 train_time:58460ms step_avg:52.95ms
+step:1105/1480 train_time:58544ms step_avg:52.98ms
+step:1106/1480 train_time:58637ms step_avg:53.02ms
+step:1107/1480 train_time:58721ms step_avg:53.05ms
+step:1108/1480 train_time:58817ms step_avg:53.08ms
+step:1109/1480 train_time:58908ms step_avg:53.12ms
+step:1110/1480 train_time:59004ms step_avg:53.16ms
+step:1111/1480 train_time:59092ms step_avg:53.19ms
+step:1112/1480 train_time:59188ms step_avg:53.23ms
+step:1113/1480 train_time:59278ms step_avg:53.26ms
+step:1114/1480 train_time:59374ms step_avg:53.30ms
+step:1115/1480 train_time:59464ms step_avg:53.33ms
+step:1116/1480 train_time:59560ms step_avg:53.37ms
+step:1117/1480 train_time:59651ms step_avg:53.40ms
+step:1118/1480 train_time:59745ms step_avg:53.44ms
+step:1119/1480 train_time:59826ms step_avg:53.46ms
+step:1120/1480 train_time:59914ms step_avg:53.49ms
+step:1121/1480 train_time:60000ms step_avg:53.52ms
+step:1122/1480 train_time:60092ms step_avg:53.56ms
+step:1123/1480 train_time:60177ms step_avg:53.59ms
+step:1124/1480 train_time:60270ms step_avg:53.62ms
+step:1125/1480 train_time:60355ms step_avg:53.65ms
+step:1126/1480 train_time:60451ms step_avg:53.69ms
+step:1127/1480 train_time:60540ms step_avg:53.72ms
+step:1128/1480 train_time:60637ms step_avg:53.76ms
+step:1129/1480 train_time:60725ms step_avg:53.79ms
+step:1130/1480 train_time:60820ms step_avg:53.82ms
+step:1131/1480 train_time:60910ms step_avg:53.85ms
+step:1132/1480 train_time:61004ms step_avg:53.89ms
+step:1133/1480 train_time:61094ms step_avg:53.92ms
+step:1134/1480 train_time:61187ms step_avg:53.96ms
+step:1135/1480 train_time:61268ms step_avg:53.98ms
+step:1136/1480 train_time:61362ms step_avg:54.02ms
+step:1137/1480 train_time:61454ms step_avg:54.05ms
+step:1138/1480 train_time:61546ms step_avg:54.08ms
+step:1139/1480 train_time:61634ms step_avg:54.11ms
+step:1140/1480 train_time:61727ms step_avg:54.15ms
+step:1141/1480 train_time:61814ms step_avg:54.17ms
+step:1142/1480 train_time:61909ms step_avg:54.21ms
+step:1143/1480 train_time:62001ms step_avg:54.24ms
+step:1144/1480 train_time:62097ms step_avg:54.28ms
+step:1145/1480 train_time:62187ms step_avg:54.31ms
+step:1146/1480 train_time:62286ms step_avg:54.35ms
+step:1147/1480 train_time:62379ms step_avg:54.38ms
+step:1148/1480 train_time:62476ms step_avg:54.42ms
+step:1149/1480 train_time:62567ms step_avg:54.45ms
+step:1150/1480 train_time:62666ms step_avg:54.49ms
+step:1151/1480 train_time:62757ms step_avg:54.52ms
+step:1152/1480 train_time:62853ms step_avg:54.56ms
+step:1153/1480 train_time:62933ms step_avg:54.58ms
+step:1154/1480 train_time:63019ms step_avg:54.61ms
+step:1155/1480 train_time:63106ms step_avg:54.64ms
+step:1156/1480 train_time:63202ms step_avg:54.67ms
+step:1157/1480 train_time:63290ms step_avg:54.70ms
+step:1158/1480 train_time:63385ms step_avg:54.74ms
+step:1159/1480 train_time:63473ms step_avg:54.77ms
+step:1160/1480 train_time:63568ms step_avg:54.80ms
+step:1161/1480 train_time:63656ms step_avg:54.83ms
+step:1162/1480 train_time:63752ms step_avg:54.86ms
+step:1163/1480 train_time:63840ms step_avg:54.89ms
+step:1164/1480 train_time:63935ms step_avg:54.93ms
+step:1165/1480 train_time:64023ms step_avg:54.95ms
+step:1166/1480 train_time:64117ms step_avg:54.99ms
+step:1167/1480 train_time:64204ms step_avg:55.02ms
+step:1168/1480 train_time:64298ms step_avg:55.05ms
+step:1169/1480 train_time:64384ms step_avg:55.08ms
+step:1170/1480 train_time:64479ms step_avg:55.11ms
+step:1171/1480 train_time:64565ms step_avg:55.14ms
+step:1172/1480 train_time:64659ms step_avg:55.17ms
+step:1173/1480 train_time:64746ms step_avg:55.20ms
+step:1174/1480 train_time:64840ms step_avg:55.23ms
+step:1175/1480 train_time:64925ms step_avg:55.26ms
+step:1176/1480 train_time:65019ms step_avg:55.29ms
+step:1177/1480 train_time:65106ms step_avg:55.31ms
+step:1178/1480 train_time:65198ms step_avg:55.35ms
+step:1179/1480 train_time:65284ms step_avg:55.37ms
+step:1180/1480 train_time:65377ms step_avg:55.40ms
+step:1181/1480 train_time:65463ms step_avg:55.43ms
+step:1182/1480 train_time:65555ms step_avg:55.46ms
+step:1183/1480 train_time:65641ms step_avg:55.49ms
+step:1184/1480 train_time:65734ms step_avg:55.52ms
+step:1185/1480 train_time:65818ms step_avg:55.54ms
+step:1186/1480 train_time:65912ms step_avg:55.57ms
+step:1187/1480 train_time:65997ms step_avg:55.60ms
+step:1188/1480 train_time:66090ms step_avg:55.63ms
+step:1189/1480 train_time:66175ms step_avg:55.66ms
+step:1190/1480 train_time:66268ms step_avg:55.69ms
+step:1191/1480 train_time:66355ms step_avg:55.71ms
+step:1192/1480 train_time:66450ms step_avg:55.75ms
+step:1193/1480 train_time:66538ms step_avg:55.77ms
+step:1194/1480 train_time:66633ms step_avg:55.81ms
+step:1195/1480 train_time:66721ms step_avg:55.83ms
+step:1196/1480 train_time:66815ms step_avg:55.87ms
+step:1197/1480 train_time:66903ms step_avg:55.89ms
+step:1198/1480 train_time:66997ms step_avg:55.92ms
+step:1199/1480 train_time:67083ms step_avg:55.95ms
+step:1200/1480 train_time:67177ms step_avg:55.98ms
+step:1201/1480 train_time:67263ms step_avg:56.01ms
+step:1202/1480 train_time:67358ms step_avg:56.04ms
+step:1203/1480 train_time:67444ms step_avg:56.06ms
+step:1204/1480 train_time:67539ms step_avg:56.10ms
+step:1205/1480 train_time:67620ms step_avg:56.12ms
+step:1206/1480 train_time:67710ms step_avg:56.14ms
+step:1207/1480 train_time:67798ms step_avg:56.17ms
+step:1208/1480 train_time:67892ms step_avg:56.20ms
+step:1209/1480 train_time:67977ms step_avg:56.23ms
+step:1210/1480 train_time:68069ms step_avg:56.26ms
+step:1211/1480 train_time:68154ms step_avg:56.28ms
+step:1212/1480 train_time:68245ms step_avg:56.31ms
+step:1213/1480 train_time:68333ms step_avg:56.33ms
+step:1214/1480 train_time:68425ms step_avg:56.36ms
+step:1215/1480 train_time:68514ms step_avg:56.39ms
+step:1216/1480 train_time:68609ms step_avg:56.42ms
+step:1217/1480 train_time:68694ms step_avg:56.45ms
+step:1218/1480 train_time:68786ms step_avg:56.47ms
+step:1219/1480 train_time:68873ms step_avg:56.50ms
+step:1220/1480 train_time:68967ms step_avg:56.53ms
+step:1221/1480 train_time:69053ms step_avg:56.55ms
+step:1222/1480 train_time:69144ms step_avg:56.58ms
+step:1223/1480 train_time:69231ms step_avg:56.61ms
+step:1224/1480 train_time:69322ms step_avg:56.64ms
+step:1225/1480 train_time:69408ms step_avg:56.66ms
+step:1226/1480 train_time:69499ms step_avg:56.69ms
+step:1227/1480 train_time:69584ms step_avg:56.71ms
+step:1228/1480 train_time:69676ms step_avg:56.74ms
+step:1229/1480 train_time:69760ms step_avg:56.76ms
+step:1230/1480 train_time:69852ms step_avg:56.79ms
+step:1231/1480 train_time:69939ms step_avg:56.81ms
+step:1232/1480 train_time:70031ms step_avg:56.84ms
+step:1233/1480 train_time:70116ms step_avg:56.87ms
+step:1234/1480 train_time:70207ms step_avg:56.89ms
+step:1235/1480 train_time:70292ms step_avg:56.92ms
+step:1236/1480 train_time:70382ms step_avg:56.94ms
+step:1237/1480 train_time:70467ms step_avg:56.97ms
+step:1238/1480 train_time:70558ms step_avg:56.99ms
+step:1239/1480 train_time:70643ms step_avg:57.02ms
+step:1240/1480 train_time:70733ms step_avg:57.04ms
+step:1241/1480 train_time:70820ms step_avg:57.07ms
+step:1242/1480 train_time:70916ms step_avg:57.10ms
+step:1243/1480 train_time:71005ms step_avg:57.12ms
+step:1244/1480 train_time:71100ms step_avg:57.15ms
+step:1245/1480 train_time:71188ms step_avg:57.18ms
+step:1246/1480 train_time:71284ms step_avg:57.21ms
+step:1247/1480 train_time:71372ms step_avg:57.24ms
+step:1248/1480 train_time:71468ms step_avg:57.27ms
+step:1249/1480 train_time:71557ms step_avg:57.29ms
+step:1250/1480 train_time:71654ms step_avg:57.32ms
+step:1250/1480 val_loss:3.3678 train_time:71778ms step_avg:57.42ms
+step:1251/1480 train_time:71797ms step_avg:57.39ms
+step:1252/1480 train_time:71840ms step_avg:57.38ms
+step:1253/1480 train_time:71926ms step_avg:57.40ms
+step:1254/1480 train_time:72025ms step_avg:57.44ms
+step:1255/1480 train_time:72111ms step_avg:57.46ms
+step:1256/1480 train_time:72201ms step_avg:57.48ms
+step:1257/1480 train_time:72288ms step_avg:57.51ms
+step:1258/1480 train_time:72378ms step_avg:57.53ms
+step:1259/1480 train_time:72466ms step_avg:57.56ms
+step:1260/1480 train_time:72557ms step_avg:57.59ms
+step:1261/1480 train_time:72644ms step_avg:57.61ms
+step:1262/1480 train_time:72740ms step_avg:57.64ms
+step:1263/1480 train_time:72830ms step_avg:57.66ms
+step:1264/1480 train_time:72922ms step_avg:57.69ms
+step:1265/1480 train_time:73012ms step_avg:57.72ms
+step:1266/1480 train_time:73109ms step_avg:57.75ms
+step:1267/1480 train_time:73199ms step_avg:57.77ms
+step:1268/1480 train_time:73295ms step_avg:57.80ms
+step:1269/1480 train_time:73384ms step_avg:57.83ms
+step:1270/1480 train_time:73478ms step_avg:57.86ms
+step:1271/1480 train_time:73569ms step_avg:57.88ms
+step:1272/1480 train_time:73664ms step_avg:57.91ms
+step:1273/1480 train_time:73746ms step_avg:57.93ms
+step:1274/1480 train_time:73836ms step_avg:57.96ms
+step:1275/1480 train_time:73925ms step_avg:57.98ms
+step:1276/1480 train_time:74015ms step_avg:58.01ms
+step:1277/1480 train_time:74106ms step_avg:58.03ms
+step:1278/1480 train_time:74199ms step_avg:58.06ms
+step:1279/1480 train_time:74286ms step_avg:58.08ms
+step:1280/1480 train_time:74378ms step_avg:58.11ms
+step:1281/1480 train_time:74465ms step_avg:58.13ms
+step:1282/1480 train_time:74559ms step_avg:58.16ms
+step:1283/1480 train_time:74646ms step_avg:58.18ms
+step:1284/1480 train_time:74740ms step_avg:58.21ms
+step:1285/1480 train_time:74830ms step_avg:58.23ms
+step:1286/1480 train_time:74924ms step_avg:58.26ms
+step:1287/1480 train_time:75012ms step_avg:58.28ms
+step:1288/1480 train_time:75106ms step_avg:58.31ms
+step:1289/1480 train_time:75194ms step_avg:58.34ms
+step:1290/1480 train_time:75289ms step_avg:58.36ms
+step:1291/1480 train_time:75377ms step_avg:58.39ms
+step:1292/1480 train_time:75471ms step_avg:58.41ms
+step:1293/1480 train_time:75558ms step_avg:58.44ms
+step:1294/1480 train_time:75652ms step_avg:58.46ms
+step:1295/1480 train_time:75740ms step_avg:58.49ms
+step:1296/1480 train_time:75833ms step_avg:58.51ms
+step:1297/1480 train_time:75920ms step_avg:58.54ms
+step:1298/1480 train_time:76015ms step_avg:58.56ms
+step:1299/1480 train_time:76104ms step_avg:58.59ms
+step:1300/1480 train_time:76198ms step_avg:58.61ms
+step:1301/1480 train_time:76284ms step_avg:58.64ms
+step:1302/1480 train_time:76378ms step_avg:58.66ms
+step:1303/1480 train_time:76465ms step_avg:58.68ms
+step:1304/1480 train_time:76558ms step_avg:58.71ms
+step:1305/1480 train_time:76644ms step_avg:58.73ms
+step:1306/1480 train_time:76738ms step_avg:58.76ms
+step:1307/1480 train_time:76821ms step_avg:58.78ms
+step:1308/1480 train_time:76914ms step_avg:58.80ms
+step:1309/1480 train_time:77008ms step_avg:58.83ms
+step:1310/1480 train_time:77100ms step_avg:58.85ms
+step:1311/1480 train_time:77192ms step_avg:58.88ms
+step:1312/1480 train_time:77287ms step_avg:58.91ms
+step:1313/1480 train_time:77377ms step_avg:58.93ms
+step:1314/1480 train_time:77472ms step_avg:58.96ms
+step:1315/1480 train_time:77558ms step_avg:58.98ms
+step:1316/1480 train_time:77652ms step_avg:59.01ms
+step:1317/1480 train_time:77737ms step_avg:59.03ms
+step:1318/1480 train_time:77829ms step_avg:59.05ms
+step:1319/1480 train_time:77916ms step_avg:59.07ms
+step:1320/1480 train_time:78008ms step_avg:59.10ms
+step:1321/1480 train_time:78094ms step_avg:59.12ms
+step:1322/1480 train_time:78186ms step_avg:59.14ms
+step:1323/1480 train_time:78271ms step_avg:59.16ms
+step:1324/1480 train_time:78363ms step_avg:59.19ms
+step:1325/1480 train_time:78448ms step_avg:59.21ms
+step:1326/1480 train_time:78539ms step_avg:59.23ms
+step:1327/1480 train_time:78625ms step_avg:59.25ms
+step:1328/1480 train_time:78716ms step_avg:59.27ms
+step:1329/1480 train_time:78802ms step_avg:59.29ms
+step:1330/1480 train_time:78893ms step_avg:59.32ms
+step:1331/1480 train_time:78980ms step_avg:59.34ms
+step:1332/1480 train_time:79073ms step_avg:59.36ms
+step:1333/1480 train_time:79159ms step_avg:59.38ms
+step:1334/1480 train_time:79251ms step_avg:59.41ms
+step:1335/1480 train_time:79336ms step_avg:59.43ms
+step:1336/1480 train_time:79430ms step_avg:59.45ms
+step:1337/1480 train_time:79516ms step_avg:59.47ms
+step:1338/1480 train_time:79610ms step_avg:59.50ms
+step:1339/1480 train_time:79696ms step_avg:59.52ms
+step:1340/1480 train_time:79789ms step_avg:59.54ms
+step:1341/1480 train_time:79875ms step_avg:59.56ms
+step:1342/1480 train_time:79968ms step_avg:59.59ms
+step:1343/1480 train_time:80056ms step_avg:59.61ms
+step:1344/1480 train_time:80149ms step_avg:59.63ms
+step:1345/1480 train_time:80236ms step_avg:59.65ms
+step:1346/1480 train_time:80329ms step_avg:59.68ms
+step:1347/1480 train_time:80415ms step_avg:59.70ms
+step:1348/1480 train_time:80508ms step_avg:59.72ms
+step:1349/1480 train_time:80594ms step_avg:59.74ms
+step:1350/1480 train_time:80687ms step_avg:59.77ms
+step:1351/1480 train_time:80774ms step_avg:59.79ms
+step:1352/1480 train_time:80866ms step_avg:59.81ms
+step:1353/1480 train_time:80953ms step_avg:59.83ms
+step:1354/1480 train_time:81045ms step_avg:59.86ms
+step:1355/1480 train_time:81131ms step_avg:59.88ms
+step:1356/1480 train_time:81223ms step_avg:59.90ms
+step:1357/1480 train_time:81308ms step_avg:59.92ms
+step:1358/1480 train_time:81400ms step_avg:59.94ms
+step:1359/1480 train_time:81485ms step_avg:59.96ms
+step:1360/1480 train_time:81576ms step_avg:59.98ms
+step:1361/1480 train_time:81661ms step_avg:60.00ms
+step:1362/1480 train_time:81752ms step_avg:60.02ms
+step:1363/1480 train_time:81837ms step_avg:60.04ms
+step:1364/1480 train_time:81931ms step_avg:60.07ms
+step:1365/1480 train_time:82018ms step_avg:60.09ms
+step:1366/1480 train_time:82111ms step_avg:60.11ms
+step:1367/1480 train_time:82201ms step_avg:60.13ms
+step:1368/1480 train_time:82297ms step_avg:60.16ms
+step:1369/1480 train_time:82386ms step_avg:60.18ms
+step:1370/1480 train_time:82481ms step_avg:60.21ms
+step:1371/1480 train_time:82570ms step_avg:60.23ms
+step:1372/1480 train_time:82666ms step_avg:60.25ms
+step:1373/1480 train_time:82756ms step_avg:60.27ms
+step:1374/1480 train_time:82851ms step_avg:60.30ms
+step:1375/1480 train_time:82939ms step_avg:60.32ms
+step:1376/1480 train_time:83034ms step_avg:60.34ms
+step:1377/1480 train_time:83122ms step_avg:60.36ms
+step:1378/1480 train_time:83215ms step_avg:60.39ms
+step:1379/1480 train_time:83304ms step_avg:60.41ms
+step:1380/1480 train_time:83398ms step_avg:60.43ms
+step:1381/1480 train_time:83486ms step_avg:60.45ms
+step:1382/1480 train_time:83579ms step_avg:60.48ms
+step:1383/1480 train_time:83667ms step_avg:60.50ms
+step:1384/1480 train_time:83760ms step_avg:60.52ms
+step:1385/1480 train_time:83847ms step_avg:60.54ms
+step:1386/1480 train_time:83940ms step_avg:60.56ms
+step:1387/1480 train_time:84028ms step_avg:60.58ms
+step:1388/1480 train_time:84121ms step_avg:60.61ms
+step:1389/1480 train_time:84208ms step_avg:60.62ms
+step:1390/1480 train_time:84301ms step_avg:60.65ms
+step:1391/1480 train_time:84387ms step_avg:60.67ms
+step:1392/1480 train_time:84480ms step_avg:60.69ms
+step:1393/1480 train_time:84566ms step_avg:60.71ms
+step:1394/1480 train_time:84659ms step_avg:60.73ms
+step:1395/1480 train_time:84745ms step_avg:60.75ms
+step:1396/1480 train_time:84837ms step_avg:60.77ms
+step:1397/1480 train_time:84923ms step_avg:60.79ms
+step:1398/1480 train_time:85014ms step_avg:60.81ms
+step:1399/1480 train_time:85100ms step_avg:60.83ms
+step:1400/1480 train_time:85191ms step_avg:60.85ms
+step:1401/1480 train_time:85275ms step_avg:60.87ms
+step:1402/1480 train_time:85368ms step_avg:60.89ms
+step:1403/1480 train_time:85453ms step_avg:60.91ms
+step:1404/1480 train_time:85546ms step_avg:60.93ms
+step:1405/1480 train_time:85632ms step_avg:60.95ms
+step:1406/1480 train_time:85723ms step_avg:60.97ms
+step:1407/1480 train_time:85809ms step_avg:60.99ms
+step:1408/1480 train_time:85904ms step_avg:61.01ms
+step:1409/1480 train_time:85994ms step_avg:61.03ms
+step:1410/1480 train_time:86090ms step_avg:61.06ms
+step:1411/1480 train_time:86179ms step_avg:61.08ms
+step:1412/1480 train_time:86274ms step_avg:61.10ms
+step:1413/1480 train_time:86363ms step_avg:61.12ms
+step:1414/1480 train_time:86457ms step_avg:61.14ms
+step:1415/1480 train_time:86545ms step_avg:61.16ms
+step:1416/1480 train_time:86639ms step_avg:61.19ms
+step:1417/1480 train_time:86726ms step_avg:61.20ms
+step:1418/1480 train_time:86820ms step_avg:61.23ms
+step:1419/1480 train_time:86907ms step_avg:61.25ms
+step:1420/1480 train_time:87001ms step_avg:61.27ms
+step:1421/1480 train_time:87088ms step_avg:61.29ms
+step:1422/1480 train_time:87181ms step_avg:61.31ms
+step:1423/1480 train_time:87266ms step_avg:61.33ms
+step:1424/1480 train_time:87357ms step_avg:61.35ms
+step:1425/1480 train_time:87449ms step_avg:61.37ms
+step:1426/1480 train_time:87542ms step_avg:61.39ms
+step:1427/1480 train_time:87633ms step_avg:61.41ms
+step:1428/1480 train_time:87731ms step_avg:61.44ms
+step:1429/1480 train_time:87819ms step_avg:61.45ms
+step:1430/1480 train_time:87913ms step_avg:61.48ms
+step:1431/1480 train_time:88001ms step_avg:61.50ms
+step:1432/1480 train_time:88094ms step_avg:61.52ms
+step:1433/1480 train_time:88181ms step_avg:61.54ms
+step:1434/1480 train_time:88274ms step_avg:61.56ms
+step:1435/1480 train_time:88362ms step_avg:61.58ms
+step:1436/1480 train_time:88456ms step_avg:61.60ms
+step:1437/1480 train_time:88543ms step_avg:61.62ms
+step:1438/1480 train_time:88638ms step_avg:61.64ms
+step:1439/1480 train_time:88725ms step_avg:61.66ms
+step:1440/1480 train_time:88818ms step_avg:61.68ms
+step:1441/1480 train_time:88908ms step_avg:61.70ms
+step:1442/1480 train_time:89004ms step_avg:61.72ms
+step:1443/1480 train_time:89091ms step_avg:61.74ms
+step:1444/1480 train_time:89186ms step_avg:61.76ms
+step:1445/1480 train_time:89273ms step_avg:61.78ms
+step:1446/1480 train_time:89368ms step_avg:61.80ms
+step:1447/1480 train_time:89455ms step_avg:61.82ms
+step:1448/1480 train_time:89550ms step_avg:61.84ms
+step:1449/1480 train_time:89637ms step_avg:61.86ms
+step:1450/1480 train_time:89731ms step_avg:61.88ms
+step:1451/1480 train_time:89819ms step_avg:61.90ms
+step:1452/1480 train_time:89913ms step_avg:61.92ms
+step:1453/1480 train_time:90000ms step_avg:61.94ms
+step:1454/1480 train_time:90094ms step_avg:61.96ms
+step:1455/1480 train_time:90183ms step_avg:61.98ms
+step:1456/1480 train_time:90275ms step_avg:62.00ms
+step:1457/1480 train_time:90362ms step_avg:62.02ms
+step:1458/1480 train_time:90456ms step_avg:62.04ms
+step:1459/1480 train_time:90539ms step_avg:62.06ms
+step:1460/1480 train_time:90636ms step_avg:62.08ms
+step:1461/1480 train_time:90728ms step_avg:62.10ms
+step:1462/1480 train_time:90820ms step_avg:62.12ms
+step:1463/1480 train_time:90910ms step_avg:62.14ms
+step:1464/1480 train_time:91005ms step_avg:62.16ms
+step:1465/1480 train_time:91093ms step_avg:62.18ms
+step:1466/1480 train_time:91189ms step_avg:62.20ms
+step:1467/1480 train_time:91275ms step_avg:62.22ms
+step:1468/1480 train_time:91375ms step_avg:62.24ms
+step:1469/1480 train_time:91468ms step_avg:62.27ms
+step:1470/1480 train_time:91567ms step_avg:62.29ms
+step:1471/1480 train_time:91659ms step_avg:62.31ms
+step:1472/1480 train_time:91757ms step_avg:62.33ms
+step:1473/1480 train_time:91847ms step_avg:62.35ms
+step:1474/1480 train_time:91945ms step_avg:62.38ms
+step:1475/1480 train_time:92035ms step_avg:62.40ms
+step:1476/1480 train_time:92133ms step_avg:62.42ms
+step:1477/1480 train_time:92223ms step_avg:62.44ms
+step:1478/1480 train_time:92320ms step_avg:62.46ms
+step:1479/1480 train_time:92409ms step_avg:62.48ms
+step:1480/1480 train_time:92506ms step_avg:62.50ms
+step:1480/1480 val_loss:3.2788 train_time:92611ms step_avg:62.57ms
+peak memory allocated: 31315 MiB reserved: 47102 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline0-1490.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline0-1490.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 15:14:49 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   38C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   37C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   34C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   38C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   66C    P0            148W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           52094      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A           52095      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A           52096      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A           52097      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A           52098      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A           52099      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A           52100      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A           52101      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8316 train_time:0ms step_avg:0.05ms
+step:1/1490 train_time:116ms step_avg:115.51ms
+step:2/1490 train_time:144ms step_avg:72.14ms
+step:3/1490 train_time:161ms step_avg:53.68ms
+step:4/1490 train_time:181ms step_avg:45.33ms
+step:5/1490 train_time:200ms step_avg:40.08ms
+step:6/1490 train_time:236ms step_avg:39.28ms
+step:7/1490 train_time:263ms step_avg:37.55ms
+step:8/1490 train_time:299ms step_avg:37.32ms
+step:9/1490 train_time:326ms step_avg:36.23ms
+step:10/1490 train_time:361ms step_avg:36.12ms
+step:11/1490 train_time:389ms step_avg:35.33ms
+step:12/1490 train_time:424ms step_avg:35.32ms
+step:13/1490 train_time:452ms step_avg:34.77ms
+step:14/1490 train_time:488ms step_avg:34.83ms
+step:15/1490 train_time:515ms step_avg:34.33ms
+step:16/1490 train_time:550ms step_avg:34.39ms
+step:17/1490 train_time:578ms step_avg:34.02ms
+step:18/1490 train_time:614ms step_avg:34.09ms
+step:19/1490 train_time:641ms step_avg:33.76ms
+step:20/1490 train_time:677ms step_avg:33.83ms
+step:21/1490 train_time:704ms step_avg:33.55ms
+step:22/1490 train_time:740ms step_avg:33.61ms
+step:23/1490 train_time:767ms step_avg:33.36ms
+step:24/1490 train_time:802ms step_avg:33.44ms
+step:25/1490 train_time:830ms step_avg:33.21ms
+step:26/1490 train_time:866ms step_avg:33.29ms
+step:27/1490 train_time:893ms step_avg:33.08ms
+step:28/1490 train_time:928ms step_avg:33.16ms
+step:29/1490 train_time:956ms step_avg:32.97ms
+step:30/1490 train_time:991ms step_avg:33.04ms
+step:31/1490 train_time:1021ms step_avg:32.94ms
+step:32/1490 train_time:1059ms step_avg:33.10ms
+step:33/1490 train_time:1089ms step_avg:33.01ms
+step:34/1490 train_time:1127ms step_avg:33.15ms
+step:35/1490 train_time:1157ms step_avg:33.05ms
+step:36/1490 train_time:1193ms step_avg:33.13ms
+step:37/1490 train_time:1222ms step_avg:33.02ms
+step:38/1490 train_time:1258ms step_avg:33.10ms
+step:39/1490 train_time:1286ms step_avg:32.98ms
+step:40/1490 train_time:1322ms step_avg:33.04ms
+step:41/1490 train_time:1350ms step_avg:32.92ms
+step:42/1490 train_time:1385ms step_avg:32.97ms
+step:43/1490 train_time:1413ms step_avg:32.86ms
+step:44/1490 train_time:1448ms step_avg:32.90ms
+step:45/1490 train_time:1476ms step_avg:32.80ms
+step:46/1490 train_time:1511ms step_avg:32.85ms
+step:47/1490 train_time:1539ms step_avg:32.75ms
+step:48/1490 train_time:1575ms step_avg:32.81ms
+step:49/1490 train_time:1603ms step_avg:32.71ms
+step:50/1490 train_time:1638ms step_avg:32.76ms
+step:51/1490 train_time:1666ms step_avg:32.66ms
+step:52/1490 train_time:1701ms step_avg:32.71ms
+step:53/1490 train_time:1729ms step_avg:32.62ms
+step:54/1490 train_time:1764ms step_avg:32.67ms
+step:55/1490 train_time:1793ms step_avg:32.59ms
+step:56/1490 train_time:1829ms step_avg:32.65ms
+step:57/1490 train_time:1857ms step_avg:32.57ms
+step:58/1490 train_time:1892ms step_avg:32.62ms
+step:59/1490 train_time:1921ms step_avg:32.55ms
+step:60/1490 train_time:1956ms step_avg:32.60ms
+step:61/1490 train_time:1984ms step_avg:32.53ms
+step:62/1490 train_time:2020ms step_avg:32.57ms
+step:63/1490 train_time:2048ms step_avg:32.51ms
+step:64/1490 train_time:2084ms step_avg:32.57ms
+step:65/1490 train_time:2113ms step_avg:32.50ms
+step:66/1490 train_time:2149ms step_avg:32.55ms
+step:67/1490 train_time:2177ms step_avg:32.49ms
+step:68/1490 train_time:2213ms step_avg:32.54ms
+step:69/1490 train_time:2241ms step_avg:32.48ms
+step:70/1490 train_time:2277ms step_avg:32.53ms
+step:71/1490 train_time:2306ms step_avg:32.47ms
+step:72/1490 train_time:2341ms step_avg:32.52ms
+step:73/1490 train_time:2369ms step_avg:32.46ms
+step:74/1490 train_time:2405ms step_avg:32.50ms
+step:75/1490 train_time:2433ms step_avg:32.44ms
+step:76/1490 train_time:2469ms step_avg:32.48ms
+step:77/1490 train_time:2497ms step_avg:32.43ms
+step:78/1490 train_time:2533ms step_avg:32.47ms
+step:79/1490 train_time:2561ms step_avg:32.42ms
+step:80/1490 train_time:2596ms step_avg:32.46ms
+step:81/1490 train_time:2625ms step_avg:32.41ms
+step:82/1490 train_time:2660ms step_avg:32.44ms
+step:83/1490 train_time:2688ms step_avg:32.39ms
+step:84/1490 train_time:2724ms step_avg:32.43ms
+step:85/1490 train_time:2753ms step_avg:32.39ms
+step:86/1490 train_time:2789ms step_avg:32.43ms
+step:87/1490 train_time:2818ms step_avg:32.39ms
+step:88/1490 train_time:2854ms step_avg:32.43ms
+step:89/1490 train_time:2882ms step_avg:32.39ms
+step:90/1490 train_time:2918ms step_avg:32.43ms
+step:91/1490 train_time:2947ms step_avg:32.38ms
+step:92/1490 train_time:2983ms step_avg:32.42ms
+step:93/1490 train_time:3012ms step_avg:32.38ms
+step:94/1490 train_time:3048ms step_avg:32.42ms
+step:95/1490 train_time:3076ms step_avg:32.38ms
+step:96/1490 train_time:3112ms step_avg:32.42ms
+step:97/1490 train_time:3141ms step_avg:32.39ms
+step:98/1490 train_time:3177ms step_avg:32.42ms
+step:99/1490 train_time:3206ms step_avg:32.39ms
+step:100/1490 train_time:3242ms step_avg:32.42ms
+step:101/1490 train_time:3271ms step_avg:32.39ms
+step:102/1490 train_time:3307ms step_avg:32.42ms
+step:103/1490 train_time:3336ms step_avg:32.39ms
+step:104/1490 train_time:3372ms step_avg:32.42ms
+step:105/1490 train_time:3401ms step_avg:32.39ms
+step:106/1490 train_time:3437ms step_avg:32.43ms
+step:107/1490 train_time:3465ms step_avg:32.39ms
+step:108/1490 train_time:3501ms step_avg:32.42ms
+step:109/1490 train_time:3530ms step_avg:32.38ms
+step:110/1490 train_time:3566ms step_avg:32.42ms
+step:111/1490 train_time:3596ms step_avg:32.39ms
+step:112/1490 train_time:3632ms step_avg:32.43ms
+step:113/1490 train_time:3661ms step_avg:32.40ms
+step:114/1490 train_time:3699ms step_avg:32.44ms
+step:115/1490 train_time:3727ms step_avg:32.41ms
+step:116/1490 train_time:3764ms step_avg:32.45ms
+step:117/1490 train_time:3793ms step_avg:32.42ms
+step:118/1490 train_time:3829ms step_avg:32.45ms
+step:119/1490 train_time:3859ms step_avg:32.43ms
+step:120/1490 train_time:3897ms step_avg:32.47ms
+step:121/1490 train_time:3924ms step_avg:32.43ms
+step:122/1490 train_time:3960ms step_avg:32.46ms
+step:123/1490 train_time:3989ms step_avg:32.43ms
+step:124/1490 train_time:4025ms step_avg:32.46ms
+step:125/1490 train_time:4055ms step_avg:32.44ms
+step:126/1490 train_time:4091ms step_avg:32.47ms
+step:127/1490 train_time:4120ms step_avg:32.44ms
+step:128/1490 train_time:4156ms step_avg:32.47ms
+step:129/1490 train_time:4185ms step_avg:32.44ms
+step:130/1490 train_time:4221ms step_avg:32.47ms
+step:131/1490 train_time:4250ms step_avg:32.45ms
+step:132/1490 train_time:4286ms step_avg:32.47ms
+step:133/1490 train_time:4316ms step_avg:32.45ms
+step:134/1490 train_time:4352ms step_avg:32.48ms
+step:135/1490 train_time:4381ms step_avg:32.45ms
+step:136/1490 train_time:4417ms step_avg:32.48ms
+step:137/1490 train_time:4446ms step_avg:32.45ms
+step:138/1490 train_time:4482ms step_avg:32.48ms
+step:139/1490 train_time:4511ms step_avg:32.45ms
+step:140/1490 train_time:4547ms step_avg:32.48ms
+step:141/1490 train_time:4576ms step_avg:32.46ms
+step:142/1490 train_time:4613ms step_avg:32.48ms
+step:143/1490 train_time:4642ms step_avg:32.46ms
+step:144/1490 train_time:4678ms step_avg:32.48ms
+step:145/1490 train_time:4708ms step_avg:32.47ms
+step:146/1490 train_time:4744ms step_avg:32.50ms
+step:147/1490 train_time:4772ms step_avg:32.46ms
+step:148/1490 train_time:4810ms step_avg:32.50ms
+step:149/1490 train_time:4837ms step_avg:32.46ms
+step:150/1490 train_time:4874ms step_avg:32.49ms
+step:151/1490 train_time:4903ms step_avg:32.47ms
+step:152/1490 train_time:4939ms step_avg:32.49ms
+step:153/1490 train_time:4967ms step_avg:32.46ms
+step:154/1490 train_time:5004ms step_avg:32.49ms
+step:155/1490 train_time:5032ms step_avg:32.47ms
+step:156/1490 train_time:5068ms step_avg:32.49ms
+step:157/1490 train_time:5097ms step_avg:32.47ms
+step:158/1490 train_time:5134ms step_avg:32.49ms
+step:159/1490 train_time:5163ms step_avg:32.47ms
+step:160/1490 train_time:5200ms step_avg:32.50ms
+step:161/1490 train_time:5228ms step_avg:32.47ms
+step:162/1490 train_time:5264ms step_avg:32.49ms
+step:163/1490 train_time:5294ms step_avg:32.48ms
+step:164/1490 train_time:5330ms step_avg:32.50ms
+step:165/1490 train_time:5359ms step_avg:32.48ms
+step:166/1490 train_time:5395ms step_avg:32.50ms
+step:167/1490 train_time:5424ms step_avg:32.48ms
+step:168/1490 train_time:5460ms step_avg:32.50ms
+step:169/1490 train_time:5489ms step_avg:32.48ms
+step:170/1490 train_time:5525ms step_avg:32.50ms
+step:171/1490 train_time:5554ms step_avg:32.48ms
+step:172/1490 train_time:5590ms step_avg:32.50ms
+step:173/1490 train_time:5618ms step_avg:32.48ms
+step:174/1490 train_time:5655ms step_avg:32.50ms
+step:175/1490 train_time:5683ms step_avg:32.48ms
+step:176/1490 train_time:5719ms step_avg:32.50ms
+step:177/1490 train_time:5748ms step_avg:32.47ms
+step:178/1490 train_time:5784ms step_avg:32.49ms
+step:179/1490 train_time:5813ms step_avg:32.47ms
+step:180/1490 train_time:5849ms step_avg:32.49ms
+step:181/1490 train_time:5878ms step_avg:32.47ms
+step:182/1490 train_time:5914ms step_avg:32.49ms
+step:183/1490 train_time:5942ms step_avg:32.47ms
+step:184/1490 train_time:5979ms step_avg:32.49ms
+step:185/1490 train_time:6008ms step_avg:32.47ms
+step:186/1490 train_time:6044ms step_avg:32.49ms
+step:187/1490 train_time:6072ms step_avg:32.47ms
+step:188/1490 train_time:6109ms step_avg:32.49ms
+step:189/1490 train_time:6137ms step_avg:32.47ms
+step:190/1490 train_time:6173ms step_avg:32.49ms
+step:191/1490 train_time:6202ms step_avg:32.47ms
+step:192/1490 train_time:6242ms step_avg:32.51ms
+step:193/1490 train_time:6274ms step_avg:32.51ms
+step:194/1490 train_time:6313ms step_avg:32.54ms
+step:195/1490 train_time:6344ms step_avg:32.54ms
+step:196/1490 train_time:6383ms step_avg:32.56ms
+step:197/1490 train_time:6414ms step_avg:32.56ms
+step:198/1490 train_time:6452ms step_avg:32.59ms
+step:199/1490 train_time:6483ms step_avg:32.58ms
+step:200/1490 train_time:6521ms step_avg:32.61ms
+step:201/1490 train_time:6552ms step_avg:32.60ms
+step:202/1490 train_time:6590ms step_avg:32.63ms
+step:203/1490 train_time:6621ms step_avg:32.62ms
+step:204/1490 train_time:6657ms step_avg:32.63ms
+step:205/1490 train_time:6684ms step_avg:32.60ms
+step:206/1490 train_time:6719ms step_avg:32.62ms
+step:207/1490 train_time:6746ms step_avg:32.59ms
+step:208/1490 train_time:6781ms step_avg:32.60ms
+step:209/1490 train_time:6809ms step_avg:32.58ms
+step:210/1490 train_time:6845ms step_avg:32.59ms
+step:211/1490 train_time:6874ms step_avg:32.58ms
+step:212/1490 train_time:6909ms step_avg:32.59ms
+step:213/1490 train_time:6938ms step_avg:32.57ms
+step:214/1490 train_time:6974ms step_avg:32.59ms
+step:215/1490 train_time:7002ms step_avg:32.57ms
+step:216/1490 train_time:7038ms step_avg:32.58ms
+step:217/1490 train_time:7066ms step_avg:32.56ms
+step:218/1490 train_time:7102ms step_avg:32.58ms
+step:219/1490 train_time:7131ms step_avg:32.56ms
+step:220/1490 train_time:7167ms step_avg:32.58ms
+step:221/1490 train_time:7196ms step_avg:32.56ms
+step:222/1490 train_time:7232ms step_avg:32.58ms
+step:223/1490 train_time:7262ms step_avg:32.56ms
+step:224/1490 train_time:7300ms step_avg:32.59ms
+step:225/1490 train_time:7330ms step_avg:32.58ms
+step:226/1490 train_time:7367ms step_avg:32.60ms
+step:227/1490 train_time:7398ms step_avg:32.59ms
+step:228/1490 train_time:7436ms step_avg:32.61ms
+step:229/1490 train_time:7466ms step_avg:32.60ms
+step:230/1490 train_time:7504ms step_avg:32.62ms
+step:231/1490 train_time:7534ms step_avg:32.62ms
+step:232/1490 train_time:7571ms step_avg:32.64ms
+step:233/1490 train_time:7602ms step_avg:32.63ms
+step:234/1490 train_time:7640ms step_avg:32.65ms
+step:235/1490 train_time:7670ms step_avg:32.64ms
+step:236/1490 train_time:7707ms step_avg:32.66ms
+step:237/1490 train_time:7738ms step_avg:32.65ms
+step:238/1490 train_time:7776ms step_avg:32.67ms
+step:239/1490 train_time:7806ms step_avg:32.66ms
+step:240/1490 train_time:7843ms step_avg:32.68ms
+step:241/1490 train_time:7873ms step_avg:32.67ms
+step:242/1490 train_time:7911ms step_avg:32.69ms
+step:243/1490 train_time:7941ms step_avg:32.68ms
+step:244/1490 train_time:7979ms step_avg:32.70ms
+step:245/1490 train_time:8008ms step_avg:32.69ms
+step:246/1490 train_time:8046ms step_avg:32.71ms
+step:247/1490 train_time:8076ms step_avg:32.70ms
+step:248/1490 train_time:8114ms step_avg:32.72ms
+step:249/1490 train_time:8143ms step_avg:32.70ms
+step:250/1490 train_time:8180ms step_avg:32.72ms
+step:250/1490 val_loss:4.4916 train_time:8227ms step_avg:32.91ms
+step:251/1490 train_time:8247ms step_avg:32.86ms
+step:252/1490 train_time:8267ms step_avg:32.81ms
+step:253/1490 train_time:8284ms step_avg:32.74ms
+step:254/1490 train_time:8316ms step_avg:32.74ms
+step:255/1490 train_time:8342ms step_avg:32.72ms
+step:256/1490 train_time:8379ms step_avg:32.73ms
+step:257/1490 train_time:8408ms step_avg:32.71ms
+step:258/1490 train_time:8444ms step_avg:32.73ms
+step:259/1490 train_time:8472ms step_avg:32.71ms
+step:260/1490 train_time:8508ms step_avg:32.72ms
+step:261/1490 train_time:8537ms step_avg:32.71ms
+step:262/1490 train_time:8573ms step_avg:32.72ms
+step:263/1490 train_time:8601ms step_avg:32.70ms
+step:264/1490 train_time:8637ms step_avg:32.72ms
+step:265/1490 train_time:8666ms step_avg:32.70ms
+step:266/1490 train_time:8702ms step_avg:32.71ms
+step:267/1490 train_time:8730ms step_avg:32.70ms
+step:268/1490 train_time:8769ms step_avg:32.72ms
+step:269/1490 train_time:8801ms step_avg:32.72ms
+step:270/1490 train_time:8840ms step_avg:32.74ms
+step:271/1490 train_time:8870ms step_avg:32.73ms
+step:272/1490 train_time:8909ms step_avg:32.76ms
+step:273/1490 train_time:8941ms step_avg:32.75ms
+step:274/1490 train_time:8980ms step_avg:32.77ms
+step:275/1490 train_time:9010ms step_avg:32.76ms
+step:276/1490 train_time:9048ms step_avg:32.78ms
+step:277/1490 train_time:9078ms step_avg:32.77ms
+step:278/1490 train_time:9116ms step_avg:32.79ms
+step:279/1490 train_time:9146ms step_avg:32.78ms
+step:280/1490 train_time:9182ms step_avg:32.79ms
+step:281/1490 train_time:9209ms step_avg:32.77ms
+step:282/1490 train_time:9244ms step_avg:32.78ms
+step:283/1490 train_time:9272ms step_avg:32.76ms
+step:284/1490 train_time:9309ms step_avg:32.78ms
+step:285/1490 train_time:9337ms step_avg:32.76ms
+step:286/1490 train_time:9373ms step_avg:32.77ms
+step:287/1490 train_time:9402ms step_avg:32.76ms
+step:288/1490 train_time:9440ms step_avg:32.78ms
+step:289/1490 train_time:9469ms step_avg:32.77ms
+step:290/1490 train_time:9506ms step_avg:32.78ms
+step:291/1490 train_time:9537ms step_avg:32.77ms
+step:292/1490 train_time:9575ms step_avg:32.79ms
+step:293/1490 train_time:9604ms step_avg:32.78ms
+step:294/1490 train_time:9641ms step_avg:32.79ms
+step:295/1490 train_time:9671ms step_avg:32.78ms
+step:296/1490 train_time:9709ms step_avg:32.80ms
+step:297/1490 train_time:9740ms step_avg:32.79ms
+step:298/1490 train_time:9777ms step_avg:32.81ms
+step:299/1490 train_time:9806ms step_avg:32.80ms
+step:300/1490 train_time:9844ms step_avg:32.81ms
+step:301/1490 train_time:9873ms step_avg:32.80ms
+step:302/1490 train_time:9911ms step_avg:32.82ms
+step:303/1490 train_time:9940ms step_avg:32.81ms
+step:304/1490 train_time:9978ms step_avg:32.82ms
+step:305/1490 train_time:10007ms step_avg:32.81ms
+step:306/1490 train_time:10045ms step_avg:32.83ms
+step:307/1490 train_time:10074ms step_avg:32.81ms
+step:308/1490 train_time:10111ms step_avg:32.83ms
+step:309/1490 train_time:10141ms step_avg:32.82ms
+step:310/1490 train_time:10179ms step_avg:32.83ms
+step:311/1490 train_time:10208ms step_avg:32.82ms
+step:312/1490 train_time:10245ms step_avg:32.84ms
+step:313/1490 train_time:10274ms step_avg:32.83ms
+step:314/1490 train_time:10311ms step_avg:32.84ms
+step:315/1490 train_time:10341ms step_avg:32.83ms
+step:316/1490 train_time:10378ms step_avg:32.84ms
+step:317/1490 train_time:10409ms step_avg:32.83ms
+step:318/1490 train_time:10446ms step_avg:32.85ms
+step:319/1490 train_time:10476ms step_avg:32.84ms
+step:320/1490 train_time:10513ms step_avg:32.85ms
+step:321/1490 train_time:10542ms step_avg:32.84ms
+step:322/1490 train_time:10579ms step_avg:32.86ms
+step:323/1490 train_time:10608ms step_avg:32.84ms
+step:324/1490 train_time:10645ms step_avg:32.86ms
+step:325/1490 train_time:10674ms step_avg:32.84ms
+step:326/1490 train_time:10711ms step_avg:32.86ms
+step:327/1490 train_time:10740ms step_avg:32.85ms
+step:328/1490 train_time:10777ms step_avg:32.86ms
+step:329/1490 train_time:10806ms step_avg:32.85ms
+step:330/1490 train_time:10843ms step_avg:32.86ms
+step:331/1490 train_time:10872ms step_avg:32.85ms
+step:332/1490 train_time:10909ms step_avg:32.86ms
+step:333/1490 train_time:10939ms step_avg:32.85ms
+step:334/1490 train_time:10976ms step_avg:32.86ms
+step:335/1490 train_time:11005ms step_avg:32.85ms
+step:336/1490 train_time:11041ms step_avg:32.86ms
+step:337/1490 train_time:11071ms step_avg:32.85ms
+step:338/1490 train_time:11107ms step_avg:32.86ms
+step:339/1490 train_time:11138ms step_avg:32.85ms
+step:340/1490 train_time:11174ms step_avg:32.87ms
+step:341/1490 train_time:11204ms step_avg:32.86ms
+step:342/1490 train_time:11240ms step_avg:32.87ms
+step:343/1490 train_time:11269ms step_avg:32.86ms
+step:344/1490 train_time:11306ms step_avg:32.87ms
+step:345/1490 train_time:11336ms step_avg:32.86ms
+step:346/1490 train_time:11372ms step_avg:32.87ms
+step:347/1490 train_time:11401ms step_avg:32.86ms
+step:348/1490 train_time:11438ms step_avg:32.87ms
+step:349/1490 train_time:11467ms step_avg:32.86ms
+step:350/1490 train_time:11504ms step_avg:32.87ms
+step:351/1490 train_time:11532ms step_avg:32.86ms
+step:352/1490 train_time:11569ms step_avg:32.87ms
+step:353/1490 train_time:11598ms step_avg:32.86ms
+step:354/1490 train_time:11634ms step_avg:32.86ms
+step:355/1490 train_time:11663ms step_avg:32.85ms
+step:356/1490 train_time:11700ms step_avg:32.86ms
+step:357/1490 train_time:11729ms step_avg:32.85ms
+step:358/1490 train_time:11765ms step_avg:32.86ms
+step:359/1490 train_time:11794ms step_avg:32.85ms
+step:360/1490 train_time:11830ms step_avg:32.86ms
+step:361/1490 train_time:11860ms step_avg:32.85ms
+step:362/1490 train_time:11896ms step_avg:32.86ms
+step:363/1490 train_time:11925ms step_avg:32.85ms
+step:364/1490 train_time:11961ms step_avg:32.86ms
+step:365/1490 train_time:11990ms step_avg:32.85ms
+step:366/1490 train_time:12027ms step_avg:32.86ms
+step:367/1490 train_time:12057ms step_avg:32.85ms
+step:368/1490 train_time:12093ms step_avg:32.86ms
+step:369/1490 train_time:12123ms step_avg:32.85ms
+step:370/1490 train_time:12160ms step_avg:32.86ms
+step:371/1490 train_time:12190ms step_avg:32.86ms
+step:372/1490 train_time:12227ms step_avg:32.87ms
+step:373/1490 train_time:12256ms step_avg:32.86ms
+step:374/1490 train_time:12293ms step_avg:32.87ms
+step:375/1490 train_time:12322ms step_avg:32.86ms
+step:376/1490 train_time:12359ms step_avg:32.87ms
+step:377/1490 train_time:12388ms step_avg:32.86ms
+step:378/1490 train_time:12425ms step_avg:32.87ms
+step:379/1490 train_time:12454ms step_avg:32.86ms
+step:380/1490 train_time:12492ms step_avg:32.87ms
+step:381/1490 train_time:12520ms step_avg:32.86ms
+step:382/1490 train_time:12557ms step_avg:32.87ms
+step:383/1490 train_time:12586ms step_avg:32.86ms
+step:384/1490 train_time:12623ms step_avg:32.87ms
+step:385/1490 train_time:12652ms step_avg:32.86ms
+step:386/1490 train_time:12689ms step_avg:32.87ms
+step:387/1490 train_time:12718ms step_avg:32.86ms
+step:388/1490 train_time:12755ms step_avg:32.87ms
+step:389/1490 train_time:12785ms step_avg:32.87ms
+step:390/1490 train_time:12822ms step_avg:32.88ms
+step:391/1490 train_time:12851ms step_avg:32.87ms
+step:392/1490 train_time:12888ms step_avg:32.88ms
+step:393/1490 train_time:12918ms step_avg:32.87ms
+step:394/1490 train_time:12954ms step_avg:32.88ms
+step:395/1490 train_time:12984ms step_avg:32.87ms
+step:396/1490 train_time:13021ms step_avg:32.88ms
+step:397/1490 train_time:13050ms step_avg:32.87ms
+step:398/1490 train_time:13087ms step_avg:32.88ms
+step:399/1490 train_time:13116ms step_avg:32.87ms
+step:400/1490 train_time:13153ms step_avg:32.88ms
+step:401/1490 train_time:13182ms step_avg:32.87ms
+step:402/1490 train_time:13219ms step_avg:32.88ms
+step:403/1490 train_time:13248ms step_avg:32.87ms
+step:404/1490 train_time:13285ms step_avg:32.88ms
+step:405/1490 train_time:13314ms step_avg:32.87ms
+step:406/1490 train_time:13351ms step_avg:32.88ms
+step:407/1490 train_time:13380ms step_avg:32.88ms
+step:408/1490 train_time:13417ms step_avg:32.88ms
+step:409/1490 train_time:13447ms step_avg:32.88ms
+step:410/1490 train_time:13483ms step_avg:32.88ms
+step:411/1490 train_time:13511ms step_avg:32.87ms
+step:412/1490 train_time:13549ms step_avg:32.88ms
+step:413/1490 train_time:13578ms step_avg:32.88ms
+step:414/1490 train_time:13614ms step_avg:32.88ms
+step:415/1490 train_time:13644ms step_avg:32.88ms
+step:416/1490 train_time:13681ms step_avg:32.89ms
+step:417/1490 train_time:13710ms step_avg:32.88ms
+step:418/1490 train_time:13747ms step_avg:32.89ms
+step:419/1490 train_time:13776ms step_avg:32.88ms
+step:420/1490 train_time:13813ms step_avg:32.89ms
+step:421/1490 train_time:13842ms step_avg:32.88ms
+step:422/1490 train_time:13879ms step_avg:32.89ms
+step:423/1490 train_time:13908ms step_avg:32.88ms
+step:424/1490 train_time:13944ms step_avg:32.89ms
+step:425/1490 train_time:13974ms step_avg:32.88ms
+step:426/1490 train_time:14011ms step_avg:32.89ms
+step:427/1490 train_time:14039ms step_avg:32.88ms
+step:428/1490 train_time:14077ms step_avg:32.89ms
+step:429/1490 train_time:14105ms step_avg:32.88ms
+step:430/1490 train_time:14141ms step_avg:32.89ms
+step:431/1490 train_time:14170ms step_avg:32.88ms
+step:432/1490 train_time:14207ms step_avg:32.89ms
+step:433/1490 train_time:14236ms step_avg:32.88ms
+step:434/1490 train_time:14272ms step_avg:32.89ms
+step:435/1490 train_time:14302ms step_avg:32.88ms
+step:436/1490 train_time:14338ms step_avg:32.89ms
+step:437/1490 train_time:14367ms step_avg:32.88ms
+step:438/1490 train_time:14404ms step_avg:32.89ms
+step:439/1490 train_time:14433ms step_avg:32.88ms
+step:440/1490 train_time:14470ms step_avg:32.89ms
+step:441/1490 train_time:14501ms step_avg:32.88ms
+step:442/1490 train_time:14540ms step_avg:32.90ms
+step:443/1490 train_time:14569ms step_avg:32.89ms
+step:444/1490 train_time:14607ms step_avg:32.90ms
+step:445/1490 train_time:14639ms step_avg:32.90ms
+step:446/1490 train_time:14677ms step_avg:32.91ms
+step:447/1490 train_time:14707ms step_avg:32.90ms
+step:448/1490 train_time:14746ms step_avg:32.91ms
+step:449/1490 train_time:14777ms step_avg:32.91ms
+step:450/1490 train_time:14815ms step_avg:32.92ms
+step:451/1490 train_time:14845ms step_avg:32.92ms
+step:452/1490 train_time:14884ms step_avg:32.93ms
+step:453/1490 train_time:14914ms step_avg:32.92ms
+step:454/1490 train_time:14952ms step_avg:32.93ms
+step:455/1490 train_time:14982ms step_avg:32.93ms
+step:456/1490 train_time:15020ms step_avg:32.94ms
+step:457/1490 train_time:15050ms step_avg:32.93ms
+step:458/1490 train_time:15089ms step_avg:32.94ms
+step:459/1490 train_time:15119ms step_avg:32.94ms
+step:460/1490 train_time:15157ms step_avg:32.95ms
+step:461/1490 train_time:15187ms step_avg:32.94ms
+step:462/1490 train_time:15224ms step_avg:32.95ms
+step:463/1490 train_time:15255ms step_avg:32.95ms
+step:464/1490 train_time:15293ms step_avg:32.96ms
+step:465/1490 train_time:15322ms step_avg:32.95ms
+step:466/1490 train_time:15360ms step_avg:32.96ms
+step:467/1490 train_time:15389ms step_avg:32.95ms
+step:468/1490 train_time:15426ms step_avg:32.96ms
+step:469/1490 train_time:15457ms step_avg:32.96ms
+step:470/1490 train_time:15494ms step_avg:32.97ms
+step:471/1490 train_time:15524ms step_avg:32.96ms
+step:472/1490 train_time:15561ms step_avg:32.97ms
+step:473/1490 train_time:15591ms step_avg:32.96ms
+step:474/1490 train_time:15628ms step_avg:32.97ms
+step:475/1490 train_time:15659ms step_avg:32.97ms
+step:476/1490 train_time:15697ms step_avg:32.98ms
+step:477/1490 train_time:15725ms step_avg:32.97ms
+step:478/1490 train_time:15762ms step_avg:32.98ms
+step:479/1490 train_time:15793ms step_avg:32.97ms
+step:480/1490 train_time:15829ms step_avg:32.98ms
+step:481/1490 train_time:15860ms step_avg:32.97ms
+step:482/1490 train_time:15897ms step_avg:32.98ms
+step:483/1490 train_time:15926ms step_avg:32.97ms
+step:484/1490 train_time:15972ms step_avg:33.00ms
+step:485/1490 train_time:16018ms step_avg:33.03ms
+step:486/1490 train_time:16080ms step_avg:33.09ms
+step:487/1490 train_time:16138ms step_avg:33.14ms
+step:488/1490 train_time:16202ms step_avg:33.20ms
+step:489/1490 train_time:16259ms step_avg:33.25ms
+step:490/1490 train_time:16325ms step_avg:33.32ms
+step:491/1490 train_time:16383ms step_avg:33.37ms
+step:492/1490 train_time:16448ms step_avg:33.43ms
+step:493/1490 train_time:16506ms step_avg:33.48ms
+step:494/1490 train_time:16571ms step_avg:33.54ms
+step:495/1490 train_time:16631ms step_avg:33.60ms
+step:496/1490 train_time:16695ms step_avg:33.66ms
+step:497/1490 train_time:16752ms step_avg:33.71ms
+step:498/1490 train_time:16816ms step_avg:33.77ms
+step:499/1490 train_time:16874ms step_avg:33.82ms
+step:500/1490 train_time:16938ms step_avg:33.88ms
+step:500/1490 val_loss:4.2078 train_time:17019ms step_avg:34.04ms
+step:501/1490 train_time:17042ms step_avg:34.02ms
+step:502/1490 train_time:17066ms step_avg:34.00ms
+step:503/1490 train_time:17123ms step_avg:34.04ms
+step:504/1490 train_time:17188ms step_avg:34.10ms
+step:505/1490 train_time:17246ms step_avg:34.15ms
+step:506/1490 train_time:17312ms step_avg:34.21ms
+step:507/1490 train_time:17371ms step_avg:34.26ms
+step:508/1490 train_time:17437ms step_avg:34.33ms
+step:509/1490 train_time:17498ms step_avg:34.38ms
+step:510/1490 train_time:17564ms step_avg:34.44ms
+step:511/1490 train_time:17620ms step_avg:34.48ms
+step:512/1490 train_time:17679ms step_avg:34.53ms
+step:513/1490 train_time:17734ms step_avg:34.57ms
+step:514/1490 train_time:17793ms step_avg:34.62ms
+step:515/1490 train_time:17850ms step_avg:34.66ms
+step:516/1490 train_time:17912ms step_avg:34.71ms
+step:517/1490 train_time:17968ms step_avg:34.76ms
+step:518/1490 train_time:18034ms step_avg:34.81ms
+step:519/1490 train_time:18094ms step_avg:34.86ms
+step:520/1490 train_time:18161ms step_avg:34.92ms
+step:521/1490 train_time:18220ms step_avg:34.97ms
+step:522/1490 train_time:18284ms step_avg:35.03ms
+step:523/1490 train_time:18342ms step_avg:35.07ms
+step:524/1490 train_time:18405ms step_avg:35.12ms
+step:525/1490 train_time:18463ms step_avg:35.17ms
+step:526/1490 train_time:18527ms step_avg:35.22ms
+step:527/1490 train_time:18584ms step_avg:35.26ms
+step:528/1490 train_time:18648ms step_avg:35.32ms
+step:529/1490 train_time:18705ms step_avg:35.36ms
+step:530/1490 train_time:18769ms step_avg:35.41ms
+step:531/1490 train_time:18826ms step_avg:35.45ms
+step:532/1490 train_time:18890ms step_avg:35.51ms
+step:533/1490 train_time:18949ms step_avg:35.55ms
+step:534/1490 train_time:19013ms step_avg:35.60ms
+step:535/1490 train_time:19071ms step_avg:35.65ms
+step:536/1490 train_time:19135ms step_avg:35.70ms
+step:537/1490 train_time:19193ms step_avg:35.74ms
+step:538/1490 train_time:19260ms step_avg:35.80ms
+step:539/1490 train_time:19319ms step_avg:35.84ms
+step:540/1490 train_time:19383ms step_avg:35.89ms
+step:541/1490 train_time:19441ms step_avg:35.94ms
+step:542/1490 train_time:19505ms step_avg:35.99ms
+step:543/1490 train_time:19562ms step_avg:36.03ms
+step:544/1490 train_time:19626ms step_avg:36.08ms
+step:545/1490 train_time:19683ms step_avg:36.12ms
+step:546/1490 train_time:19747ms step_avg:36.17ms
+step:547/1490 train_time:19804ms step_avg:36.21ms
+step:548/1490 train_time:19868ms step_avg:36.26ms
+step:549/1490 train_time:19925ms step_avg:36.29ms
+step:550/1490 train_time:19988ms step_avg:36.34ms
+step:551/1490 train_time:20045ms step_avg:36.38ms
+step:552/1490 train_time:20108ms step_avg:36.43ms
+step:553/1490 train_time:20164ms step_avg:36.46ms
+step:554/1490 train_time:20227ms step_avg:36.51ms
+step:555/1490 train_time:20284ms step_avg:36.55ms
+step:556/1490 train_time:20347ms step_avg:36.60ms
+step:557/1490 train_time:20404ms step_avg:36.63ms
+step:558/1490 train_time:20467ms step_avg:36.68ms
+step:559/1490 train_time:20524ms step_avg:36.72ms
+step:560/1490 train_time:20588ms step_avg:36.76ms
+step:561/1490 train_time:20646ms step_avg:36.80ms
+step:562/1490 train_time:20710ms step_avg:36.85ms
+step:563/1490 train_time:20768ms step_avg:36.89ms
+step:564/1490 train_time:20832ms step_avg:36.94ms
+step:565/1490 train_time:20890ms step_avg:36.97ms
+step:566/1490 train_time:20957ms step_avg:37.03ms
+step:567/1490 train_time:21017ms step_avg:37.07ms
+step:568/1490 train_time:21081ms step_avg:37.11ms
+step:569/1490 train_time:21141ms step_avg:37.15ms
+step:570/1490 train_time:21207ms step_avg:37.20ms
+step:571/1490 train_time:21263ms step_avg:37.24ms
+step:572/1490 train_time:21327ms step_avg:37.28ms
+step:573/1490 train_time:21384ms step_avg:37.32ms
+step:574/1490 train_time:21447ms step_avg:37.36ms
+step:575/1490 train_time:21509ms step_avg:37.41ms
+step:576/1490 train_time:21580ms step_avg:37.47ms
+step:577/1490 train_time:21645ms step_avg:37.51ms
+step:578/1490 train_time:21716ms step_avg:37.57ms
+step:579/1490 train_time:21767ms step_avg:37.59ms
+step:580/1490 train_time:21827ms step_avg:37.63ms
+step:581/1490 train_time:21883ms step_avg:37.67ms
+step:582/1490 train_time:21947ms step_avg:37.71ms
+step:583/1490 train_time:22003ms step_avg:37.74ms
+step:584/1490 train_time:22065ms step_avg:37.78ms
+step:585/1490 train_time:22123ms step_avg:37.82ms
+step:586/1490 train_time:22193ms step_avg:37.87ms
+step:587/1490 train_time:22254ms step_avg:37.91ms
+step:588/1490 train_time:22326ms step_avg:37.97ms
+step:589/1490 train_time:22383ms step_avg:38.00ms
+step:590/1490 train_time:22451ms step_avg:38.05ms
+step:591/1490 train_time:22512ms step_avg:38.09ms
+step:592/1490 train_time:22579ms step_avg:38.14ms
+step:593/1490 train_time:22642ms step_avg:38.18ms
+step:594/1490 train_time:22709ms step_avg:38.23ms
+step:595/1490 train_time:22768ms step_avg:38.27ms
+step:596/1490 train_time:22835ms step_avg:38.31ms
+step:597/1490 train_time:22897ms step_avg:38.35ms
+step:598/1490 train_time:22958ms step_avg:38.39ms
+step:599/1490 train_time:23013ms step_avg:38.42ms
+step:600/1490 train_time:23072ms step_avg:38.45ms
+step:601/1490 train_time:23126ms step_avg:38.48ms
+step:602/1490 train_time:23189ms step_avg:38.52ms
+step:603/1490 train_time:23244ms step_avg:38.55ms
+step:604/1490 train_time:23306ms step_avg:38.59ms
+step:605/1490 train_time:23362ms step_avg:38.62ms
+step:606/1490 train_time:23424ms step_avg:38.65ms
+step:607/1490 train_time:23480ms step_avg:38.68ms
+step:608/1490 train_time:23545ms step_avg:38.73ms
+step:609/1490 train_time:23603ms step_avg:38.76ms
+step:610/1490 train_time:23665ms step_avg:38.80ms
+step:611/1490 train_time:23722ms step_avg:38.82ms
+step:612/1490 train_time:23787ms step_avg:38.87ms
+step:613/1490 train_time:23843ms step_avg:38.90ms
+step:614/1490 train_time:23906ms step_avg:38.93ms
+step:615/1490 train_time:23966ms step_avg:38.97ms
+step:616/1490 train_time:24037ms step_avg:39.02ms
+step:617/1490 train_time:24103ms step_avg:39.06ms
+step:618/1490 train_time:24171ms step_avg:39.11ms
+step:619/1490 train_time:24234ms step_avg:39.15ms
+step:620/1490 train_time:24303ms step_avg:39.20ms
+step:621/1490 train_time:24365ms step_avg:39.24ms
+step:622/1490 train_time:24425ms step_avg:39.27ms
+step:623/1490 train_time:24479ms step_avg:39.29ms
+step:624/1490 train_time:24539ms step_avg:39.32ms
+step:625/1490 train_time:24594ms step_avg:39.35ms
+step:626/1490 train_time:24657ms step_avg:39.39ms
+step:627/1490 train_time:24717ms step_avg:39.42ms
+step:628/1490 train_time:24784ms step_avg:39.46ms
+step:629/1490 train_time:24843ms step_avg:39.50ms
+step:630/1490 train_time:24907ms step_avg:39.53ms
+step:631/1490 train_time:24963ms step_avg:39.56ms
+step:632/1490 train_time:25027ms step_avg:39.60ms
+step:633/1490 train_time:25083ms step_avg:39.63ms
+step:634/1490 train_time:25146ms step_avg:39.66ms
+step:635/1490 train_time:25204ms step_avg:39.69ms
+step:636/1490 train_time:25267ms step_avg:39.73ms
+step:637/1490 train_time:25326ms step_avg:39.76ms
+step:638/1490 train_time:25388ms step_avg:39.79ms
+step:639/1490 train_time:25447ms step_avg:39.82ms
+step:640/1490 train_time:25511ms step_avg:39.86ms
+step:641/1490 train_time:25570ms step_avg:39.89ms
+step:642/1490 train_time:25635ms step_avg:39.93ms
+step:643/1490 train_time:25696ms step_avg:39.96ms
+step:644/1490 train_time:25759ms step_avg:40.00ms
+step:645/1490 train_time:25818ms step_avg:40.03ms
+step:646/1490 train_time:25884ms step_avg:40.07ms
+step:647/1490 train_time:25942ms step_avg:40.10ms
+step:648/1490 train_time:26005ms step_avg:40.13ms
+step:649/1490 train_time:26062ms step_avg:40.16ms
+step:650/1490 train_time:26127ms step_avg:40.19ms
+step:651/1490 train_time:26184ms step_avg:40.22ms
+step:652/1490 train_time:26247ms step_avg:40.26ms
+step:653/1490 train_time:26304ms step_avg:40.28ms
+step:654/1490 train_time:26367ms step_avg:40.32ms
+step:655/1490 train_time:26427ms step_avg:40.35ms
+step:656/1490 train_time:26498ms step_avg:40.39ms
+step:657/1490 train_time:26562ms step_avg:40.43ms
+step:658/1490 train_time:26626ms step_avg:40.46ms
+step:659/1490 train_time:26682ms step_avg:40.49ms
+step:660/1490 train_time:26746ms step_avg:40.52ms
+step:661/1490 train_time:26804ms step_avg:40.55ms
+step:662/1490 train_time:26870ms step_avg:40.59ms
+step:663/1490 train_time:26926ms step_avg:40.61ms
+step:664/1490 train_time:26988ms step_avg:40.65ms
+step:665/1490 train_time:27051ms step_avg:40.68ms
+step:666/1490 train_time:27120ms step_avg:40.72ms
+step:667/1490 train_time:27182ms step_avg:40.75ms
+step:668/1490 train_time:27251ms step_avg:40.79ms
+step:669/1490 train_time:27313ms step_avg:40.83ms
+step:670/1490 train_time:27382ms step_avg:40.87ms
+step:671/1490 train_time:27445ms step_avg:40.90ms
+step:672/1490 train_time:27512ms step_avg:40.94ms
+step:673/1490 train_time:27573ms step_avg:40.97ms
+step:674/1490 train_time:27642ms step_avg:41.01ms
+step:675/1490 train_time:27697ms step_avg:41.03ms
+step:676/1490 train_time:27757ms step_avg:41.06ms
+step:677/1490 train_time:27810ms step_avg:41.08ms
+step:678/1490 train_time:27883ms step_avg:41.13ms
+step:679/1490 train_time:27925ms step_avg:41.13ms
+step:680/1490 train_time:27987ms step_avg:41.16ms
+step:681/1490 train_time:28044ms step_avg:41.18ms
+step:682/1490 train_time:28107ms step_avg:41.21ms
+step:683/1490 train_time:28163ms step_avg:41.23ms
+step:684/1490 train_time:28228ms step_avg:41.27ms
+step:685/1490 train_time:28286ms step_avg:41.29ms
+step:686/1490 train_time:28349ms step_avg:41.33ms
+step:687/1490 train_time:28407ms step_avg:41.35ms
+step:688/1490 train_time:28470ms step_avg:41.38ms
+step:689/1490 train_time:28530ms step_avg:41.41ms
+step:690/1490 train_time:28595ms step_avg:41.44ms
+step:691/1490 train_time:28653ms step_avg:41.47ms
+step:692/1490 train_time:28715ms step_avg:41.50ms
+step:693/1490 train_time:28773ms step_avg:41.52ms
+step:694/1490 train_time:28835ms step_avg:41.55ms
+step:695/1490 train_time:28892ms step_avg:41.57ms
+step:696/1490 train_time:28955ms step_avg:41.60ms
+step:697/1490 train_time:29012ms step_avg:41.62ms
+step:698/1490 train_time:29074ms step_avg:41.65ms
+step:699/1490 train_time:29132ms step_avg:41.68ms
+step:700/1490 train_time:29195ms step_avg:41.71ms
+step:701/1490 train_time:29255ms step_avg:41.73ms
+step:702/1490 train_time:29320ms step_avg:41.77ms
+step:703/1490 train_time:29380ms step_avg:41.79ms
+step:704/1490 train_time:29446ms step_avg:41.83ms
+step:705/1490 train_time:29504ms step_avg:41.85ms
+step:706/1490 train_time:29569ms step_avg:41.88ms
+step:707/1490 train_time:29626ms step_avg:41.90ms
+step:708/1490 train_time:29691ms step_avg:41.94ms
+step:709/1490 train_time:29751ms step_avg:41.96ms
+step:710/1490 train_time:29816ms step_avg:41.99ms
+step:711/1490 train_time:29875ms step_avg:42.02ms
+step:712/1490 train_time:29941ms step_avg:42.05ms
+step:713/1490 train_time:30001ms step_avg:42.08ms
+step:714/1490 train_time:30064ms step_avg:42.11ms
+step:715/1490 train_time:30121ms step_avg:42.13ms
+step:716/1490 train_time:30185ms step_avg:42.16ms
+step:717/1490 train_time:30243ms step_avg:42.18ms
+step:718/1490 train_time:30305ms step_avg:42.21ms
+step:719/1490 train_time:30362ms step_avg:42.23ms
+step:720/1490 train_time:30425ms step_avg:42.26ms
+step:721/1490 train_time:30483ms step_avg:42.28ms
+step:722/1490 train_time:30546ms step_avg:42.31ms
+step:723/1490 train_time:30603ms step_avg:42.33ms
+step:724/1490 train_time:30666ms step_avg:42.36ms
+step:725/1490 train_time:30726ms step_avg:42.38ms
+step:726/1490 train_time:30796ms step_avg:42.42ms
+step:727/1490 train_time:30860ms step_avg:42.45ms
+step:728/1490 train_time:30930ms step_avg:42.49ms
+step:729/1490 train_time:30991ms step_avg:42.51ms
+step:730/1490 train_time:31060ms step_avg:42.55ms
+step:731/1490 train_time:31123ms step_avg:42.58ms
+step:732/1490 train_time:31191ms step_avg:42.61ms
+step:733/1490 train_time:31253ms step_avg:42.64ms
+step:734/1490 train_time:31321ms step_avg:42.67ms
+step:735/1490 train_time:31375ms step_avg:42.69ms
+step:736/1490 train_time:31434ms step_avg:42.71ms
+step:737/1490 train_time:31488ms step_avg:42.72ms
+step:738/1490 train_time:31549ms step_avg:42.75ms
+step:739/1490 train_time:31606ms step_avg:42.77ms
+step:740/1490 train_time:31668ms step_avg:42.80ms
+step:741/1490 train_time:31725ms step_avg:42.81ms
+step:742/1490 train_time:31789ms step_avg:42.84ms
+step:743/1490 train_time:31848ms step_avg:42.86ms
+step:744/1490 train_time:31913ms step_avg:42.89ms
+step:745/1490 train_time:31971ms step_avg:42.91ms
+step:746/1490 train_time:32035ms step_avg:42.94ms
+step:747/1490 train_time:32096ms step_avg:42.97ms
+step:748/1490 train_time:32160ms step_avg:43.00ms
+step:749/1490 train_time:32219ms step_avg:43.02ms
+step:750/1490 train_time:32284ms step_avg:43.05ms
+step:750/1490 val_loss:3.8043 train_time:32367ms step_avg:43.16ms
+step:751/1490 train_time:32386ms step_avg:43.12ms
+step:752/1490 train_time:32409ms step_avg:43.10ms
+step:753/1490 train_time:32471ms step_avg:43.12ms
+step:754/1490 train_time:32539ms step_avg:43.15ms
+step:755/1490 train_time:32596ms step_avg:43.17ms
+step:756/1490 train_time:32655ms step_avg:43.19ms
+step:757/1490 train_time:32711ms step_avg:43.21ms
+step:758/1490 train_time:32773ms step_avg:43.24ms
+step:759/1490 train_time:32830ms step_avg:43.25ms
+step:760/1490 train_time:32892ms step_avg:43.28ms
+step:761/1490 train_time:32951ms step_avg:43.30ms
+step:762/1490 train_time:33017ms step_avg:43.33ms
+step:763/1490 train_time:33076ms step_avg:43.35ms
+step:764/1490 train_time:33141ms step_avg:43.38ms
+step:765/1490 train_time:33200ms step_avg:43.40ms
+step:766/1490 train_time:33266ms step_avg:43.43ms
+step:767/1490 train_time:33324ms step_avg:43.45ms
+step:768/1490 train_time:33389ms step_avg:43.48ms
+step:769/1490 train_time:33447ms step_avg:43.49ms
+step:770/1490 train_time:33511ms step_avg:43.52ms
+step:771/1490 train_time:33568ms step_avg:43.54ms
+step:772/1490 train_time:33633ms step_avg:43.57ms
+step:773/1490 train_time:33690ms step_avg:43.58ms
+step:774/1490 train_time:33754ms step_avg:43.61ms
+step:775/1490 train_time:33811ms step_avg:43.63ms
+step:776/1490 train_time:33875ms step_avg:43.65ms
+step:777/1490 train_time:33934ms step_avg:43.67ms
+step:778/1490 train_time:33998ms step_avg:43.70ms
+step:779/1490 train_time:34058ms step_avg:43.72ms
+step:780/1490 train_time:34123ms step_avg:43.75ms
+step:781/1490 train_time:34181ms step_avg:43.77ms
+step:782/1490 train_time:34244ms step_avg:43.79ms
+step:783/1490 train_time:34302ms step_avg:43.81ms
+step:784/1490 train_time:34367ms step_avg:43.84ms
+step:785/1490 train_time:34426ms step_avg:43.85ms
+step:786/1490 train_time:34490ms step_avg:43.88ms
+step:787/1490 train_time:34549ms step_avg:43.90ms
+step:788/1490 train_time:34614ms step_avg:43.93ms
+step:789/1490 train_time:34674ms step_avg:43.95ms
+step:790/1490 train_time:34740ms step_avg:43.98ms
+step:791/1490 train_time:34799ms step_avg:43.99ms
+step:792/1490 train_time:34863ms step_avg:44.02ms
+step:793/1490 train_time:34921ms step_avg:44.04ms
+step:794/1490 train_time:34985ms step_avg:44.06ms
+step:795/1490 train_time:35043ms step_avg:44.08ms
+step:796/1490 train_time:35106ms step_avg:44.10ms
+step:797/1490 train_time:35164ms step_avg:44.12ms
+step:798/1490 train_time:35227ms step_avg:44.14ms
+step:799/1490 train_time:35285ms step_avg:44.16ms
+step:800/1490 train_time:35348ms step_avg:44.18ms
+step:801/1490 train_time:35406ms step_avg:44.20ms
+step:802/1490 train_time:35468ms step_avg:44.22ms
+step:803/1490 train_time:35525ms step_avg:44.24ms
+step:804/1490 train_time:35587ms step_avg:44.26ms
+step:805/1490 train_time:35648ms step_avg:44.28ms
+step:806/1490 train_time:35720ms step_avg:44.32ms
+step:807/1490 train_time:35786ms step_avg:44.34ms
+step:808/1490 train_time:35855ms step_avg:44.38ms
+step:809/1490 train_time:35920ms step_avg:44.40ms
+step:810/1490 train_time:35991ms step_avg:44.43ms
+step:811/1490 train_time:36053ms step_avg:44.45ms
+step:812/1490 train_time:36112ms step_avg:44.47ms
+step:813/1490 train_time:36166ms step_avg:44.48ms
+step:814/1490 train_time:36226ms step_avg:44.50ms
+step:815/1490 train_time:36282ms step_avg:44.52ms
+step:816/1490 train_time:36344ms step_avg:44.54ms
+step:817/1490 train_time:36399ms step_avg:44.55ms
+step:818/1490 train_time:36465ms step_avg:44.58ms
+step:819/1490 train_time:36523ms step_avg:44.59ms
+step:820/1490 train_time:36585ms step_avg:44.62ms
+step:821/1490 train_time:36642ms step_avg:44.63ms
+step:822/1490 train_time:36706ms step_avg:44.66ms
+step:823/1490 train_time:36764ms step_avg:44.67ms
+step:824/1490 train_time:36829ms step_avg:44.70ms
+step:825/1490 train_time:36888ms step_avg:44.71ms
+step:826/1490 train_time:36952ms step_avg:44.74ms
+step:827/1490 train_time:37010ms step_avg:44.75ms
+step:828/1490 train_time:37076ms step_avg:44.78ms
+step:829/1490 train_time:37135ms step_avg:44.79ms
+step:830/1490 train_time:37201ms step_avg:44.82ms
+step:831/1490 train_time:37261ms step_avg:44.84ms
+step:832/1490 train_time:37326ms step_avg:44.86ms
+step:833/1490 train_time:37384ms step_avg:44.88ms
+step:834/1490 train_time:37448ms step_avg:44.90ms
+step:835/1490 train_time:37507ms step_avg:44.92ms
+step:836/1490 train_time:37571ms step_avg:44.94ms
+step:837/1490 train_time:37630ms step_avg:44.96ms
+step:838/1490 train_time:37694ms step_avg:44.98ms
+step:839/1490 train_time:37752ms step_avg:45.00ms
+step:840/1490 train_time:37817ms step_avg:45.02ms
+step:841/1490 train_time:37877ms step_avg:45.04ms
+step:842/1490 train_time:37942ms step_avg:45.06ms
+step:843/1490 train_time:38001ms step_avg:45.08ms
+step:844/1490 train_time:38067ms step_avg:45.10ms
+step:845/1490 train_time:38126ms step_avg:45.12ms
+step:846/1490 train_time:38190ms step_avg:45.14ms
+step:847/1490 train_time:38250ms step_avg:45.16ms
+step:848/1490 train_time:38315ms step_avg:45.18ms
+step:849/1490 train_time:38373ms step_avg:45.20ms
+step:850/1490 train_time:38438ms step_avg:45.22ms
+step:851/1490 train_time:38497ms step_avg:45.24ms
+step:852/1490 train_time:38562ms step_avg:45.26ms
+step:853/1490 train_time:38620ms step_avg:45.28ms
+step:854/1490 train_time:38685ms step_avg:45.30ms
+step:855/1490 train_time:38743ms step_avg:45.31ms
+step:856/1490 train_time:38807ms step_avg:45.34ms
+step:857/1490 train_time:38865ms step_avg:45.35ms
+step:858/1490 train_time:38929ms step_avg:45.37ms
+step:859/1490 train_time:38987ms step_avg:45.39ms
+step:860/1490 train_time:39050ms step_avg:45.41ms
+step:861/1490 train_time:39108ms step_avg:45.42ms
+step:862/1490 train_time:39173ms step_avg:45.44ms
+step:863/1490 train_time:39231ms step_avg:45.46ms
+step:864/1490 train_time:39295ms step_avg:45.48ms
+step:865/1490 train_time:39353ms step_avg:45.49ms
+step:866/1490 train_time:39418ms step_avg:45.52ms
+step:867/1490 train_time:39476ms step_avg:45.53ms
+step:868/1490 train_time:39541ms step_avg:45.55ms
+step:869/1490 train_time:39599ms step_avg:45.57ms
+step:870/1490 train_time:39666ms step_avg:45.59ms
+step:871/1490 train_time:39724ms step_avg:45.61ms
+step:872/1490 train_time:39788ms step_avg:45.63ms
+step:873/1490 train_time:39847ms step_avg:45.64ms
+step:874/1490 train_time:39912ms step_avg:45.67ms
+step:875/1490 train_time:39969ms step_avg:45.68ms
+step:876/1490 train_time:40034ms step_avg:45.70ms
+step:877/1490 train_time:40091ms step_avg:45.71ms
+step:878/1490 train_time:40156ms step_avg:45.74ms
+step:879/1490 train_time:40215ms step_avg:45.75ms
+step:880/1490 train_time:40279ms step_avg:45.77ms
+step:881/1490 train_time:40337ms step_avg:45.79ms
+step:882/1490 train_time:40402ms step_avg:45.81ms
+step:883/1490 train_time:40460ms step_avg:45.82ms
+step:884/1490 train_time:40524ms step_avg:45.84ms
+step:885/1490 train_time:40582ms step_avg:45.86ms
+step:886/1490 train_time:40646ms step_avg:45.88ms
+step:887/1490 train_time:40704ms step_avg:45.89ms
+step:888/1490 train_time:40768ms step_avg:45.91ms
+step:889/1490 train_time:40827ms step_avg:45.93ms
+step:890/1490 train_time:40894ms step_avg:45.95ms
+step:891/1490 train_time:40953ms step_avg:45.96ms
+step:892/1490 train_time:41020ms step_avg:45.99ms
+step:893/1490 train_time:41080ms step_avg:46.00ms
+step:894/1490 train_time:41146ms step_avg:46.03ms
+step:895/1490 train_time:41205ms step_avg:46.04ms
+step:896/1490 train_time:41271ms step_avg:46.06ms
+step:897/1490 train_time:41330ms step_avg:46.08ms
+step:898/1490 train_time:41395ms step_avg:46.10ms
+step:899/1490 train_time:41454ms step_avg:46.11ms
+step:900/1490 train_time:41521ms step_avg:46.13ms
+step:901/1490 train_time:41581ms step_avg:46.15ms
+step:902/1490 train_time:41646ms step_avg:46.17ms
+step:903/1490 train_time:41704ms step_avg:46.18ms
+step:904/1490 train_time:41769ms step_avg:46.20ms
+step:905/1490 train_time:41828ms step_avg:46.22ms
+step:906/1490 train_time:41893ms step_avg:46.24ms
+step:907/1490 train_time:41951ms step_avg:46.25ms
+step:908/1490 train_time:42016ms step_avg:46.27ms
+step:909/1490 train_time:42075ms step_avg:46.29ms
+step:910/1490 train_time:42140ms step_avg:46.31ms
+step:911/1490 train_time:42200ms step_avg:46.32ms
+step:912/1490 train_time:42267ms step_avg:46.35ms
+step:913/1490 train_time:42327ms step_avg:46.36ms
+step:914/1490 train_time:42392ms step_avg:46.38ms
+step:915/1490 train_time:42450ms step_avg:46.39ms
+step:916/1490 train_time:42514ms step_avg:46.41ms
+step:917/1490 train_time:42572ms step_avg:46.43ms
+step:918/1490 train_time:42637ms step_avg:46.45ms
+step:919/1490 train_time:42696ms step_avg:46.46ms
+step:920/1490 train_time:42760ms step_avg:46.48ms
+step:921/1490 train_time:42819ms step_avg:46.49ms
+step:922/1490 train_time:42883ms step_avg:46.51ms
+step:923/1490 train_time:42940ms step_avg:46.52ms
+step:924/1490 train_time:43004ms step_avg:46.54ms
+step:925/1490 train_time:43061ms step_avg:46.55ms
+step:926/1490 train_time:43125ms step_avg:46.57ms
+step:927/1490 train_time:43183ms step_avg:46.58ms
+step:928/1490 train_time:43246ms step_avg:46.60ms
+step:929/1490 train_time:43303ms step_avg:46.61ms
+step:930/1490 train_time:43367ms step_avg:46.63ms
+step:931/1490 train_time:43424ms step_avg:46.64ms
+step:932/1490 train_time:43488ms step_avg:46.66ms
+step:933/1490 train_time:43547ms step_avg:46.67ms
+step:934/1490 train_time:43612ms step_avg:46.69ms
+step:935/1490 train_time:43671ms step_avg:46.71ms
+step:936/1490 train_time:43737ms step_avg:46.73ms
+step:937/1490 train_time:43797ms step_avg:46.74ms
+step:938/1490 train_time:43861ms step_avg:46.76ms
+step:939/1490 train_time:43919ms step_avg:46.77ms
+step:940/1490 train_time:43982ms step_avg:46.79ms
+step:941/1490 train_time:44041ms step_avg:46.80ms
+step:942/1490 train_time:44104ms step_avg:46.82ms
+step:943/1490 train_time:44161ms step_avg:46.83ms
+step:944/1490 train_time:44226ms step_avg:46.85ms
+step:945/1490 train_time:44283ms step_avg:46.86ms
+step:946/1490 train_time:44346ms step_avg:46.88ms
+step:947/1490 train_time:44403ms step_avg:46.89ms
+step:948/1490 train_time:44466ms step_avg:46.91ms
+step:949/1490 train_time:44525ms step_avg:46.92ms
+step:950/1490 train_time:44589ms step_avg:46.94ms
+step:951/1490 train_time:44647ms step_avg:46.95ms
+step:952/1490 train_time:44712ms step_avg:46.97ms
+step:953/1490 train_time:44769ms step_avg:46.98ms
+step:954/1490 train_time:44835ms step_avg:47.00ms
+step:955/1490 train_time:44894ms step_avg:47.01ms
+step:956/1490 train_time:44959ms step_avg:47.03ms
+step:957/1490 train_time:45019ms step_avg:47.04ms
+step:958/1490 train_time:45084ms step_avg:47.06ms
+step:959/1490 train_time:45142ms step_avg:47.07ms
+step:960/1490 train_time:45207ms step_avg:47.09ms
+step:961/1490 train_time:45265ms step_avg:47.10ms
+step:962/1490 train_time:45329ms step_avg:47.12ms
+step:963/1490 train_time:45387ms step_avg:47.13ms
+step:964/1490 train_time:45451ms step_avg:47.15ms
+step:965/1490 train_time:45509ms step_avg:47.16ms
+step:966/1490 train_time:45573ms step_avg:47.18ms
+step:967/1490 train_time:45634ms step_avg:47.19ms
+step:968/1490 train_time:45704ms step_avg:47.21ms
+step:969/1490 train_time:45787ms step_avg:47.25ms
+step:970/1490 train_time:45881ms step_avg:47.30ms
+step:971/1490 train_time:45970ms step_avg:47.34ms
+step:972/1490 train_time:46062ms step_avg:47.39ms
+step:973/1490 train_time:46148ms step_avg:47.43ms
+step:974/1490 train_time:46239ms step_avg:47.47ms
+step:975/1490 train_time:46327ms step_avg:47.51ms
+step:976/1490 train_time:46417ms step_avg:47.56ms
+step:977/1490 train_time:46501ms step_avg:47.60ms
+step:978/1490 train_time:46592ms step_avg:47.64ms
+step:979/1490 train_time:46675ms step_avg:47.68ms
+step:980/1490 train_time:46767ms step_avg:47.72ms
+step:981/1490 train_time:46852ms step_avg:47.76ms
+step:982/1490 train_time:46944ms step_avg:47.80ms
+step:983/1490 train_time:47029ms step_avg:47.84ms
+step:984/1490 train_time:47120ms step_avg:47.89ms
+step:985/1490 train_time:47207ms step_avg:47.93ms
+step:986/1490 train_time:47297ms step_avg:47.97ms
+step:987/1490 train_time:47381ms step_avg:48.01ms
+step:988/1490 train_time:47475ms step_avg:48.05ms
+step:989/1490 train_time:47563ms step_avg:48.09ms
+step:990/1490 train_time:47657ms step_avg:48.14ms
+step:991/1490 train_time:47745ms step_avg:48.18ms
+step:992/1490 train_time:47840ms step_avg:48.23ms
+step:993/1490 train_time:47931ms step_avg:48.27ms
+step:994/1490 train_time:48024ms step_avg:48.31ms
+step:995/1490 train_time:48113ms step_avg:48.35ms
+step:996/1490 train_time:48207ms step_avg:48.40ms
+step:997/1490 train_time:48294ms step_avg:48.44ms
+step:998/1490 train_time:48389ms step_avg:48.49ms
+step:999/1490 train_time:48476ms step_avg:48.52ms
+step:1000/1490 train_time:48571ms step_avg:48.57ms
+step:1000/1490 val_loss:3.5133 train_time:48690ms step_avg:48.69ms
+step:1001/1490 train_time:48711ms step_avg:48.66ms
+step:1002/1490 train_time:48753ms step_avg:48.66ms
+step:1003/1490 train_time:48843ms step_avg:48.70ms
+step:1004/1490 train_time:48936ms step_avg:48.74ms
+step:1005/1490 train_time:49024ms step_avg:48.78ms
+step:1006/1490 train_time:49114ms step_avg:48.82ms
+step:1007/1490 train_time:49207ms step_avg:48.87ms
+step:1008/1490 train_time:49307ms step_avg:48.92ms
+step:1009/1490 train_time:49397ms step_avg:48.96ms
+step:1010/1490 train_time:49493ms step_avg:49.00ms
+step:1011/1490 train_time:49583ms step_avg:49.04ms
+step:1012/1490 train_time:49679ms step_avg:49.09ms
+step:1013/1490 train_time:49769ms step_avg:49.13ms
+step:1014/1490 train_time:49864ms step_avg:49.18ms
+step:1015/1490 train_time:49953ms step_avg:49.22ms
+step:1016/1490 train_time:50041ms step_avg:49.25ms
+step:1017/1490 train_time:50123ms step_avg:49.29ms
+step:1018/1490 train_time:50215ms step_avg:49.33ms
+step:1019/1490 train_time:50298ms step_avg:49.36ms
+step:1020/1490 train_time:50388ms step_avg:49.40ms
+step:1021/1490 train_time:50477ms step_avg:49.44ms
+step:1022/1490 train_time:50570ms step_avg:49.48ms
+step:1023/1490 train_time:50658ms step_avg:49.52ms
+step:1024/1490 train_time:50751ms step_avg:49.56ms
+step:1025/1490 train_time:50841ms step_avg:49.60ms
+step:1026/1490 train_time:50936ms step_avg:49.65ms
+step:1027/1490 train_time:51026ms step_avg:49.68ms
+step:1028/1490 train_time:51123ms step_avg:49.73ms
+step:1029/1490 train_time:51211ms step_avg:49.77ms
+step:1030/1490 train_time:51308ms step_avg:49.81ms
+step:1031/1490 train_time:51398ms step_avg:49.85ms
+step:1032/1490 train_time:51494ms step_avg:49.90ms
+step:1033/1490 train_time:51582ms step_avg:49.93ms
+step:1034/1490 train_time:51677ms step_avg:49.98ms
+step:1035/1490 train_time:51766ms step_avg:50.02ms
+step:1036/1490 train_time:51861ms step_avg:50.06ms
+step:1037/1490 train_time:51948ms step_avg:50.09ms
+step:1038/1490 train_time:52044ms step_avg:50.14ms
+step:1039/1490 train_time:52130ms step_avg:50.17ms
+step:1040/1490 train_time:52225ms step_avg:50.22ms
+step:1041/1490 train_time:52312ms step_avg:50.25ms
+step:1042/1490 train_time:52408ms step_avg:50.30ms
+step:1043/1490 train_time:52490ms step_avg:50.33ms
+step:1044/1490 train_time:52578ms step_avg:50.36ms
+step:1045/1490 train_time:52662ms step_avg:50.39ms
+step:1046/1490 train_time:52758ms step_avg:50.44ms
+step:1047/1490 train_time:52853ms step_avg:50.48ms
+step:1048/1490 train_time:52946ms step_avg:50.52ms
+step:1049/1490 train_time:53033ms step_avg:50.56ms
+step:1050/1490 train_time:53128ms step_avg:50.60ms
+step:1051/1490 train_time:53215ms step_avg:50.63ms
+step:1052/1490 train_time:53309ms step_avg:50.67ms
+step:1053/1490 train_time:53401ms step_avg:50.71ms
+step:1054/1490 train_time:53496ms step_avg:50.76ms
+step:1055/1490 train_time:53585ms step_avg:50.79ms
+step:1056/1490 train_time:53681ms step_avg:50.83ms
+step:1057/1490 train_time:53769ms step_avg:50.87ms
+step:1058/1490 train_time:53865ms step_avg:50.91ms
+step:1059/1490 train_time:53955ms step_avg:50.95ms
+step:1060/1490 train_time:54049ms step_avg:50.99ms
+step:1061/1490 train_time:54131ms step_avg:51.02ms
+step:1062/1490 train_time:54221ms step_avg:51.06ms
+step:1063/1490 train_time:54308ms step_avg:51.09ms
+step:1064/1490 train_time:54407ms step_avg:51.13ms
+step:1065/1490 train_time:54502ms step_avg:51.18ms
+step:1066/1490 train_time:54596ms step_avg:51.22ms
+step:1067/1490 train_time:54682ms step_avg:51.25ms
+step:1068/1490 train_time:54777ms step_avg:51.29ms
+step:1069/1490 train_time:54863ms step_avg:51.32ms
+step:1070/1490 train_time:54954ms step_avg:51.36ms
+step:1071/1490 train_time:55040ms step_avg:51.39ms
+step:1072/1490 train_time:55132ms step_avg:51.43ms
+step:1073/1490 train_time:55218ms step_avg:51.46ms
+step:1074/1490 train_time:55310ms step_avg:51.50ms
+step:1075/1490 train_time:55394ms step_avg:51.53ms
+step:1076/1490 train_time:55483ms step_avg:51.56ms
+step:1077/1490 train_time:55568ms step_avg:51.60ms
+step:1078/1490 train_time:55661ms step_avg:51.63ms
+step:1079/1490 train_time:55746ms step_avg:51.66ms
+step:1080/1490 train_time:55838ms step_avg:51.70ms
+step:1081/1490 train_time:55923ms step_avg:51.73ms
+step:1082/1490 train_time:56012ms step_avg:51.77ms
+step:1083/1490 train_time:56098ms step_avg:51.80ms
+step:1084/1490 train_time:56193ms step_avg:51.84ms
+step:1085/1490 train_time:56281ms step_avg:51.87ms
+step:1086/1490 train_time:56372ms step_avg:51.91ms
+step:1087/1490 train_time:56459ms step_avg:51.94ms
+step:1088/1490 train_time:56551ms step_avg:51.98ms
+step:1089/1490 train_time:56637ms step_avg:52.01ms
+step:1090/1490 train_time:56728ms step_avg:52.04ms
+step:1091/1490 train_time:56814ms step_avg:52.07ms
+step:1092/1490 train_time:56905ms step_avg:52.11ms
+step:1093/1490 train_time:56990ms step_avg:52.14ms
+step:1094/1490 train_time:57081ms step_avg:52.18ms
+step:1095/1490 train_time:57165ms step_avg:52.21ms
+step:1096/1490 train_time:57259ms step_avg:52.24ms
+step:1097/1490 train_time:57346ms step_avg:52.27ms
+step:1098/1490 train_time:57440ms step_avg:52.31ms
+step:1099/1490 train_time:57524ms step_avg:52.34ms
+step:1100/1490 train_time:57617ms step_avg:52.38ms
+step:1101/1490 train_time:57704ms step_avg:52.41ms
+step:1102/1490 train_time:57799ms step_avg:52.45ms
+step:1103/1490 train_time:57884ms step_avg:52.48ms
+step:1104/1490 train_time:57978ms step_avg:52.52ms
+step:1105/1490 train_time:58065ms step_avg:52.55ms
+step:1106/1490 train_time:58160ms step_avg:52.59ms
+step:1107/1490 train_time:58246ms step_avg:52.62ms
+step:1108/1490 train_time:58341ms step_avg:52.65ms
+step:1109/1490 train_time:58428ms step_avg:52.68ms
+step:1110/1490 train_time:58521ms step_avg:52.72ms
+step:1111/1490 train_time:58608ms step_avg:52.75ms
+step:1112/1490 train_time:58703ms step_avg:52.79ms
+step:1113/1490 train_time:58789ms step_avg:52.82ms
+step:1114/1490 train_time:58881ms step_avg:52.86ms
+step:1115/1490 train_time:58966ms step_avg:52.88ms
+step:1116/1490 train_time:59059ms step_avg:52.92ms
+step:1117/1490 train_time:59145ms step_avg:52.95ms
+step:1118/1490 train_time:59242ms step_avg:52.99ms
+step:1119/1490 train_time:59330ms step_avg:53.02ms
+step:1120/1490 train_time:59426ms step_avg:53.06ms
+step:1121/1490 train_time:59514ms step_avg:53.09ms
+step:1122/1490 train_time:59609ms step_avg:53.13ms
+step:1123/1490 train_time:59697ms step_avg:53.16ms
+step:1124/1490 train_time:59791ms step_avg:53.19ms
+step:1125/1490 train_time:59880ms step_avg:53.23ms
+step:1126/1490 train_time:59974ms step_avg:53.26ms
+step:1127/1490 train_time:60062ms step_avg:53.29ms
+step:1128/1490 train_time:60156ms step_avg:53.33ms
+step:1129/1490 train_time:60244ms step_avg:53.36ms
+step:1130/1490 train_time:60338ms step_avg:53.40ms
+step:1131/1490 train_time:60425ms step_avg:53.43ms
+step:1132/1490 train_time:60520ms step_avg:53.46ms
+step:1133/1490 train_time:60607ms step_avg:53.49ms
+step:1134/1490 train_time:60702ms step_avg:53.53ms
+step:1135/1490 train_time:60786ms step_avg:53.56ms
+step:1136/1490 train_time:60881ms step_avg:53.59ms
+step:1137/1490 train_time:60966ms step_avg:53.62ms
+step:1138/1490 train_time:61060ms step_avg:53.66ms
+step:1139/1490 train_time:61146ms step_avg:53.68ms
+step:1140/1490 train_time:61239ms step_avg:53.72ms
+step:1141/1490 train_time:61325ms step_avg:53.75ms
+step:1142/1490 train_time:61420ms step_avg:53.78ms
+step:1143/1490 train_time:61505ms step_avg:53.81ms
+step:1144/1490 train_time:61599ms step_avg:53.85ms
+step:1145/1490 train_time:61682ms step_avg:53.87ms
+step:1146/1490 train_time:61774ms step_avg:53.90ms
+step:1147/1490 train_time:61858ms step_avg:53.93ms
+step:1148/1490 train_time:61949ms step_avg:53.96ms
+step:1149/1490 train_time:62033ms step_avg:53.99ms
+step:1150/1490 train_time:62124ms step_avg:54.02ms
+step:1151/1490 train_time:62207ms step_avg:54.05ms
+step:1152/1490 train_time:62299ms step_avg:54.08ms
+step:1153/1490 train_time:62382ms step_avg:54.10ms
+step:1154/1490 train_time:62474ms step_avg:54.14ms
+step:1155/1490 train_time:62559ms step_avg:54.16ms
+step:1156/1490 train_time:62651ms step_avg:54.20ms
+step:1157/1490 train_time:62739ms step_avg:54.23ms
+step:1158/1490 train_time:62829ms step_avg:54.26ms
+step:1159/1490 train_time:62918ms step_avg:54.29ms
+step:1160/1490 train_time:63014ms step_avg:54.32ms
+step:1161/1490 train_time:63106ms step_avg:54.35ms
+step:1162/1490 train_time:63202ms step_avg:54.39ms
+step:1163/1490 train_time:63289ms step_avg:54.42ms
+step:1164/1490 train_time:63384ms step_avg:54.45ms
+step:1165/1490 train_time:63472ms step_avg:54.48ms
+step:1166/1490 train_time:63569ms step_avg:54.52ms
+step:1167/1490 train_time:63657ms step_avg:54.55ms
+step:1168/1490 train_time:63753ms step_avg:54.58ms
+step:1169/1490 train_time:63842ms step_avg:54.61ms
+step:1170/1490 train_time:63937ms step_avg:54.65ms
+step:1171/1490 train_time:64025ms step_avg:54.68ms
+step:1172/1490 train_time:64120ms step_avg:54.71ms
+step:1173/1490 train_time:64208ms step_avg:54.74ms
+step:1174/1490 train_time:64303ms step_avg:54.77ms
+step:1175/1490 train_time:64390ms step_avg:54.80ms
+step:1176/1490 train_time:64484ms step_avg:54.83ms
+step:1177/1490 train_time:64570ms step_avg:54.86ms
+step:1178/1490 train_time:64664ms step_avg:54.89ms
+step:1179/1490 train_time:64751ms step_avg:54.92ms
+step:1180/1490 train_time:64844ms step_avg:54.95ms
+step:1181/1490 train_time:64930ms step_avg:54.98ms
+step:1182/1490 train_time:65024ms step_avg:55.01ms
+step:1183/1490 train_time:65109ms step_avg:55.04ms
+step:1184/1490 train_time:65203ms step_avg:55.07ms
+step:1185/1490 train_time:65288ms step_avg:55.10ms
+step:1186/1490 train_time:65383ms step_avg:55.13ms
+step:1187/1490 train_time:65468ms step_avg:55.15ms
+step:1188/1490 train_time:65562ms step_avg:55.19ms
+step:1189/1490 train_time:65648ms step_avg:55.21ms
+step:1190/1490 train_time:65742ms step_avg:55.25ms
+step:1191/1490 train_time:65827ms step_avg:55.27ms
+step:1192/1490 train_time:65922ms step_avg:55.30ms
+step:1193/1490 train_time:66008ms step_avg:55.33ms
+step:1194/1490 train_time:66102ms step_avg:55.36ms
+step:1195/1490 train_time:66187ms step_avg:55.39ms
+step:1196/1490 train_time:66280ms step_avg:55.42ms
+step:1197/1490 train_time:66366ms step_avg:55.44ms
+step:1198/1490 train_time:66461ms step_avg:55.48ms
+step:1199/1490 train_time:66545ms step_avg:55.50ms
+step:1200/1490 train_time:66640ms step_avg:55.53ms
+step:1201/1490 train_time:66725ms step_avg:55.56ms
+step:1202/1490 train_time:66819ms step_avg:55.59ms
+step:1203/1490 train_time:66906ms step_avg:55.62ms
+step:1204/1490 train_time:66999ms step_avg:55.65ms
+step:1205/1490 train_time:67087ms step_avg:55.67ms
+step:1206/1490 train_time:67183ms step_avg:55.71ms
+step:1207/1490 train_time:67270ms step_avg:55.73ms
+step:1208/1490 train_time:67365ms step_avg:55.77ms
+step:1209/1490 train_time:67452ms step_avg:55.79ms
+step:1210/1490 train_time:67547ms step_avg:55.82ms
+step:1211/1490 train_time:67634ms step_avg:55.85ms
+step:1212/1490 train_time:67729ms step_avg:55.88ms
+step:1213/1490 train_time:67819ms step_avg:55.91ms
+step:1214/1490 train_time:67912ms step_avg:55.94ms
+step:1215/1490 train_time:68000ms step_avg:55.97ms
+step:1216/1490 train_time:68094ms step_avg:56.00ms
+step:1217/1490 train_time:68181ms step_avg:56.02ms
+step:1218/1490 train_time:68274ms step_avg:56.05ms
+step:1219/1490 train_time:68362ms step_avg:56.08ms
+step:1220/1490 train_time:68456ms step_avg:56.11ms
+step:1221/1490 train_time:68542ms step_avg:56.14ms
+step:1222/1490 train_time:68635ms step_avg:56.17ms
+step:1223/1490 train_time:68723ms step_avg:56.19ms
+step:1224/1490 train_time:68816ms step_avg:56.22ms
+step:1225/1490 train_time:68902ms step_avg:56.25ms
+step:1226/1490 train_time:68994ms step_avg:56.28ms
+step:1227/1490 train_time:69080ms step_avg:56.30ms
+step:1228/1490 train_time:69171ms step_avg:56.33ms
+step:1229/1490 train_time:69258ms step_avg:56.35ms
+step:1230/1490 train_time:69348ms step_avg:56.38ms
+step:1231/1490 train_time:69436ms step_avg:56.41ms
+step:1232/1490 train_time:69525ms step_avg:56.43ms
+step:1233/1490 train_time:69609ms step_avg:56.46ms
+step:1234/1490 train_time:69698ms step_avg:56.48ms
+step:1235/1490 train_time:69780ms step_avg:56.50ms
+step:1236/1490 train_time:69872ms step_avg:56.53ms
+step:1237/1490 train_time:69960ms step_avg:56.56ms
+step:1238/1490 train_time:70050ms step_avg:56.58ms
+step:1239/1490 train_time:70136ms step_avg:56.61ms
+step:1240/1490 train_time:70229ms step_avg:56.64ms
+step:1241/1490 train_time:70316ms step_avg:56.66ms
+step:1242/1490 train_time:70407ms step_avg:56.69ms
+step:1243/1490 train_time:70495ms step_avg:56.71ms
+step:1244/1490 train_time:70590ms step_avg:56.74ms
+step:1245/1490 train_time:70681ms step_avg:56.77ms
+step:1246/1490 train_time:70776ms step_avg:56.80ms
+step:1247/1490 train_time:70865ms step_avg:56.83ms
+step:1248/1490 train_time:70961ms step_avg:56.86ms
+step:1249/1490 train_time:71049ms step_avg:56.89ms
+step:1250/1490 train_time:71145ms step_avg:56.92ms
+step:1250/1490 val_loss:3.3701 train_time:71267ms step_avg:57.01ms
+step:1251/1490 train_time:71288ms step_avg:56.98ms
+step:1252/1490 train_time:71330ms step_avg:56.97ms
+step:1253/1490 train_time:71423ms step_avg:57.00ms
+step:1254/1490 train_time:71520ms step_avg:57.03ms
+step:1255/1490 train_time:71607ms step_avg:57.06ms
+step:1256/1490 train_time:71700ms step_avg:57.09ms
+step:1257/1490 train_time:71786ms step_avg:57.11ms
+step:1258/1490 train_time:71881ms step_avg:57.14ms
+step:1259/1490 train_time:71967ms step_avg:57.16ms
+step:1260/1490 train_time:72060ms step_avg:57.19ms
+step:1261/1490 train_time:72145ms step_avg:57.21ms
+step:1262/1490 train_time:72238ms step_avg:57.24ms
+step:1263/1490 train_time:72323ms step_avg:57.26ms
+step:1264/1490 train_time:72417ms step_avg:57.29ms
+step:1265/1490 train_time:72503ms step_avg:57.31ms
+step:1266/1490 train_time:72593ms step_avg:57.34ms
+step:1267/1490 train_time:72677ms step_avg:57.36ms
+step:1268/1490 train_time:72765ms step_avg:57.39ms
+step:1269/1490 train_time:72852ms step_avg:57.41ms
+step:1270/1490 train_time:72945ms step_avg:57.44ms
+step:1271/1490 train_time:73034ms step_avg:57.46ms
+step:1272/1490 train_time:73128ms step_avg:57.49ms
+step:1273/1490 train_time:73214ms step_avg:57.51ms
+step:1274/1490 train_time:73308ms step_avg:57.54ms
+step:1275/1490 train_time:73395ms step_avg:57.56ms
+step:1276/1490 train_time:73489ms step_avg:57.59ms
+step:1277/1490 train_time:73576ms step_avg:57.62ms
+step:1278/1490 train_time:73668ms step_avg:57.64ms
+step:1279/1490 train_time:73756ms step_avg:57.67ms
+step:1280/1490 train_time:73849ms step_avg:57.69ms
+step:1281/1490 train_time:73936ms step_avg:57.72ms
+step:1282/1490 train_time:74030ms step_avg:57.75ms
+step:1283/1490 train_time:74118ms step_avg:57.77ms
+step:1284/1490 train_time:74210ms step_avg:57.80ms
+step:1285/1490 train_time:74298ms step_avg:57.82ms
+step:1286/1490 train_time:74390ms step_avg:57.85ms
+step:1287/1490 train_time:74478ms step_avg:57.87ms
+step:1288/1490 train_time:74571ms step_avg:57.90ms
+step:1289/1490 train_time:74659ms step_avg:57.92ms
+step:1290/1490 train_time:74750ms step_avg:57.95ms
+step:1291/1490 train_time:74838ms step_avg:57.97ms
+step:1292/1490 train_time:74930ms step_avg:58.00ms
+step:1293/1490 train_time:75018ms step_avg:58.02ms
+step:1294/1490 train_time:75111ms step_avg:58.05ms
+step:1295/1490 train_time:75198ms step_avg:58.07ms
+step:1296/1490 train_time:75290ms step_avg:58.09ms
+step:1297/1490 train_time:75377ms step_avg:58.12ms
+step:1298/1490 train_time:75470ms step_avg:58.14ms
+step:1299/1490 train_time:75558ms step_avg:58.17ms
+step:1300/1490 train_time:75650ms step_avg:58.19ms
+step:1301/1490 train_time:75737ms step_avg:58.21ms
+step:1302/1490 train_time:75828ms step_avg:58.24ms
+step:1303/1490 train_time:75914ms step_avg:58.26ms
+step:1304/1490 train_time:76006ms step_avg:58.29ms
+step:1305/1490 train_time:76092ms step_avg:58.31ms
+step:1306/1490 train_time:76185ms step_avg:58.33ms
+step:1307/1490 train_time:76271ms step_avg:58.36ms
+step:1308/1490 train_time:76362ms step_avg:58.38ms
+step:1309/1490 train_time:76447ms step_avg:58.40ms
+step:1310/1490 train_time:76539ms step_avg:58.43ms
+step:1311/1490 train_time:76624ms step_avg:58.45ms
+step:1312/1490 train_time:76716ms step_avg:58.47ms
+step:1313/1490 train_time:76801ms step_avg:58.49ms
+step:1314/1490 train_time:76890ms step_avg:58.52ms
+step:1315/1490 train_time:76978ms step_avg:58.54ms
+step:1316/1490 train_time:77072ms step_avg:58.57ms
+step:1317/1490 train_time:77161ms step_avg:58.59ms
+step:1318/1490 train_time:77255ms step_avg:58.62ms
+step:1319/1490 train_time:77344ms step_avg:58.64ms
+step:1320/1490 train_time:77440ms step_avg:58.67ms
+step:1321/1490 train_time:77528ms step_avg:58.69ms
+step:1322/1490 train_time:77625ms step_avg:58.72ms
+step:1323/1490 train_time:77713ms step_avg:58.74ms
+step:1324/1490 train_time:77808ms step_avg:58.77ms
+step:1325/1490 train_time:77897ms step_avg:58.79ms
+step:1326/1490 train_time:77991ms step_avg:58.82ms
+step:1327/1490 train_time:78073ms step_avg:58.83ms
+step:1328/1490 train_time:78163ms step_avg:58.86ms
+step:1329/1490 train_time:78252ms step_avg:58.88ms
+step:1330/1490 train_time:78343ms step_avg:58.90ms
+step:1331/1490 train_time:78432ms step_avg:58.93ms
+step:1332/1490 train_time:78525ms step_avg:58.95ms
+step:1333/1490 train_time:78612ms step_avg:58.97ms
+step:1334/1490 train_time:78703ms step_avg:59.00ms
+step:1335/1490 train_time:78790ms step_avg:59.02ms
+step:1336/1490 train_time:78885ms step_avg:59.05ms
+step:1337/1490 train_time:78974ms step_avg:59.07ms
+step:1338/1490 train_time:79068ms step_avg:59.09ms
+step:1339/1490 train_time:79155ms step_avg:59.12ms
+step:1340/1490 train_time:79247ms step_avg:59.14ms
+step:1341/1490 train_time:79336ms step_avg:59.16ms
+step:1342/1490 train_time:79429ms step_avg:59.19ms
+step:1343/1490 train_time:79518ms step_avg:59.21ms
+step:1344/1490 train_time:79612ms step_avg:59.23ms
+step:1345/1490 train_time:79699ms step_avg:59.26ms
+step:1346/1490 train_time:79794ms step_avg:59.28ms
+step:1347/1490 train_time:79882ms step_avg:59.30ms
+step:1348/1490 train_time:79976ms step_avg:59.33ms
+step:1349/1490 train_time:80063ms step_avg:59.35ms
+step:1350/1490 train_time:80159ms step_avg:59.38ms
+step:1351/1490 train_time:80245ms step_avg:59.40ms
+step:1352/1490 train_time:80339ms step_avg:59.42ms
+step:1353/1490 train_time:80425ms step_avg:59.44ms
+step:1354/1490 train_time:80519ms step_avg:59.47ms
+step:1355/1490 train_time:80605ms step_avg:59.49ms
+step:1356/1490 train_time:80700ms step_avg:59.51ms
+step:1357/1490 train_time:80785ms step_avg:59.53ms
+step:1358/1490 train_time:80879ms step_avg:59.56ms
+step:1359/1490 train_time:80966ms step_avg:59.58ms
+step:1360/1490 train_time:81060ms step_avg:59.60ms
+step:1361/1490 train_time:81146ms step_avg:59.62ms
+step:1362/1490 train_time:81240ms step_avg:59.65ms
+step:1363/1490 train_time:81326ms step_avg:59.67ms
+step:1364/1490 train_time:81420ms step_avg:59.69ms
+step:1365/1490 train_time:81506ms step_avg:59.71ms
+step:1366/1490 train_time:81600ms step_avg:59.74ms
+step:1367/1490 train_time:81686ms step_avg:59.76ms
+step:1368/1490 train_time:81781ms step_avg:59.78ms
+step:1369/1490 train_time:81867ms step_avg:59.80ms
+step:1370/1490 train_time:81961ms step_avg:59.83ms
+step:1371/1490 train_time:82047ms step_avg:59.84ms
+step:1372/1490 train_time:82141ms step_avg:59.87ms
+step:1373/1490 train_time:82227ms step_avg:59.89ms
+step:1374/1490 train_time:82320ms step_avg:59.91ms
+step:1375/1490 train_time:82406ms step_avg:59.93ms
+step:1376/1490 train_time:82500ms step_avg:59.96ms
+step:1377/1490 train_time:82583ms step_avg:59.97ms
+step:1378/1490 train_time:82678ms step_avg:60.00ms
+step:1379/1490 train_time:82766ms step_avg:60.02ms
+step:1380/1490 train_time:82862ms step_avg:60.04ms
+step:1381/1490 train_time:82950ms step_avg:60.07ms
+step:1382/1490 train_time:83043ms step_avg:60.09ms
+step:1383/1490 train_time:83132ms step_avg:60.11ms
+step:1384/1490 train_time:83224ms step_avg:60.13ms
+step:1385/1490 train_time:83314ms step_avg:60.15ms
+step:1386/1490 train_time:83411ms step_avg:60.18ms
+step:1387/1490 train_time:83500ms step_avg:60.20ms
+step:1388/1490 train_time:83594ms step_avg:60.23ms
+step:1389/1490 train_time:83682ms step_avg:60.25ms
+step:1390/1490 train_time:83777ms step_avg:60.27ms
+step:1391/1490 train_time:83865ms step_avg:60.29ms
+step:1392/1490 train_time:83960ms step_avg:60.32ms
+step:1393/1490 train_time:84048ms step_avg:60.34ms
+step:1394/1490 train_time:84142ms step_avg:60.36ms
+step:1395/1490 train_time:84229ms step_avg:60.38ms
+step:1396/1490 train_time:84324ms step_avg:60.40ms
+step:1397/1490 train_time:84411ms step_avg:60.42ms
+step:1398/1490 train_time:84505ms step_avg:60.45ms
+step:1399/1490 train_time:84593ms step_avg:60.47ms
+step:1400/1490 train_time:84687ms step_avg:60.49ms
+step:1401/1490 train_time:84776ms step_avg:60.51ms
+step:1402/1490 train_time:84870ms step_avg:60.53ms
+step:1403/1490 train_time:84958ms step_avg:60.55ms
+step:1404/1490 train_time:85052ms step_avg:60.58ms
+step:1405/1490 train_time:85139ms step_avg:60.60ms
+step:1406/1490 train_time:85231ms step_avg:60.62ms
+step:1407/1490 train_time:85320ms step_avg:60.64ms
+step:1408/1490 train_time:85412ms step_avg:60.66ms
+step:1409/1490 train_time:85500ms step_avg:60.68ms
+step:1410/1490 train_time:85594ms step_avg:60.70ms
+step:1411/1490 train_time:85681ms step_avg:60.72ms
+step:1412/1490 train_time:85776ms step_avg:60.75ms
+step:1413/1490 train_time:85857ms step_avg:60.76ms
+step:1414/1490 train_time:85946ms step_avg:60.78ms
+step:1415/1490 train_time:86038ms step_avg:60.80ms
+step:1416/1490 train_time:86133ms step_avg:60.83ms
+step:1417/1490 train_time:86219ms step_avg:60.85ms
+step:1418/1490 train_time:86310ms step_avg:60.87ms
+step:1419/1490 train_time:86397ms step_avg:60.89ms
+step:1420/1490 train_time:86488ms step_avg:60.91ms
+step:1421/1490 train_time:86573ms step_avg:60.92ms
+step:1422/1490 train_time:86667ms step_avg:60.95ms
+step:1423/1490 train_time:86756ms step_avg:60.97ms
+step:1424/1490 train_time:86851ms step_avg:60.99ms
+step:1425/1490 train_time:86939ms step_avg:61.01ms
+step:1426/1490 train_time:87035ms step_avg:61.03ms
+step:1427/1490 train_time:87122ms step_avg:61.05ms
+step:1428/1490 train_time:87218ms step_avg:61.08ms
+step:1429/1490 train_time:87304ms step_avg:61.09ms
+step:1430/1490 train_time:87400ms step_avg:61.12ms
+step:1431/1490 train_time:87487ms step_avg:61.14ms
+step:1432/1490 train_time:87581ms step_avg:61.16ms
+step:1433/1490 train_time:87669ms step_avg:61.18ms
+step:1434/1490 train_time:87764ms step_avg:61.20ms
+step:1435/1490 train_time:87851ms step_avg:61.22ms
+step:1436/1490 train_time:87944ms step_avg:61.24ms
+step:1437/1490 train_time:88030ms step_avg:61.26ms
+step:1438/1490 train_time:88124ms step_avg:61.28ms
+step:1439/1490 train_time:88211ms step_avg:61.30ms
+step:1440/1490 train_time:88304ms step_avg:61.32ms
+step:1441/1490 train_time:88391ms step_avg:61.34ms
+step:1442/1490 train_time:88486ms step_avg:61.36ms
+step:1443/1490 train_time:88573ms step_avg:61.38ms
+step:1444/1490 train_time:88667ms step_avg:61.40ms
+step:1445/1490 train_time:88754ms step_avg:61.42ms
+step:1446/1490 train_time:88847ms step_avg:61.44ms
+step:1447/1490 train_time:88934ms step_avg:61.46ms
+step:1448/1490 train_time:89027ms step_avg:61.48ms
+step:1449/1490 train_time:89113ms step_avg:61.50ms
+step:1450/1490 train_time:89205ms step_avg:61.52ms
+step:1451/1490 train_time:89295ms step_avg:61.54ms
+step:1452/1490 train_time:89391ms step_avg:61.56ms
+step:1453/1490 train_time:89478ms step_avg:61.58ms
+step:1454/1490 train_time:89572ms step_avg:61.60ms
+step:1455/1490 train_time:89660ms step_avg:61.62ms
+step:1456/1490 train_time:89751ms step_avg:61.64ms
+step:1457/1490 train_time:89839ms step_avg:61.66ms
+step:1458/1490 train_time:89933ms step_avg:61.68ms
+step:1459/1490 train_time:90019ms step_avg:61.70ms
+step:1460/1490 train_time:90113ms step_avg:61.72ms
+step:1461/1490 train_time:90200ms step_avg:61.74ms
+step:1462/1490 train_time:90293ms step_avg:61.76ms
+step:1463/1490 train_time:90380ms step_avg:61.78ms
+step:1464/1490 train_time:90473ms step_avg:61.80ms
+step:1465/1490 train_time:90561ms step_avg:61.82ms
+step:1466/1490 train_time:90653ms step_avg:61.84ms
+step:1467/1490 train_time:90739ms step_avg:61.85ms
+step:1468/1490 train_time:90829ms step_avg:61.87ms
+step:1469/1490 train_time:90914ms step_avg:61.89ms
+step:1470/1490 train_time:91004ms step_avg:61.91ms
+step:1471/1490 train_time:91090ms step_avg:61.92ms
+step:1472/1490 train_time:91185ms step_avg:61.95ms
+step:1473/1490 train_time:91275ms step_avg:61.97ms
+step:1474/1490 train_time:91369ms step_avg:61.99ms
+step:1475/1490 train_time:91457ms step_avg:62.00ms
+step:1476/1490 train_time:91553ms step_avg:62.03ms
+step:1477/1490 train_time:91641ms step_avg:62.05ms
+step:1478/1490 train_time:91736ms step_avg:62.07ms
+step:1479/1490 train_time:91823ms step_avg:62.08ms
+step:1480/1490 train_time:91918ms step_avg:62.11ms
+step:1481/1490 train_time:92004ms step_avg:62.12ms
+step:1482/1490 train_time:92099ms step_avg:62.15ms
+step:1483/1490 train_time:92185ms step_avg:62.16ms
+step:1484/1490 train_time:92277ms step_avg:62.18ms
+step:1485/1490 train_time:92362ms step_avg:62.20ms
+step:1486/1490 train_time:92453ms step_avg:62.22ms
+step:1487/1490 train_time:92537ms step_avg:62.23ms
+step:1488/1490 train_time:92627ms step_avg:62.25ms
+step:1489/1490 train_time:92715ms step_avg:62.27ms
+step:1490/1490 train_time:92808ms step_avg:62.29ms
+step:1490/1490 val_loss:3.2777 train_time:92928ms step_avg:62.37ms
+peak memory allocated: 31296 MiB reserved: 47202 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline1-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline1-1480.txt
@@ -1,0 +1,4447 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:14:27 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   39C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   38C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   35C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   39C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   36C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   66C    P0            151W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          288394      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          288395      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          288396      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          288397      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          288398      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          288399      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          288400      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          288401      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8295 train_time:0ms step_avg:0.04ms
+step:1/1480 train_time:87ms step_avg:86.79ms
+step:2/1480 train_time:110ms step_avg:55.09ms
+step:3/1480 train_time:125ms step_avg:41.81ms
+step:4/1480 train_time:144ms step_avg:35.97ms
+step:5/1480 train_time:171ms step_avg:34.21ms
+step:6/1480 train_time:206ms step_avg:34.32ms
+step:7/1480 train_time:234ms step_avg:33.42ms
+step:8/1480 train_time:269ms step_avg:33.65ms
+step:9/1480 train_time:297ms step_avg:33.00ms
+step:10/1480 train_time:332ms step_avg:33.22ms
+step:11/1480 train_time:360ms step_avg:32.74ms
+step:12/1480 train_time:395ms step_avg:32.91ms
+step:13/1480 train_time:423ms step_avg:32.54ms
+step:14/1480 train_time:458ms step_avg:32.72ms
+step:15/1480 train_time:486ms step_avg:32.43ms
+step:16/1480 train_time:521ms step_avg:32.57ms
+step:17/1480 train_time:550ms step_avg:32.38ms
+step:18/1480 train_time:585ms step_avg:32.50ms
+step:19/1480 train_time:614ms step_avg:32.30ms
+step:20/1480 train_time:649ms step_avg:32.43ms
+step:21/1480 train_time:677ms step_avg:32.23ms
+step:22/1480 train_time:712ms step_avg:32.37ms
+step:23/1480 train_time:741ms step_avg:32.22ms
+step:24/1480 train_time:777ms step_avg:32.39ms
+step:25/1480 train_time:806ms step_avg:32.22ms
+step:26/1480 train_time:842ms step_avg:32.38ms
+step:27/1480 train_time:871ms step_avg:32.25ms
+step:28/1480 train_time:907ms step_avg:32.40ms
+step:29/1480 train_time:936ms step_avg:32.26ms
+step:30/1480 train_time:971ms step_avg:32.38ms
+step:31/1480 train_time:1000ms step_avg:32.26ms
+step:32/1480 train_time:1036ms step_avg:32.38ms
+step:33/1480 train_time:1065ms step_avg:32.26ms
+step:34/1480 train_time:1100ms step_avg:32.35ms
+step:35/1480 train_time:1128ms step_avg:32.24ms
+step:36/1480 train_time:1164ms step_avg:32.33ms
+step:37/1480 train_time:1192ms step_avg:32.23ms
+step:38/1480 train_time:1229ms step_avg:32.33ms
+step:39/1480 train_time:1259ms step_avg:32.28ms
+step:40/1480 train_time:1296ms step_avg:32.40ms
+step:41/1480 train_time:1326ms step_avg:32.34ms
+step:42/1480 train_time:1363ms step_avg:32.46ms
+step:43/1480 train_time:1394ms step_avg:32.43ms
+step:44/1480 train_time:1433ms step_avg:32.56ms
+step:45/1480 train_time:1461ms step_avg:32.47ms
+step:46/1480 train_time:1498ms step_avg:32.56ms
+step:47/1480 train_time:1528ms step_avg:32.51ms
+step:48/1480 train_time:1565ms step_avg:32.60ms
+step:49/1480 train_time:1595ms step_avg:32.55ms
+step:50/1480 train_time:1632ms step_avg:32.65ms
+step:51/1480 train_time:1662ms step_avg:32.59ms
+step:52/1480 train_time:1699ms step_avg:32.67ms
+step:53/1480 train_time:1729ms step_avg:32.62ms
+step:54/1480 train_time:1766ms step_avg:32.70ms
+step:55/1480 train_time:1795ms step_avg:32.64ms
+step:56/1480 train_time:1832ms step_avg:32.71ms
+step:57/1480 train_time:1860ms step_avg:32.63ms
+step:58/1480 train_time:1895ms step_avg:32.68ms
+step:59/1480 train_time:1923ms step_avg:32.59ms
+step:60/1480 train_time:1958ms step_avg:32.64ms
+step:61/1480 train_time:1987ms step_avg:32.57ms
+step:62/1480 train_time:2021ms step_avg:32.60ms
+step:63/1480 train_time:2051ms step_avg:32.55ms
+step:64/1480 train_time:2086ms step_avg:32.60ms
+step:65/1480 train_time:2116ms step_avg:32.56ms
+step:66/1480 train_time:2153ms step_avg:32.62ms
+step:67/1480 train_time:2182ms step_avg:32.56ms
+step:68/1480 train_time:2218ms step_avg:32.61ms
+step:69/1480 train_time:2248ms step_avg:32.58ms
+step:70/1480 train_time:2285ms step_avg:32.64ms
+step:71/1480 train_time:2316ms step_avg:32.62ms
+step:72/1480 train_time:2354ms step_avg:32.69ms
+step:73/1480 train_time:2384ms step_avg:32.66ms
+step:74/1480 train_time:2422ms step_avg:32.72ms
+step:75/1480 train_time:2453ms step_avg:32.70ms
+step:76/1480 train_time:2489ms step_avg:32.75ms
+step:77/1480 train_time:2519ms step_avg:32.72ms
+step:78/1480 train_time:2557ms step_avg:32.78ms
+step:79/1480 train_time:2587ms step_avg:32.75ms
+step:80/1480 train_time:2624ms step_avg:32.80ms
+step:81/1480 train_time:2655ms step_avg:32.77ms
+step:82/1480 train_time:2691ms step_avg:32.82ms
+step:83/1480 train_time:2721ms step_avg:32.78ms
+step:84/1480 train_time:2758ms step_avg:32.84ms
+step:85/1480 train_time:2788ms step_avg:32.80ms
+step:86/1480 train_time:2824ms step_avg:32.84ms
+step:87/1480 train_time:2854ms step_avg:32.81ms
+step:88/1480 train_time:2889ms step_avg:32.83ms
+step:89/1480 train_time:2917ms step_avg:32.78ms
+step:90/1480 train_time:2953ms step_avg:32.81ms
+step:91/1480 train_time:2980ms step_avg:32.75ms
+step:92/1480 train_time:3015ms step_avg:32.77ms
+step:93/1480 train_time:3043ms step_avg:32.73ms
+step:94/1480 train_time:3081ms step_avg:32.78ms
+step:95/1480 train_time:3113ms step_avg:32.76ms
+step:96/1480 train_time:3150ms step_avg:32.81ms
+step:97/1480 train_time:3181ms step_avg:32.79ms
+step:98/1480 train_time:3219ms step_avg:32.84ms
+step:99/1480 train_time:3250ms step_avg:32.83ms
+step:100/1480 train_time:3287ms step_avg:32.87ms
+step:101/1480 train_time:3318ms step_avg:32.85ms
+step:102/1480 train_time:3356ms step_avg:32.90ms
+step:103/1480 train_time:3387ms step_avg:32.88ms
+step:104/1480 train_time:3424ms step_avg:32.92ms
+step:105/1480 train_time:3455ms step_avg:32.91ms
+step:106/1480 train_time:3490ms step_avg:32.93ms
+step:107/1480 train_time:3518ms step_avg:32.88ms
+step:108/1480 train_time:3554ms step_avg:32.90ms
+step:109/1480 train_time:3582ms step_avg:32.86ms
+step:110/1480 train_time:3616ms step_avg:32.88ms
+step:111/1480 train_time:3644ms step_avg:32.83ms
+step:112/1480 train_time:3680ms step_avg:32.86ms
+step:113/1480 train_time:3710ms step_avg:32.83ms
+step:114/1480 train_time:3745ms step_avg:32.85ms
+step:115/1480 train_time:3775ms step_avg:32.82ms
+step:116/1480 train_time:3810ms step_avg:32.84ms
+step:117/1480 train_time:3839ms step_avg:32.81ms
+step:118/1480 train_time:3875ms step_avg:32.84ms
+step:119/1480 train_time:3903ms step_avg:32.80ms
+step:120/1480 train_time:3939ms step_avg:32.83ms
+step:121/1480 train_time:3968ms step_avg:32.80ms
+step:122/1480 train_time:4003ms step_avg:32.82ms
+step:123/1480 train_time:4033ms step_avg:32.79ms
+step:124/1480 train_time:4068ms step_avg:32.81ms
+step:125/1480 train_time:4097ms step_avg:32.78ms
+step:126/1480 train_time:4134ms step_avg:32.81ms
+step:127/1480 train_time:4163ms step_avg:32.78ms
+step:128/1480 train_time:4199ms step_avg:32.81ms
+step:129/1480 train_time:4229ms step_avg:32.78ms
+step:130/1480 train_time:4264ms step_avg:32.80ms
+step:131/1480 train_time:4294ms step_avg:32.78ms
+step:132/1480 train_time:4330ms step_avg:32.80ms
+step:133/1480 train_time:4360ms step_avg:32.78ms
+step:134/1480 train_time:4396ms step_avg:32.81ms
+step:135/1480 train_time:4425ms step_avg:32.78ms
+step:136/1480 train_time:4461ms step_avg:32.80ms
+step:137/1480 train_time:4491ms step_avg:32.78ms
+step:138/1480 train_time:4526ms step_avg:32.80ms
+step:139/1480 train_time:4556ms step_avg:32.78ms
+step:140/1480 train_time:4592ms step_avg:32.80ms
+step:141/1480 train_time:4621ms step_avg:32.77ms
+step:142/1480 train_time:4658ms step_avg:32.80ms
+step:143/1480 train_time:4687ms step_avg:32.77ms
+step:144/1480 train_time:4723ms step_avg:32.80ms
+step:145/1480 train_time:4752ms step_avg:32.77ms
+step:146/1480 train_time:4788ms step_avg:32.79ms
+step:147/1480 train_time:4817ms step_avg:32.77ms
+step:148/1480 train_time:4853ms step_avg:32.79ms
+step:149/1480 train_time:4883ms step_avg:32.77ms
+step:150/1480 train_time:4919ms step_avg:32.79ms
+step:151/1480 train_time:4949ms step_avg:32.77ms
+step:152/1480 train_time:4985ms step_avg:32.79ms
+step:153/1480 train_time:5014ms step_avg:32.77ms
+step:154/1480 train_time:5050ms step_avg:32.79ms
+step:155/1480 train_time:5079ms step_avg:32.77ms
+step:156/1480 train_time:5115ms step_avg:32.79ms
+step:157/1480 train_time:5145ms step_avg:32.77ms
+step:158/1480 train_time:5181ms step_avg:32.79ms
+step:159/1480 train_time:5211ms step_avg:32.77ms
+step:160/1480 train_time:5246ms step_avg:32.79ms
+step:161/1480 train_time:5276ms step_avg:32.77ms
+step:162/1480 train_time:5313ms step_avg:32.80ms
+step:163/1480 train_time:5342ms step_avg:32.77ms
+step:164/1480 train_time:5378ms step_avg:32.79ms
+step:165/1480 train_time:5408ms step_avg:32.77ms
+step:166/1480 train_time:5443ms step_avg:32.79ms
+step:167/1480 train_time:5473ms step_avg:32.77ms
+step:168/1480 train_time:5509ms step_avg:32.79ms
+step:169/1480 train_time:5540ms step_avg:32.78ms
+step:170/1480 train_time:5578ms step_avg:32.81ms
+step:171/1480 train_time:5608ms step_avg:32.80ms
+step:172/1480 train_time:5646ms step_avg:32.83ms
+step:173/1480 train_time:5677ms step_avg:32.82ms
+step:174/1480 train_time:5716ms step_avg:32.85ms
+step:175/1480 train_time:5746ms step_avg:32.83ms
+step:176/1480 train_time:5783ms step_avg:32.86ms
+step:177/1480 train_time:5815ms step_avg:32.85ms
+step:178/1480 train_time:5852ms step_avg:32.88ms
+step:179/1480 train_time:5883ms step_avg:32.86ms
+step:180/1480 train_time:5920ms step_avg:32.89ms
+step:181/1480 train_time:5951ms step_avg:32.88ms
+step:182/1480 train_time:5989ms step_avg:32.91ms
+step:183/1480 train_time:6019ms step_avg:32.89ms
+step:184/1480 train_time:6058ms step_avg:32.92ms
+step:185/1480 train_time:6088ms step_avg:32.91ms
+step:186/1480 train_time:6125ms step_avg:32.93ms
+step:187/1480 train_time:6156ms step_avg:32.92ms
+step:188/1480 train_time:6193ms step_avg:32.94ms
+step:189/1480 train_time:6223ms step_avg:32.92ms
+step:190/1480 train_time:6260ms step_avg:32.95ms
+step:191/1480 train_time:6291ms step_avg:32.94ms
+step:192/1480 train_time:6327ms step_avg:32.95ms
+step:193/1480 train_time:6355ms step_avg:32.93ms
+step:194/1480 train_time:6390ms step_avg:32.94ms
+step:195/1480 train_time:6418ms step_avg:32.91ms
+step:196/1480 train_time:6453ms step_avg:32.92ms
+step:197/1480 train_time:6481ms step_avg:32.90ms
+step:198/1480 train_time:6517ms step_avg:32.92ms
+step:199/1480 train_time:6546ms step_avg:32.89ms
+step:200/1480 train_time:6582ms step_avg:32.91ms
+step:201/1480 train_time:6611ms step_avg:32.89ms
+step:202/1480 train_time:6647ms step_avg:32.91ms
+step:203/1480 train_time:6677ms step_avg:32.89ms
+step:204/1480 train_time:6713ms step_avg:32.91ms
+step:205/1480 train_time:6742ms step_avg:32.89ms
+step:206/1480 train_time:6778ms step_avg:32.90ms
+step:207/1480 train_time:6808ms step_avg:32.89ms
+step:208/1480 train_time:6843ms step_avg:32.90ms
+step:209/1480 train_time:6873ms step_avg:32.89ms
+step:210/1480 train_time:6909ms step_avg:32.90ms
+step:211/1480 train_time:6938ms step_avg:32.88ms
+step:212/1480 train_time:6974ms step_avg:32.90ms
+step:213/1480 train_time:7003ms step_avg:32.88ms
+step:214/1480 train_time:7039ms step_avg:32.89ms
+step:215/1480 train_time:7068ms step_avg:32.88ms
+step:216/1480 train_time:7104ms step_avg:32.89ms
+step:217/1480 train_time:7133ms step_avg:32.87ms
+step:218/1480 train_time:7171ms step_avg:32.89ms
+step:219/1480 train_time:7202ms step_avg:32.88ms
+step:220/1480 train_time:7240ms step_avg:32.91ms
+step:221/1480 train_time:7273ms step_avg:32.91ms
+step:222/1480 train_time:7310ms step_avg:32.93ms
+step:223/1480 train_time:7340ms step_avg:32.91ms
+step:224/1480 train_time:7377ms step_avg:32.93ms
+step:225/1480 train_time:7407ms step_avg:32.92ms
+step:226/1480 train_time:7444ms step_avg:32.94ms
+step:227/1480 train_time:7475ms step_avg:32.93ms
+step:228/1480 train_time:7513ms step_avg:32.95ms
+step:229/1480 train_time:7543ms step_avg:32.94ms
+step:230/1480 train_time:7580ms step_avg:32.96ms
+step:231/1480 train_time:7611ms step_avg:32.95ms
+step:232/1480 train_time:7647ms step_avg:32.96ms
+step:233/1480 train_time:7678ms step_avg:32.95ms
+step:234/1480 train_time:7716ms step_avg:32.97ms
+step:235/1480 train_time:7746ms step_avg:32.96ms
+step:236/1480 train_time:7783ms step_avg:32.98ms
+step:237/1480 train_time:7814ms step_avg:32.97ms
+step:238/1480 train_time:7850ms step_avg:32.99ms
+step:239/1480 train_time:7881ms step_avg:32.98ms
+step:240/1480 train_time:7919ms step_avg:33.00ms
+step:241/1480 train_time:7949ms step_avg:32.98ms
+step:242/1480 train_time:7986ms step_avg:33.00ms
+step:243/1480 train_time:8017ms step_avg:32.99ms
+step:244/1480 train_time:8054ms step_avg:33.01ms
+step:245/1480 train_time:8084ms step_avg:33.00ms
+step:246/1480 train_time:8121ms step_avg:33.01ms
+step:247/1480 train_time:8153ms step_avg:33.01ms
+step:248/1480 train_time:8189ms step_avg:33.02ms
+step:249/1480 train_time:8219ms step_avg:33.01ms
+step:250/1480 train_time:8257ms step_avg:33.03ms
+step:250/1480 val_loss:4.5089 train_time:8304ms step_avg:33.22ms
+step:251/1480 train_time:8321ms step_avg:33.15ms
+step:252/1480 train_time:8338ms step_avg:33.09ms
+step:253/1480 train_time:8355ms step_avg:33.02ms
+step:254/1480 train_time:8391ms step_avg:33.04ms
+step:255/1480 train_time:8420ms step_avg:33.02ms
+step:256/1480 train_time:8456ms step_avg:33.03ms
+step:257/1480 train_time:8485ms step_avg:33.02ms
+step:258/1480 train_time:8521ms step_avg:33.03ms
+step:259/1480 train_time:8550ms step_avg:33.01ms
+step:260/1480 train_time:8586ms step_avg:33.02ms
+step:261/1480 train_time:8615ms step_avg:33.01ms
+step:262/1480 train_time:8651ms step_avg:33.02ms
+step:263/1480 train_time:8680ms step_avg:33.00ms
+step:264/1480 train_time:8716ms step_avg:33.01ms
+step:265/1480 train_time:8744ms step_avg:33.00ms
+step:266/1480 train_time:8781ms step_avg:33.01ms
+step:267/1480 train_time:8810ms step_avg:33.00ms
+step:268/1480 train_time:8846ms step_avg:33.01ms
+step:269/1480 train_time:8875ms step_avg:32.99ms
+step:270/1480 train_time:8911ms step_avg:33.01ms
+step:271/1480 train_time:8941ms step_avg:32.99ms
+step:272/1480 train_time:8977ms step_avg:33.00ms
+step:273/1480 train_time:9007ms step_avg:32.99ms
+step:274/1480 train_time:9042ms step_avg:33.00ms
+step:275/1480 train_time:9072ms step_avg:32.99ms
+step:276/1480 train_time:9108ms step_avg:33.00ms
+step:277/1480 train_time:9138ms step_avg:32.99ms
+step:278/1480 train_time:9175ms step_avg:33.00ms
+step:279/1480 train_time:9204ms step_avg:32.99ms
+step:280/1480 train_time:9240ms step_avg:33.00ms
+step:281/1480 train_time:9270ms step_avg:32.99ms
+step:282/1480 train_time:9306ms step_avg:33.00ms
+step:283/1480 train_time:9337ms step_avg:32.99ms
+step:284/1480 train_time:9374ms step_avg:33.01ms
+step:285/1480 train_time:9405ms step_avg:33.00ms
+step:286/1480 train_time:9442ms step_avg:33.02ms
+step:287/1480 train_time:9474ms step_avg:33.01ms
+step:288/1480 train_time:9510ms step_avg:33.02ms
+step:289/1480 train_time:9541ms step_avg:33.01ms
+step:290/1480 train_time:9578ms step_avg:33.03ms
+step:291/1480 train_time:9608ms step_avg:33.02ms
+step:292/1480 train_time:9645ms step_avg:33.03ms
+step:293/1480 train_time:9676ms step_avg:33.02ms
+step:294/1480 train_time:9712ms step_avg:33.04ms
+step:295/1480 train_time:9742ms step_avg:33.02ms
+step:296/1480 train_time:9779ms step_avg:33.04ms
+step:297/1480 train_time:9809ms step_avg:33.03ms
+step:298/1480 train_time:9845ms step_avg:33.04ms
+step:299/1480 train_time:9876ms step_avg:33.03ms
+step:300/1480 train_time:9912ms step_avg:33.04ms
+step:301/1480 train_time:9942ms step_avg:33.03ms
+step:302/1480 train_time:9980ms step_avg:33.05ms
+step:303/1480 train_time:10010ms step_avg:33.04ms
+step:304/1480 train_time:10047ms step_avg:33.05ms
+step:305/1480 train_time:10077ms step_avg:33.04ms
+step:306/1480 train_time:10114ms step_avg:33.05ms
+step:307/1480 train_time:10144ms step_avg:33.04ms
+step:308/1480 train_time:10181ms step_avg:33.05ms
+step:309/1480 train_time:10211ms step_avg:33.04ms
+step:310/1480 train_time:10247ms step_avg:33.05ms
+step:311/1480 train_time:10277ms step_avg:33.05ms
+step:312/1480 train_time:10314ms step_avg:33.06ms
+step:313/1480 train_time:10343ms step_avg:33.05ms
+step:314/1480 train_time:10380ms step_avg:33.06ms
+step:315/1480 train_time:10410ms step_avg:33.05ms
+step:316/1480 train_time:10446ms step_avg:33.06ms
+step:317/1480 train_time:10476ms step_avg:33.05ms
+step:318/1480 train_time:10513ms step_avg:33.06ms
+step:319/1480 train_time:10542ms step_avg:33.05ms
+step:320/1480 train_time:10579ms step_avg:33.06ms
+step:321/1480 train_time:10609ms step_avg:33.05ms
+step:322/1480 train_time:10645ms step_avg:33.06ms
+step:323/1480 train_time:10676ms step_avg:33.05ms
+step:324/1480 train_time:10712ms step_avg:33.06ms
+step:325/1480 train_time:10741ms step_avg:33.05ms
+step:326/1480 train_time:10778ms step_avg:33.06ms
+step:327/1480 train_time:10808ms step_avg:33.05ms
+step:328/1480 train_time:10844ms step_avg:33.06ms
+step:329/1480 train_time:10875ms step_avg:33.05ms
+step:330/1480 train_time:10911ms step_avg:33.06ms
+step:331/1480 train_time:10940ms step_avg:33.05ms
+step:332/1480 train_time:10977ms step_avg:33.06ms
+step:333/1480 train_time:11006ms step_avg:33.05ms
+step:334/1480 train_time:11042ms step_avg:33.06ms
+step:335/1480 train_time:11073ms step_avg:33.05ms
+step:336/1480 train_time:11108ms step_avg:33.06ms
+step:337/1480 train_time:11138ms step_avg:33.05ms
+step:338/1480 train_time:11174ms step_avg:33.06ms
+step:339/1480 train_time:11204ms step_avg:33.05ms
+step:340/1480 train_time:11240ms step_avg:33.06ms
+step:341/1480 train_time:11270ms step_avg:33.05ms
+step:342/1480 train_time:11306ms step_avg:33.06ms
+step:343/1480 train_time:11336ms step_avg:33.05ms
+step:344/1480 train_time:11372ms step_avg:33.06ms
+step:345/1480 train_time:11402ms step_avg:33.05ms
+step:346/1480 train_time:11438ms step_avg:33.06ms
+step:347/1480 train_time:11468ms step_avg:33.05ms
+step:348/1480 train_time:11504ms step_avg:33.06ms
+step:349/1480 train_time:11534ms step_avg:33.05ms
+step:350/1480 train_time:11570ms step_avg:33.06ms
+step:351/1480 train_time:11599ms step_avg:33.05ms
+step:352/1480 train_time:11636ms step_avg:33.06ms
+step:353/1480 train_time:11665ms step_avg:33.05ms
+step:354/1480 train_time:11701ms step_avg:33.05ms
+step:355/1480 train_time:11731ms step_avg:33.04ms
+step:356/1480 train_time:11767ms step_avg:33.05ms
+step:357/1480 train_time:11797ms step_avg:33.04ms
+step:358/1480 train_time:11834ms step_avg:33.06ms
+step:359/1480 train_time:11863ms step_avg:33.04ms
+step:360/1480 train_time:11899ms step_avg:33.05ms
+step:361/1480 train_time:11929ms step_avg:33.05ms
+step:362/1480 train_time:11965ms step_avg:33.05ms
+step:363/1480 train_time:11996ms step_avg:33.05ms
+step:364/1480 train_time:12033ms step_avg:33.06ms
+step:365/1480 train_time:12063ms step_avg:33.05ms
+step:366/1480 train_time:12101ms step_avg:33.06ms
+step:367/1480 train_time:12131ms step_avg:33.05ms
+step:368/1480 train_time:12167ms step_avg:33.06ms
+step:369/1480 train_time:12198ms step_avg:33.06ms
+step:370/1480 train_time:12235ms step_avg:33.07ms
+step:371/1480 train_time:12265ms step_avg:33.06ms
+step:372/1480 train_time:12302ms step_avg:33.07ms
+step:373/1480 train_time:12332ms step_avg:33.06ms
+step:374/1480 train_time:12368ms step_avg:33.07ms
+step:375/1480 train_time:12398ms step_avg:33.06ms
+step:376/1480 train_time:12436ms step_avg:33.07ms
+step:377/1480 train_time:12466ms step_avg:33.07ms
+step:378/1480 train_time:12503ms step_avg:33.08ms
+step:379/1480 train_time:12533ms step_avg:33.07ms
+step:380/1480 train_time:12569ms step_avg:33.08ms
+step:381/1480 train_time:12600ms step_avg:33.07ms
+step:382/1480 train_time:12637ms step_avg:33.08ms
+step:383/1480 train_time:12667ms step_avg:33.07ms
+step:384/1480 train_time:12704ms step_avg:33.08ms
+step:385/1480 train_time:12734ms step_avg:33.08ms
+step:386/1480 train_time:12771ms step_avg:33.09ms
+step:387/1480 train_time:12801ms step_avg:33.08ms
+step:388/1480 train_time:12838ms step_avg:33.09ms
+step:389/1480 train_time:12868ms step_avg:33.08ms
+step:390/1480 train_time:12905ms step_avg:33.09ms
+step:391/1480 train_time:12935ms step_avg:33.08ms
+step:392/1480 train_time:12972ms step_avg:33.09ms
+step:393/1480 train_time:13003ms step_avg:33.09ms
+step:394/1480 train_time:13040ms step_avg:33.10ms
+step:395/1480 train_time:13070ms step_avg:33.09ms
+step:396/1480 train_time:13107ms step_avg:33.10ms
+step:397/1480 train_time:13136ms step_avg:33.09ms
+step:398/1480 train_time:13170ms step_avg:33.09ms
+step:399/1480 train_time:13199ms step_avg:33.08ms
+step:400/1480 train_time:13233ms step_avg:33.08ms
+step:401/1480 train_time:13263ms step_avg:33.08ms
+step:402/1480 train_time:13301ms step_avg:33.09ms
+step:403/1480 train_time:13331ms step_avg:33.08ms
+step:404/1480 train_time:13368ms step_avg:33.09ms
+step:405/1480 train_time:13399ms step_avg:33.08ms
+step:406/1480 train_time:13435ms step_avg:33.09ms
+step:407/1480 train_time:13465ms step_avg:33.08ms
+step:408/1480 train_time:13501ms step_avg:33.09ms
+step:409/1480 train_time:13532ms step_avg:33.09ms
+step:410/1480 train_time:13568ms step_avg:33.09ms
+step:411/1480 train_time:13598ms step_avg:33.08ms
+step:412/1480 train_time:13635ms step_avg:33.09ms
+step:413/1480 train_time:13663ms step_avg:33.08ms
+step:414/1480 train_time:13700ms step_avg:33.09ms
+step:415/1480 train_time:13729ms step_avg:33.08ms
+step:416/1480 train_time:13766ms step_avg:33.09ms
+step:417/1480 train_time:13797ms step_avg:33.09ms
+step:418/1480 train_time:13834ms step_avg:33.10ms
+step:419/1480 train_time:13864ms step_avg:33.09ms
+step:420/1480 train_time:13901ms step_avg:33.10ms
+step:421/1480 train_time:13933ms step_avg:33.09ms
+step:422/1480 train_time:13969ms step_avg:33.10ms
+step:423/1480 train_time:14000ms step_avg:33.10ms
+step:424/1480 train_time:14038ms step_avg:33.11ms
+step:425/1480 train_time:14068ms step_avg:33.10ms
+step:426/1480 train_time:14105ms step_avg:33.11ms
+step:427/1480 train_time:14136ms step_avg:33.11ms
+step:428/1480 train_time:14174ms step_avg:33.12ms
+step:429/1480 train_time:14204ms step_avg:33.11ms
+step:430/1480 train_time:14242ms step_avg:33.12ms
+step:431/1480 train_time:14273ms step_avg:33.12ms
+step:432/1480 train_time:14310ms step_avg:33.13ms
+step:433/1480 train_time:14341ms step_avg:33.12ms
+step:434/1480 train_time:14379ms step_avg:33.13ms
+step:435/1480 train_time:14409ms step_avg:33.12ms
+step:436/1480 train_time:14446ms step_avg:33.13ms
+step:437/1480 train_time:14477ms step_avg:33.13ms
+step:438/1480 train_time:14514ms step_avg:33.14ms
+step:439/1480 train_time:14544ms step_avg:33.13ms
+step:440/1480 train_time:14581ms step_avg:33.14ms
+step:441/1480 train_time:14611ms step_avg:33.13ms
+step:442/1480 train_time:14648ms step_avg:33.14ms
+step:443/1480 train_time:14678ms step_avg:33.13ms
+step:444/1480 train_time:14715ms step_avg:33.14ms
+step:445/1480 train_time:14745ms step_avg:33.14ms
+step:446/1480 train_time:14782ms step_avg:33.14ms
+step:447/1480 train_time:14813ms step_avg:33.14ms
+step:448/1480 train_time:14849ms step_avg:33.15ms
+step:449/1480 train_time:14879ms step_avg:33.14ms
+step:450/1480 train_time:14916ms step_avg:33.15ms
+step:451/1480 train_time:14946ms step_avg:33.14ms
+step:452/1480 train_time:14983ms step_avg:33.15ms
+step:453/1480 train_time:15013ms step_avg:33.14ms
+step:454/1480 train_time:15050ms step_avg:33.15ms
+step:455/1480 train_time:15079ms step_avg:33.14ms
+step:456/1480 train_time:15117ms step_avg:33.15ms
+step:457/1480 train_time:15146ms step_avg:33.14ms
+step:458/1480 train_time:15183ms step_avg:33.15ms
+step:459/1480 train_time:15213ms step_avg:33.14ms
+step:460/1480 train_time:15250ms step_avg:33.15ms
+step:461/1480 train_time:15279ms step_avg:33.14ms
+step:462/1480 train_time:15316ms step_avg:33.15ms
+step:463/1480 train_time:15345ms step_avg:33.14ms
+step:464/1480 train_time:15382ms step_avg:33.15ms
+step:465/1480 train_time:15412ms step_avg:33.14ms
+step:466/1480 train_time:15448ms step_avg:33.15ms
+step:467/1480 train_time:15478ms step_avg:33.14ms
+step:468/1480 train_time:15515ms step_avg:33.15ms
+step:469/1480 train_time:15544ms step_avg:33.14ms
+step:470/1480 train_time:15580ms step_avg:33.15ms
+step:471/1480 train_time:15611ms step_avg:33.14ms
+step:472/1480 train_time:15647ms step_avg:33.15ms
+step:473/1480 train_time:15677ms step_avg:33.14ms
+step:474/1480 train_time:15714ms step_avg:33.15ms
+step:475/1480 train_time:15743ms step_avg:33.14ms
+step:476/1480 train_time:15780ms step_avg:33.15ms
+step:477/1480 train_time:15810ms step_avg:33.14ms
+step:478/1480 train_time:15846ms step_avg:33.15ms
+step:479/1480 train_time:15876ms step_avg:33.14ms
+step:480/1480 train_time:15913ms step_avg:33.15ms
+step:481/1480 train_time:15945ms step_avg:33.15ms
+step:482/1480 train_time:16004ms step_avg:33.20ms
+step:483/1480 train_time:16061ms step_avg:33.25ms
+step:484/1480 train_time:16125ms step_avg:33.32ms
+step:485/1480 train_time:16184ms step_avg:33.37ms
+step:486/1480 train_time:16248ms step_avg:33.43ms
+step:487/1480 train_time:16305ms step_avg:33.48ms
+step:488/1480 train_time:16369ms step_avg:33.54ms
+step:489/1480 train_time:16427ms step_avg:33.59ms
+step:490/1480 train_time:16492ms step_avg:33.66ms
+step:491/1480 train_time:16551ms step_avg:33.71ms
+step:492/1480 train_time:16615ms step_avg:33.77ms
+step:493/1480 train_time:16674ms step_avg:33.82ms
+step:494/1480 train_time:16739ms step_avg:33.88ms
+step:495/1480 train_time:16799ms step_avg:33.94ms
+step:496/1480 train_time:16863ms step_avg:34.00ms
+step:497/1480 train_time:16919ms step_avg:34.04ms
+step:498/1480 train_time:16983ms step_avg:34.10ms
+step:499/1480 train_time:17041ms step_avg:34.15ms
+step:500/1480 train_time:17107ms step_avg:34.21ms
+step:500/1480 val_loss:4.2332 train_time:17190ms step_avg:34.38ms
+step:501/1480 train_time:17207ms step_avg:34.35ms
+step:502/1480 train_time:17232ms step_avg:34.33ms
+step:503/1480 train_time:17294ms step_avg:34.38ms
+step:504/1480 train_time:17369ms step_avg:34.46ms
+step:505/1480 train_time:17439ms step_avg:34.53ms
+step:506/1480 train_time:17508ms step_avg:34.60ms
+step:507/1480 train_time:17562ms step_avg:34.64ms
+step:508/1480 train_time:17621ms step_avg:34.69ms
+step:509/1480 train_time:17675ms step_avg:34.72ms
+step:510/1480 train_time:17736ms step_avg:34.78ms
+step:511/1480 train_time:17796ms step_avg:34.83ms
+step:512/1480 train_time:17863ms step_avg:34.89ms
+step:513/1480 train_time:17924ms step_avg:34.94ms
+step:514/1480 train_time:17991ms step_avg:35.00ms
+step:515/1480 train_time:18050ms step_avg:35.05ms
+step:516/1480 train_time:18116ms step_avg:35.11ms
+step:517/1480 train_time:18174ms step_avg:35.15ms
+step:518/1480 train_time:18238ms step_avg:35.21ms
+step:519/1480 train_time:18297ms step_avg:35.25ms
+step:520/1480 train_time:18364ms step_avg:35.32ms
+step:521/1480 train_time:18424ms step_avg:35.36ms
+step:522/1480 train_time:18488ms step_avg:35.42ms
+step:523/1480 train_time:18546ms step_avg:35.46ms
+step:524/1480 train_time:18613ms step_avg:35.52ms
+step:525/1480 train_time:18671ms step_avg:35.56ms
+step:526/1480 train_time:18735ms step_avg:35.62ms
+step:527/1480 train_time:18792ms step_avg:35.66ms
+step:528/1480 train_time:18856ms step_avg:35.71ms
+step:529/1480 train_time:18915ms step_avg:35.76ms
+step:530/1480 train_time:18979ms step_avg:35.81ms
+step:531/1480 train_time:19036ms step_avg:35.85ms
+step:532/1480 train_time:19100ms step_avg:35.90ms
+step:533/1480 train_time:19158ms step_avg:35.94ms
+step:534/1480 train_time:19222ms step_avg:36.00ms
+step:535/1480 train_time:19279ms step_avg:36.04ms
+step:536/1480 train_time:19344ms step_avg:36.09ms
+step:537/1480 train_time:19402ms step_avg:36.13ms
+step:538/1480 train_time:19466ms step_avg:36.18ms
+step:539/1480 train_time:19525ms step_avg:36.22ms
+step:540/1480 train_time:19590ms step_avg:36.28ms
+step:541/1480 train_time:19648ms step_avg:36.32ms
+step:542/1480 train_time:19713ms step_avg:36.37ms
+step:543/1480 train_time:19771ms step_avg:36.41ms
+step:544/1480 train_time:19834ms step_avg:36.46ms
+step:545/1480 train_time:19892ms step_avg:36.50ms
+step:546/1480 train_time:19957ms step_avg:36.55ms
+step:547/1480 train_time:20016ms step_avg:36.59ms
+step:548/1480 train_time:20080ms step_avg:36.64ms
+step:549/1480 train_time:20138ms step_avg:36.68ms
+step:550/1480 train_time:20201ms step_avg:36.73ms
+step:551/1480 train_time:20258ms step_avg:36.77ms
+step:552/1480 train_time:20321ms step_avg:36.81ms
+step:553/1480 train_time:20377ms step_avg:36.85ms
+step:554/1480 train_time:20440ms step_avg:36.90ms
+step:555/1480 train_time:20498ms step_avg:36.93ms
+step:556/1480 train_time:20562ms step_avg:36.98ms
+step:557/1480 train_time:20620ms step_avg:37.02ms
+step:558/1480 train_time:20685ms step_avg:37.07ms
+step:559/1480 train_time:20745ms step_avg:37.11ms
+step:560/1480 train_time:20808ms step_avg:37.16ms
+step:561/1480 train_time:20866ms step_avg:37.19ms
+step:562/1480 train_time:20932ms step_avg:37.25ms
+step:563/1480 train_time:20989ms step_avg:37.28ms
+step:564/1480 train_time:21053ms step_avg:37.33ms
+step:565/1480 train_time:21111ms step_avg:37.36ms
+step:566/1480 train_time:21174ms step_avg:37.41ms
+step:567/1480 train_time:21231ms step_avg:37.44ms
+step:568/1480 train_time:21294ms step_avg:37.49ms
+step:569/1480 train_time:21351ms step_avg:37.52ms
+step:570/1480 train_time:21414ms step_avg:37.57ms
+step:571/1480 train_time:21470ms step_avg:37.60ms
+step:572/1480 train_time:21532ms step_avg:37.64ms
+step:573/1480 train_time:21592ms step_avg:37.68ms
+step:574/1480 train_time:21661ms step_avg:37.74ms
+step:575/1480 train_time:21723ms step_avg:37.78ms
+step:576/1480 train_time:21791ms step_avg:37.83ms
+step:577/1480 train_time:21853ms step_avg:37.87ms
+step:578/1480 train_time:21920ms step_avg:37.92ms
+step:579/1480 train_time:21982ms step_avg:37.97ms
+step:580/1480 train_time:22050ms step_avg:38.02ms
+step:581/1480 train_time:22111ms step_avg:38.06ms
+step:582/1480 train_time:22178ms step_avg:38.11ms
+step:583/1480 train_time:22238ms step_avg:38.14ms
+step:584/1480 train_time:22306ms step_avg:38.19ms
+step:585/1480 train_time:22367ms step_avg:38.23ms
+step:586/1480 train_time:22429ms step_avg:38.27ms
+step:587/1480 train_time:22482ms step_avg:38.30ms
+step:588/1480 train_time:22542ms step_avg:38.34ms
+step:589/1480 train_time:22596ms step_avg:38.36ms
+step:590/1480 train_time:22658ms step_avg:38.40ms
+step:591/1480 train_time:22714ms step_avg:38.43ms
+step:592/1480 train_time:22776ms step_avg:38.47ms
+step:593/1480 train_time:22838ms step_avg:38.51ms
+step:594/1480 train_time:22904ms step_avg:38.56ms
+step:595/1480 train_time:22962ms step_avg:38.59ms
+step:596/1480 train_time:23027ms step_avg:38.64ms
+step:597/1480 train_time:23086ms step_avg:38.67ms
+step:598/1480 train_time:23151ms step_avg:38.71ms
+step:599/1480 train_time:23210ms step_avg:38.75ms
+step:600/1480 train_time:23275ms step_avg:38.79ms
+step:601/1480 train_time:23332ms step_avg:38.82ms
+step:602/1480 train_time:23397ms step_avg:38.86ms
+step:603/1480 train_time:23455ms step_avg:38.90ms
+step:604/1480 train_time:23520ms step_avg:38.94ms
+step:605/1480 train_time:23578ms step_avg:38.97ms
+step:606/1480 train_time:23643ms step_avg:39.01ms
+step:607/1480 train_time:23701ms step_avg:39.05ms
+step:608/1480 train_time:23766ms step_avg:39.09ms
+step:609/1480 train_time:23825ms step_avg:39.12ms
+step:610/1480 train_time:23891ms step_avg:39.17ms
+step:611/1480 train_time:23950ms step_avg:39.20ms
+step:612/1480 train_time:24015ms step_avg:39.24ms
+step:613/1480 train_time:24072ms step_avg:39.27ms
+step:614/1480 train_time:24136ms step_avg:39.31ms
+step:615/1480 train_time:24194ms step_avg:39.34ms
+step:616/1480 train_time:24259ms step_avg:39.38ms
+step:617/1480 train_time:24317ms step_avg:39.41ms
+step:618/1480 train_time:24382ms step_avg:39.45ms
+step:619/1480 train_time:24440ms step_avg:39.48ms
+step:620/1480 train_time:24504ms step_avg:39.52ms
+step:621/1480 train_time:24563ms step_avg:39.55ms
+step:622/1480 train_time:24627ms step_avg:39.59ms
+step:623/1480 train_time:24686ms step_avg:39.62ms
+step:624/1480 train_time:24750ms step_avg:39.66ms
+step:625/1480 train_time:24809ms step_avg:39.69ms
+step:626/1480 train_time:24874ms step_avg:39.73ms
+step:627/1480 train_time:24931ms step_avg:39.76ms
+step:628/1480 train_time:24995ms step_avg:39.80ms
+step:629/1480 train_time:25053ms step_avg:39.83ms
+step:630/1480 train_time:25119ms step_avg:39.87ms
+step:631/1480 train_time:25179ms step_avg:39.90ms
+step:632/1480 train_time:25245ms step_avg:39.94ms
+step:633/1480 train_time:25304ms step_avg:39.97ms
+step:634/1480 train_time:25368ms step_avg:40.01ms
+step:635/1480 train_time:25427ms step_avg:40.04ms
+step:636/1480 train_time:25492ms step_avg:40.08ms
+step:637/1480 train_time:25551ms step_avg:40.11ms
+step:638/1480 train_time:25615ms step_avg:40.15ms
+step:639/1480 train_time:25673ms step_avg:40.18ms
+step:640/1480 train_time:25737ms step_avg:40.21ms
+step:641/1480 train_time:25794ms step_avg:40.24ms
+step:642/1480 train_time:25859ms step_avg:40.28ms
+step:643/1480 train_time:25918ms step_avg:40.31ms
+step:644/1480 train_time:25981ms step_avg:40.34ms
+step:645/1480 train_time:26040ms step_avg:40.37ms
+step:646/1480 train_time:26105ms step_avg:40.41ms
+step:647/1480 train_time:26164ms step_avg:40.44ms
+step:648/1480 train_time:26229ms step_avg:40.48ms
+step:649/1480 train_time:26288ms step_avg:40.51ms
+step:650/1480 train_time:26352ms step_avg:40.54ms
+step:651/1480 train_time:26410ms step_avg:40.57ms
+step:652/1480 train_time:26474ms step_avg:40.60ms
+step:653/1480 train_time:26532ms step_avg:40.63ms
+step:654/1480 train_time:26596ms step_avg:40.67ms
+step:655/1480 train_time:26653ms step_avg:40.69ms
+step:656/1480 train_time:26717ms step_avg:40.73ms
+step:657/1480 train_time:26776ms step_avg:40.75ms
+step:658/1480 train_time:26843ms step_avg:40.79ms
+step:659/1480 train_time:26903ms step_avg:40.82ms
+step:660/1480 train_time:26968ms step_avg:40.86ms
+step:661/1480 train_time:27027ms step_avg:40.89ms
+step:662/1480 train_time:27093ms step_avg:40.93ms
+step:663/1480 train_time:27152ms step_avg:40.95ms
+step:664/1480 train_time:27216ms step_avg:40.99ms
+step:665/1480 train_time:27272ms step_avg:41.01ms
+step:666/1480 train_time:27336ms step_avg:41.05ms
+step:667/1480 train_time:27393ms step_avg:41.07ms
+step:668/1480 train_time:27457ms step_avg:41.10ms
+step:669/1480 train_time:27516ms step_avg:41.13ms
+step:670/1480 train_time:27580ms step_avg:41.16ms
+step:671/1480 train_time:27638ms step_avg:41.19ms
+step:672/1480 train_time:27702ms step_avg:41.22ms
+step:673/1480 train_time:27760ms step_avg:41.25ms
+step:674/1480 train_time:27823ms step_avg:41.28ms
+step:675/1480 train_time:27881ms step_avg:41.30ms
+step:676/1480 train_time:27945ms step_avg:41.34ms
+step:677/1480 train_time:28003ms step_avg:41.36ms
+step:678/1480 train_time:28066ms step_avg:41.40ms
+step:679/1480 train_time:28124ms step_avg:41.42ms
+step:680/1480 train_time:28187ms step_avg:41.45ms
+step:681/1480 train_time:28245ms step_avg:41.48ms
+step:682/1480 train_time:28308ms step_avg:41.51ms
+step:683/1480 train_time:28366ms step_avg:41.53ms
+step:684/1480 train_time:28429ms step_avg:41.56ms
+step:685/1480 train_time:28486ms step_avg:41.59ms
+step:686/1480 train_time:28550ms step_avg:41.62ms
+step:687/1480 train_time:28609ms step_avg:41.64ms
+step:688/1480 train_time:28674ms step_avg:41.68ms
+step:689/1480 train_time:28733ms step_avg:41.70ms
+step:690/1480 train_time:28796ms step_avg:41.73ms
+step:691/1480 train_time:28853ms step_avg:41.75ms
+step:692/1480 train_time:28915ms step_avg:41.79ms
+step:693/1480 train_time:28972ms step_avg:41.81ms
+step:694/1480 train_time:29034ms step_avg:41.84ms
+step:695/1480 train_time:29091ms step_avg:41.86ms
+step:696/1480 train_time:29154ms step_avg:41.89ms
+step:697/1480 train_time:29213ms step_avg:41.91ms
+step:698/1480 train_time:29277ms step_avg:41.94ms
+step:699/1480 train_time:29336ms step_avg:41.97ms
+step:700/1480 train_time:29401ms step_avg:42.00ms
+step:701/1480 train_time:29460ms step_avg:42.03ms
+step:702/1480 train_time:29524ms step_avg:42.06ms
+step:703/1480 train_time:29581ms step_avg:42.08ms
+step:704/1480 train_time:29645ms step_avg:42.11ms
+step:705/1480 train_time:29707ms step_avg:42.14ms
+step:706/1480 train_time:29773ms step_avg:42.17ms
+step:707/1480 train_time:29831ms step_avg:42.19ms
+step:708/1480 train_time:29896ms step_avg:42.23ms
+step:709/1480 train_time:29955ms step_avg:42.25ms
+step:710/1480 train_time:30019ms step_avg:42.28ms
+step:711/1480 train_time:30078ms step_avg:42.30ms
+step:712/1480 train_time:30143ms step_avg:42.34ms
+step:713/1480 train_time:30202ms step_avg:42.36ms
+step:714/1480 train_time:30267ms step_avg:42.39ms
+step:715/1480 train_time:30326ms step_avg:42.41ms
+step:716/1480 train_time:30391ms step_avg:42.45ms
+step:717/1480 train_time:30450ms step_avg:42.47ms
+step:718/1480 train_time:30514ms step_avg:42.50ms
+step:719/1480 train_time:30572ms step_avg:42.52ms
+step:720/1480 train_time:30636ms step_avg:42.55ms
+step:721/1480 train_time:30694ms step_avg:42.57ms
+step:722/1480 train_time:30759ms step_avg:42.60ms
+step:723/1480 train_time:30817ms step_avg:42.62ms
+step:724/1480 train_time:30881ms step_avg:42.65ms
+step:725/1480 train_time:30939ms step_avg:42.68ms
+step:726/1480 train_time:31005ms step_avg:42.71ms
+step:727/1480 train_time:31063ms step_avg:42.73ms
+step:728/1480 train_time:31128ms step_avg:42.76ms
+step:729/1480 train_time:31186ms step_avg:42.78ms
+step:730/1480 train_time:31251ms step_avg:42.81ms
+step:731/1480 train_time:31309ms step_avg:42.83ms
+step:732/1480 train_time:31373ms step_avg:42.86ms
+step:733/1480 train_time:31431ms step_avg:42.88ms
+step:734/1480 train_time:31495ms step_avg:42.91ms
+step:735/1480 train_time:31553ms step_avg:42.93ms
+step:736/1480 train_time:31616ms step_avg:42.96ms
+step:737/1480 train_time:31674ms step_avg:42.98ms
+step:738/1480 train_time:31738ms step_avg:43.00ms
+step:739/1480 train_time:31796ms step_avg:43.03ms
+step:740/1480 train_time:31860ms step_avg:43.05ms
+step:741/1480 train_time:31918ms step_avg:43.07ms
+step:742/1480 train_time:31981ms step_avg:43.10ms
+step:743/1480 train_time:32040ms step_avg:43.12ms
+step:744/1480 train_time:32105ms step_avg:43.15ms
+step:745/1480 train_time:32163ms step_avg:43.17ms
+step:746/1480 train_time:32230ms step_avg:43.20ms
+step:747/1480 train_time:32289ms step_avg:43.22ms
+step:748/1480 train_time:32353ms step_avg:43.25ms
+step:749/1480 train_time:32411ms step_avg:43.27ms
+step:750/1480 train_time:32475ms step_avg:43.30ms
+step:750/1480 val_loss:3.8055 train_time:32556ms step_avg:43.41ms
+step:751/1480 train_time:32573ms step_avg:43.37ms
+step:752/1480 train_time:32598ms step_avg:43.35ms
+step:753/1480 train_time:32659ms step_avg:43.37ms
+step:754/1480 train_time:32726ms step_avg:43.40ms
+step:755/1480 train_time:32787ms step_avg:43.43ms
+step:756/1480 train_time:32852ms step_avg:43.45ms
+step:757/1480 train_time:32910ms step_avg:43.47ms
+step:758/1480 train_time:32975ms step_avg:43.50ms
+step:759/1480 train_time:33034ms step_avg:43.52ms
+step:760/1480 train_time:33099ms step_avg:43.55ms
+step:761/1480 train_time:33158ms step_avg:43.57ms
+step:762/1480 train_time:33223ms step_avg:43.60ms
+step:763/1480 train_time:33279ms step_avg:43.62ms
+step:764/1480 train_time:33339ms step_avg:43.64ms
+step:765/1480 train_time:33394ms step_avg:43.65ms
+step:766/1480 train_time:33458ms step_avg:43.68ms
+step:767/1480 train_time:33515ms step_avg:43.70ms
+step:768/1480 train_time:33578ms step_avg:43.72ms
+step:769/1480 train_time:33634ms step_avg:43.74ms
+step:770/1480 train_time:33697ms step_avg:43.76ms
+step:771/1480 train_time:33756ms step_avg:43.78ms
+step:772/1480 train_time:33822ms step_avg:43.81ms
+step:773/1480 train_time:33882ms step_avg:43.83ms
+step:774/1480 train_time:33950ms step_avg:43.86ms
+step:775/1480 train_time:34010ms step_avg:43.88ms
+step:776/1480 train_time:34078ms step_avg:43.92ms
+step:777/1480 train_time:34141ms step_avg:43.94ms
+step:778/1480 train_time:34208ms step_avg:43.97ms
+step:779/1480 train_time:34270ms step_avg:43.99ms
+step:780/1480 train_time:34337ms step_avg:44.02ms
+step:781/1480 train_time:34398ms step_avg:44.04ms
+step:782/1480 train_time:34466ms step_avg:44.07ms
+step:783/1480 train_time:34527ms step_avg:44.10ms
+step:784/1480 train_time:34594ms step_avg:44.13ms
+step:785/1480 train_time:34655ms step_avg:44.15ms
+step:786/1480 train_time:34719ms step_avg:44.17ms
+step:787/1480 train_time:34772ms step_avg:44.18ms
+step:788/1480 train_time:34832ms step_avg:44.20ms
+step:789/1480 train_time:34889ms step_avg:44.22ms
+step:790/1480 train_time:34950ms step_avg:44.24ms
+step:791/1480 train_time:35006ms step_avg:44.25ms
+step:792/1480 train_time:35068ms step_avg:44.28ms
+step:793/1480 train_time:35124ms step_avg:44.29ms
+step:794/1480 train_time:35188ms step_avg:44.32ms
+step:795/1480 train_time:35243ms step_avg:44.33ms
+step:796/1480 train_time:35308ms step_avg:44.36ms
+step:797/1480 train_time:35366ms step_avg:44.37ms
+step:798/1480 train_time:35431ms step_avg:44.40ms
+step:799/1480 train_time:35488ms step_avg:44.42ms
+step:800/1480 train_time:35552ms step_avg:44.44ms
+step:801/1480 train_time:35610ms step_avg:44.46ms
+step:802/1480 train_time:35673ms step_avg:44.48ms
+step:803/1480 train_time:35731ms step_avg:44.50ms
+step:804/1480 train_time:35796ms step_avg:44.52ms
+step:805/1480 train_time:35852ms step_avg:44.54ms
+step:806/1480 train_time:35917ms step_avg:44.56ms
+step:807/1480 train_time:35976ms step_avg:44.58ms
+step:808/1480 train_time:36041ms step_avg:44.60ms
+step:809/1480 train_time:36098ms step_avg:44.62ms
+step:810/1480 train_time:36163ms step_avg:44.65ms
+step:811/1480 train_time:36223ms step_avg:44.66ms
+step:812/1480 train_time:36286ms step_avg:44.69ms
+step:813/1480 train_time:36343ms step_avg:44.70ms
+step:814/1480 train_time:36407ms step_avg:44.73ms
+step:815/1480 train_time:36464ms step_avg:44.74ms
+step:816/1480 train_time:36527ms step_avg:44.76ms
+step:817/1480 train_time:36585ms step_avg:44.78ms
+step:818/1480 train_time:36648ms step_avg:44.80ms
+step:819/1480 train_time:36705ms step_avg:44.82ms
+step:820/1480 train_time:36767ms step_avg:44.84ms
+step:821/1480 train_time:36825ms step_avg:44.85ms
+step:822/1480 train_time:36890ms step_avg:44.88ms
+step:823/1480 train_time:36949ms step_avg:44.90ms
+step:824/1480 train_time:37013ms step_avg:44.92ms
+step:825/1480 train_time:37074ms step_avg:44.94ms
+step:826/1480 train_time:37138ms step_avg:44.96ms
+step:827/1480 train_time:37196ms step_avg:44.98ms
+step:828/1480 train_time:37263ms step_avg:45.00ms
+step:829/1480 train_time:37325ms step_avg:45.02ms
+step:830/1480 train_time:37390ms step_avg:45.05ms
+step:831/1480 train_time:37448ms step_avg:45.06ms
+step:832/1480 train_time:37512ms step_avg:45.09ms
+step:833/1480 train_time:37571ms step_avg:45.10ms
+step:834/1480 train_time:37635ms step_avg:45.13ms
+step:835/1480 train_time:37693ms step_avg:45.14ms
+step:836/1480 train_time:37759ms step_avg:45.17ms
+step:837/1480 train_time:37817ms step_avg:45.18ms
+step:838/1480 train_time:37881ms step_avg:45.20ms
+step:839/1480 train_time:37940ms step_avg:45.22ms
+step:840/1480 train_time:38004ms step_avg:45.24ms
+step:841/1480 train_time:38065ms step_avg:45.26ms
+step:842/1480 train_time:38131ms step_avg:45.29ms
+step:843/1480 train_time:38188ms step_avg:45.30ms
+step:844/1480 train_time:38251ms step_avg:45.32ms
+step:845/1480 train_time:38309ms step_avg:45.34ms
+step:846/1480 train_time:38372ms step_avg:45.36ms
+step:847/1480 train_time:38430ms step_avg:45.37ms
+step:848/1480 train_time:38494ms step_avg:45.39ms
+step:849/1480 train_time:38553ms step_avg:45.41ms
+step:850/1480 train_time:38617ms step_avg:45.43ms
+step:851/1480 train_time:38677ms step_avg:45.45ms
+step:852/1480 train_time:38743ms step_avg:45.47ms
+step:853/1480 train_time:38801ms step_avg:45.49ms
+step:854/1480 train_time:38866ms step_avg:45.51ms
+step:855/1480 train_time:38924ms step_avg:45.53ms
+step:856/1480 train_time:38989ms step_avg:45.55ms
+step:857/1480 train_time:39046ms step_avg:45.56ms
+step:858/1480 train_time:39110ms step_avg:45.58ms
+step:859/1480 train_time:39167ms step_avg:45.60ms
+step:860/1480 train_time:39231ms step_avg:45.62ms
+step:861/1480 train_time:39288ms step_avg:45.63ms
+step:862/1480 train_time:39352ms step_avg:45.65ms
+step:863/1480 train_time:39411ms step_avg:45.67ms
+step:864/1480 train_time:39483ms step_avg:45.70ms
+step:865/1480 train_time:39549ms step_avg:45.72ms
+step:866/1480 train_time:39618ms step_avg:45.75ms
+step:867/1480 train_time:39672ms step_avg:45.76ms
+step:868/1480 train_time:39731ms step_avg:45.77ms
+step:869/1480 train_time:39788ms step_avg:45.79ms
+step:870/1480 train_time:39853ms step_avg:45.81ms
+step:871/1480 train_time:39910ms step_avg:45.82ms
+step:872/1480 train_time:39974ms step_avg:45.84ms
+step:873/1480 train_time:40032ms step_avg:45.86ms
+step:874/1480 train_time:40095ms step_avg:45.88ms
+step:875/1480 train_time:40152ms step_avg:45.89ms
+step:876/1480 train_time:40217ms step_avg:45.91ms
+step:877/1480 train_time:40277ms step_avg:45.93ms
+step:878/1480 train_time:40341ms step_avg:45.95ms
+step:879/1480 train_time:40399ms step_avg:45.96ms
+step:880/1480 train_time:40465ms step_avg:45.98ms
+step:881/1480 train_time:40525ms step_avg:46.00ms
+step:882/1480 train_time:40589ms step_avg:46.02ms
+step:883/1480 train_time:40646ms step_avg:46.03ms
+step:884/1480 train_time:40709ms step_avg:46.05ms
+step:885/1480 train_time:40766ms step_avg:46.06ms
+step:886/1480 train_time:40830ms step_avg:46.08ms
+step:887/1480 train_time:40887ms step_avg:46.10ms
+step:888/1480 train_time:40951ms step_avg:46.12ms
+step:889/1480 train_time:41008ms step_avg:46.13ms
+step:890/1480 train_time:41071ms step_avg:46.15ms
+step:891/1480 train_time:41129ms step_avg:46.16ms
+step:892/1480 train_time:41193ms step_avg:46.18ms
+step:893/1480 train_time:41250ms step_avg:46.19ms
+step:894/1480 train_time:41314ms step_avg:46.21ms
+step:895/1480 train_time:41373ms step_avg:46.23ms
+step:896/1480 train_time:41438ms step_avg:46.25ms
+step:897/1480 train_time:41496ms step_avg:46.26ms
+step:898/1480 train_time:41562ms step_avg:46.28ms
+step:899/1480 train_time:41622ms step_avg:46.30ms
+step:900/1480 train_time:41685ms step_avg:46.32ms
+step:901/1480 train_time:41744ms step_avg:46.33ms
+step:902/1480 train_time:41810ms step_avg:46.35ms
+step:903/1480 train_time:41867ms step_avg:46.36ms
+step:904/1480 train_time:41931ms step_avg:46.38ms
+step:905/1480 train_time:41988ms step_avg:46.40ms
+step:906/1480 train_time:42052ms step_avg:46.41ms
+step:907/1480 train_time:42108ms step_avg:46.43ms
+step:908/1480 train_time:42171ms step_avg:46.44ms
+step:909/1480 train_time:42229ms step_avg:46.46ms
+step:910/1480 train_time:42292ms step_avg:46.47ms
+step:911/1480 train_time:42350ms step_avg:46.49ms
+step:912/1480 train_time:42414ms step_avg:46.51ms
+step:913/1480 train_time:42473ms step_avg:46.52ms
+step:914/1480 train_time:42538ms step_avg:46.54ms
+step:915/1480 train_time:42596ms step_avg:46.55ms
+step:916/1480 train_time:42660ms step_avg:46.57ms
+step:917/1480 train_time:42720ms step_avg:46.59ms
+step:918/1480 train_time:42785ms step_avg:46.61ms
+step:919/1480 train_time:42843ms step_avg:46.62ms
+step:920/1480 train_time:42909ms step_avg:46.64ms
+step:921/1480 train_time:42967ms step_avg:46.65ms
+step:922/1480 train_time:43032ms step_avg:46.67ms
+step:923/1480 train_time:43090ms step_avg:46.68ms
+step:924/1480 train_time:43154ms step_avg:46.70ms
+step:925/1480 train_time:43212ms step_avg:46.72ms
+step:926/1480 train_time:43276ms step_avg:46.73ms
+step:927/1480 train_time:43335ms step_avg:46.75ms
+step:928/1480 train_time:43400ms step_avg:46.77ms
+step:929/1480 train_time:43459ms step_avg:46.78ms
+step:930/1480 train_time:43524ms step_avg:46.80ms
+step:931/1480 train_time:43582ms step_avg:46.81ms
+step:932/1480 train_time:43647ms step_avg:46.83ms
+step:933/1480 train_time:43707ms step_avg:46.85ms
+step:934/1480 train_time:43771ms step_avg:46.86ms
+step:935/1480 train_time:43828ms step_avg:46.88ms
+step:936/1480 train_time:43893ms step_avg:46.89ms
+step:937/1480 train_time:43951ms step_avg:46.91ms
+step:938/1480 train_time:44015ms step_avg:46.92ms
+step:939/1480 train_time:44073ms step_avg:46.94ms
+step:940/1480 train_time:44138ms step_avg:46.96ms
+step:941/1480 train_time:44195ms step_avg:46.97ms
+step:942/1480 train_time:44261ms step_avg:46.99ms
+step:943/1480 train_time:44322ms step_avg:47.00ms
+step:944/1480 train_time:44386ms step_avg:47.02ms
+step:945/1480 train_time:44443ms step_avg:47.03ms
+step:946/1480 train_time:44507ms step_avg:47.05ms
+step:947/1480 train_time:44565ms step_avg:47.06ms
+step:948/1480 train_time:44630ms step_avg:47.08ms
+step:949/1480 train_time:44687ms step_avg:47.09ms
+step:950/1480 train_time:44750ms step_avg:47.10ms
+step:951/1480 train_time:44807ms step_avg:47.12ms
+step:952/1480 train_time:44871ms step_avg:47.13ms
+step:953/1480 train_time:44929ms step_avg:47.14ms
+step:954/1480 train_time:44994ms step_avg:47.16ms
+step:955/1480 train_time:45053ms step_avg:47.18ms
+step:956/1480 train_time:45119ms step_avg:47.20ms
+step:957/1480 train_time:45179ms step_avg:47.21ms
+step:958/1480 train_time:45245ms step_avg:47.23ms
+step:959/1480 train_time:45304ms step_avg:47.24ms
+step:960/1480 train_time:45370ms step_avg:47.26ms
+step:961/1480 train_time:45432ms step_avg:47.28ms
+step:962/1480 train_time:45521ms step_avg:47.32ms
+step:963/1480 train_time:45610ms step_avg:47.36ms
+step:964/1480 train_time:45707ms step_avg:47.41ms
+step:965/1480 train_time:45794ms step_avg:47.46ms
+step:966/1480 train_time:45889ms step_avg:47.50ms
+step:967/1480 train_time:45976ms step_avg:47.54ms
+step:968/1480 train_time:46069ms step_avg:47.59ms
+step:969/1480 train_time:46155ms step_avg:47.63ms
+step:970/1480 train_time:46250ms step_avg:47.68ms
+step:971/1480 train_time:46336ms step_avg:47.72ms
+step:972/1480 train_time:46429ms step_avg:47.77ms
+step:973/1480 train_time:46516ms step_avg:47.81ms
+step:974/1480 train_time:46608ms step_avg:47.85ms
+step:975/1480 train_time:46694ms step_avg:47.89ms
+step:976/1480 train_time:46787ms step_avg:47.94ms
+step:977/1480 train_time:46873ms step_avg:47.98ms
+step:978/1480 train_time:46966ms step_avg:48.02ms
+step:979/1480 train_time:47049ms step_avg:48.06ms
+step:980/1480 train_time:47142ms step_avg:48.10ms
+step:981/1480 train_time:47235ms step_avg:48.15ms
+step:982/1480 train_time:47331ms step_avg:48.20ms
+step:983/1480 train_time:47416ms step_avg:48.24ms
+step:984/1480 train_time:47507ms step_avg:48.28ms
+step:985/1480 train_time:47593ms step_avg:48.32ms
+step:986/1480 train_time:47685ms step_avg:48.36ms
+step:987/1480 train_time:47769ms step_avg:48.40ms
+step:988/1480 train_time:47864ms step_avg:48.45ms
+step:989/1480 train_time:47955ms step_avg:48.49ms
+step:990/1480 train_time:48052ms step_avg:48.54ms
+step:991/1480 train_time:48142ms step_avg:48.58ms
+step:992/1480 train_time:48240ms step_avg:48.63ms
+step:993/1480 train_time:48329ms step_avg:48.67ms
+step:994/1480 train_time:48426ms step_avg:48.72ms
+step:995/1480 train_time:48517ms step_avg:48.76ms
+step:996/1480 train_time:48613ms step_avg:48.81ms
+step:997/1480 train_time:48703ms step_avg:48.85ms
+step:998/1480 train_time:48799ms step_avg:48.90ms
+step:999/1480 train_time:48880ms step_avg:48.93ms
+step:1000/1480 train_time:48965ms step_avg:48.97ms
+step:1000/1480 val_loss:3.5098 train_time:49080ms step_avg:49.08ms
+step:1001/1480 train_time:49097ms step_avg:49.05ms
+step:1002/1480 train_time:49142ms step_avg:49.04ms
+step:1003/1480 train_time:49232ms step_avg:49.08ms
+step:1004/1480 train_time:49327ms step_avg:49.13ms
+step:1005/1480 train_time:49414ms step_avg:49.17ms
+step:1006/1480 train_time:49508ms step_avg:49.21ms
+step:1007/1480 train_time:49596ms step_avg:49.25ms
+step:1008/1480 train_time:49690ms step_avg:49.30ms
+step:1009/1480 train_time:49777ms step_avg:49.33ms
+step:1010/1480 train_time:49870ms step_avg:49.38ms
+step:1011/1480 train_time:49956ms step_avg:49.41ms
+step:1012/1480 train_time:50049ms step_avg:49.46ms
+step:1013/1480 train_time:50135ms step_avg:49.49ms
+step:1014/1480 train_time:50228ms step_avg:49.53ms
+step:1015/1480 train_time:50315ms step_avg:49.57ms
+step:1016/1480 train_time:50407ms step_avg:49.61ms
+step:1017/1480 train_time:50494ms step_avg:49.65ms
+step:1018/1480 train_time:50584ms step_avg:49.69ms
+step:1019/1480 train_time:50670ms step_avg:49.73ms
+step:1020/1480 train_time:50761ms step_avg:49.77ms
+step:1021/1480 train_time:50849ms step_avg:49.80ms
+step:1022/1480 train_time:50942ms step_avg:49.85ms
+step:1023/1480 train_time:51029ms step_avg:49.88ms
+step:1024/1480 train_time:51121ms step_avg:49.92ms
+step:1025/1480 train_time:51206ms step_avg:49.96ms
+step:1026/1480 train_time:51298ms step_avg:50.00ms
+step:1027/1480 train_time:51385ms step_avg:50.03ms
+step:1028/1480 train_time:51477ms step_avg:50.08ms
+step:1029/1480 train_time:51564ms step_avg:50.11ms
+step:1030/1480 train_time:51658ms step_avg:50.15ms
+step:1031/1480 train_time:51743ms step_avg:50.19ms
+step:1032/1480 train_time:51837ms step_avg:50.23ms
+step:1033/1480 train_time:51923ms step_avg:50.26ms
+step:1034/1480 train_time:52015ms step_avg:50.30ms
+step:1035/1480 train_time:52100ms step_avg:50.34ms
+step:1036/1480 train_time:52194ms step_avg:50.38ms
+step:1037/1480 train_time:52280ms step_avg:50.41ms
+step:1038/1480 train_time:52372ms step_avg:50.45ms
+step:1039/1480 train_time:52457ms step_avg:50.49ms
+step:1040/1480 train_time:52547ms step_avg:50.53ms
+step:1041/1480 train_time:52633ms step_avg:50.56ms
+step:1042/1480 train_time:52725ms step_avg:50.60ms
+step:1043/1480 train_time:52813ms step_avg:50.64ms
+step:1044/1480 train_time:52908ms step_avg:50.68ms
+step:1045/1480 train_time:52997ms step_avg:50.71ms
+step:1046/1480 train_time:53092ms step_avg:50.76ms
+step:1047/1480 train_time:53180ms step_avg:50.79ms
+step:1048/1480 train_time:53275ms step_avg:50.84ms
+step:1049/1480 train_time:53363ms step_avg:50.87ms
+step:1050/1480 train_time:53458ms step_avg:50.91ms
+step:1051/1480 train_time:53545ms step_avg:50.95ms
+step:1052/1480 train_time:53639ms step_avg:50.99ms
+step:1053/1480 train_time:53726ms step_avg:51.02ms
+step:1054/1480 train_time:53819ms step_avg:51.06ms
+step:1055/1480 train_time:53906ms step_avg:51.10ms
+step:1056/1480 train_time:54002ms step_avg:51.14ms
+step:1057/1480 train_time:54088ms step_avg:51.17ms
+step:1058/1480 train_time:54181ms step_avg:51.21ms
+step:1059/1480 train_time:54268ms step_avg:51.24ms
+step:1060/1480 train_time:54361ms step_avg:51.28ms
+step:1061/1480 train_time:54447ms step_avg:51.32ms
+step:1062/1480 train_time:54540ms step_avg:51.36ms
+step:1063/1480 train_time:54627ms step_avg:51.39ms
+step:1064/1480 train_time:54720ms step_avg:51.43ms
+step:1065/1480 train_time:54806ms step_avg:51.46ms
+step:1066/1480 train_time:54899ms step_avg:51.50ms
+step:1067/1480 train_time:54985ms step_avg:51.53ms
+step:1068/1480 train_time:55077ms step_avg:51.57ms
+step:1069/1480 train_time:55163ms step_avg:51.60ms
+step:1070/1480 train_time:55257ms step_avg:51.64ms
+step:1071/1480 train_time:55343ms step_avg:51.67ms
+step:1072/1480 train_time:55436ms step_avg:51.71ms
+step:1073/1480 train_time:55522ms step_avg:51.74ms
+step:1074/1480 train_time:55615ms step_avg:51.78ms
+step:1075/1480 train_time:55702ms step_avg:51.82ms
+step:1076/1480 train_time:55795ms step_avg:51.85ms
+step:1077/1480 train_time:55881ms step_avg:51.89ms
+step:1078/1480 train_time:55975ms step_avg:51.93ms
+step:1079/1480 train_time:56062ms step_avg:51.96ms
+step:1080/1480 train_time:56156ms step_avg:52.00ms
+step:1081/1480 train_time:56242ms step_avg:52.03ms
+step:1082/1480 train_time:56336ms step_avg:52.07ms
+step:1083/1480 train_time:56423ms step_avg:52.10ms
+step:1084/1480 train_time:56515ms step_avg:52.14ms
+step:1085/1480 train_time:56602ms step_avg:52.17ms
+step:1086/1480 train_time:56695ms step_avg:52.21ms
+step:1087/1480 train_time:56781ms step_avg:52.24ms
+step:1088/1480 train_time:56873ms step_avg:52.27ms
+step:1089/1480 train_time:56960ms step_avg:52.31ms
+step:1090/1480 train_time:57055ms step_avg:52.34ms
+step:1091/1480 train_time:57141ms step_avg:52.37ms
+step:1092/1480 train_time:57234ms step_avg:52.41ms
+step:1093/1480 train_time:57320ms step_avg:52.44ms
+step:1094/1480 train_time:57413ms step_avg:52.48ms
+step:1095/1480 train_time:57499ms step_avg:52.51ms
+step:1096/1480 train_time:57593ms step_avg:52.55ms
+step:1097/1480 train_time:57679ms step_avg:52.58ms
+step:1098/1480 train_time:57773ms step_avg:52.62ms
+step:1099/1480 train_time:57859ms step_avg:52.65ms
+step:1100/1480 train_time:57952ms step_avg:52.68ms
+step:1101/1480 train_time:58037ms step_avg:52.71ms
+step:1102/1480 train_time:58130ms step_avg:52.75ms
+step:1103/1480 train_time:58216ms step_avg:52.78ms
+step:1104/1480 train_time:58309ms step_avg:52.82ms
+step:1105/1480 train_time:58395ms step_avg:52.85ms
+step:1106/1480 train_time:58488ms step_avg:52.88ms
+step:1107/1480 train_time:58573ms step_avg:52.91ms
+step:1108/1480 train_time:58665ms step_avg:52.95ms
+step:1109/1480 train_time:58754ms step_avg:52.98ms
+step:1110/1480 train_time:58849ms step_avg:53.02ms
+step:1111/1480 train_time:58938ms step_avg:53.05ms
+step:1112/1480 train_time:59034ms step_avg:53.09ms
+step:1113/1480 train_time:59123ms step_avg:53.12ms
+step:1114/1480 train_time:59218ms step_avg:53.16ms
+step:1115/1480 train_time:59306ms step_avg:53.19ms
+step:1116/1480 train_time:59400ms step_avg:53.23ms
+step:1117/1480 train_time:59488ms step_avg:53.26ms
+step:1118/1480 train_time:59582ms step_avg:53.29ms
+step:1119/1480 train_time:59669ms step_avg:53.32ms
+step:1120/1480 train_time:59763ms step_avg:53.36ms
+step:1121/1480 train_time:59850ms step_avg:53.39ms
+step:1122/1480 train_time:59942ms step_avg:53.42ms
+step:1123/1480 train_time:60031ms step_avg:53.46ms
+step:1124/1480 train_time:60124ms step_avg:53.49ms
+step:1125/1480 train_time:60211ms step_avg:53.52ms
+step:1126/1480 train_time:60304ms step_avg:53.56ms
+step:1127/1480 train_time:60390ms step_avg:53.59ms
+step:1128/1480 train_time:60483ms step_avg:53.62ms
+step:1129/1480 train_time:60570ms step_avg:53.65ms
+step:1130/1480 train_time:60663ms step_avg:53.68ms
+step:1131/1480 train_time:60746ms step_avg:53.71ms
+step:1132/1480 train_time:60847ms step_avg:53.75ms
+step:1133/1480 train_time:60939ms step_avg:53.79ms
+step:1134/1480 train_time:61036ms step_avg:53.82ms
+step:1135/1480 train_time:61125ms step_avg:53.85ms
+step:1136/1480 train_time:61217ms step_avg:53.89ms
+step:1137/1480 train_time:61308ms step_avg:53.92ms
+step:1138/1480 train_time:61404ms step_avg:53.96ms
+step:1139/1480 train_time:61491ms step_avg:53.99ms
+step:1140/1480 train_time:61584ms step_avg:54.02ms
+step:1141/1480 train_time:61672ms step_avg:54.05ms
+step:1142/1480 train_time:61765ms step_avg:54.09ms
+step:1143/1480 train_time:61855ms step_avg:54.12ms
+step:1144/1480 train_time:61951ms step_avg:54.15ms
+step:1145/1480 train_time:62041ms step_avg:54.18ms
+step:1146/1480 train_time:62137ms step_avg:54.22ms
+step:1147/1480 train_time:62227ms step_avg:54.25ms
+step:1148/1480 train_time:62322ms step_avg:54.29ms
+step:1149/1480 train_time:62409ms step_avg:54.32ms
+step:1150/1480 train_time:62504ms step_avg:54.35ms
+step:1151/1480 train_time:62586ms step_avg:54.38ms
+step:1152/1480 train_time:62678ms step_avg:54.41ms
+step:1153/1480 train_time:62763ms step_avg:54.43ms
+step:1154/1480 train_time:62855ms step_avg:54.47ms
+step:1155/1480 train_time:62939ms step_avg:54.49ms
+step:1156/1480 train_time:63033ms step_avg:54.53ms
+step:1157/1480 train_time:63121ms step_avg:54.56ms
+step:1158/1480 train_time:63213ms step_avg:54.59ms
+step:1159/1480 train_time:63298ms step_avg:54.61ms
+step:1160/1480 train_time:63393ms step_avg:54.65ms
+step:1161/1480 train_time:63481ms step_avg:54.68ms
+step:1162/1480 train_time:63574ms step_avg:54.71ms
+step:1163/1480 train_time:63661ms step_avg:54.74ms
+step:1164/1480 train_time:63757ms step_avg:54.77ms
+step:1165/1480 train_time:63845ms step_avg:54.80ms
+step:1166/1480 train_time:63938ms step_avg:54.84ms
+step:1167/1480 train_time:64027ms step_avg:54.86ms
+step:1168/1480 train_time:64120ms step_avg:54.90ms
+step:1169/1480 train_time:64207ms step_avg:54.92ms
+step:1170/1480 train_time:64301ms step_avg:54.96ms
+step:1171/1480 train_time:64386ms step_avg:54.98ms
+step:1172/1480 train_time:64477ms step_avg:55.01ms
+step:1173/1480 train_time:64561ms step_avg:55.04ms
+step:1174/1480 train_time:64652ms step_avg:55.07ms
+step:1175/1480 train_time:64735ms step_avg:55.09ms
+step:1176/1480 train_time:64828ms step_avg:55.13ms
+step:1177/1480 train_time:64916ms step_avg:55.15ms
+step:1178/1480 train_time:65010ms step_avg:55.19ms
+step:1179/1480 train_time:65097ms step_avg:55.21ms
+step:1180/1480 train_time:65192ms step_avg:55.25ms
+step:1181/1480 train_time:65278ms step_avg:55.27ms
+step:1182/1480 train_time:65373ms step_avg:55.31ms
+step:1183/1480 train_time:65460ms step_avg:55.33ms
+step:1184/1480 train_time:65553ms step_avg:55.37ms
+step:1185/1480 train_time:65642ms step_avg:55.39ms
+step:1186/1480 train_time:65740ms step_avg:55.43ms
+step:1187/1480 train_time:65832ms step_avg:55.46ms
+step:1188/1480 train_time:65929ms step_avg:55.50ms
+step:1189/1480 train_time:66020ms step_avg:55.53ms
+step:1190/1480 train_time:66118ms step_avg:55.56ms
+step:1191/1480 train_time:66210ms step_avg:55.59ms
+step:1192/1480 train_time:66296ms step_avg:55.62ms
+step:1193/1480 train_time:66375ms step_avg:55.64ms
+step:1194/1480 train_time:66465ms step_avg:55.67ms
+step:1195/1480 train_time:66552ms step_avg:55.69ms
+step:1196/1480 train_time:66641ms step_avg:55.72ms
+step:1197/1480 train_time:66726ms step_avg:55.74ms
+step:1198/1480 train_time:66818ms step_avg:55.77ms
+step:1199/1480 train_time:66905ms step_avg:55.80ms
+step:1200/1480 train_time:66996ms step_avg:55.83ms
+step:1201/1480 train_time:67086ms step_avg:55.86ms
+step:1202/1480 train_time:67186ms step_avg:55.89ms
+step:1203/1480 train_time:67275ms step_avg:55.92ms
+step:1204/1480 train_time:67371ms step_avg:55.96ms
+step:1205/1480 train_time:67462ms step_avg:55.98ms
+step:1206/1480 train_time:67558ms step_avg:56.02ms
+step:1207/1480 train_time:67649ms step_avg:56.05ms
+step:1208/1480 train_time:67745ms step_avg:56.08ms
+step:1209/1480 train_time:67835ms step_avg:56.11ms
+step:1210/1480 train_time:67932ms step_avg:56.14ms
+step:1211/1480 train_time:68023ms step_avg:56.17ms
+step:1212/1480 train_time:68111ms step_avg:56.20ms
+step:1213/1480 train_time:68192ms step_avg:56.22ms
+step:1214/1480 train_time:68281ms step_avg:56.24ms
+step:1215/1480 train_time:68366ms step_avg:56.27ms
+step:1216/1480 train_time:68461ms step_avg:56.30ms
+step:1217/1480 train_time:68549ms step_avg:56.33ms
+step:1218/1480 train_time:68640ms step_avg:56.35ms
+step:1219/1480 train_time:68734ms step_avg:56.39ms
+step:1220/1480 train_time:68839ms step_avg:56.43ms
+step:1221/1480 train_time:68924ms step_avg:56.45ms
+step:1222/1480 train_time:69015ms step_avg:56.48ms
+step:1223/1480 train_time:69105ms step_avg:56.50ms
+step:1224/1480 train_time:69198ms step_avg:56.53ms
+step:1225/1480 train_time:69283ms step_avg:56.56ms
+step:1226/1480 train_time:69378ms step_avg:56.59ms
+step:1227/1480 train_time:69463ms step_avg:56.61ms
+step:1228/1480 train_time:69561ms step_avg:56.65ms
+step:1229/1480 train_time:69652ms step_avg:56.67ms
+step:1230/1480 train_time:69748ms step_avg:56.71ms
+step:1231/1480 train_time:69841ms step_avg:56.73ms
+step:1232/1480 train_time:69936ms step_avg:56.77ms
+step:1233/1480 train_time:70028ms step_avg:56.79ms
+step:1234/1480 train_time:70125ms step_avg:56.83ms
+step:1235/1480 train_time:70214ms step_avg:56.85ms
+step:1236/1480 train_time:70310ms step_avg:56.89ms
+step:1237/1480 train_time:70400ms step_avg:56.91ms
+step:1238/1480 train_time:70495ms step_avg:56.94ms
+step:1239/1480 train_time:70577ms step_avg:56.96ms
+step:1240/1480 train_time:70662ms step_avg:56.99ms
+step:1241/1480 train_time:70745ms step_avg:57.01ms
+step:1242/1480 train_time:70836ms step_avg:57.03ms
+step:1243/1480 train_time:70920ms step_avg:57.06ms
+step:1244/1480 train_time:71014ms step_avg:57.09ms
+step:1245/1480 train_time:71100ms step_avg:57.11ms
+step:1246/1480 train_time:71197ms step_avg:57.14ms
+step:1247/1480 train_time:71286ms step_avg:57.17ms
+step:1248/1480 train_time:71382ms step_avg:57.20ms
+step:1249/1480 train_time:71472ms step_avg:57.22ms
+step:1250/1480 train_time:71568ms step_avg:57.25ms
+step:1250/1480 val_loss:3.3686 train_time:71691ms step_avg:57.35ms
+step:1251/1480 train_time:71708ms step_avg:57.32ms
+step:1252/1480 train_time:71753ms step_avg:57.31ms
+step:1253/1480 train_time:71834ms step_avg:57.33ms
+step:1254/1480 train_time:71923ms step_avg:57.35ms
+step:1255/1480 train_time:72012ms step_avg:57.38ms
+step:1256/1480 train_time:72107ms step_avg:57.41ms
+step:1257/1480 train_time:72193ms step_avg:57.43ms
+step:1258/1480 train_time:72286ms step_avg:57.46ms
+step:1259/1480 train_time:72374ms step_avg:57.49ms
+step:1260/1480 train_time:72466ms step_avg:57.51ms
+step:1261/1480 train_time:72553ms step_avg:57.54ms
+step:1262/1480 train_time:72648ms step_avg:57.57ms
+step:1263/1480 train_time:72735ms step_avg:57.59ms
+step:1264/1480 train_time:72828ms step_avg:57.62ms
+step:1265/1480 train_time:72915ms step_avg:57.64ms
+step:1266/1480 train_time:73008ms step_avg:57.67ms
+step:1267/1480 train_time:73095ms step_avg:57.69ms
+step:1268/1480 train_time:73188ms step_avg:57.72ms
+step:1269/1480 train_time:73275ms step_avg:57.74ms
+step:1270/1480 train_time:73368ms step_avg:57.77ms
+step:1271/1480 train_time:73454ms step_avg:57.79ms
+step:1272/1480 train_time:73547ms step_avg:57.82ms
+step:1273/1480 train_time:73636ms step_avg:57.84ms
+step:1274/1480 train_time:73728ms step_avg:57.87ms
+step:1275/1480 train_time:73819ms step_avg:57.90ms
+step:1276/1480 train_time:73912ms step_avg:57.92ms
+step:1277/1480 train_time:74000ms step_avg:57.95ms
+step:1278/1480 train_time:74095ms step_avg:57.98ms
+step:1279/1480 train_time:74182ms step_avg:58.00ms
+step:1280/1480 train_time:74277ms step_avg:58.03ms
+step:1281/1480 train_time:74365ms step_avg:58.05ms
+step:1282/1480 train_time:74458ms step_avg:58.08ms
+step:1283/1480 train_time:74543ms step_avg:58.10ms
+step:1284/1480 train_time:74637ms step_avg:58.13ms
+step:1285/1480 train_time:74725ms step_avg:58.15ms
+step:1286/1480 train_time:74820ms step_avg:58.18ms
+step:1287/1480 train_time:74906ms step_avg:58.20ms
+step:1288/1480 train_time:75000ms step_avg:58.23ms
+step:1289/1480 train_time:75086ms step_avg:58.25ms
+step:1290/1480 train_time:75181ms step_avg:58.28ms
+step:1291/1480 train_time:75266ms step_avg:58.30ms
+step:1292/1480 train_time:75362ms step_avg:58.33ms
+step:1293/1480 train_time:75448ms step_avg:58.35ms
+step:1294/1480 train_time:75539ms step_avg:58.38ms
+step:1295/1480 train_time:75624ms step_avg:58.40ms
+step:1296/1480 train_time:75714ms step_avg:58.42ms
+step:1297/1480 train_time:75798ms step_avg:58.44ms
+step:1298/1480 train_time:75889ms step_avg:58.47ms
+step:1299/1480 train_time:75973ms step_avg:58.49ms
+step:1300/1480 train_time:76066ms step_avg:58.51ms
+step:1301/1480 train_time:76154ms step_avg:58.53ms
+step:1302/1480 train_time:76246ms step_avg:58.56ms
+step:1303/1480 train_time:76334ms step_avg:58.58ms
+step:1304/1480 train_time:76425ms step_avg:58.61ms
+step:1305/1480 train_time:76511ms step_avg:58.63ms
+step:1306/1480 train_time:76604ms step_avg:58.66ms
+step:1307/1480 train_time:76689ms step_avg:58.68ms
+step:1308/1480 train_time:76780ms step_avg:58.70ms
+step:1309/1480 train_time:76864ms step_avg:58.72ms
+step:1310/1480 train_time:76955ms step_avg:58.74ms
+step:1311/1480 train_time:77039ms step_avg:58.76ms
+step:1312/1480 train_time:77131ms step_avg:58.79ms
+step:1313/1480 train_time:77222ms step_avg:58.81ms
+step:1314/1480 train_time:77316ms step_avg:58.84ms
+step:1315/1480 train_time:77403ms step_avg:58.86ms
+step:1316/1480 train_time:77498ms step_avg:58.89ms
+step:1317/1480 train_time:77585ms step_avg:58.91ms
+step:1318/1480 train_time:77679ms step_avg:58.94ms
+step:1319/1480 train_time:77765ms step_avg:58.96ms
+step:1320/1480 train_time:77858ms step_avg:58.98ms
+step:1321/1480 train_time:77945ms step_avg:59.00ms
+step:1322/1480 train_time:78039ms step_avg:59.03ms
+step:1323/1480 train_time:78125ms step_avg:59.05ms
+step:1324/1480 train_time:78218ms step_avg:59.08ms
+step:1325/1480 train_time:78304ms step_avg:59.10ms
+step:1326/1480 train_time:78398ms step_avg:59.12ms
+step:1327/1480 train_time:78483ms step_avg:59.14ms
+step:1328/1480 train_time:78577ms step_avg:59.17ms
+step:1329/1480 train_time:78662ms step_avg:59.19ms
+step:1330/1480 train_time:78755ms step_avg:59.21ms
+step:1331/1480 train_time:78842ms step_avg:59.23ms
+step:1332/1480 train_time:78935ms step_avg:59.26ms
+step:1333/1480 train_time:79020ms step_avg:59.28ms
+step:1334/1480 train_time:79112ms step_avg:59.30ms
+step:1335/1480 train_time:79198ms step_avg:59.32ms
+step:1336/1480 train_time:79292ms step_avg:59.35ms
+step:1337/1480 train_time:79378ms step_avg:59.37ms
+step:1338/1480 train_time:79471ms step_avg:59.39ms
+step:1339/1480 train_time:79556ms step_avg:59.41ms
+step:1340/1480 train_time:79646ms step_avg:59.44ms
+step:1341/1480 train_time:79732ms step_avg:59.46ms
+step:1342/1480 train_time:79823ms step_avg:59.48ms
+step:1343/1480 train_time:79909ms step_avg:59.50ms
+step:1344/1480 train_time:80000ms step_avg:59.52ms
+step:1345/1480 train_time:80086ms step_avg:59.54ms
+step:1346/1480 train_time:80178ms step_avg:59.57ms
+step:1347/1480 train_time:80261ms step_avg:59.58ms
+step:1348/1480 train_time:80351ms step_avg:59.61ms
+step:1349/1480 train_time:80435ms step_avg:59.63ms
+step:1350/1480 train_time:80526ms step_avg:59.65ms
+step:1351/1480 train_time:80612ms step_avg:59.67ms
+step:1352/1480 train_time:80702ms step_avg:59.69ms
+step:1353/1480 train_time:80787ms step_avg:59.71ms
+step:1354/1480 train_time:80878ms step_avg:59.73ms
+step:1355/1480 train_time:80962ms step_avg:59.75ms
+step:1356/1480 train_time:81056ms step_avg:59.78ms
+step:1357/1480 train_time:81143ms step_avg:59.80ms
+step:1358/1480 train_time:81242ms step_avg:59.82ms
+step:1359/1480 train_time:81333ms step_avg:59.85ms
+step:1360/1480 train_time:81429ms step_avg:59.87ms
+step:1361/1480 train_time:81519ms step_avg:59.90ms
+step:1362/1480 train_time:81616ms step_avg:59.92ms
+step:1363/1480 train_time:81705ms step_avg:59.95ms
+step:1364/1480 train_time:81801ms step_avg:59.97ms
+step:1365/1480 train_time:81891ms step_avg:59.99ms
+step:1366/1480 train_time:81987ms step_avg:60.02ms
+step:1367/1480 train_time:82077ms step_avg:60.04ms
+step:1368/1480 train_time:82172ms step_avg:60.07ms
+step:1369/1480 train_time:82253ms step_avg:60.08ms
+step:1370/1480 train_time:82341ms step_avg:60.10ms
+step:1371/1480 train_time:82426ms step_avg:60.12ms
+step:1372/1480 train_time:82519ms step_avg:60.15ms
+step:1373/1480 train_time:82606ms step_avg:60.16ms
+step:1374/1480 train_time:82700ms step_avg:60.19ms
+step:1375/1480 train_time:82784ms step_avg:60.21ms
+step:1376/1480 train_time:82882ms step_avg:60.23ms
+step:1377/1480 train_time:82968ms step_avg:60.25ms
+step:1378/1480 train_time:83063ms step_avg:60.28ms
+step:1379/1480 train_time:83154ms step_avg:60.30ms
+step:1380/1480 train_time:83250ms step_avg:60.33ms
+step:1381/1480 train_time:83341ms step_avg:60.35ms
+step:1382/1480 train_time:83437ms step_avg:60.37ms
+step:1383/1480 train_time:83527ms step_avg:60.40ms
+step:1384/1480 train_time:83624ms step_avg:60.42ms
+step:1385/1480 train_time:83714ms step_avg:60.44ms
+step:1386/1480 train_time:83809ms step_avg:60.47ms
+step:1387/1480 train_time:83892ms step_avg:60.48ms
+step:1388/1480 train_time:83978ms step_avg:60.50ms
+step:1389/1480 train_time:84064ms step_avg:60.52ms
+step:1390/1480 train_time:84157ms step_avg:60.54ms
+step:1391/1480 train_time:84242ms step_avg:60.56ms
+step:1392/1480 train_time:84335ms step_avg:60.59ms
+step:1393/1480 train_time:84420ms step_avg:60.60ms
+step:1394/1480 train_time:84513ms step_avg:60.63ms
+step:1395/1480 train_time:84600ms step_avg:60.65ms
+step:1396/1480 train_time:84694ms step_avg:60.67ms
+step:1397/1480 train_time:84782ms step_avg:60.69ms
+step:1398/1480 train_time:84876ms step_avg:60.71ms
+step:1399/1480 train_time:84963ms step_avg:60.73ms
+step:1400/1480 train_time:85056ms step_avg:60.75ms
+step:1401/1480 train_time:85143ms step_avg:60.77ms
+step:1402/1480 train_time:85237ms step_avg:60.80ms
+step:1403/1480 train_time:85324ms step_avg:60.82ms
+step:1404/1480 train_time:85419ms step_avg:60.84ms
+step:1405/1480 train_time:85507ms step_avg:60.86ms
+step:1406/1480 train_time:85601ms step_avg:60.88ms
+step:1407/1480 train_time:85688ms step_avg:60.90ms
+step:1408/1480 train_time:85780ms step_avg:60.92ms
+step:1409/1480 train_time:85868ms step_avg:60.94ms
+step:1410/1480 train_time:85960ms step_avg:60.96ms
+step:1411/1480 train_time:86048ms step_avg:60.98ms
+step:1412/1480 train_time:86142ms step_avg:61.01ms
+step:1413/1480 train_time:86229ms step_avg:61.03ms
+step:1414/1480 train_time:86323ms step_avg:61.05ms
+step:1415/1480 train_time:86410ms step_avg:61.07ms
+step:1416/1480 train_time:86505ms step_avg:61.09ms
+step:1417/1480 train_time:86591ms step_avg:61.11ms
+step:1418/1480 train_time:86684ms step_avg:61.13ms
+step:1419/1480 train_time:86771ms step_avg:61.15ms
+step:1420/1480 train_time:86864ms step_avg:61.17ms
+step:1421/1480 train_time:86951ms step_avg:61.19ms
+step:1422/1480 train_time:87044ms step_avg:61.21ms
+step:1423/1480 train_time:87131ms step_avg:61.23ms
+step:1424/1480 train_time:87225ms step_avg:61.25ms
+step:1425/1480 train_time:87312ms step_avg:61.27ms
+step:1426/1480 train_time:87403ms step_avg:61.29ms
+step:1427/1480 train_time:87487ms step_avg:61.31ms
+step:1428/1480 train_time:87580ms step_avg:61.33ms
+step:1429/1480 train_time:87664ms step_avg:61.35ms
+step:1430/1480 train_time:87757ms step_avg:61.37ms
+step:1431/1480 train_time:87843ms step_avg:61.39ms
+step:1432/1480 train_time:87936ms step_avg:61.41ms
+step:1433/1480 train_time:88022ms step_avg:61.43ms
+step:1434/1480 train_time:88116ms step_avg:61.45ms
+step:1435/1480 train_time:88203ms step_avg:61.47ms
+step:1436/1480 train_time:88297ms step_avg:61.49ms
+step:1437/1480 train_time:88383ms step_avg:61.50ms
+step:1438/1480 train_time:88477ms step_avg:61.53ms
+step:1439/1480 train_time:88563ms step_avg:61.55ms
+step:1440/1480 train_time:88657ms step_avg:61.57ms
+step:1441/1480 train_time:88748ms step_avg:61.59ms
+step:1442/1480 train_time:88843ms step_avg:61.61ms
+step:1443/1480 train_time:88930ms step_avg:61.63ms
+step:1444/1480 train_time:89024ms step_avg:61.65ms
+step:1445/1480 train_time:89111ms step_avg:61.67ms
+step:1446/1480 train_time:89204ms step_avg:61.69ms
+step:1447/1480 train_time:89290ms step_avg:61.71ms
+step:1448/1480 train_time:89387ms step_avg:61.73ms
+step:1449/1480 train_time:89472ms step_avg:61.75ms
+step:1450/1480 train_time:89564ms step_avg:61.77ms
+step:1451/1480 train_time:89651ms step_avg:61.79ms
+step:1452/1480 train_time:89743ms step_avg:61.81ms
+step:1453/1480 train_time:89829ms step_avg:61.82ms
+step:1454/1480 train_time:89922ms step_avg:61.84ms
+step:1455/1480 train_time:90009ms step_avg:61.86ms
+step:1456/1480 train_time:90101ms step_avg:61.88ms
+step:1457/1480 train_time:90187ms step_avg:61.90ms
+step:1458/1480 train_time:90279ms step_avg:61.92ms
+step:1459/1480 train_time:90362ms step_avg:61.93ms
+step:1460/1480 train_time:90458ms step_avg:61.96ms
+step:1461/1480 train_time:90547ms step_avg:61.98ms
+step:1462/1480 train_time:90644ms step_avg:62.00ms
+step:1463/1480 train_time:90734ms step_avg:62.02ms
+step:1464/1480 train_time:90829ms step_avg:62.04ms
+step:1465/1480 train_time:90918ms step_avg:62.06ms
+step:1466/1480 train_time:91013ms step_avg:62.08ms
+step:1467/1480 train_time:91101ms step_avg:62.10ms
+step:1468/1480 train_time:91197ms step_avg:62.12ms
+step:1469/1480 train_time:91286ms step_avg:62.14ms
+step:1470/1480 train_time:91382ms step_avg:62.16ms
+step:1471/1480 train_time:91471ms step_avg:62.18ms
+step:1472/1480 train_time:91565ms step_avg:62.20ms
+step:1473/1480 train_time:91653ms step_avg:62.22ms
+step:1474/1480 train_time:91747ms step_avg:62.24ms
+step:1475/1480 train_time:91835ms step_avg:62.26ms
+step:1476/1480 train_time:91928ms step_avg:62.28ms
+step:1477/1480 train_time:92016ms step_avg:62.30ms
+step:1478/1480 train_time:92110ms step_avg:62.32ms
+step:1479/1480 train_time:92197ms step_avg:62.34ms
+step:1480/1480 train_time:92293ms step_avg:62.36ms
+step:1480/1480 val_loss:3.2788 train_time:92412ms step_avg:62.44ms
+peak memory allocated: 31315 MiB reserved: 47302 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline1-1490.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline1-1490.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 15:36:36 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   38C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   38C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   34C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   38C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   66C    P0            150W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          141798      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          141799      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          141800      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          141801      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          141802      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          141803      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          141804      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          141805      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8303 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:76ms step_avg:75.94ms
+step:2/1490 train_time:99ms step_avg:49.63ms
+step:3/1490 train_time:118ms step_avg:39.26ms
+step:4/1490 train_time:140ms step_avg:34.91ms
+step:5/1490 train_time:167ms step_avg:33.32ms
+step:6/1490 train_time:202ms step_avg:33.70ms
+step:7/1490 train_time:229ms step_avg:32.73ms
+step:8/1490 train_time:264ms step_avg:33.02ms
+step:9/1490 train_time:292ms step_avg:32.41ms
+step:10/1490 train_time:326ms step_avg:32.64ms
+step:11/1490 train_time:354ms step_avg:32.18ms
+step:12/1490 train_time:389ms step_avg:32.39ms
+step:13/1490 train_time:416ms step_avg:32.04ms
+step:14/1490 train_time:451ms step_avg:32.22ms
+step:15/1490 train_time:479ms step_avg:31.94ms
+step:16/1490 train_time:514ms step_avg:32.13ms
+step:17/1490 train_time:542ms step_avg:31.89ms
+step:18/1490 train_time:577ms step_avg:32.05ms
+step:19/1490 train_time:605ms step_avg:31.84ms
+step:20/1490 train_time:640ms step_avg:31.99ms
+step:21/1490 train_time:668ms step_avg:31.82ms
+step:22/1490 train_time:703ms step_avg:31.95ms
+step:23/1490 train_time:731ms step_avg:31.77ms
+step:24/1490 train_time:766ms step_avg:31.91ms
+step:25/1490 train_time:794ms step_avg:31.75ms
+step:26/1490 train_time:828ms step_avg:31.86ms
+step:27/1490 train_time:857ms step_avg:31.73ms
+step:28/1490 train_time:891ms step_avg:31.83ms
+step:29/1490 train_time:920ms step_avg:31.72ms
+step:30/1490 train_time:956ms step_avg:31.85ms
+step:31/1490 train_time:986ms step_avg:31.80ms
+step:32/1490 train_time:1024ms step_avg:32.00ms
+step:33/1490 train_time:1055ms step_avg:31.96ms
+step:34/1490 train_time:1091ms step_avg:32.10ms
+step:35/1490 train_time:1121ms step_avg:32.02ms
+step:36/1490 train_time:1157ms step_avg:32.13ms
+step:37/1490 train_time:1186ms step_avg:32.05ms
+step:38/1490 train_time:1221ms step_avg:32.14ms
+step:39/1490 train_time:1250ms step_avg:32.05ms
+step:40/1490 train_time:1285ms step_avg:32.11ms
+step:41/1490 train_time:1312ms step_avg:32.01ms
+step:42/1490 train_time:1347ms step_avg:32.07ms
+step:43/1490 train_time:1375ms step_avg:31.98ms
+step:44/1490 train_time:1410ms step_avg:32.04ms
+step:45/1490 train_time:1437ms step_avg:31.94ms
+step:46/1490 train_time:1472ms step_avg:32.01ms
+step:47/1490 train_time:1501ms step_avg:31.93ms
+step:48/1490 train_time:1536ms step_avg:31.99ms
+step:49/1490 train_time:1564ms step_avg:31.92ms
+step:50/1490 train_time:1600ms step_avg:32.00ms
+step:51/1490 train_time:1628ms step_avg:31.93ms
+step:52/1490 train_time:1663ms step_avg:31.99ms
+step:53/1490 train_time:1692ms step_avg:31.92ms
+step:54/1490 train_time:1726ms step_avg:31.97ms
+step:55/1490 train_time:1754ms step_avg:31.90ms
+step:56/1490 train_time:1789ms step_avg:31.94ms
+step:57/1490 train_time:1817ms step_avg:31.87ms
+step:58/1490 train_time:1851ms step_avg:31.92ms
+step:59/1490 train_time:1880ms step_avg:31.86ms
+step:60/1490 train_time:1915ms step_avg:31.92ms
+step:61/1490 train_time:1944ms step_avg:31.87ms
+step:62/1490 train_time:1980ms step_avg:31.94ms
+step:63/1490 train_time:2009ms step_avg:31.89ms
+step:64/1490 train_time:2045ms step_avg:31.96ms
+step:65/1490 train_time:2074ms step_avg:31.91ms
+step:66/1490 train_time:2110ms step_avg:31.97ms
+step:67/1490 train_time:2140ms step_avg:31.93ms
+step:68/1490 train_time:2175ms step_avg:31.99ms
+step:69/1490 train_time:2204ms step_avg:31.95ms
+step:70/1490 train_time:2240ms step_avg:32.00ms
+step:71/1490 train_time:2269ms step_avg:31.96ms
+step:72/1490 train_time:2305ms step_avg:32.01ms
+step:73/1490 train_time:2332ms step_avg:31.95ms
+step:74/1490 train_time:2367ms step_avg:31.99ms
+step:75/1490 train_time:2396ms step_avg:31.94ms
+step:76/1490 train_time:2431ms step_avg:31.98ms
+step:77/1490 train_time:2459ms step_avg:31.94ms
+step:78/1490 train_time:2494ms step_avg:31.98ms
+step:79/1490 train_time:2523ms step_avg:31.94ms
+step:80/1490 train_time:2560ms step_avg:31.99ms
+step:81/1490 train_time:2590ms step_avg:31.97ms
+step:82/1490 train_time:2627ms step_avg:32.04ms
+step:83/1490 train_time:2658ms step_avg:32.02ms
+step:84/1490 train_time:2694ms step_avg:32.08ms
+step:85/1490 train_time:2725ms step_avg:32.06ms
+step:86/1490 train_time:2762ms step_avg:32.12ms
+step:87/1490 train_time:2842ms step_avg:32.66ms
+step:88/1490 train_time:2862ms step_avg:32.52ms
+step:89/1490 train_time:2879ms step_avg:32.34ms
+step:90/1490 train_time:2909ms step_avg:32.32ms
+step:91/1490 train_time:2936ms step_avg:32.26ms
+step:92/1490 train_time:2971ms step_avg:32.29ms
+step:93/1490 train_time:3000ms step_avg:32.26ms
+step:94/1490 train_time:3036ms step_avg:32.30ms
+step:95/1490 train_time:3064ms step_avg:32.26ms
+step:96/1490 train_time:3100ms step_avg:32.30ms
+step:97/1490 train_time:3128ms step_avg:32.25ms
+step:98/1490 train_time:3164ms step_avg:32.28ms
+step:99/1490 train_time:3192ms step_avg:32.25ms
+step:100/1490 train_time:3228ms step_avg:32.28ms
+step:101/1490 train_time:3256ms step_avg:32.24ms
+step:102/1490 train_time:3292ms step_avg:32.27ms
+step:103/1490 train_time:3321ms step_avg:32.24ms
+step:104/1490 train_time:3356ms step_avg:32.27ms
+step:105/1490 train_time:3385ms step_avg:32.23ms
+step:106/1490 train_time:3421ms step_avg:32.27ms
+step:107/1490 train_time:3450ms step_avg:32.24ms
+step:108/1490 train_time:3485ms step_avg:32.27ms
+step:109/1490 train_time:3514ms step_avg:32.24ms
+step:110/1490 train_time:3549ms step_avg:32.26ms
+step:111/1490 train_time:3578ms step_avg:32.23ms
+step:112/1490 train_time:3614ms step_avg:32.26ms
+step:113/1490 train_time:3642ms step_avg:32.23ms
+step:114/1490 train_time:3678ms step_avg:32.26ms
+step:115/1490 train_time:3706ms step_avg:32.23ms
+step:116/1490 train_time:3742ms step_avg:32.26ms
+step:117/1490 train_time:3771ms step_avg:32.23ms
+step:118/1490 train_time:3806ms step_avg:32.25ms
+step:119/1490 train_time:3835ms step_avg:32.23ms
+step:120/1490 train_time:3871ms step_avg:32.26ms
+step:121/1490 train_time:3900ms step_avg:32.23ms
+step:122/1490 train_time:3935ms step_avg:32.25ms
+step:123/1490 train_time:3963ms step_avg:32.22ms
+step:124/1490 train_time:4001ms step_avg:32.27ms
+step:125/1490 train_time:4031ms step_avg:32.25ms
+step:126/1490 train_time:4069ms step_avg:32.29ms
+step:127/1490 train_time:4100ms step_avg:32.28ms
+step:128/1490 train_time:4137ms step_avg:32.32ms
+step:129/1490 train_time:4168ms step_avg:32.31ms
+step:130/1490 train_time:4205ms step_avg:32.35ms
+step:131/1490 train_time:4236ms step_avg:32.34ms
+step:132/1490 train_time:4273ms step_avg:32.37ms
+step:133/1490 train_time:4304ms step_avg:32.36ms
+step:134/1490 train_time:4342ms step_avg:32.40ms
+step:135/1490 train_time:4373ms step_avg:32.39ms
+step:136/1490 train_time:4410ms step_avg:32.43ms
+step:137/1490 train_time:4441ms step_avg:32.42ms
+step:138/1490 train_time:4478ms step_avg:32.45ms
+step:139/1490 train_time:4508ms step_avg:32.43ms
+step:140/1490 train_time:4546ms step_avg:32.47ms
+step:141/1490 train_time:4576ms step_avg:32.45ms
+step:142/1490 train_time:4613ms step_avg:32.49ms
+step:143/1490 train_time:4644ms step_avg:32.48ms
+step:144/1490 train_time:4682ms step_avg:32.52ms
+step:145/1490 train_time:4712ms step_avg:32.50ms
+step:146/1490 train_time:4749ms step_avg:32.53ms
+step:147/1490 train_time:4780ms step_avg:32.52ms
+step:148/1490 train_time:4816ms step_avg:32.54ms
+step:149/1490 train_time:4844ms step_avg:32.51ms
+step:150/1490 train_time:4879ms step_avg:32.53ms
+step:151/1490 train_time:4907ms step_avg:32.50ms
+step:152/1490 train_time:4942ms step_avg:32.51ms
+step:153/1490 train_time:4970ms step_avg:32.48ms
+step:154/1490 train_time:5005ms step_avg:32.50ms
+step:155/1490 train_time:5033ms step_avg:32.47ms
+step:156/1490 train_time:5069ms step_avg:32.50ms
+step:157/1490 train_time:5098ms step_avg:32.47ms
+step:158/1490 train_time:5135ms step_avg:32.50ms
+step:159/1490 train_time:5164ms step_avg:32.48ms
+step:160/1490 train_time:5203ms step_avg:32.52ms
+step:161/1490 train_time:5232ms step_avg:32.50ms
+step:162/1490 train_time:5269ms step_avg:32.52ms
+step:163/1490 train_time:5298ms step_avg:32.50ms
+step:164/1490 train_time:5334ms step_avg:32.52ms
+step:165/1490 train_time:5363ms step_avg:32.50ms
+step:166/1490 train_time:5399ms step_avg:32.53ms
+step:167/1490 train_time:5428ms step_avg:32.50ms
+step:168/1490 train_time:5464ms step_avg:32.53ms
+step:169/1490 train_time:5493ms step_avg:32.51ms
+step:170/1490 train_time:5530ms step_avg:32.53ms
+step:171/1490 train_time:5560ms step_avg:32.51ms
+step:172/1490 train_time:5596ms step_avg:32.53ms
+step:173/1490 train_time:5625ms step_avg:32.52ms
+step:174/1490 train_time:5662ms step_avg:32.54ms
+step:175/1490 train_time:5691ms step_avg:32.52ms
+step:176/1490 train_time:5727ms step_avg:32.54ms
+step:177/1490 train_time:5757ms step_avg:32.52ms
+step:178/1490 train_time:5793ms step_avg:32.55ms
+step:179/1490 train_time:5823ms step_avg:32.53ms
+step:180/1490 train_time:5859ms step_avg:32.55ms
+step:181/1490 train_time:5888ms step_avg:32.53ms
+step:182/1490 train_time:5925ms step_avg:32.55ms
+step:183/1490 train_time:5954ms step_avg:32.53ms
+step:184/1490 train_time:5990ms step_avg:32.55ms
+step:185/1490 train_time:6019ms step_avg:32.54ms
+step:186/1490 train_time:6055ms step_avg:32.56ms
+step:187/1490 train_time:6085ms step_avg:32.54ms
+step:188/1490 train_time:6121ms step_avg:32.56ms
+step:189/1490 train_time:6151ms step_avg:32.54ms
+step:190/1490 train_time:6187ms step_avg:32.56ms
+step:191/1490 train_time:6216ms step_avg:32.54ms
+step:192/1490 train_time:6252ms step_avg:32.56ms
+step:193/1490 train_time:6281ms step_avg:32.55ms
+step:194/1490 train_time:6318ms step_avg:32.57ms
+step:195/1490 train_time:6347ms step_avg:32.55ms
+step:196/1490 train_time:6383ms step_avg:32.57ms
+step:197/1490 train_time:6412ms step_avg:32.55ms
+step:198/1490 train_time:6448ms step_avg:32.57ms
+step:199/1490 train_time:6478ms step_avg:32.55ms
+step:200/1490 train_time:6514ms step_avg:32.57ms
+step:201/1490 train_time:6543ms step_avg:32.55ms
+step:202/1490 train_time:6580ms step_avg:32.57ms
+step:203/1490 train_time:6609ms step_avg:32.56ms
+step:204/1490 train_time:6645ms step_avg:32.58ms
+step:205/1490 train_time:6674ms step_avg:32.56ms
+step:206/1490 train_time:6711ms step_avg:32.58ms
+step:207/1490 train_time:6740ms step_avg:32.56ms
+step:208/1490 train_time:6776ms step_avg:32.58ms
+step:209/1490 train_time:6806ms step_avg:32.56ms
+step:210/1490 train_time:6842ms step_avg:32.58ms
+step:211/1490 train_time:6871ms step_avg:32.57ms
+step:212/1490 train_time:6907ms step_avg:32.58ms
+step:213/1490 train_time:6937ms step_avg:32.57ms
+step:214/1490 train_time:6973ms step_avg:32.58ms
+step:215/1490 train_time:7002ms step_avg:32.57ms
+step:216/1490 train_time:7039ms step_avg:32.59ms
+step:217/1490 train_time:7067ms step_avg:32.57ms
+step:218/1490 train_time:7104ms step_avg:32.59ms
+step:219/1490 train_time:7133ms step_avg:32.57ms
+step:220/1490 train_time:7169ms step_avg:32.59ms
+step:221/1490 train_time:7199ms step_avg:32.57ms
+step:222/1490 train_time:7235ms step_avg:32.59ms
+step:223/1490 train_time:7264ms step_avg:32.57ms
+step:224/1490 train_time:7300ms step_avg:32.59ms
+step:225/1490 train_time:7329ms step_avg:32.57ms
+step:226/1490 train_time:7365ms step_avg:32.59ms
+step:227/1490 train_time:7394ms step_avg:32.57ms
+step:228/1490 train_time:7430ms step_avg:32.59ms
+step:229/1490 train_time:7459ms step_avg:32.57ms
+step:230/1490 train_time:7495ms step_avg:32.59ms
+step:231/1490 train_time:7524ms step_avg:32.57ms
+step:232/1490 train_time:7560ms step_avg:32.59ms
+step:233/1490 train_time:7589ms step_avg:32.57ms
+step:234/1490 train_time:7626ms step_avg:32.59ms
+step:235/1490 train_time:7655ms step_avg:32.57ms
+step:236/1490 train_time:7691ms step_avg:32.59ms
+step:237/1490 train_time:7720ms step_avg:32.57ms
+step:238/1490 train_time:7756ms step_avg:32.59ms
+step:239/1490 train_time:7785ms step_avg:32.57ms
+step:240/1490 train_time:7822ms step_avg:32.59ms
+step:241/1490 train_time:7851ms step_avg:32.58ms
+step:242/1490 train_time:7887ms step_avg:32.59ms
+step:243/1490 train_time:7916ms step_avg:32.58ms
+step:244/1490 train_time:7952ms step_avg:32.59ms
+step:245/1490 train_time:7982ms step_avg:32.58ms
+step:246/1490 train_time:8019ms step_avg:32.60ms
+step:247/1490 train_time:8048ms step_avg:32.58ms
+step:248/1490 train_time:8085ms step_avg:32.60ms
+step:249/1490 train_time:8115ms step_avg:32.59ms
+step:250/1490 train_time:8151ms step_avg:32.60ms
+step:250/1490 val_loss:4.4934 train_time:8198ms step_avg:32.79ms
+step:251/1490 train_time:8216ms step_avg:32.73ms
+step:252/1490 train_time:8236ms step_avg:32.68ms
+step:253/1490 train_time:8252ms step_avg:32.62ms
+step:254/1490 train_time:8285ms step_avg:32.62ms
+step:255/1490 train_time:8316ms step_avg:32.61ms
+step:256/1490 train_time:8352ms step_avg:32.63ms
+step:257/1490 train_time:8381ms step_avg:32.61ms
+step:258/1490 train_time:8417ms step_avg:32.62ms
+step:259/1490 train_time:8446ms step_avg:32.61ms
+step:260/1490 train_time:8482ms step_avg:32.62ms
+step:261/1490 train_time:8511ms step_avg:32.61ms
+step:262/1490 train_time:8546ms step_avg:32.62ms
+step:263/1490 train_time:8575ms step_avg:32.60ms
+step:264/1490 train_time:8611ms step_avg:32.62ms
+step:265/1490 train_time:8640ms step_avg:32.60ms
+step:266/1490 train_time:8676ms step_avg:32.62ms
+step:267/1490 train_time:8705ms step_avg:32.60ms
+step:268/1490 train_time:8742ms step_avg:32.62ms
+step:269/1490 train_time:8771ms step_avg:32.60ms
+step:270/1490 train_time:8808ms step_avg:32.62ms
+step:271/1490 train_time:8837ms step_avg:32.61ms
+step:272/1490 train_time:8873ms step_avg:32.62ms
+step:273/1490 train_time:8903ms step_avg:32.61ms
+step:274/1490 train_time:8940ms step_avg:32.63ms
+step:275/1490 train_time:8969ms step_avg:32.62ms
+step:276/1490 train_time:9006ms step_avg:32.63ms
+step:277/1490 train_time:9037ms step_avg:32.62ms
+step:278/1490 train_time:9074ms step_avg:32.64ms
+step:279/1490 train_time:9104ms step_avg:32.63ms
+step:280/1490 train_time:9141ms step_avg:32.65ms
+step:281/1490 train_time:9171ms step_avg:32.64ms
+step:282/1490 train_time:9208ms step_avg:32.65ms
+step:283/1490 train_time:9238ms step_avg:32.64ms
+step:284/1490 train_time:9274ms step_avg:32.66ms
+step:285/1490 train_time:9304ms step_avg:32.65ms
+step:286/1490 train_time:9341ms step_avg:32.66ms
+step:287/1490 train_time:9371ms step_avg:32.65ms
+step:288/1490 train_time:9408ms step_avg:32.67ms
+step:289/1490 train_time:9437ms step_avg:32.65ms
+step:290/1490 train_time:9474ms step_avg:32.67ms
+step:291/1490 train_time:9504ms step_avg:32.66ms
+step:292/1490 train_time:9540ms step_avg:32.67ms
+step:293/1490 train_time:9570ms step_avg:32.66ms
+step:294/1490 train_time:9607ms step_avg:32.68ms
+step:295/1490 train_time:9637ms step_avg:32.67ms
+step:296/1490 train_time:9673ms step_avg:32.68ms
+step:297/1490 train_time:9702ms step_avg:32.67ms
+step:298/1490 train_time:9739ms step_avg:32.68ms
+step:299/1490 train_time:9769ms step_avg:32.67ms
+step:300/1490 train_time:9805ms step_avg:32.68ms
+step:301/1490 train_time:9835ms step_avg:32.67ms
+step:302/1490 train_time:9871ms step_avg:32.69ms
+step:303/1490 train_time:9901ms step_avg:32.68ms
+step:304/1490 train_time:9938ms step_avg:32.69ms
+step:305/1490 train_time:9968ms step_avg:32.68ms
+step:306/1490 train_time:10004ms step_avg:32.69ms
+step:307/1490 train_time:10034ms step_avg:32.68ms
+step:308/1490 train_time:10071ms step_avg:32.70ms
+step:309/1490 train_time:10100ms step_avg:32.69ms
+step:310/1490 train_time:10137ms step_avg:32.70ms
+step:311/1490 train_time:10167ms step_avg:32.69ms
+step:312/1490 train_time:10203ms step_avg:32.70ms
+step:313/1490 train_time:10233ms step_avg:32.69ms
+step:314/1490 train_time:10270ms step_avg:32.71ms
+step:315/1490 train_time:10299ms step_avg:32.70ms
+step:316/1490 train_time:10336ms step_avg:32.71ms
+step:317/1490 train_time:10365ms step_avg:32.70ms
+step:318/1490 train_time:10400ms step_avg:32.71ms
+step:319/1490 train_time:10428ms step_avg:32.69ms
+step:320/1490 train_time:10465ms step_avg:32.70ms
+step:321/1490 train_time:10494ms step_avg:32.69ms
+step:322/1490 train_time:10529ms step_avg:32.70ms
+step:323/1490 train_time:10559ms step_avg:32.69ms
+step:324/1490 train_time:10598ms step_avg:32.71ms
+step:325/1490 train_time:10631ms step_avg:32.71ms
+step:326/1490 train_time:10671ms step_avg:32.73ms
+step:327/1490 train_time:10701ms step_avg:32.72ms
+step:328/1490 train_time:10739ms step_avg:32.74ms
+step:329/1490 train_time:10769ms step_avg:32.73ms
+step:330/1490 train_time:10805ms step_avg:32.74ms
+step:331/1490 train_time:10832ms step_avg:32.73ms
+step:332/1490 train_time:10868ms step_avg:32.73ms
+step:333/1490 train_time:10897ms step_avg:32.72ms
+step:334/1490 train_time:10932ms step_avg:32.73ms
+step:335/1490 train_time:10962ms step_avg:32.72ms
+step:336/1490 train_time:11001ms step_avg:32.74ms
+step:337/1490 train_time:11032ms step_avg:32.74ms
+step:338/1490 train_time:11071ms step_avg:32.75ms
+step:339/1490 train_time:11100ms step_avg:32.74ms
+step:340/1490 train_time:11140ms step_avg:32.76ms
+step:341/1490 train_time:11170ms step_avg:32.76ms
+step:342/1490 train_time:11208ms step_avg:32.77ms
+step:343/1490 train_time:11239ms step_avg:32.77ms
+step:344/1490 train_time:11277ms step_avg:32.78ms
+step:345/1490 train_time:11307ms step_avg:32.77ms
+step:346/1490 train_time:11346ms step_avg:32.79ms
+step:347/1490 train_time:11376ms step_avg:32.78ms
+step:348/1490 train_time:11411ms step_avg:32.79ms
+step:349/1490 train_time:11439ms step_avg:32.78ms
+step:350/1490 train_time:11474ms step_avg:32.78ms
+step:351/1490 train_time:11502ms step_avg:32.77ms
+step:352/1490 train_time:11539ms step_avg:32.78ms
+step:353/1490 train_time:11567ms step_avg:32.77ms
+step:354/1490 train_time:11603ms step_avg:32.78ms
+step:355/1490 train_time:11632ms step_avg:32.77ms
+step:356/1490 train_time:11668ms step_avg:32.78ms
+step:357/1490 train_time:11697ms step_avg:32.77ms
+step:358/1490 train_time:11734ms step_avg:32.78ms
+step:359/1490 train_time:11763ms step_avg:32.77ms
+step:360/1490 train_time:11800ms step_avg:32.78ms
+step:361/1490 train_time:11829ms step_avg:32.77ms
+step:362/1490 train_time:11866ms step_avg:32.78ms
+step:363/1490 train_time:11895ms step_avg:32.77ms
+step:364/1490 train_time:11932ms step_avg:32.78ms
+step:365/1490 train_time:11961ms step_avg:32.77ms
+step:366/1490 train_time:11998ms step_avg:32.78ms
+step:367/1490 train_time:12027ms step_avg:32.77ms
+step:368/1490 train_time:12064ms step_avg:32.78ms
+step:369/1490 train_time:12093ms step_avg:32.77ms
+step:370/1490 train_time:12131ms step_avg:32.79ms
+step:371/1490 train_time:12160ms step_avg:32.78ms
+step:372/1490 train_time:12197ms step_avg:32.79ms
+step:373/1490 train_time:12226ms step_avg:32.78ms
+step:374/1490 train_time:12263ms step_avg:32.79ms
+step:375/1490 train_time:12292ms step_avg:32.78ms
+step:376/1490 train_time:12329ms step_avg:32.79ms
+step:377/1490 train_time:12358ms step_avg:32.78ms
+step:378/1490 train_time:12394ms step_avg:32.79ms
+step:379/1490 train_time:12424ms step_avg:32.78ms
+step:380/1490 train_time:12462ms step_avg:32.79ms
+step:381/1490 train_time:12492ms step_avg:32.79ms
+step:382/1490 train_time:12530ms step_avg:32.80ms
+step:383/1490 train_time:12560ms step_avg:32.79ms
+step:384/1490 train_time:12598ms step_avg:32.81ms
+step:385/1490 train_time:12628ms step_avg:32.80ms
+step:386/1490 train_time:12666ms step_avg:32.81ms
+step:387/1490 train_time:12695ms step_avg:32.80ms
+step:388/1490 train_time:12733ms step_avg:32.82ms
+step:389/1490 train_time:12764ms step_avg:32.81ms
+step:390/1490 train_time:12801ms step_avg:32.82ms
+step:391/1490 train_time:12831ms step_avg:32.82ms
+step:392/1490 train_time:12869ms step_avg:32.83ms
+step:393/1490 train_time:12899ms step_avg:32.82ms
+step:394/1490 train_time:12936ms step_avg:32.83ms
+step:395/1490 train_time:12966ms step_avg:32.83ms
+step:396/1490 train_time:13003ms step_avg:32.84ms
+step:397/1490 train_time:13033ms step_avg:32.83ms
+step:398/1490 train_time:13070ms step_avg:32.84ms
+step:399/1490 train_time:13100ms step_avg:32.83ms
+step:400/1490 train_time:13138ms step_avg:32.84ms
+step:401/1490 train_time:13168ms step_avg:32.84ms
+step:402/1490 train_time:13205ms step_avg:32.85ms
+step:403/1490 train_time:13235ms step_avg:32.84ms
+step:404/1490 train_time:13272ms step_avg:32.85ms
+step:405/1490 train_time:13301ms step_avg:32.84ms
+step:406/1490 train_time:13338ms step_avg:32.85ms
+step:407/1490 train_time:13368ms step_avg:32.85ms
+step:408/1490 train_time:13405ms step_avg:32.86ms
+step:409/1490 train_time:13434ms step_avg:32.85ms
+step:410/1490 train_time:13470ms step_avg:32.85ms
+step:411/1490 train_time:13497ms step_avg:32.84ms
+step:412/1490 train_time:13533ms step_avg:32.85ms
+step:413/1490 train_time:13562ms step_avg:32.84ms
+step:414/1490 train_time:13599ms step_avg:32.85ms
+step:415/1490 train_time:13628ms step_avg:32.84ms
+step:416/1490 train_time:13665ms step_avg:32.85ms
+step:417/1490 train_time:13694ms step_avg:32.84ms
+step:418/1490 train_time:13730ms step_avg:32.85ms
+step:419/1490 train_time:13759ms step_avg:32.84ms
+step:420/1490 train_time:13795ms step_avg:32.85ms
+step:421/1490 train_time:13823ms step_avg:32.83ms
+step:422/1490 train_time:13860ms step_avg:32.84ms
+step:423/1490 train_time:13889ms step_avg:32.84ms
+step:424/1490 train_time:13926ms step_avg:32.84ms
+step:425/1490 train_time:13956ms step_avg:32.84ms
+step:426/1490 train_time:13993ms step_avg:32.85ms
+step:427/1490 train_time:14022ms step_avg:32.84ms
+step:428/1490 train_time:14059ms step_avg:32.85ms
+step:429/1490 train_time:14088ms step_avg:32.84ms
+step:430/1490 train_time:14125ms step_avg:32.85ms
+step:431/1490 train_time:14155ms step_avg:32.84ms
+step:432/1490 train_time:14193ms step_avg:32.85ms
+step:433/1490 train_time:14222ms step_avg:32.84ms
+step:434/1490 train_time:14259ms step_avg:32.86ms
+step:435/1490 train_time:14289ms step_avg:32.85ms
+step:436/1490 train_time:14326ms step_avg:32.86ms
+step:437/1490 train_time:14356ms step_avg:32.85ms
+step:438/1490 train_time:14393ms step_avg:32.86ms
+step:439/1490 train_time:14422ms step_avg:32.85ms
+step:440/1490 train_time:14459ms step_avg:32.86ms
+step:441/1490 train_time:14489ms step_avg:32.85ms
+step:442/1490 train_time:14526ms step_avg:32.86ms
+step:443/1490 train_time:14556ms step_avg:32.86ms
+step:444/1490 train_time:14594ms step_avg:32.87ms
+step:445/1490 train_time:14623ms step_avg:32.86ms
+step:446/1490 train_time:14660ms step_avg:32.87ms
+step:447/1490 train_time:14690ms step_avg:32.86ms
+step:448/1490 train_time:14727ms step_avg:32.87ms
+step:449/1490 train_time:14757ms step_avg:32.87ms
+step:450/1490 train_time:14794ms step_avg:32.88ms
+step:451/1490 train_time:14824ms step_avg:32.87ms
+step:452/1490 train_time:14861ms step_avg:32.88ms
+step:453/1490 train_time:14891ms step_avg:32.87ms
+step:454/1490 train_time:14928ms step_avg:32.88ms
+step:455/1490 train_time:14958ms step_avg:32.87ms
+step:456/1490 train_time:14995ms step_avg:32.88ms
+step:457/1490 train_time:15024ms step_avg:32.88ms
+step:458/1490 train_time:15061ms step_avg:32.88ms
+step:459/1490 train_time:15090ms step_avg:32.88ms
+step:460/1490 train_time:15128ms step_avg:32.89ms
+step:461/1490 train_time:15157ms step_avg:32.88ms
+step:462/1490 train_time:15194ms step_avg:32.89ms
+step:463/1490 train_time:15223ms step_avg:32.88ms
+step:464/1490 train_time:15260ms step_avg:32.89ms
+step:465/1490 train_time:15290ms step_avg:32.88ms
+step:466/1490 train_time:15327ms step_avg:32.89ms
+step:467/1490 train_time:15356ms step_avg:32.88ms
+step:468/1490 train_time:15393ms step_avg:32.89ms
+step:469/1490 train_time:15422ms step_avg:32.88ms
+step:470/1490 train_time:15460ms step_avg:32.89ms
+step:471/1490 train_time:15489ms step_avg:32.88ms
+step:472/1490 train_time:15530ms step_avg:32.90ms
+step:473/1490 train_time:15556ms step_avg:32.89ms
+step:474/1490 train_time:15593ms step_avg:32.90ms
+step:475/1490 train_time:15622ms step_avg:32.89ms
+step:476/1490 train_time:15660ms step_avg:32.90ms
+step:477/1490 train_time:15689ms step_avg:32.89ms
+step:478/1490 train_time:15725ms step_avg:32.90ms
+step:479/1490 train_time:15755ms step_avg:32.89ms
+step:480/1490 train_time:15792ms step_avg:32.90ms
+step:481/1490 train_time:15822ms step_avg:32.89ms
+step:482/1490 train_time:15859ms step_avg:32.90ms
+step:483/1490 train_time:15889ms step_avg:32.90ms
+step:484/1490 train_time:15928ms step_avg:32.91ms
+step:485/1490 train_time:15980ms step_avg:32.95ms
+step:486/1490 train_time:16042ms step_avg:33.01ms
+step:487/1490 train_time:16101ms step_avg:33.06ms
+step:488/1490 train_time:16165ms step_avg:33.12ms
+step:489/1490 train_time:16222ms step_avg:33.17ms
+step:490/1490 train_time:16286ms step_avg:33.24ms
+step:491/1490 train_time:16346ms step_avg:33.29ms
+step:492/1490 train_time:16408ms step_avg:33.35ms
+step:493/1490 train_time:16465ms step_avg:33.40ms
+step:494/1490 train_time:16528ms step_avg:33.46ms
+step:495/1490 train_time:16586ms step_avg:33.51ms
+step:496/1490 train_time:16650ms step_avg:33.57ms
+step:497/1490 train_time:16706ms step_avg:33.61ms
+step:498/1490 train_time:16769ms step_avg:33.67ms
+step:499/1490 train_time:16826ms step_avg:33.72ms
+step:500/1490 train_time:16890ms step_avg:33.78ms
+step:500/1490 val_loss:4.2219 train_time:16978ms step_avg:33.96ms
+step:501/1490 train_time:17001ms step_avg:33.93ms
+step:502/1490 train_time:17023ms step_avg:33.91ms
+step:503/1490 train_time:17078ms step_avg:33.95ms
+step:504/1490 train_time:17146ms step_avg:34.02ms
+step:505/1490 train_time:17206ms step_avg:34.07ms
+step:506/1490 train_time:17272ms step_avg:34.13ms
+step:507/1490 train_time:17330ms step_avg:34.18ms
+step:508/1490 train_time:17394ms step_avg:34.24ms
+step:509/1490 train_time:17453ms step_avg:34.29ms
+step:510/1490 train_time:17518ms step_avg:34.35ms
+step:511/1490 train_time:17577ms step_avg:34.40ms
+step:512/1490 train_time:17642ms step_avg:34.46ms
+step:513/1490 train_time:17700ms step_avg:34.50ms
+step:514/1490 train_time:17764ms step_avg:34.56ms
+step:515/1490 train_time:17823ms step_avg:34.61ms
+step:516/1490 train_time:17888ms step_avg:34.67ms
+step:517/1490 train_time:17948ms step_avg:34.71ms
+step:518/1490 train_time:18013ms step_avg:34.77ms
+step:519/1490 train_time:18073ms step_avg:34.82ms
+step:520/1490 train_time:18137ms step_avg:34.88ms
+step:521/1490 train_time:18192ms step_avg:34.92ms
+step:522/1490 train_time:18253ms step_avg:34.97ms
+step:523/1490 train_time:18309ms step_avg:35.01ms
+step:524/1490 train_time:18374ms step_avg:35.06ms
+step:525/1490 train_time:18431ms step_avg:35.11ms
+step:526/1490 train_time:18495ms step_avg:35.16ms
+step:527/1490 train_time:18554ms step_avg:35.21ms
+step:528/1490 train_time:18620ms step_avg:35.26ms
+step:529/1490 train_time:18679ms step_avg:35.31ms
+step:530/1490 train_time:18742ms step_avg:35.36ms
+step:531/1490 train_time:18803ms step_avg:35.41ms
+step:532/1490 train_time:18872ms step_avg:35.47ms
+step:533/1490 train_time:18934ms step_avg:35.52ms
+step:534/1490 train_time:19001ms step_avg:35.58ms
+step:535/1490 train_time:19061ms step_avg:35.63ms
+step:536/1490 train_time:19129ms step_avg:35.69ms
+step:537/1490 train_time:19191ms step_avg:35.74ms
+step:538/1490 train_time:19258ms step_avg:35.80ms
+step:539/1490 train_time:19319ms step_avg:35.84ms
+step:540/1490 train_time:19386ms step_avg:35.90ms
+step:541/1490 train_time:19439ms step_avg:35.93ms
+step:542/1490 train_time:19499ms step_avg:35.98ms
+step:543/1490 train_time:19553ms step_avg:36.01ms
+step:544/1490 train_time:19616ms step_avg:36.06ms
+step:545/1490 train_time:19673ms step_avg:36.10ms
+step:546/1490 train_time:19736ms step_avg:36.15ms
+step:547/1490 train_time:19793ms step_avg:36.18ms
+step:548/1490 train_time:19856ms step_avg:36.23ms
+step:549/1490 train_time:19914ms step_avg:36.27ms
+step:550/1490 train_time:19977ms step_avg:36.32ms
+step:551/1490 train_time:20036ms step_avg:36.36ms
+step:552/1490 train_time:20099ms step_avg:36.41ms
+step:553/1490 train_time:20157ms step_avg:36.45ms
+step:554/1490 train_time:20221ms step_avg:36.50ms
+step:555/1490 train_time:20281ms step_avg:36.54ms
+step:556/1490 train_time:20347ms step_avg:36.59ms
+step:557/1490 train_time:20404ms step_avg:36.63ms
+step:558/1490 train_time:20467ms step_avg:36.68ms
+step:559/1490 train_time:20524ms step_avg:36.72ms
+step:560/1490 train_time:20586ms step_avg:36.76ms
+step:561/1490 train_time:20644ms step_avg:36.80ms
+step:562/1490 train_time:20707ms step_avg:36.85ms
+step:563/1490 train_time:20764ms step_avg:36.88ms
+step:564/1490 train_time:20828ms step_avg:36.93ms
+step:565/1490 train_time:20888ms step_avg:36.97ms
+step:566/1490 train_time:20954ms step_avg:37.02ms
+step:567/1490 train_time:21012ms step_avg:37.06ms
+step:568/1490 train_time:21076ms step_avg:37.11ms
+step:569/1490 train_time:21134ms step_avg:37.14ms
+step:570/1490 train_time:21196ms step_avg:37.19ms
+step:571/1490 train_time:21253ms step_avg:37.22ms
+step:572/1490 train_time:21317ms step_avg:37.27ms
+step:573/1490 train_time:21374ms step_avg:37.30ms
+step:574/1490 train_time:21437ms step_avg:37.35ms
+step:575/1490 train_time:21495ms step_avg:37.38ms
+step:576/1490 train_time:21558ms step_avg:37.43ms
+step:577/1490 train_time:21616ms step_avg:37.46ms
+step:578/1490 train_time:21679ms step_avg:37.51ms
+step:579/1490 train_time:21737ms step_avg:37.54ms
+step:580/1490 train_time:21799ms step_avg:37.59ms
+step:581/1490 train_time:21857ms step_avg:37.62ms
+step:582/1490 train_time:21920ms step_avg:37.66ms
+step:583/1490 train_time:21977ms step_avg:37.70ms
+step:584/1490 train_time:22040ms step_avg:37.74ms
+step:585/1490 train_time:22098ms step_avg:37.77ms
+step:586/1490 train_time:22161ms step_avg:37.82ms
+step:587/1490 train_time:22220ms step_avg:37.85ms
+step:588/1490 train_time:22285ms step_avg:37.90ms
+step:589/1490 train_time:22342ms step_avg:37.93ms
+step:590/1490 train_time:22407ms step_avg:37.98ms
+step:591/1490 train_time:22466ms step_avg:38.01ms
+step:592/1490 train_time:22532ms step_avg:38.06ms
+step:593/1490 train_time:22591ms step_avg:38.10ms
+step:594/1490 train_time:22654ms step_avg:38.14ms
+step:595/1490 train_time:22714ms step_avg:38.17ms
+step:596/1490 train_time:22779ms step_avg:38.22ms
+step:597/1490 train_time:22837ms step_avg:38.25ms
+step:598/1490 train_time:22901ms step_avg:38.30ms
+step:599/1490 train_time:22958ms step_avg:38.33ms
+step:600/1490 train_time:23021ms step_avg:38.37ms
+step:601/1490 train_time:23079ms step_avg:38.40ms
+step:602/1490 train_time:23144ms step_avg:38.45ms
+step:603/1490 train_time:23201ms step_avg:38.48ms
+step:604/1490 train_time:23266ms step_avg:38.52ms
+step:605/1490 train_time:23324ms step_avg:38.55ms
+step:606/1490 train_time:23387ms step_avg:38.59ms
+step:607/1490 train_time:23445ms step_avg:38.62ms
+step:608/1490 train_time:23510ms step_avg:38.67ms
+step:609/1490 train_time:23568ms step_avg:38.70ms
+step:610/1490 train_time:23632ms step_avg:38.74ms
+step:611/1490 train_time:23692ms step_avg:38.78ms
+step:612/1490 train_time:23763ms step_avg:38.83ms
+step:613/1490 train_time:23824ms step_avg:38.87ms
+step:614/1490 train_time:23891ms step_avg:38.91ms
+step:615/1490 train_time:23952ms step_avg:38.95ms
+step:616/1490 train_time:24019ms step_avg:38.99ms
+step:617/1490 train_time:24081ms step_avg:39.03ms
+step:618/1490 train_time:24149ms step_avg:39.08ms
+step:619/1490 train_time:24209ms step_avg:39.11ms
+step:620/1490 train_time:24277ms step_avg:39.16ms
+step:621/1490 train_time:24333ms step_avg:39.18ms
+step:622/1490 train_time:24393ms step_avg:39.22ms
+step:623/1490 train_time:24447ms step_avg:39.24ms
+step:624/1490 train_time:24506ms step_avg:39.27ms
+step:625/1490 train_time:24563ms step_avg:39.30ms
+step:626/1490 train_time:24628ms step_avg:39.34ms
+step:627/1490 train_time:24684ms step_avg:39.37ms
+step:628/1490 train_time:24749ms step_avg:39.41ms
+step:629/1490 train_time:24807ms step_avg:39.44ms
+step:630/1490 train_time:24872ms step_avg:39.48ms
+step:631/1490 train_time:24932ms step_avg:39.51ms
+step:632/1490 train_time:25000ms step_avg:39.56ms
+step:633/1490 train_time:25061ms step_avg:39.59ms
+step:634/1490 train_time:25128ms step_avg:39.63ms
+step:635/1490 train_time:25188ms step_avg:39.67ms
+step:636/1490 train_time:25255ms step_avg:39.71ms
+step:637/1490 train_time:25316ms step_avg:39.74ms
+step:638/1490 train_time:25383ms step_avg:39.78ms
+step:639/1490 train_time:25441ms step_avg:39.81ms
+step:640/1490 train_time:25507ms step_avg:39.85ms
+step:641/1490 train_time:25564ms step_avg:39.88ms
+step:642/1490 train_time:25624ms step_avg:39.91ms
+step:643/1490 train_time:25679ms step_avg:39.94ms
+step:644/1490 train_time:25740ms step_avg:39.97ms
+step:645/1490 train_time:25795ms step_avg:39.99ms
+step:646/1490 train_time:25857ms step_avg:40.03ms
+step:647/1490 train_time:25915ms step_avg:40.05ms
+step:648/1490 train_time:25979ms step_avg:40.09ms
+step:649/1490 train_time:26037ms step_avg:40.12ms
+step:650/1490 train_time:26102ms step_avg:40.16ms
+step:651/1490 train_time:26161ms step_avg:40.19ms
+step:652/1490 train_time:26233ms step_avg:40.23ms
+step:653/1490 train_time:26296ms step_avg:40.27ms
+step:654/1490 train_time:26366ms step_avg:40.32ms
+step:655/1490 train_time:26429ms step_avg:40.35ms
+step:656/1490 train_time:26498ms step_avg:40.39ms
+step:657/1490 train_time:26560ms step_avg:40.43ms
+step:658/1490 train_time:26620ms step_avg:40.46ms
+step:659/1490 train_time:26674ms step_avg:40.48ms
+step:660/1490 train_time:26734ms step_avg:40.51ms
+step:661/1490 train_time:26789ms step_avg:40.53ms
+step:662/1490 train_time:26853ms step_avg:40.56ms
+step:663/1490 train_time:26912ms step_avg:40.59ms
+step:664/1490 train_time:26978ms step_avg:40.63ms
+step:665/1490 train_time:27037ms step_avg:40.66ms
+step:666/1490 train_time:27100ms step_avg:40.69ms
+step:667/1490 train_time:27158ms step_avg:40.72ms
+step:668/1490 train_time:27223ms step_avg:40.75ms
+step:669/1490 train_time:27280ms step_avg:40.78ms
+step:670/1490 train_time:27345ms step_avg:40.81ms
+step:671/1490 train_time:27402ms step_avg:40.84ms
+step:672/1490 train_time:27467ms step_avg:40.87ms
+step:673/1490 train_time:27522ms step_avg:40.89ms
+step:674/1490 train_time:27586ms step_avg:40.93ms
+step:675/1490 train_time:27643ms step_avg:40.95ms
+step:676/1490 train_time:27707ms step_avg:40.99ms
+step:677/1490 train_time:27765ms step_avg:41.01ms
+step:678/1490 train_time:27830ms step_avg:41.05ms
+step:679/1490 train_time:27888ms step_avg:41.07ms
+step:680/1490 train_time:27953ms step_avg:41.11ms
+step:681/1490 train_time:28012ms step_avg:41.13ms
+step:682/1490 train_time:28077ms step_avg:41.17ms
+step:683/1490 train_time:28135ms step_avg:41.19ms
+step:684/1490 train_time:28199ms step_avg:41.23ms
+step:685/1490 train_time:28258ms step_avg:41.25ms
+step:686/1490 train_time:28322ms step_avg:41.29ms
+step:687/1490 train_time:28381ms step_avg:41.31ms
+step:688/1490 train_time:28445ms step_avg:41.34ms
+step:689/1490 train_time:28503ms step_avg:41.37ms
+step:690/1490 train_time:28568ms step_avg:41.40ms
+step:691/1490 train_time:28628ms step_avg:41.43ms
+step:692/1490 train_time:28692ms step_avg:41.46ms
+step:693/1490 train_time:28750ms step_avg:41.49ms
+step:694/1490 train_time:28816ms step_avg:41.52ms
+step:695/1490 train_time:28875ms step_avg:41.55ms
+step:696/1490 train_time:28940ms step_avg:41.58ms
+step:697/1490 train_time:28999ms step_avg:41.61ms
+step:698/1490 train_time:29064ms step_avg:41.64ms
+step:699/1490 train_time:29122ms step_avg:41.66ms
+step:700/1490 train_time:29187ms step_avg:41.70ms
+step:701/1490 train_time:29243ms step_avg:41.72ms
+step:702/1490 train_time:29307ms step_avg:41.75ms
+step:703/1490 train_time:29365ms step_avg:41.77ms
+step:704/1490 train_time:29430ms step_avg:41.80ms
+step:705/1490 train_time:29489ms step_avg:41.83ms
+step:706/1490 train_time:29556ms step_avg:41.86ms
+step:707/1490 train_time:29614ms step_avg:41.89ms
+step:708/1490 train_time:29679ms step_avg:41.92ms
+step:709/1490 train_time:29738ms step_avg:41.94ms
+step:710/1490 train_time:29801ms step_avg:41.97ms
+step:711/1490 train_time:29859ms step_avg:42.00ms
+step:712/1490 train_time:29924ms step_avg:42.03ms
+step:713/1490 train_time:29981ms step_avg:42.05ms
+step:714/1490 train_time:30045ms step_avg:42.08ms
+step:715/1490 train_time:30102ms step_avg:42.10ms
+step:716/1490 train_time:30166ms step_avg:42.13ms
+step:717/1490 train_time:30224ms step_avg:42.15ms
+step:718/1490 train_time:30287ms step_avg:42.18ms
+step:719/1490 train_time:30344ms step_avg:42.20ms
+step:720/1490 train_time:30407ms step_avg:42.23ms
+step:721/1490 train_time:30464ms step_avg:42.25ms
+step:722/1490 train_time:30528ms step_avg:42.28ms
+step:723/1490 train_time:30586ms step_avg:42.30ms
+step:724/1490 train_time:30649ms step_avg:42.33ms
+step:725/1490 train_time:30706ms step_avg:42.35ms
+step:726/1490 train_time:30771ms step_avg:42.38ms
+step:727/1490 train_time:30829ms step_avg:42.41ms
+step:728/1490 train_time:30894ms step_avg:42.44ms
+step:729/1490 train_time:30952ms step_avg:42.46ms
+step:730/1490 train_time:31017ms step_avg:42.49ms
+step:731/1490 train_time:31077ms step_avg:42.51ms
+step:732/1490 train_time:31142ms step_avg:42.54ms
+step:733/1490 train_time:31199ms step_avg:42.56ms
+step:734/1490 train_time:31263ms step_avg:42.59ms
+step:735/1490 train_time:31322ms step_avg:42.62ms
+step:736/1490 train_time:31387ms step_avg:42.65ms
+step:737/1490 train_time:31445ms step_avg:42.67ms
+step:738/1490 train_time:31510ms step_avg:42.70ms
+step:739/1490 train_time:31569ms step_avg:42.72ms
+step:740/1490 train_time:31635ms step_avg:42.75ms
+step:741/1490 train_time:31694ms step_avg:42.77ms
+step:742/1490 train_time:31757ms step_avg:42.80ms
+step:743/1490 train_time:31816ms step_avg:42.82ms
+step:744/1490 train_time:31879ms step_avg:42.85ms
+step:745/1490 train_time:31937ms step_avg:42.87ms
+step:746/1490 train_time:31999ms step_avg:42.89ms
+step:747/1490 train_time:32057ms step_avg:42.91ms
+step:748/1490 train_time:32120ms step_avg:42.94ms
+step:749/1490 train_time:32177ms step_avg:42.96ms
+step:750/1490 train_time:32240ms step_avg:42.99ms
+step:750/1490 val_loss:3.8069 train_time:32319ms step_avg:43.09ms
+step:751/1490 train_time:32338ms step_avg:43.06ms
+step:752/1490 train_time:32361ms step_avg:43.03ms
+step:753/1490 train_time:32419ms step_avg:43.05ms
+step:754/1490 train_time:32487ms step_avg:43.09ms
+step:755/1490 train_time:32549ms step_avg:43.11ms
+step:756/1490 train_time:32616ms step_avg:43.14ms
+step:757/1490 train_time:32676ms step_avg:43.17ms
+step:758/1490 train_time:32743ms step_avg:43.20ms
+step:759/1490 train_time:32803ms step_avg:43.22ms
+step:760/1490 train_time:32869ms step_avg:43.25ms
+step:761/1490 train_time:32930ms step_avg:43.27ms
+step:762/1490 train_time:32997ms step_avg:43.30ms
+step:763/1490 train_time:33057ms step_avg:43.32ms
+step:764/1490 train_time:33122ms step_avg:43.35ms
+step:765/1490 train_time:33182ms step_avg:43.37ms
+step:766/1490 train_time:33247ms step_avg:43.40ms
+step:767/1490 train_time:33307ms step_avg:43.42ms
+step:768/1490 train_time:33373ms step_avg:43.45ms
+step:769/1490 train_time:33432ms step_avg:43.47ms
+step:770/1490 train_time:33498ms step_avg:43.50ms
+step:771/1490 train_time:33557ms step_avg:43.52ms
+step:772/1490 train_time:33622ms step_avg:43.55ms
+step:773/1490 train_time:33680ms step_avg:43.57ms
+step:774/1490 train_time:33744ms step_avg:43.60ms
+step:775/1490 train_time:33804ms step_avg:43.62ms
+step:776/1490 train_time:33869ms step_avg:43.65ms
+step:777/1490 train_time:33928ms step_avg:43.67ms
+step:778/1490 train_time:33993ms step_avg:43.69ms
+step:779/1490 train_time:34053ms step_avg:43.71ms
+step:780/1490 train_time:34118ms step_avg:43.74ms
+step:781/1490 train_time:34175ms step_avg:43.76ms
+step:782/1490 train_time:34240ms step_avg:43.78ms
+step:783/1490 train_time:34298ms step_avg:43.80ms
+step:784/1490 train_time:34361ms step_avg:43.83ms
+step:785/1490 train_time:34418ms step_avg:43.84ms
+step:786/1490 train_time:34482ms step_avg:43.87ms
+step:787/1490 train_time:34540ms step_avg:43.89ms
+step:788/1490 train_time:34604ms step_avg:43.91ms
+step:789/1490 train_time:34662ms step_avg:43.93ms
+step:790/1490 train_time:34726ms step_avg:43.96ms
+step:791/1490 train_time:34783ms step_avg:43.97ms
+step:792/1490 train_time:34847ms step_avg:44.00ms
+step:793/1490 train_time:34905ms step_avg:44.02ms
+step:794/1490 train_time:34969ms step_avg:44.04ms
+step:795/1490 train_time:35027ms step_avg:44.06ms
+step:796/1490 train_time:35091ms step_avg:44.08ms
+step:797/1490 train_time:35150ms step_avg:44.10ms
+step:798/1490 train_time:35216ms step_avg:44.13ms
+step:799/1490 train_time:35276ms step_avg:44.15ms
+step:800/1490 train_time:35340ms step_avg:44.17ms
+step:801/1490 train_time:35399ms step_avg:44.19ms
+step:802/1490 train_time:35464ms step_avg:44.22ms
+step:803/1490 train_time:35522ms step_avg:44.24ms
+step:804/1490 train_time:35588ms step_avg:44.26ms
+step:805/1490 train_time:35648ms step_avg:44.28ms
+step:806/1490 train_time:35714ms step_avg:44.31ms
+step:807/1490 train_time:35773ms step_avg:44.33ms
+step:808/1490 train_time:35837ms step_avg:44.35ms
+step:809/1490 train_time:35895ms step_avg:44.37ms
+step:810/1490 train_time:35959ms step_avg:44.39ms
+step:811/1490 train_time:36017ms step_avg:44.41ms
+step:812/1490 train_time:36082ms step_avg:44.44ms
+step:813/1490 train_time:36141ms step_avg:44.45ms
+step:814/1490 train_time:36207ms step_avg:44.48ms
+step:815/1490 train_time:36265ms step_avg:44.50ms
+step:816/1490 train_time:36329ms step_avg:44.52ms
+step:817/1490 train_time:36386ms step_avg:44.54ms
+step:818/1490 train_time:36450ms step_avg:44.56ms
+step:819/1490 train_time:36510ms step_avg:44.58ms
+step:820/1490 train_time:36575ms step_avg:44.60ms
+step:821/1490 train_time:36632ms step_avg:44.62ms
+step:822/1490 train_time:36695ms step_avg:44.64ms
+step:823/1490 train_time:36753ms step_avg:44.66ms
+step:824/1490 train_time:36817ms step_avg:44.68ms
+step:825/1490 train_time:36875ms step_avg:44.70ms
+step:826/1490 train_time:36940ms step_avg:44.72ms
+step:827/1490 train_time:36998ms step_avg:44.74ms
+step:828/1490 train_time:37063ms step_avg:44.76ms
+step:829/1490 train_time:37120ms step_avg:44.78ms
+step:830/1490 train_time:37185ms step_avg:44.80ms
+step:831/1490 train_time:37243ms step_avg:44.82ms
+step:832/1490 train_time:37308ms step_avg:44.84ms
+step:833/1490 train_time:37367ms step_avg:44.86ms
+step:834/1490 train_time:37432ms step_avg:44.88ms
+step:835/1490 train_time:37491ms step_avg:44.90ms
+step:836/1490 train_time:37556ms step_avg:44.92ms
+step:837/1490 train_time:37614ms step_avg:44.94ms
+step:838/1490 train_time:37678ms step_avg:44.96ms
+step:839/1490 train_time:37736ms step_avg:44.98ms
+step:840/1490 train_time:37800ms step_avg:45.00ms
+step:841/1490 train_time:37858ms step_avg:45.02ms
+step:842/1490 train_time:37922ms step_avg:45.04ms
+step:843/1490 train_time:37981ms step_avg:45.05ms
+step:844/1490 train_time:38046ms step_avg:45.08ms
+step:845/1490 train_time:38104ms step_avg:45.09ms
+step:846/1490 train_time:38168ms step_avg:45.12ms
+step:847/1490 train_time:38226ms step_avg:45.13ms
+step:848/1490 train_time:38291ms step_avg:45.15ms
+step:849/1490 train_time:38350ms step_avg:45.17ms
+step:850/1490 train_time:38415ms step_avg:45.19ms
+step:851/1490 train_time:38473ms step_avg:45.21ms
+step:852/1490 train_time:38537ms step_avg:45.23ms
+step:853/1490 train_time:38596ms step_avg:45.25ms
+step:854/1490 train_time:38660ms step_avg:45.27ms
+step:855/1490 train_time:38717ms step_avg:45.28ms
+step:856/1490 train_time:38780ms step_avg:45.30ms
+step:857/1490 train_time:38838ms step_avg:45.32ms
+step:858/1490 train_time:38902ms step_avg:45.34ms
+step:859/1490 train_time:38959ms step_avg:45.35ms
+step:860/1490 train_time:39023ms step_avg:45.38ms
+step:861/1490 train_time:39080ms step_avg:45.39ms
+step:862/1490 train_time:39143ms step_avg:45.41ms
+step:863/1490 train_time:39200ms step_avg:45.42ms
+step:864/1490 train_time:39263ms step_avg:45.44ms
+step:865/1490 train_time:39321ms step_avg:45.46ms
+step:866/1490 train_time:39385ms step_avg:45.48ms
+step:867/1490 train_time:39442ms step_avg:45.49ms
+step:868/1490 train_time:39505ms step_avg:45.51ms
+step:869/1490 train_time:39562ms step_avg:45.53ms
+step:870/1490 train_time:39626ms step_avg:45.55ms
+step:871/1490 train_time:39684ms step_avg:45.56ms
+step:872/1490 train_time:39747ms step_avg:45.58ms
+step:873/1490 train_time:39805ms step_avg:45.60ms
+step:874/1490 train_time:39868ms step_avg:45.62ms
+step:875/1490 train_time:39926ms step_avg:45.63ms
+step:876/1490 train_time:39989ms step_avg:45.65ms
+step:877/1490 train_time:40047ms step_avg:45.66ms
+step:878/1490 train_time:40110ms step_avg:45.68ms
+step:879/1490 train_time:40168ms step_avg:45.70ms
+step:880/1490 train_time:40232ms step_avg:45.72ms
+step:881/1490 train_time:40292ms step_avg:45.73ms
+step:882/1490 train_time:40361ms step_avg:45.76ms
+step:883/1490 train_time:40423ms step_avg:45.78ms
+step:884/1490 train_time:40491ms step_avg:45.80ms
+step:885/1490 train_time:40553ms step_avg:45.82ms
+step:886/1490 train_time:40621ms step_avg:45.85ms
+step:887/1490 train_time:40683ms step_avg:45.87ms
+step:888/1490 train_time:40751ms step_avg:45.89ms
+step:889/1490 train_time:40813ms step_avg:45.91ms
+step:890/1490 train_time:40881ms step_avg:45.93ms
+step:891/1490 train_time:40941ms step_avg:45.95ms
+step:892/1490 train_time:41009ms step_avg:45.97ms
+step:893/1490 train_time:41071ms step_avg:45.99ms
+step:894/1490 train_time:41133ms step_avg:46.01ms
+step:895/1490 train_time:41187ms step_avg:46.02ms
+step:896/1490 train_time:41246ms step_avg:46.03ms
+step:897/1490 train_time:41304ms step_avg:46.05ms
+step:898/1490 train_time:41368ms step_avg:46.07ms
+step:899/1490 train_time:41426ms step_avg:46.08ms
+step:900/1490 train_time:41491ms step_avg:46.10ms
+step:901/1490 train_time:41550ms step_avg:46.12ms
+step:902/1490 train_time:41614ms step_avg:46.14ms
+step:903/1490 train_time:41672ms step_avg:46.15ms
+step:904/1490 train_time:41737ms step_avg:46.17ms
+step:905/1490 train_time:41795ms step_avg:46.18ms
+step:906/1490 train_time:41860ms step_avg:46.20ms
+step:907/1490 train_time:41916ms step_avg:46.21ms
+step:908/1490 train_time:41981ms step_avg:46.23ms
+step:909/1490 train_time:42038ms step_avg:46.25ms
+step:910/1490 train_time:42102ms step_avg:46.27ms
+step:911/1490 train_time:42160ms step_avg:46.28ms
+step:912/1490 train_time:42224ms step_avg:46.30ms
+step:913/1490 train_time:42282ms step_avg:46.31ms
+step:914/1490 train_time:42348ms step_avg:46.33ms
+step:915/1490 train_time:42409ms step_avg:46.35ms
+step:916/1490 train_time:42475ms step_avg:46.37ms
+step:917/1490 train_time:42534ms step_avg:46.38ms
+step:918/1490 train_time:42600ms step_avg:46.41ms
+step:919/1490 train_time:42659ms step_avg:46.42ms
+step:920/1490 train_time:42723ms step_avg:46.44ms
+step:921/1490 train_time:42782ms step_avg:46.45ms
+step:922/1490 train_time:42847ms step_avg:46.47ms
+step:923/1490 train_time:42906ms step_avg:46.49ms
+step:924/1490 train_time:42971ms step_avg:46.51ms
+step:925/1490 train_time:43030ms step_avg:46.52ms
+step:926/1490 train_time:43095ms step_avg:46.54ms
+step:927/1490 train_time:43155ms step_avg:46.55ms
+step:928/1490 train_time:43219ms step_avg:46.57ms
+step:929/1490 train_time:43276ms step_avg:46.58ms
+step:930/1490 train_time:43341ms step_avg:46.60ms
+step:931/1490 train_time:43400ms step_avg:46.62ms
+step:932/1490 train_time:43464ms step_avg:46.64ms
+step:933/1490 train_time:43522ms step_avg:46.65ms
+step:934/1490 train_time:43587ms step_avg:46.67ms
+step:935/1490 train_time:43645ms step_avg:46.68ms
+step:936/1490 train_time:43710ms step_avg:46.70ms
+step:937/1490 train_time:43768ms step_avg:46.71ms
+step:938/1490 train_time:43833ms step_avg:46.73ms
+step:939/1490 train_time:43892ms step_avg:46.74ms
+step:940/1490 train_time:43956ms step_avg:46.76ms
+step:941/1490 train_time:44015ms step_avg:46.77ms
+step:942/1490 train_time:44078ms step_avg:46.79ms
+step:943/1490 train_time:44136ms step_avg:46.80ms
+step:944/1490 train_time:44200ms step_avg:46.82ms
+step:945/1490 train_time:44258ms step_avg:46.83ms
+step:946/1490 train_time:44322ms step_avg:46.85ms
+step:947/1490 train_time:44379ms step_avg:46.86ms
+step:948/1490 train_time:44443ms step_avg:46.88ms
+step:949/1490 train_time:44503ms step_avg:46.89ms
+step:950/1490 train_time:44564ms step_avg:46.91ms
+step:951/1490 train_time:44622ms step_avg:46.92ms
+step:952/1490 train_time:44684ms step_avg:46.94ms
+step:953/1490 train_time:44741ms step_avg:46.95ms
+step:954/1490 train_time:44806ms step_avg:46.97ms
+step:955/1490 train_time:44864ms step_avg:46.98ms
+step:956/1490 train_time:44930ms step_avg:47.00ms
+step:957/1490 train_time:44990ms step_avg:47.01ms
+step:958/1490 train_time:45057ms step_avg:47.03ms
+step:959/1490 train_time:45115ms step_avg:47.04ms
+step:960/1490 train_time:45180ms step_avg:47.06ms
+step:961/1490 train_time:45239ms step_avg:47.07ms
+step:962/1490 train_time:45303ms step_avg:47.09ms
+step:963/1490 train_time:45362ms step_avg:47.10ms
+step:964/1490 train_time:45427ms step_avg:47.12ms
+step:965/1490 train_time:45485ms step_avg:47.13ms
+step:966/1490 train_time:45551ms step_avg:47.15ms
+step:967/1490 train_time:45610ms step_avg:47.17ms
+step:968/1490 train_time:45678ms step_avg:47.19ms
+step:969/1490 train_time:45760ms step_avg:47.22ms
+step:970/1490 train_time:45853ms step_avg:47.27ms
+step:971/1490 train_time:45941ms step_avg:47.31ms
+step:972/1490 train_time:46034ms step_avg:47.36ms
+step:973/1490 train_time:46120ms step_avg:47.40ms
+step:974/1490 train_time:46214ms step_avg:47.45ms
+step:975/1490 train_time:46297ms step_avg:47.48ms
+step:976/1490 train_time:46390ms step_avg:47.53ms
+step:977/1490 train_time:46478ms step_avg:47.57ms
+step:978/1490 train_time:46570ms step_avg:47.62ms
+step:979/1490 train_time:46656ms step_avg:47.66ms
+step:980/1490 train_time:46749ms step_avg:47.70ms
+step:981/1490 train_time:46833ms step_avg:47.74ms
+step:982/1490 train_time:46926ms step_avg:47.79ms
+step:983/1490 train_time:47012ms step_avg:47.82ms
+step:984/1490 train_time:47106ms step_avg:47.87ms
+step:985/1490 train_time:47194ms step_avg:47.91ms
+step:986/1490 train_time:47290ms step_avg:47.96ms
+step:987/1490 train_time:47379ms step_avg:48.00ms
+step:988/1490 train_time:47473ms step_avg:48.05ms
+step:989/1490 train_time:47563ms step_avg:48.09ms
+step:990/1490 train_time:47657ms step_avg:48.14ms
+step:991/1490 train_time:47747ms step_avg:48.18ms
+step:992/1490 train_time:47842ms step_avg:48.23ms
+step:993/1490 train_time:47924ms step_avg:48.26ms
+step:994/1490 train_time:48010ms step_avg:48.30ms
+step:995/1490 train_time:48095ms step_avg:48.34ms
+step:996/1490 train_time:48185ms step_avg:48.38ms
+step:997/1490 train_time:48269ms step_avg:48.41ms
+step:998/1490 train_time:48363ms step_avg:48.46ms
+step:999/1490 train_time:48449ms step_avg:48.50ms
+step:1000/1490 train_time:48544ms step_avg:48.54ms
+step:1000/1490 val_loss:3.5144 train_time:48664ms step_avg:48.66ms
+step:1001/1490 train_time:48683ms step_avg:48.63ms
+step:1002/1490 train_time:48727ms step_avg:48.63ms
+step:1003/1490 train_time:48816ms step_avg:48.67ms
+step:1004/1490 train_time:48912ms step_avg:48.72ms
+step:1005/1490 train_time:48999ms step_avg:48.75ms
+step:1006/1490 train_time:49093ms step_avg:48.80ms
+step:1007/1490 train_time:49181ms step_avg:48.84ms
+step:1008/1490 train_time:49275ms step_avg:48.88ms
+step:1009/1490 train_time:49357ms step_avg:48.92ms
+step:1010/1490 train_time:49442ms step_avg:48.95ms
+step:1011/1490 train_time:49526ms step_avg:48.99ms
+step:1012/1490 train_time:49619ms step_avg:49.03ms
+step:1013/1490 train_time:49703ms step_avg:49.07ms
+step:1014/1490 train_time:49796ms step_avg:49.11ms
+step:1015/1490 train_time:49881ms step_avg:49.14ms
+step:1016/1490 train_time:49976ms step_avg:49.19ms
+step:1017/1490 train_time:50062ms step_avg:49.23ms
+step:1018/1490 train_time:50156ms step_avg:49.27ms
+step:1019/1490 train_time:50243ms step_avg:49.31ms
+step:1020/1490 train_time:50341ms step_avg:49.35ms
+step:1021/1490 train_time:50427ms step_avg:49.39ms
+step:1022/1490 train_time:50522ms step_avg:49.43ms
+step:1023/1490 train_time:50611ms step_avg:49.47ms
+step:1024/1490 train_time:50704ms step_avg:49.52ms
+step:1025/1490 train_time:50793ms step_avg:49.55ms
+step:1026/1490 train_time:50885ms step_avg:49.60ms
+step:1027/1490 train_time:50974ms step_avg:49.63ms
+step:1028/1490 train_time:51066ms step_avg:49.68ms
+step:1029/1490 train_time:51153ms step_avg:49.71ms
+step:1030/1490 train_time:51246ms step_avg:49.75ms
+step:1031/1490 train_time:51334ms step_avg:49.79ms
+step:1032/1490 train_time:51427ms step_avg:49.83ms
+step:1033/1490 train_time:51515ms step_avg:49.87ms
+step:1034/1490 train_time:51607ms step_avg:49.91ms
+step:1035/1490 train_time:51694ms step_avg:49.95ms
+step:1036/1490 train_time:51786ms step_avg:49.99ms
+step:1037/1490 train_time:51874ms step_avg:50.02ms
+step:1038/1490 train_time:51967ms step_avg:50.06ms
+step:1039/1490 train_time:52055ms step_avg:50.10ms
+step:1040/1490 train_time:52151ms step_avg:50.14ms
+step:1041/1490 train_time:52236ms step_avg:50.18ms
+step:1042/1490 train_time:52328ms step_avg:50.22ms
+step:1043/1490 train_time:52414ms step_avg:50.25ms
+step:1044/1490 train_time:52506ms step_avg:50.29ms
+step:1045/1490 train_time:52593ms step_avg:50.33ms
+step:1046/1490 train_time:52685ms step_avg:50.37ms
+step:1047/1490 train_time:52774ms step_avg:50.40ms
+step:1048/1490 train_time:52865ms step_avg:50.44ms
+step:1049/1490 train_time:52953ms step_avg:50.48ms
+step:1050/1490 train_time:53044ms step_avg:50.52ms
+step:1051/1490 train_time:53131ms step_avg:50.55ms
+step:1052/1490 train_time:53223ms step_avg:50.59ms
+step:1053/1490 train_time:53309ms step_avg:50.63ms
+step:1054/1490 train_time:53402ms step_avg:50.67ms
+step:1055/1490 train_time:53488ms step_avg:50.70ms
+step:1056/1490 train_time:53580ms step_avg:50.74ms
+step:1057/1490 train_time:53665ms step_avg:50.77ms
+step:1058/1490 train_time:53756ms step_avg:50.81ms
+step:1059/1490 train_time:53841ms step_avg:50.84ms
+step:1060/1490 train_time:53936ms step_avg:50.88ms
+step:1061/1490 train_time:54021ms step_avg:50.92ms
+step:1062/1490 train_time:54114ms step_avg:50.96ms
+step:1063/1490 train_time:54199ms step_avg:50.99ms
+step:1064/1490 train_time:54291ms step_avg:51.03ms
+step:1065/1490 train_time:54376ms step_avg:51.06ms
+step:1066/1490 train_time:54467ms step_avg:51.09ms
+step:1067/1490 train_time:54554ms step_avg:51.13ms
+step:1068/1490 train_time:54648ms step_avg:51.17ms
+step:1069/1490 train_time:54738ms step_avg:51.20ms
+step:1070/1490 train_time:54830ms step_avg:51.24ms
+step:1071/1490 train_time:54917ms step_avg:51.28ms
+step:1072/1490 train_time:55011ms step_avg:51.32ms
+step:1073/1490 train_time:55097ms step_avg:51.35ms
+step:1074/1490 train_time:55189ms step_avg:51.39ms
+step:1075/1490 train_time:55275ms step_avg:51.42ms
+step:1076/1490 train_time:55366ms step_avg:51.46ms
+step:1077/1490 train_time:55452ms step_avg:51.49ms
+step:1078/1490 train_time:55542ms step_avg:51.52ms
+step:1079/1490 train_time:55628ms step_avg:51.56ms
+step:1080/1490 train_time:55719ms step_avg:51.59ms
+step:1081/1490 train_time:55802ms step_avg:51.62ms
+step:1082/1490 train_time:55893ms step_avg:51.66ms
+step:1083/1490 train_time:55977ms step_avg:51.69ms
+step:1084/1490 train_time:56068ms step_avg:51.72ms
+step:1085/1490 train_time:56154ms step_avg:51.76ms
+step:1086/1490 train_time:56244ms step_avg:51.79ms
+step:1087/1490 train_time:56330ms step_avg:51.82ms
+step:1088/1490 train_time:56421ms step_avg:51.86ms
+step:1089/1490 train_time:56508ms step_avg:51.89ms
+step:1090/1490 train_time:56605ms step_avg:51.93ms
+step:1091/1490 train_time:56695ms step_avg:51.97ms
+step:1092/1490 train_time:56790ms step_avg:52.01ms
+step:1093/1490 train_time:56881ms step_avg:52.04ms
+step:1094/1490 train_time:56975ms step_avg:52.08ms
+step:1095/1490 train_time:57064ms step_avg:52.11ms
+step:1096/1490 train_time:57160ms step_avg:52.15ms
+step:1097/1490 train_time:57250ms step_avg:52.19ms
+step:1098/1490 train_time:57346ms step_avg:52.23ms
+step:1099/1490 train_time:57437ms step_avg:52.26ms
+step:1100/1490 train_time:57532ms step_avg:52.30ms
+step:1101/1490 train_time:57621ms step_avg:52.34ms
+step:1102/1490 train_time:57716ms step_avg:52.37ms
+step:1103/1490 train_time:57804ms step_avg:52.41ms
+step:1104/1490 train_time:57900ms step_avg:52.45ms
+step:1105/1490 train_time:57988ms step_avg:52.48ms
+step:1106/1490 train_time:58082ms step_avg:52.52ms
+step:1107/1490 train_time:58165ms step_avg:52.54ms
+step:1108/1490 train_time:58253ms step_avg:52.58ms
+step:1109/1490 train_time:58340ms step_avg:52.61ms
+step:1110/1490 train_time:58434ms step_avg:52.64ms
+step:1111/1490 train_time:58526ms step_avg:52.68ms
+step:1112/1490 train_time:58619ms step_avg:52.71ms
+step:1113/1490 train_time:58706ms step_avg:52.75ms
+step:1114/1490 train_time:58800ms step_avg:52.78ms
+step:1115/1490 train_time:58885ms step_avg:52.81ms
+step:1116/1490 train_time:58979ms step_avg:52.85ms
+step:1117/1490 train_time:59068ms step_avg:52.88ms
+step:1118/1490 train_time:59164ms step_avg:52.92ms
+step:1119/1490 train_time:59254ms step_avg:52.95ms
+step:1120/1490 train_time:59348ms step_avg:52.99ms
+step:1121/1490 train_time:59437ms step_avg:53.02ms
+step:1122/1490 train_time:59531ms step_avg:53.06ms
+step:1123/1490 train_time:59619ms step_avg:53.09ms
+step:1124/1490 train_time:59713ms step_avg:53.13ms
+step:1125/1490 train_time:59800ms step_avg:53.16ms
+step:1126/1490 train_time:59895ms step_avg:53.19ms
+step:1127/1490 train_time:59981ms step_avg:53.22ms
+step:1128/1490 train_time:60076ms step_avg:53.26ms
+step:1129/1490 train_time:60162ms step_avg:53.29ms
+step:1130/1490 train_time:60256ms step_avg:53.32ms
+step:1131/1490 train_time:60342ms step_avg:53.35ms
+step:1132/1490 train_time:60436ms step_avg:53.39ms
+step:1133/1490 train_time:60520ms step_avg:53.42ms
+step:1134/1490 train_time:60616ms step_avg:53.45ms
+step:1135/1490 train_time:60701ms step_avg:53.48ms
+step:1136/1490 train_time:60796ms step_avg:53.52ms
+step:1137/1490 train_time:60881ms step_avg:53.55ms
+step:1138/1490 train_time:60976ms step_avg:53.58ms
+step:1139/1490 train_time:61061ms step_avg:53.61ms
+step:1140/1490 train_time:61155ms step_avg:53.64ms
+step:1141/1490 train_time:61238ms step_avg:53.67ms
+step:1142/1490 train_time:61334ms step_avg:53.71ms
+step:1143/1490 train_time:61425ms step_avg:53.74ms
+step:1144/1490 train_time:61520ms step_avg:53.78ms
+step:1145/1490 train_time:61609ms step_avg:53.81ms
+step:1146/1490 train_time:61707ms step_avg:53.85ms
+step:1147/1490 train_time:61798ms step_avg:53.88ms
+step:1148/1490 train_time:61893ms step_avg:53.91ms
+step:1149/1490 train_time:61982ms step_avg:53.94ms
+step:1150/1490 train_time:62077ms step_avg:53.98ms
+step:1151/1490 train_time:62164ms step_avg:54.01ms
+step:1152/1490 train_time:62259ms step_avg:54.04ms
+step:1153/1490 train_time:62348ms step_avg:54.07ms
+step:1154/1490 train_time:62443ms step_avg:54.11ms
+step:1155/1490 train_time:62533ms step_avg:54.14ms
+step:1156/1490 train_time:62626ms step_avg:54.17ms
+step:1157/1490 train_time:62714ms step_avg:54.20ms
+step:1158/1490 train_time:62808ms step_avg:54.24ms
+step:1159/1490 train_time:62896ms step_avg:54.27ms
+step:1160/1490 train_time:62988ms step_avg:54.30ms
+step:1161/1490 train_time:63076ms step_avg:54.33ms
+step:1162/1490 train_time:63170ms step_avg:54.36ms
+step:1163/1490 train_time:63256ms step_avg:54.39ms
+step:1164/1490 train_time:63349ms step_avg:54.42ms
+step:1165/1490 train_time:63435ms step_avg:54.45ms
+step:1166/1490 train_time:63528ms step_avg:54.48ms
+step:1167/1490 train_time:63614ms step_avg:54.51ms
+step:1168/1490 train_time:63707ms step_avg:54.54ms
+step:1169/1490 train_time:63793ms step_avg:54.57ms
+step:1170/1490 train_time:63885ms step_avg:54.60ms
+step:1171/1490 train_time:63973ms step_avg:54.63ms
+step:1172/1490 train_time:64064ms step_avg:54.66ms
+step:1173/1490 train_time:64151ms step_avg:54.69ms
+step:1174/1490 train_time:64243ms step_avg:54.72ms
+step:1175/1490 train_time:64329ms step_avg:54.75ms
+step:1176/1490 train_time:64421ms step_avg:54.78ms
+step:1177/1490 train_time:64507ms step_avg:54.81ms
+step:1178/1490 train_time:64600ms step_avg:54.84ms
+step:1179/1490 train_time:64687ms step_avg:54.87ms
+step:1180/1490 train_time:64781ms step_avg:54.90ms
+step:1181/1490 train_time:64869ms step_avg:54.93ms
+step:1182/1490 train_time:64962ms step_avg:54.96ms
+step:1183/1490 train_time:65051ms step_avg:54.99ms
+step:1184/1490 train_time:65144ms step_avg:55.02ms
+step:1185/1490 train_time:65233ms step_avg:55.05ms
+step:1186/1490 train_time:65327ms step_avg:55.08ms
+step:1187/1490 train_time:65416ms step_avg:55.11ms
+step:1188/1490 train_time:65509ms step_avg:55.14ms
+step:1189/1490 train_time:65597ms step_avg:55.17ms
+step:1190/1490 train_time:65690ms step_avg:55.20ms
+step:1191/1490 train_time:65777ms step_avg:55.23ms
+step:1192/1490 train_time:65871ms step_avg:55.26ms
+step:1193/1490 train_time:65956ms step_avg:55.29ms
+step:1194/1490 train_time:66049ms step_avg:55.32ms
+step:1195/1490 train_time:66134ms step_avg:55.34ms
+step:1196/1490 train_time:66227ms step_avg:55.37ms
+step:1197/1490 train_time:66314ms step_avg:55.40ms
+step:1198/1490 train_time:66404ms step_avg:55.43ms
+step:1199/1490 train_time:66489ms step_avg:55.45ms
+step:1200/1490 train_time:66580ms step_avg:55.48ms
+step:1201/1490 train_time:66664ms step_avg:55.51ms
+step:1202/1490 train_time:66757ms step_avg:55.54ms
+step:1203/1490 train_time:66843ms step_avg:55.56ms
+step:1204/1490 train_time:66939ms step_avg:55.60ms
+step:1205/1490 train_time:67025ms step_avg:55.62ms
+step:1206/1490 train_time:67120ms step_avg:55.66ms
+step:1207/1490 train_time:67206ms step_avg:55.68ms
+step:1208/1490 train_time:67301ms step_avg:55.71ms
+step:1209/1490 train_time:67384ms step_avg:55.73ms
+step:1210/1490 train_time:67479ms step_avg:55.77ms
+step:1211/1490 train_time:67570ms step_avg:55.80ms
+step:1212/1490 train_time:67661ms step_avg:55.83ms
+step:1213/1490 train_time:67749ms step_avg:55.85ms
+step:1214/1490 train_time:67843ms step_avg:55.88ms
+step:1215/1490 train_time:67930ms step_avg:55.91ms
+step:1216/1490 train_time:68026ms step_avg:55.94ms
+step:1217/1490 train_time:68115ms step_avg:55.97ms
+step:1218/1490 train_time:68209ms step_avg:56.00ms
+step:1219/1490 train_time:68297ms step_avg:56.03ms
+step:1220/1490 train_time:68391ms step_avg:56.06ms
+step:1221/1490 train_time:68481ms step_avg:56.09ms
+step:1222/1490 train_time:68578ms step_avg:56.12ms
+step:1223/1490 train_time:68666ms step_avg:56.15ms
+step:1224/1490 train_time:68762ms step_avg:56.18ms
+step:1225/1490 train_time:68852ms step_avg:56.21ms
+step:1226/1490 train_time:68947ms step_avg:56.24ms
+step:1227/1490 train_time:69037ms step_avg:56.27ms
+step:1228/1490 train_time:69132ms step_avg:56.30ms
+step:1229/1490 train_time:69213ms step_avg:56.32ms
+step:1230/1490 train_time:69303ms step_avg:56.34ms
+step:1231/1490 train_time:69393ms step_avg:56.37ms
+step:1232/1490 train_time:69484ms step_avg:56.40ms
+step:1233/1490 train_time:69570ms step_avg:56.42ms
+step:1234/1490 train_time:69660ms step_avg:56.45ms
+step:1235/1490 train_time:69745ms step_avg:56.47ms
+step:1236/1490 train_time:69839ms step_avg:56.50ms
+step:1237/1490 train_time:69927ms step_avg:56.53ms
+step:1238/1490 train_time:70021ms step_avg:56.56ms
+step:1239/1490 train_time:70111ms step_avg:56.59ms
+step:1240/1490 train_time:70205ms step_avg:56.62ms
+step:1241/1490 train_time:70294ms step_avg:56.64ms
+step:1242/1490 train_time:70389ms step_avg:56.67ms
+step:1243/1490 train_time:70478ms step_avg:56.70ms
+step:1244/1490 train_time:70572ms step_avg:56.73ms
+step:1245/1490 train_time:70654ms step_avg:56.75ms
+step:1246/1490 train_time:70744ms step_avg:56.78ms
+step:1247/1490 train_time:70833ms step_avg:56.80ms
+step:1248/1490 train_time:70923ms step_avg:56.83ms
+step:1249/1490 train_time:71008ms step_avg:56.85ms
+step:1250/1490 train_time:71102ms step_avg:56.88ms
+step:1250/1490 val_loss:3.3695 train_time:71222ms step_avg:56.98ms
+step:1251/1490 train_time:71242ms step_avg:56.95ms
+step:1252/1490 train_time:71285ms step_avg:56.94ms
+step:1253/1490 train_time:71373ms step_avg:56.96ms
+step:1254/1490 train_time:71461ms step_avg:56.99ms
+step:1255/1490 train_time:71542ms step_avg:57.01ms
+step:1256/1490 train_time:71632ms step_avg:57.03ms
+step:1257/1490 train_time:71717ms step_avg:57.05ms
+step:1258/1490 train_time:71810ms step_avg:57.08ms
+step:1259/1490 train_time:71896ms step_avg:57.11ms
+step:1260/1490 train_time:71989ms step_avg:57.13ms
+step:1261/1490 train_time:72074ms step_avg:57.16ms
+step:1262/1490 train_time:72168ms step_avg:57.19ms
+step:1263/1490 train_time:72254ms step_avg:57.21ms
+step:1264/1490 train_time:72345ms step_avg:57.24ms
+step:1265/1490 train_time:72435ms step_avg:57.26ms
+step:1266/1490 train_time:72527ms step_avg:57.29ms
+step:1267/1490 train_time:72613ms step_avg:57.31ms
+step:1268/1490 train_time:72707ms step_avg:57.34ms
+step:1269/1490 train_time:72793ms step_avg:57.36ms
+step:1270/1490 train_time:72889ms step_avg:57.39ms
+step:1271/1490 train_time:72976ms step_avg:57.42ms
+step:1272/1490 train_time:73072ms step_avg:57.45ms
+step:1273/1490 train_time:73159ms step_avg:57.47ms
+step:1274/1490 train_time:73255ms step_avg:57.50ms
+step:1275/1490 train_time:73343ms step_avg:57.52ms
+step:1276/1490 train_time:73439ms step_avg:57.55ms
+step:1277/1490 train_time:73528ms step_avg:57.58ms
+step:1278/1490 train_time:73622ms step_avg:57.61ms
+step:1279/1490 train_time:73710ms step_avg:57.63ms
+step:1280/1490 train_time:73805ms step_avg:57.66ms
+step:1281/1490 train_time:73892ms step_avg:57.68ms
+step:1282/1490 train_time:73986ms step_avg:57.71ms
+step:1283/1490 train_time:74073ms step_avg:57.73ms
+step:1284/1490 train_time:74167ms step_avg:57.76ms
+step:1285/1490 train_time:74253ms step_avg:57.78ms
+step:1286/1490 train_time:74347ms step_avg:57.81ms
+step:1287/1490 train_time:74435ms step_avg:57.84ms
+step:1288/1490 train_time:74530ms step_avg:57.86ms
+step:1289/1490 train_time:74614ms step_avg:57.89ms
+step:1290/1490 train_time:74708ms step_avg:57.91ms
+step:1291/1490 train_time:74794ms step_avg:57.93ms
+step:1292/1490 train_time:74888ms step_avg:57.96ms
+step:1293/1490 train_time:74974ms step_avg:57.98ms
+step:1294/1490 train_time:75068ms step_avg:58.01ms
+step:1295/1490 train_time:75155ms step_avg:58.03ms
+step:1296/1490 train_time:75247ms step_avg:58.06ms
+step:1297/1490 train_time:75334ms step_avg:58.08ms
+step:1298/1490 train_time:75427ms step_avg:58.11ms
+step:1299/1490 train_time:75511ms step_avg:58.13ms
+step:1300/1490 train_time:75600ms step_avg:58.15ms
+step:1301/1490 train_time:75685ms step_avg:58.17ms
+step:1302/1490 train_time:75775ms step_avg:58.20ms
+step:1303/1490 train_time:75861ms step_avg:58.22ms
+step:1304/1490 train_time:75956ms step_avg:58.25ms
+step:1305/1490 train_time:76044ms step_avg:58.27ms
+step:1306/1490 train_time:76137ms step_avg:58.30ms
+step:1307/1490 train_time:76225ms step_avg:58.32ms
+step:1308/1490 train_time:76318ms step_avg:58.35ms
+step:1309/1490 train_time:76407ms step_avg:58.37ms
+step:1310/1490 train_time:76501ms step_avg:58.40ms
+step:1311/1490 train_time:76589ms step_avg:58.42ms
+step:1312/1490 train_time:76682ms step_avg:58.45ms
+step:1313/1490 train_time:76770ms step_avg:58.47ms
+step:1314/1490 train_time:76864ms step_avg:58.50ms
+step:1315/1490 train_time:76952ms step_avg:58.52ms
+step:1316/1490 train_time:77045ms step_avg:58.55ms
+step:1317/1490 train_time:77134ms step_avg:58.57ms
+step:1318/1490 train_time:77227ms step_avg:58.59ms
+step:1319/1490 train_time:77314ms step_avg:58.62ms
+step:1320/1490 train_time:77408ms step_avg:58.64ms
+step:1321/1490 train_time:77493ms step_avg:58.66ms
+step:1322/1490 train_time:77587ms step_avg:58.69ms
+step:1323/1490 train_time:77673ms step_avg:58.71ms
+step:1324/1490 train_time:77767ms step_avg:58.74ms
+step:1325/1490 train_time:77853ms step_avg:58.76ms
+step:1326/1490 train_time:77947ms step_avg:58.78ms
+step:1327/1490 train_time:78035ms step_avg:58.81ms
+step:1328/1490 train_time:78128ms step_avg:58.83ms
+step:1329/1490 train_time:78214ms step_avg:58.85ms
+step:1330/1490 train_time:78308ms step_avg:58.88ms
+step:1331/1490 train_time:78394ms step_avg:58.90ms
+step:1332/1490 train_time:78486ms step_avg:58.92ms
+step:1333/1490 train_time:78572ms step_avg:58.94ms
+step:1334/1490 train_time:78663ms step_avg:58.97ms
+step:1335/1490 train_time:78748ms step_avg:58.99ms
+step:1336/1490 train_time:78838ms step_avg:59.01ms
+step:1337/1490 train_time:78921ms step_avg:59.03ms
+step:1338/1490 train_time:79011ms step_avg:59.05ms
+step:1339/1490 train_time:79099ms step_avg:59.07ms
+step:1340/1490 train_time:79193ms step_avg:59.10ms
+step:1341/1490 train_time:79278ms step_avg:59.12ms
+step:1342/1490 train_time:79372ms step_avg:59.14ms
+step:1343/1490 train_time:79457ms step_avg:59.16ms
+step:1344/1490 train_time:79552ms step_avg:59.19ms
+step:1345/1490 train_time:79638ms step_avg:59.21ms
+step:1346/1490 train_time:79733ms step_avg:59.24ms
+step:1347/1490 train_time:79817ms step_avg:59.26ms
+step:1348/1490 train_time:79909ms step_avg:59.28ms
+step:1349/1490 train_time:79994ms step_avg:59.30ms
+step:1350/1490 train_time:80084ms step_avg:59.32ms
+step:1351/1490 train_time:80168ms step_avg:59.34ms
+step:1352/1490 train_time:80264ms step_avg:59.37ms
+step:1353/1490 train_time:80355ms step_avg:59.39ms
+step:1354/1490 train_time:80450ms step_avg:59.42ms
+step:1355/1490 train_time:80537ms step_avg:59.44ms
+step:1356/1490 train_time:80632ms step_avg:59.46ms
+step:1357/1490 train_time:80718ms step_avg:59.48ms
+step:1358/1490 train_time:80814ms step_avg:59.51ms
+step:1359/1490 train_time:80902ms step_avg:59.53ms
+step:1360/1490 train_time:80997ms step_avg:59.56ms
+step:1361/1490 train_time:81081ms step_avg:59.57ms
+step:1362/1490 train_time:81171ms step_avg:59.60ms
+step:1363/1490 train_time:81258ms step_avg:59.62ms
+step:1364/1490 train_time:81350ms step_avg:59.64ms
+step:1365/1490 train_time:81438ms step_avg:59.66ms
+step:1366/1490 train_time:81530ms step_avg:59.69ms
+step:1367/1490 train_time:81617ms step_avg:59.71ms
+step:1368/1490 train_time:81711ms step_avg:59.73ms
+step:1369/1490 train_time:81797ms step_avg:59.75ms
+step:1370/1490 train_time:81890ms step_avg:59.77ms
+step:1371/1490 train_time:81977ms step_avg:59.79ms
+step:1372/1490 train_time:82073ms step_avg:59.82ms
+step:1373/1490 train_time:82163ms step_avg:59.84ms
+step:1374/1490 train_time:82260ms step_avg:59.87ms
+step:1375/1490 train_time:82351ms step_avg:59.89ms
+step:1376/1490 train_time:82446ms step_avg:59.92ms
+step:1377/1490 train_time:82536ms step_avg:59.94ms
+step:1378/1490 train_time:82633ms step_avg:59.97ms
+step:1379/1490 train_time:82715ms step_avg:59.98ms
+step:1380/1490 train_time:82806ms step_avg:60.00ms
+step:1381/1490 train_time:82894ms step_avg:60.02ms
+step:1382/1490 train_time:82986ms step_avg:60.05ms
+step:1383/1490 train_time:83076ms step_avg:60.07ms
+step:1384/1490 train_time:83169ms step_avg:60.09ms
+step:1385/1490 train_time:83255ms step_avg:60.11ms
+step:1386/1490 train_time:83346ms step_avg:60.13ms
+step:1387/1490 train_time:83435ms step_avg:60.16ms
+step:1388/1490 train_time:83531ms step_avg:60.18ms
+step:1389/1490 train_time:83618ms step_avg:60.20ms
+step:1390/1490 train_time:83715ms step_avg:60.23ms
+step:1391/1490 train_time:83804ms step_avg:60.25ms
+step:1392/1490 train_time:83900ms step_avg:60.27ms
+step:1393/1490 train_time:83990ms step_avg:60.29ms
+step:1394/1490 train_time:84085ms step_avg:60.32ms
+step:1395/1490 train_time:84175ms step_avg:60.34ms
+step:1396/1490 train_time:84270ms step_avg:60.37ms
+step:1397/1490 train_time:84357ms step_avg:60.38ms
+step:1398/1490 train_time:84452ms step_avg:60.41ms
+step:1399/1490 train_time:84540ms step_avg:60.43ms
+step:1400/1490 train_time:84636ms step_avg:60.45ms
+step:1401/1490 train_time:84725ms step_avg:60.47ms
+step:1402/1490 train_time:84820ms step_avg:60.50ms
+step:1403/1490 train_time:84907ms step_avg:60.52ms
+step:1404/1490 train_time:85000ms step_avg:60.54ms
+step:1405/1490 train_time:85090ms step_avg:60.56ms
+step:1406/1490 train_time:85182ms step_avg:60.58ms
+step:1407/1490 train_time:85270ms step_avg:60.60ms
+step:1408/1490 train_time:85364ms step_avg:60.63ms
+step:1409/1490 train_time:85451ms step_avg:60.65ms
+step:1410/1490 train_time:85545ms step_avg:60.67ms
+step:1411/1490 train_time:85631ms step_avg:60.69ms
+step:1412/1490 train_time:85725ms step_avg:60.71ms
+step:1413/1490 train_time:85811ms step_avg:60.73ms
+step:1414/1490 train_time:85903ms step_avg:60.75ms
+step:1415/1490 train_time:85993ms step_avg:60.77ms
+step:1416/1490 train_time:86084ms step_avg:60.79ms
+step:1417/1490 train_time:86171ms step_avg:60.81ms
+step:1418/1490 train_time:86262ms step_avg:60.83ms
+step:1419/1490 train_time:86351ms step_avg:60.85ms
+step:1420/1490 train_time:86444ms step_avg:60.88ms
+step:1421/1490 train_time:86531ms step_avg:60.89ms
+step:1422/1490 train_time:86622ms step_avg:60.92ms
+step:1423/1490 train_time:86707ms step_avg:60.93ms
+step:1424/1490 train_time:86799ms step_avg:60.95ms
+step:1425/1490 train_time:86886ms step_avg:60.97ms
+step:1426/1490 train_time:86978ms step_avg:60.99ms
+step:1427/1490 train_time:87062ms step_avg:61.01ms
+step:1428/1490 train_time:87153ms step_avg:61.03ms
+step:1429/1490 train_time:87236ms step_avg:61.05ms
+step:1430/1490 train_time:87327ms step_avg:61.07ms
+step:1431/1490 train_time:87416ms step_avg:61.09ms
+step:1432/1490 train_time:87508ms step_avg:61.11ms
+step:1433/1490 train_time:87596ms step_avg:61.13ms
+step:1434/1490 train_time:87690ms step_avg:61.15ms
+step:1435/1490 train_time:87776ms step_avg:61.17ms
+step:1436/1490 train_time:87870ms step_avg:61.19ms
+step:1437/1490 train_time:87955ms step_avg:61.21ms
+step:1438/1490 train_time:88049ms step_avg:61.23ms
+step:1439/1490 train_time:88135ms step_avg:61.25ms
+step:1440/1490 train_time:88229ms step_avg:61.27ms
+step:1441/1490 train_time:88316ms step_avg:61.29ms
+step:1442/1490 train_time:88410ms step_avg:61.31ms
+step:1443/1490 train_time:88496ms step_avg:61.33ms
+step:1444/1490 train_time:88592ms step_avg:61.35ms
+step:1445/1490 train_time:88680ms step_avg:61.37ms
+step:1446/1490 train_time:88776ms step_avg:61.39ms
+step:1447/1490 train_time:88864ms step_avg:61.41ms
+step:1448/1490 train_time:88958ms step_avg:61.43ms
+step:1449/1490 train_time:89045ms step_avg:61.45ms
+step:1450/1490 train_time:89139ms step_avg:61.47ms
+step:1451/1490 train_time:89231ms step_avg:61.50ms
+step:1452/1490 train_time:89326ms step_avg:61.52ms
+step:1453/1490 train_time:89412ms step_avg:61.54ms
+step:1454/1490 train_time:89508ms step_avg:61.56ms
+step:1455/1490 train_time:89595ms step_avg:61.58ms
+step:1456/1490 train_time:89688ms step_avg:61.60ms
+step:1457/1490 train_time:89775ms step_avg:61.62ms
+step:1458/1490 train_time:89870ms step_avg:61.64ms
+step:1459/1490 train_time:89956ms step_avg:61.66ms
+step:1460/1490 train_time:90049ms step_avg:61.68ms
+step:1461/1490 train_time:90135ms step_avg:61.69ms
+step:1462/1490 train_time:90227ms step_avg:61.71ms
+step:1463/1490 train_time:90312ms step_avg:61.73ms
+step:1464/1490 train_time:90404ms step_avg:61.75ms
+step:1465/1490 train_time:90491ms step_avg:61.77ms
+step:1466/1490 train_time:90582ms step_avg:61.79ms
+step:1467/1490 train_time:90669ms step_avg:61.81ms
+step:1468/1490 train_time:90761ms step_avg:61.83ms
+step:1469/1490 train_time:90850ms step_avg:61.84ms
+step:1470/1490 train_time:90943ms step_avg:61.87ms
+step:1471/1490 train_time:91031ms step_avg:61.88ms
+step:1472/1490 train_time:91124ms step_avg:61.90ms
+step:1473/1490 train_time:91210ms step_avg:61.92ms
+step:1474/1490 train_time:91301ms step_avg:61.94ms
+step:1475/1490 train_time:91391ms step_avg:61.96ms
+step:1476/1490 train_time:91483ms step_avg:61.98ms
+step:1477/1490 train_time:91572ms step_avg:62.00ms
+step:1478/1490 train_time:91667ms step_avg:62.02ms
+step:1479/1490 train_time:91755ms step_avg:62.04ms
+step:1480/1490 train_time:91850ms step_avg:62.06ms
+step:1481/1490 train_time:91937ms step_avg:62.08ms
+step:1482/1490 train_time:92031ms step_avg:62.10ms
+step:1483/1490 train_time:92117ms step_avg:62.12ms
+step:1484/1490 train_time:92212ms step_avg:62.14ms
+step:1485/1490 train_time:92298ms step_avg:62.15ms
+step:1486/1490 train_time:92392ms step_avg:62.18ms
+step:1487/1490 train_time:92477ms step_avg:62.19ms
+step:1488/1490 train_time:92569ms step_avg:62.21ms
+step:1489/1490 train_time:92655ms step_avg:62.23ms
+step:1490/1490 train_time:92748ms step_avg:62.25ms
+step:1490/1490 val_loss:3.2772 train_time:92871ms step_avg:62.33ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline2-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline2-1480.txt
@@ -1,0 +1,4447 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:17:34 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   42C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   36C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   41C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   36C    P0            125W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   41C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   37C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   38C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   67C    P0            153W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          304789      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          304790      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          304791      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          304792      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          304793      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          304794      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          304795      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          304796      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8308 train_time:0ms step_avg:0.04ms
+step:1/1480 train_time:73ms step_avg:73.14ms
+step:2/1480 train_time:95ms step_avg:47.65ms
+step:3/1480 train_time:113ms step_avg:37.71ms
+step:4/1480 train_time:138ms step_avg:34.57ms
+step:5/1480 train_time:165ms step_avg:33.09ms
+step:6/1480 train_time:200ms step_avg:33.39ms
+step:7/1480 train_time:228ms step_avg:32.60ms
+step:8/1480 train_time:263ms step_avg:32.92ms
+step:9/1480 train_time:292ms step_avg:32.39ms
+step:10/1480 train_time:328ms step_avg:32.83ms
+step:11/1480 train_time:356ms step_avg:32.35ms
+step:12/1480 train_time:391ms step_avg:32.58ms
+step:13/1480 train_time:420ms step_avg:32.31ms
+step:14/1480 train_time:455ms step_avg:32.48ms
+step:15/1480 train_time:484ms step_avg:32.26ms
+step:16/1480 train_time:519ms step_avg:32.44ms
+step:17/1480 train_time:548ms step_avg:32.23ms
+step:18/1480 train_time:584ms step_avg:32.42ms
+step:19/1480 train_time:612ms step_avg:32.21ms
+step:20/1480 train_time:648ms step_avg:32.40ms
+step:21/1480 train_time:676ms step_avg:32.20ms
+step:22/1480 train_time:711ms step_avg:32.34ms
+step:23/1480 train_time:740ms step_avg:32.19ms
+step:24/1480 train_time:775ms step_avg:32.31ms
+step:25/1480 train_time:804ms step_avg:32.18ms
+step:26/1480 train_time:840ms step_avg:32.30ms
+step:27/1480 train_time:868ms step_avg:32.15ms
+step:28/1480 train_time:904ms step_avg:32.27ms
+step:29/1480 train_time:932ms step_avg:32.14ms
+step:30/1480 train_time:968ms step_avg:32.26ms
+step:31/1480 train_time:996ms step_avg:32.12ms
+step:32/1480 train_time:1032ms step_avg:32.25ms
+step:33/1480 train_time:1060ms step_avg:32.13ms
+step:34/1480 train_time:1095ms step_avg:32.22ms
+step:35/1480 train_time:1124ms step_avg:32.12ms
+step:36/1480 train_time:1159ms step_avg:32.19ms
+step:37/1480 train_time:1187ms step_avg:32.09ms
+step:38/1480 train_time:1223ms step_avg:32.19ms
+step:39/1480 train_time:1252ms step_avg:32.10ms
+step:40/1480 train_time:1288ms step_avg:32.20ms
+step:41/1480 train_time:1317ms step_avg:32.11ms
+step:42/1480 train_time:1353ms step_avg:32.21ms
+step:43/1480 train_time:1382ms step_avg:32.13ms
+step:44/1480 train_time:1417ms step_avg:32.20ms
+step:45/1480 train_time:1446ms step_avg:32.14ms
+step:46/1480 train_time:1482ms step_avg:32.21ms
+step:47/1480 train_time:1511ms step_avg:32.14ms
+step:48/1480 train_time:1547ms step_avg:32.22ms
+step:49/1480 train_time:1575ms step_avg:32.15ms
+step:50/1480 train_time:1611ms step_avg:32.21ms
+step:51/1480 train_time:1640ms step_avg:32.15ms
+step:52/1480 train_time:1675ms step_avg:32.22ms
+step:53/1480 train_time:1704ms step_avg:32.16ms
+step:54/1480 train_time:1739ms step_avg:32.21ms
+step:55/1480 train_time:1768ms step_avg:32.15ms
+step:56/1480 train_time:1804ms step_avg:32.22ms
+step:57/1480 train_time:1833ms step_avg:32.16ms
+step:58/1480 train_time:1868ms step_avg:32.21ms
+step:59/1480 train_time:1897ms step_avg:32.15ms
+step:60/1480 train_time:1932ms step_avg:32.20ms
+step:61/1480 train_time:1961ms step_avg:32.15ms
+step:62/1480 train_time:1997ms step_avg:32.20ms
+step:63/1480 train_time:2026ms step_avg:32.15ms
+step:64/1480 train_time:2061ms step_avg:32.20ms
+step:65/1480 train_time:2090ms step_avg:32.16ms
+step:66/1480 train_time:2127ms step_avg:32.23ms
+step:67/1480 train_time:2156ms step_avg:32.19ms
+step:68/1480 train_time:2193ms step_avg:32.24ms
+step:69/1480 train_time:2222ms step_avg:32.21ms
+step:70/1480 train_time:2258ms step_avg:32.26ms
+step:71/1480 train_time:2289ms step_avg:32.24ms
+step:72/1480 train_time:2328ms step_avg:32.33ms
+step:73/1480 train_time:2359ms step_avg:32.31ms
+step:74/1480 train_time:2397ms step_avg:32.39ms
+step:75/1480 train_time:2428ms step_avg:32.38ms
+step:76/1480 train_time:2466ms step_avg:32.45ms
+step:77/1480 train_time:2496ms step_avg:32.42ms
+step:78/1480 train_time:2533ms step_avg:32.48ms
+step:79/1480 train_time:2564ms step_avg:32.45ms
+step:80/1480 train_time:2600ms step_avg:32.51ms
+step:81/1480 train_time:2631ms step_avg:32.49ms
+step:82/1480 train_time:2669ms step_avg:32.55ms
+step:83/1480 train_time:2700ms step_avg:32.53ms
+step:84/1480 train_time:2737ms step_avg:32.59ms
+step:85/1480 train_time:2768ms step_avg:32.57ms
+step:86/1480 train_time:2806ms step_avg:32.63ms
+step:87/1480 train_time:2836ms step_avg:32.60ms
+step:88/1480 train_time:2874ms step_avg:32.66ms
+step:89/1480 train_time:2905ms step_avg:32.64ms
+step:90/1480 train_time:2941ms step_avg:32.68ms
+step:91/1480 train_time:2972ms step_avg:32.66ms
+step:92/1480 train_time:3009ms step_avg:32.71ms
+step:93/1480 train_time:3040ms step_avg:32.69ms
+step:94/1480 train_time:3076ms step_avg:32.73ms
+step:95/1480 train_time:3105ms step_avg:32.68ms
+step:96/1480 train_time:3140ms step_avg:32.71ms
+step:97/1480 train_time:3167ms step_avg:32.65ms
+step:98/1480 train_time:3202ms step_avg:32.68ms
+step:99/1480 train_time:3230ms step_avg:32.63ms
+step:100/1480 train_time:3265ms step_avg:32.65ms
+step:101/1480 train_time:3295ms step_avg:32.62ms
+step:102/1480 train_time:3330ms step_avg:32.65ms
+step:103/1480 train_time:3359ms step_avg:32.61ms
+step:104/1480 train_time:3394ms step_avg:32.63ms
+step:105/1480 train_time:3423ms step_avg:32.60ms
+step:106/1480 train_time:3459ms step_avg:32.63ms
+step:107/1480 train_time:3488ms step_avg:32.60ms
+step:108/1480 train_time:3525ms step_avg:32.64ms
+step:109/1480 train_time:3555ms step_avg:32.62ms
+step:110/1480 train_time:3591ms step_avg:32.64ms
+step:111/1480 train_time:3621ms step_avg:32.63ms
+step:112/1480 train_time:3659ms step_avg:32.67ms
+step:113/1480 train_time:3690ms step_avg:32.66ms
+step:114/1480 train_time:3729ms step_avg:32.71ms
+step:115/1480 train_time:3757ms step_avg:32.67ms
+step:116/1480 train_time:3794ms step_avg:32.71ms
+step:117/1480 train_time:3824ms step_avg:32.69ms
+step:118/1480 train_time:3861ms step_avg:32.72ms
+step:119/1480 train_time:3894ms step_avg:32.72ms
+step:120/1480 train_time:3933ms step_avg:32.78ms
+step:121/1480 train_time:3966ms step_avg:32.78ms
+step:122/1480 train_time:4006ms step_avg:32.83ms
+step:123/1480 train_time:4038ms step_avg:32.83ms
+step:124/1480 train_time:4078ms step_avg:32.88ms
+step:125/1480 train_time:4109ms step_avg:32.87ms
+step:126/1480 train_time:4147ms step_avg:32.91ms
+step:127/1480 train_time:4179ms step_avg:32.90ms
+step:128/1480 train_time:4217ms step_avg:32.94ms
+step:129/1480 train_time:4248ms step_avg:32.93ms
+step:130/1480 train_time:4287ms step_avg:32.98ms
+step:131/1480 train_time:4319ms step_avg:32.97ms
+step:132/1480 train_time:4357ms step_avg:33.01ms
+step:133/1480 train_time:4389ms step_avg:33.00ms
+step:134/1480 train_time:4427ms step_avg:33.04ms
+step:135/1480 train_time:4459ms step_avg:33.03ms
+step:136/1480 train_time:4497ms step_avg:33.06ms
+step:137/1480 train_time:4525ms step_avg:33.03ms
+step:138/1480 train_time:4559ms step_avg:33.04ms
+step:139/1480 train_time:4587ms step_avg:33.00ms
+step:140/1480 train_time:4622ms step_avg:33.02ms
+step:141/1480 train_time:4651ms step_avg:32.98ms
+step:142/1480 train_time:4686ms step_avg:33.00ms
+step:143/1480 train_time:4714ms step_avg:32.97ms
+step:144/1480 train_time:4749ms step_avg:32.98ms
+step:145/1480 train_time:4777ms step_avg:32.94ms
+step:146/1480 train_time:4814ms step_avg:32.97ms
+step:147/1480 train_time:4842ms step_avg:32.94ms
+step:148/1480 train_time:4879ms step_avg:32.97ms
+step:149/1480 train_time:4911ms step_avg:32.96ms
+step:150/1480 train_time:4949ms step_avg:32.99ms
+step:151/1480 train_time:4979ms step_avg:32.97ms
+step:152/1480 train_time:5017ms step_avg:33.01ms
+step:153/1480 train_time:5048ms step_avg:33.00ms
+step:154/1480 train_time:5087ms step_avg:33.03ms
+step:155/1480 train_time:5117ms step_avg:33.01ms
+step:156/1480 train_time:5154ms step_avg:33.04ms
+step:157/1480 train_time:5185ms step_avg:33.03ms
+step:158/1480 train_time:5223ms step_avg:33.05ms
+step:159/1480 train_time:5254ms step_avg:33.04ms
+step:160/1480 train_time:5292ms step_avg:33.07ms
+step:161/1480 train_time:5323ms step_avg:33.06ms
+step:162/1480 train_time:5360ms step_avg:33.08ms
+step:163/1480 train_time:5390ms step_avg:33.07ms
+step:164/1480 train_time:5428ms step_avg:33.10ms
+step:165/1480 train_time:5459ms step_avg:33.09ms
+step:166/1480 train_time:5496ms step_avg:33.11ms
+step:167/1480 train_time:5527ms step_avg:33.10ms
+step:168/1480 train_time:5565ms step_avg:33.12ms
+step:169/1480 train_time:5595ms step_avg:33.10ms
+step:170/1480 train_time:5632ms step_avg:33.13ms
+step:171/1480 train_time:5663ms step_avg:33.12ms
+step:172/1480 train_time:5700ms step_avg:33.14ms
+step:173/1480 train_time:5730ms step_avg:33.12ms
+step:174/1480 train_time:5766ms step_avg:33.14ms
+step:175/1480 train_time:5793ms step_avg:33.11ms
+step:176/1480 train_time:5828ms step_avg:33.12ms
+step:177/1480 train_time:5857ms step_avg:33.09ms
+step:178/1480 train_time:5891ms step_avg:33.10ms
+step:179/1480 train_time:5920ms step_avg:33.07ms
+step:180/1480 train_time:5958ms step_avg:33.10ms
+step:181/1480 train_time:5987ms step_avg:33.08ms
+step:182/1480 train_time:6023ms step_avg:33.09ms
+step:183/1480 train_time:6052ms step_avg:33.07ms
+step:184/1480 train_time:6088ms step_avg:33.09ms
+step:185/1480 train_time:6117ms step_avg:33.06ms
+step:186/1480 train_time:6152ms step_avg:33.08ms
+step:187/1480 train_time:6183ms step_avg:33.06ms
+step:188/1480 train_time:6218ms step_avg:33.08ms
+step:189/1480 train_time:6248ms step_avg:33.06ms
+step:190/1480 train_time:6285ms step_avg:33.08ms
+step:191/1480 train_time:6315ms step_avg:33.06ms
+step:192/1480 train_time:6351ms step_avg:33.08ms
+step:193/1480 train_time:6381ms step_avg:33.06ms
+step:194/1480 train_time:6417ms step_avg:33.08ms
+step:195/1480 train_time:6447ms step_avg:33.06ms
+step:196/1480 train_time:6484ms step_avg:33.08ms
+step:197/1480 train_time:6513ms step_avg:33.06ms
+step:198/1480 train_time:6550ms step_avg:33.08ms
+step:199/1480 train_time:6580ms step_avg:33.06ms
+step:200/1480 train_time:6615ms step_avg:33.08ms
+step:201/1480 train_time:6646ms step_avg:33.06ms
+step:202/1480 train_time:6682ms step_avg:33.08ms
+step:203/1480 train_time:6711ms step_avg:33.06ms
+step:204/1480 train_time:6749ms step_avg:33.08ms
+step:205/1480 train_time:6777ms step_avg:33.06ms
+step:206/1480 train_time:6814ms step_avg:33.08ms
+step:207/1480 train_time:6844ms step_avg:33.06ms
+step:208/1480 train_time:6880ms step_avg:33.08ms
+step:209/1480 train_time:6909ms step_avg:33.06ms
+step:210/1480 train_time:6946ms step_avg:33.08ms
+step:211/1480 train_time:6975ms step_avg:33.06ms
+step:212/1480 train_time:7012ms step_avg:33.08ms
+step:213/1480 train_time:7042ms step_avg:33.06ms
+step:214/1480 train_time:7078ms step_avg:33.08ms
+step:215/1480 train_time:7108ms step_avg:33.06ms
+step:216/1480 train_time:7145ms step_avg:33.08ms
+step:217/1480 train_time:7175ms step_avg:33.06ms
+step:218/1480 train_time:7212ms step_avg:33.08ms
+step:219/1480 train_time:7242ms step_avg:33.07ms
+step:220/1480 train_time:7277ms step_avg:33.08ms
+step:221/1480 train_time:7307ms step_avg:33.07ms
+step:222/1480 train_time:7344ms step_avg:33.08ms
+step:223/1480 train_time:7373ms step_avg:33.06ms
+step:224/1480 train_time:7410ms step_avg:33.08ms
+step:225/1480 train_time:7439ms step_avg:33.06ms
+step:226/1480 train_time:7475ms step_avg:33.08ms
+step:227/1480 train_time:7505ms step_avg:33.06ms
+step:228/1480 train_time:7541ms step_avg:33.07ms
+step:229/1480 train_time:7570ms step_avg:33.06ms
+step:230/1480 train_time:7606ms step_avg:33.07ms
+step:231/1480 train_time:7635ms step_avg:33.05ms
+step:232/1480 train_time:7672ms step_avg:33.07ms
+step:233/1480 train_time:7701ms step_avg:33.05ms
+step:234/1480 train_time:7737ms step_avg:33.06ms
+step:235/1480 train_time:7767ms step_avg:33.05ms
+step:236/1480 train_time:7805ms step_avg:33.07ms
+step:237/1480 train_time:7836ms step_avg:33.06ms
+step:238/1480 train_time:7875ms step_avg:33.09ms
+step:239/1480 train_time:7905ms step_avg:33.08ms
+step:240/1480 train_time:7942ms step_avg:33.09ms
+step:241/1480 train_time:7973ms step_avg:33.08ms
+step:242/1480 train_time:8010ms step_avg:33.10ms
+step:243/1480 train_time:8041ms step_avg:33.09ms
+step:244/1480 train_time:8078ms step_avg:33.11ms
+step:245/1480 train_time:8110ms step_avg:33.10ms
+step:246/1480 train_time:8149ms step_avg:33.12ms
+step:247/1480 train_time:8180ms step_avg:33.12ms
+step:248/1480 train_time:8217ms step_avg:33.13ms
+step:249/1480 train_time:8248ms step_avg:33.13ms
+step:250/1480 train_time:8286ms step_avg:33.14ms
+step:250/1480 val_loss:4.5047 train_time:8334ms step_avg:33.34ms
+step:251/1480 train_time:8351ms step_avg:33.27ms
+step:252/1480 train_time:8370ms step_avg:33.21ms
+step:253/1480 train_time:8388ms step_avg:33.15ms
+step:254/1480 train_time:8424ms step_avg:33.17ms
+step:255/1480 train_time:8452ms step_avg:33.15ms
+step:256/1480 train_time:8487ms step_avg:33.15ms
+step:257/1480 train_time:8515ms step_avg:33.13ms
+step:258/1480 train_time:8549ms step_avg:33.14ms
+step:259/1480 train_time:8577ms step_avg:33.12ms
+step:260/1480 train_time:8612ms step_avg:33.12ms
+step:261/1480 train_time:8640ms step_avg:33.10ms
+step:262/1480 train_time:8676ms step_avg:33.11ms
+step:263/1480 train_time:8705ms step_avg:33.10ms
+step:264/1480 train_time:8740ms step_avg:33.11ms
+step:265/1480 train_time:8769ms step_avg:33.09ms
+step:266/1480 train_time:8806ms step_avg:33.10ms
+step:267/1480 train_time:8836ms step_avg:33.09ms
+step:268/1480 train_time:8872ms step_avg:33.10ms
+step:269/1480 train_time:8901ms step_avg:33.09ms
+step:270/1480 train_time:8937ms step_avg:33.10ms
+step:271/1480 train_time:8966ms step_avg:33.09ms
+step:272/1480 train_time:9003ms step_avg:33.10ms
+step:273/1480 train_time:9033ms step_avg:33.09ms
+step:274/1480 train_time:9069ms step_avg:33.10ms
+step:275/1480 train_time:9098ms step_avg:33.08ms
+step:276/1480 train_time:9134ms step_avg:33.09ms
+step:277/1480 train_time:9163ms step_avg:33.08ms
+step:278/1480 train_time:9199ms step_avg:33.09ms
+step:279/1480 train_time:9228ms step_avg:33.08ms
+step:280/1480 train_time:9264ms step_avg:33.09ms
+step:281/1480 train_time:9294ms step_avg:33.08ms
+step:282/1480 train_time:9330ms step_avg:33.08ms
+step:283/1480 train_time:9359ms step_avg:33.07ms
+step:284/1480 train_time:9396ms step_avg:33.08ms
+step:285/1480 train_time:9425ms step_avg:33.07ms
+step:286/1480 train_time:9464ms step_avg:33.09ms
+step:287/1480 train_time:9497ms step_avg:33.09ms
+step:288/1480 train_time:9537ms step_avg:33.11ms
+step:289/1480 train_time:9569ms step_avg:33.11ms
+step:290/1480 train_time:9607ms step_avg:33.13ms
+step:291/1480 train_time:9640ms step_avg:33.13ms
+step:292/1480 train_time:9678ms step_avg:33.15ms
+step:293/1480 train_time:9710ms step_avg:33.14ms
+step:294/1480 train_time:9748ms step_avg:33.16ms
+step:295/1480 train_time:9780ms step_avg:33.15ms
+step:296/1480 train_time:9819ms step_avg:33.17ms
+step:297/1480 train_time:9850ms step_avg:33.17ms
+step:298/1480 train_time:9885ms step_avg:33.17ms
+step:299/1480 train_time:9913ms step_avg:33.16ms
+step:300/1480 train_time:9948ms step_avg:33.16ms
+step:301/1480 train_time:9976ms step_avg:33.14ms
+step:302/1480 train_time:10010ms step_avg:33.15ms
+step:303/1480 train_time:10038ms step_avg:33.13ms
+step:304/1480 train_time:10076ms step_avg:33.14ms
+step:305/1480 train_time:10106ms step_avg:33.14ms
+step:306/1480 train_time:10144ms step_avg:33.15ms
+step:307/1480 train_time:10175ms step_avg:33.14ms
+step:308/1480 train_time:10212ms step_avg:33.15ms
+step:309/1480 train_time:10242ms step_avg:33.15ms
+step:310/1480 train_time:10280ms step_avg:33.16ms
+step:311/1480 train_time:10310ms step_avg:33.15ms
+step:312/1480 train_time:10347ms step_avg:33.16ms
+step:313/1480 train_time:10377ms step_avg:33.15ms
+step:314/1480 train_time:10415ms step_avg:33.17ms
+step:315/1480 train_time:10445ms step_avg:33.16ms
+step:316/1480 train_time:10483ms step_avg:33.17ms
+step:317/1480 train_time:10514ms step_avg:33.17ms
+step:318/1480 train_time:10550ms step_avg:33.18ms
+step:319/1480 train_time:10580ms step_avg:33.17ms
+step:320/1480 train_time:10618ms step_avg:33.18ms
+step:321/1480 train_time:10648ms step_avg:33.17ms
+step:322/1480 train_time:10685ms step_avg:33.18ms
+step:323/1480 train_time:10716ms step_avg:33.18ms
+step:324/1480 train_time:10752ms step_avg:33.19ms
+step:325/1480 train_time:10782ms step_avg:33.18ms
+step:326/1480 train_time:10819ms step_avg:33.19ms
+step:327/1480 train_time:10850ms step_avg:33.18ms
+step:328/1480 train_time:10886ms step_avg:33.19ms
+step:329/1480 train_time:10917ms step_avg:33.18ms
+step:330/1480 train_time:10954ms step_avg:33.19ms
+step:331/1480 train_time:10983ms step_avg:33.18ms
+step:332/1480 train_time:11019ms step_avg:33.19ms
+step:333/1480 train_time:11049ms step_avg:33.18ms
+step:334/1480 train_time:11086ms step_avg:33.19ms
+step:335/1480 train_time:11116ms step_avg:33.18ms
+step:336/1480 train_time:11153ms step_avg:33.19ms
+step:337/1480 train_time:11182ms step_avg:33.18ms
+step:338/1480 train_time:11219ms step_avg:33.19ms
+step:339/1480 train_time:11249ms step_avg:33.18ms
+step:340/1480 train_time:11285ms step_avg:33.19ms
+step:341/1480 train_time:11315ms step_avg:33.18ms
+step:342/1480 train_time:11352ms step_avg:33.19ms
+step:343/1480 train_time:11382ms step_avg:33.18ms
+step:344/1480 train_time:11419ms step_avg:33.19ms
+step:345/1480 train_time:11448ms step_avg:33.18ms
+step:346/1480 train_time:11484ms step_avg:33.19ms
+step:347/1480 train_time:11515ms step_avg:33.18ms
+step:348/1480 train_time:11551ms step_avg:33.19ms
+step:349/1480 train_time:11581ms step_avg:33.18ms
+step:350/1480 train_time:11617ms step_avg:33.19ms
+step:351/1480 train_time:11647ms step_avg:33.18ms
+step:352/1480 train_time:11684ms step_avg:33.19ms
+step:353/1480 train_time:11714ms step_avg:33.18ms
+step:354/1480 train_time:11750ms step_avg:33.19ms
+step:355/1480 train_time:11780ms step_avg:33.18ms
+step:356/1480 train_time:11816ms step_avg:33.19ms
+step:357/1480 train_time:11846ms step_avg:33.18ms
+step:358/1480 train_time:11882ms step_avg:33.19ms
+step:359/1480 train_time:11912ms step_avg:33.18ms
+step:360/1480 train_time:11948ms step_avg:33.19ms
+step:361/1480 train_time:11978ms step_avg:33.18ms
+step:362/1480 train_time:12014ms step_avg:33.19ms
+step:363/1480 train_time:12044ms step_avg:33.18ms
+step:364/1480 train_time:12081ms step_avg:33.19ms
+step:365/1480 train_time:12111ms step_avg:33.18ms
+step:366/1480 train_time:12146ms step_avg:33.19ms
+step:367/1480 train_time:12176ms step_avg:33.18ms
+step:368/1480 train_time:12212ms step_avg:33.18ms
+step:369/1480 train_time:12241ms step_avg:33.17ms
+step:370/1480 train_time:12279ms step_avg:33.19ms
+step:371/1480 train_time:12308ms step_avg:33.17ms
+step:372/1480 train_time:12344ms step_avg:33.18ms
+step:373/1480 train_time:12373ms step_avg:33.17ms
+step:374/1480 train_time:12409ms step_avg:33.18ms
+step:375/1480 train_time:12438ms step_avg:33.17ms
+step:376/1480 train_time:12475ms step_avg:33.18ms
+step:377/1480 train_time:12503ms step_avg:33.17ms
+step:378/1480 train_time:12540ms step_avg:33.17ms
+step:379/1480 train_time:12569ms step_avg:33.16ms
+step:380/1480 train_time:12605ms step_avg:33.17ms
+step:381/1480 train_time:12635ms step_avg:33.16ms
+step:382/1480 train_time:12671ms step_avg:33.17ms
+step:383/1480 train_time:12700ms step_avg:33.16ms
+step:384/1480 train_time:12739ms step_avg:33.17ms
+step:385/1480 train_time:12771ms step_avg:33.17ms
+step:386/1480 train_time:12810ms step_avg:33.19ms
+step:387/1480 train_time:12842ms step_avg:33.18ms
+step:388/1480 train_time:12881ms step_avg:33.20ms
+step:389/1480 train_time:12912ms step_avg:33.19ms
+step:390/1480 train_time:12949ms step_avg:33.20ms
+step:391/1480 train_time:12981ms step_avg:33.20ms
+step:392/1480 train_time:13019ms step_avg:33.21ms
+step:393/1480 train_time:13050ms step_avg:33.21ms
+step:394/1480 train_time:13088ms step_avg:33.22ms
+step:395/1480 train_time:13119ms step_avg:33.21ms
+step:396/1480 train_time:13157ms step_avg:33.22ms
+step:397/1480 train_time:13189ms step_avg:33.22ms
+step:398/1480 train_time:13228ms step_avg:33.24ms
+step:399/1480 train_time:13260ms step_avg:33.23ms
+step:400/1480 train_time:13297ms step_avg:33.24ms
+step:401/1480 train_time:13328ms step_avg:33.24ms
+step:402/1480 train_time:13363ms step_avg:33.24ms
+step:403/1480 train_time:13391ms step_avg:33.23ms
+step:404/1480 train_time:13426ms step_avg:33.23ms
+step:405/1480 train_time:13454ms step_avg:33.22ms
+step:406/1480 train_time:13490ms step_avg:33.23ms
+step:407/1480 train_time:13517ms step_avg:33.21ms
+step:408/1480 train_time:13554ms step_avg:33.22ms
+step:409/1480 train_time:13584ms step_avg:33.21ms
+step:410/1480 train_time:13622ms step_avg:33.22ms
+step:411/1480 train_time:13652ms step_avg:33.22ms
+step:412/1480 train_time:13690ms step_avg:33.23ms
+step:413/1480 train_time:13720ms step_avg:33.22ms
+step:414/1480 train_time:13758ms step_avg:33.23ms
+step:415/1480 train_time:13788ms step_avg:33.22ms
+step:416/1480 train_time:13825ms step_avg:33.23ms
+step:417/1480 train_time:13856ms step_avg:33.23ms
+step:418/1480 train_time:13893ms step_avg:33.24ms
+step:419/1480 train_time:13923ms step_avg:33.23ms
+step:420/1480 train_time:13961ms step_avg:33.24ms
+step:421/1480 train_time:13991ms step_avg:33.23ms
+step:422/1480 train_time:14027ms step_avg:33.24ms
+step:423/1480 train_time:14058ms step_avg:33.23ms
+step:424/1480 train_time:14095ms step_avg:33.24ms
+step:425/1480 train_time:14125ms step_avg:33.24ms
+step:426/1480 train_time:14163ms step_avg:33.25ms
+step:427/1480 train_time:14194ms step_avg:33.24ms
+step:428/1480 train_time:14230ms step_avg:33.25ms
+step:429/1480 train_time:14260ms step_avg:33.24ms
+step:430/1480 train_time:14298ms step_avg:33.25ms
+step:431/1480 train_time:14328ms step_avg:33.24ms
+step:432/1480 train_time:14365ms step_avg:33.25ms
+step:433/1480 train_time:14395ms step_avg:33.25ms
+step:434/1480 train_time:14432ms step_avg:33.25ms
+step:435/1480 train_time:14462ms step_avg:33.24ms
+step:436/1480 train_time:14499ms step_avg:33.25ms
+step:437/1480 train_time:14529ms step_avg:33.25ms
+step:438/1480 train_time:14565ms step_avg:33.25ms
+step:439/1480 train_time:14596ms step_avg:33.25ms
+step:440/1480 train_time:14632ms step_avg:33.25ms
+step:441/1480 train_time:14662ms step_avg:33.25ms
+step:442/1480 train_time:14699ms step_avg:33.26ms
+step:443/1480 train_time:14728ms step_avg:33.25ms
+step:444/1480 train_time:14765ms step_avg:33.25ms
+step:445/1480 train_time:14795ms step_avg:33.25ms
+step:446/1480 train_time:14832ms step_avg:33.25ms
+step:447/1480 train_time:14862ms step_avg:33.25ms
+step:448/1480 train_time:14898ms step_avg:33.26ms
+step:449/1480 train_time:14928ms step_avg:33.25ms
+step:450/1480 train_time:14965ms step_avg:33.26ms
+step:451/1480 train_time:14995ms step_avg:33.25ms
+step:452/1480 train_time:15032ms step_avg:33.26ms
+step:453/1480 train_time:15061ms step_avg:33.25ms
+step:454/1480 train_time:15099ms step_avg:33.26ms
+step:455/1480 train_time:15128ms step_avg:33.25ms
+step:456/1480 train_time:15166ms step_avg:33.26ms
+step:457/1480 train_time:15196ms step_avg:33.25ms
+step:458/1480 train_time:15232ms step_avg:33.26ms
+step:459/1480 train_time:15262ms step_avg:33.25ms
+step:460/1480 train_time:15299ms step_avg:33.26ms
+step:461/1480 train_time:15328ms step_avg:33.25ms
+step:462/1480 train_time:15365ms step_avg:33.26ms
+step:463/1480 train_time:15396ms step_avg:33.25ms
+step:464/1480 train_time:15432ms step_avg:33.26ms
+step:465/1480 train_time:15461ms step_avg:33.25ms
+step:466/1480 train_time:15498ms step_avg:33.26ms
+step:467/1480 train_time:15528ms step_avg:33.25ms
+step:468/1480 train_time:15565ms step_avg:33.26ms
+step:469/1480 train_time:15595ms step_avg:33.25ms
+step:470/1480 train_time:15631ms step_avg:33.26ms
+step:471/1480 train_time:15661ms step_avg:33.25ms
+step:472/1480 train_time:15698ms step_avg:33.26ms
+step:473/1480 train_time:15728ms step_avg:33.25ms
+step:474/1480 train_time:15765ms step_avg:33.26ms
+step:475/1480 train_time:15795ms step_avg:33.25ms
+step:476/1480 train_time:15832ms step_avg:33.26ms
+step:477/1480 train_time:15861ms step_avg:33.25ms
+step:478/1480 train_time:15899ms step_avg:33.26ms
+step:479/1480 train_time:15929ms step_avg:33.25ms
+step:480/1480 train_time:15965ms step_avg:33.26ms
+step:481/1480 train_time:15999ms step_avg:33.26ms
+step:482/1480 train_time:16058ms step_avg:33.31ms
+step:483/1480 train_time:16115ms step_avg:33.36ms
+step:484/1480 train_time:16179ms step_avg:33.43ms
+step:485/1480 train_time:16237ms step_avg:33.48ms
+step:486/1480 train_time:16302ms step_avg:33.54ms
+step:487/1480 train_time:16360ms step_avg:33.59ms
+step:488/1480 train_time:16424ms step_avg:33.66ms
+step:489/1480 train_time:16483ms step_avg:33.71ms
+step:490/1480 train_time:16547ms step_avg:33.77ms
+step:491/1480 train_time:16606ms step_avg:33.82ms
+step:492/1480 train_time:16671ms step_avg:33.88ms
+step:493/1480 train_time:16729ms step_avg:33.93ms
+step:494/1480 train_time:16793ms step_avg:33.99ms
+step:495/1480 train_time:16850ms step_avg:34.04ms
+step:496/1480 train_time:16913ms step_avg:34.10ms
+step:497/1480 train_time:16970ms step_avg:34.14ms
+step:498/1480 train_time:17034ms step_avg:34.21ms
+step:499/1480 train_time:17094ms step_avg:34.26ms
+step:500/1480 train_time:17158ms step_avg:34.32ms
+step:500/1480 val_loss:4.2368 train_time:17242ms step_avg:34.48ms
+step:501/1480 train_time:17259ms step_avg:34.45ms
+step:502/1480 train_time:17284ms step_avg:34.43ms
+step:503/1480 train_time:17342ms step_avg:34.48ms
+step:504/1480 train_time:17406ms step_avg:34.54ms
+step:505/1480 train_time:17465ms step_avg:34.58ms
+step:506/1480 train_time:17528ms step_avg:34.64ms
+step:507/1480 train_time:17587ms step_avg:34.69ms
+step:508/1480 train_time:17652ms step_avg:34.75ms
+step:509/1480 train_time:17710ms step_avg:34.79ms
+step:510/1480 train_time:17774ms step_avg:34.85ms
+step:511/1480 train_time:17831ms step_avg:34.89ms
+step:512/1480 train_time:17895ms step_avg:34.95ms
+step:513/1480 train_time:17954ms step_avg:35.00ms
+step:514/1480 train_time:18019ms step_avg:35.06ms
+step:515/1480 train_time:18078ms step_avg:35.10ms
+step:516/1480 train_time:18145ms step_avg:35.16ms
+step:517/1480 train_time:18203ms step_avg:35.21ms
+step:518/1480 train_time:18266ms step_avg:35.26ms
+step:519/1480 train_time:18325ms step_avg:35.31ms
+step:520/1480 train_time:18391ms step_avg:35.37ms
+step:521/1480 train_time:18448ms step_avg:35.41ms
+step:522/1480 train_time:18512ms step_avg:35.46ms
+step:523/1480 train_time:18569ms step_avg:35.50ms
+step:524/1480 train_time:18632ms step_avg:35.56ms
+step:525/1480 train_time:18690ms step_avg:35.60ms
+step:526/1480 train_time:18756ms step_avg:35.66ms
+step:527/1480 train_time:18813ms step_avg:35.70ms
+step:528/1480 train_time:18876ms step_avg:35.75ms
+step:529/1480 train_time:18933ms step_avg:35.79ms
+step:530/1480 train_time:18996ms step_avg:35.84ms
+step:531/1480 train_time:19054ms step_avg:35.88ms
+step:532/1480 train_time:19118ms step_avg:35.94ms
+step:533/1480 train_time:19178ms step_avg:35.98ms
+step:534/1480 train_time:19243ms step_avg:36.03ms
+step:535/1480 train_time:19301ms step_avg:36.08ms
+step:536/1480 train_time:19364ms step_avg:36.13ms
+step:537/1480 train_time:19422ms step_avg:36.17ms
+step:538/1480 train_time:19486ms step_avg:36.22ms
+step:539/1480 train_time:19544ms step_avg:36.26ms
+step:540/1480 train_time:19607ms step_avg:36.31ms
+step:541/1480 train_time:19665ms step_avg:36.35ms
+step:542/1480 train_time:19727ms step_avg:36.40ms
+step:543/1480 train_time:19785ms step_avg:36.44ms
+step:544/1480 train_time:19848ms step_avg:36.49ms
+step:545/1480 train_time:19906ms step_avg:36.52ms
+step:546/1480 train_time:19969ms step_avg:36.57ms
+step:547/1480 train_time:20026ms step_avg:36.61ms
+step:548/1480 train_time:20089ms step_avg:36.66ms
+step:549/1480 train_time:20148ms step_avg:36.70ms
+step:550/1480 train_time:20215ms step_avg:36.75ms
+step:551/1480 train_time:20274ms step_avg:36.80ms
+step:552/1480 train_time:20342ms step_avg:36.85ms
+step:553/1480 train_time:20404ms step_avg:36.90ms
+step:554/1480 train_time:20470ms step_avg:36.95ms
+step:555/1480 train_time:20533ms step_avg:37.00ms
+step:556/1480 train_time:20601ms step_avg:37.05ms
+step:557/1480 train_time:20661ms step_avg:37.09ms
+step:558/1480 train_time:20728ms step_avg:37.15ms
+step:559/1480 train_time:20789ms step_avg:37.19ms
+step:560/1480 train_time:20856ms step_avg:37.24ms
+step:561/1480 train_time:20916ms step_avg:37.28ms
+step:562/1480 train_time:20980ms step_avg:37.33ms
+step:563/1480 train_time:21034ms step_avg:37.36ms
+step:564/1480 train_time:21093ms step_avg:37.40ms
+step:565/1480 train_time:21148ms step_avg:37.43ms
+step:566/1480 train_time:21211ms step_avg:37.48ms
+step:567/1480 train_time:21268ms step_avg:37.51ms
+step:568/1480 train_time:21331ms step_avg:37.55ms
+step:569/1480 train_time:21390ms step_avg:37.59ms
+step:570/1480 train_time:21458ms step_avg:37.65ms
+step:571/1480 train_time:21517ms step_avg:37.68ms
+step:572/1480 train_time:21584ms step_avg:37.73ms
+step:573/1480 train_time:21644ms step_avg:37.77ms
+step:574/1480 train_time:21710ms step_avg:37.82ms
+step:575/1480 train_time:21769ms step_avg:37.86ms
+step:576/1480 train_time:21835ms step_avg:37.91ms
+step:577/1480 train_time:21894ms step_avg:37.95ms
+step:578/1480 train_time:21959ms step_avg:37.99ms
+step:579/1480 train_time:22018ms step_avg:38.03ms
+step:580/1480 train_time:22084ms step_avg:38.08ms
+step:581/1480 train_time:22144ms step_avg:38.11ms
+step:582/1480 train_time:22208ms step_avg:38.16ms
+step:583/1480 train_time:22268ms step_avg:38.19ms
+step:584/1480 train_time:22333ms step_avg:38.24ms
+step:585/1480 train_time:22392ms step_avg:38.28ms
+step:586/1480 train_time:22456ms step_avg:38.32ms
+step:587/1480 train_time:22515ms step_avg:38.36ms
+step:588/1480 train_time:22579ms step_avg:38.40ms
+step:589/1480 train_time:22639ms step_avg:38.44ms
+step:590/1480 train_time:22704ms step_avg:38.48ms
+step:591/1480 train_time:22761ms step_avg:38.51ms
+step:592/1480 train_time:22826ms step_avg:38.56ms
+step:593/1480 train_time:22885ms step_avg:38.59ms
+step:594/1480 train_time:22950ms step_avg:38.64ms
+step:595/1480 train_time:23007ms step_avg:38.67ms
+step:596/1480 train_time:23072ms step_avg:38.71ms
+step:597/1480 train_time:23130ms step_avg:38.74ms
+step:598/1480 train_time:23194ms step_avg:38.79ms
+step:599/1480 train_time:23251ms step_avg:38.82ms
+step:600/1480 train_time:23315ms step_avg:38.86ms
+step:601/1480 train_time:23372ms step_avg:38.89ms
+step:602/1480 train_time:23436ms step_avg:38.93ms
+step:603/1480 train_time:23494ms step_avg:38.96ms
+step:604/1480 train_time:23557ms step_avg:39.00ms
+step:605/1480 train_time:23614ms step_avg:39.03ms
+step:606/1480 train_time:23677ms step_avg:39.07ms
+step:607/1480 train_time:23735ms step_avg:39.10ms
+step:608/1480 train_time:23798ms step_avg:39.14ms
+step:609/1480 train_time:23857ms step_avg:39.17ms
+step:610/1480 train_time:23922ms step_avg:39.22ms
+step:611/1480 train_time:23981ms step_avg:39.25ms
+step:612/1480 train_time:24047ms step_avg:39.29ms
+step:613/1480 train_time:24105ms step_avg:39.32ms
+step:614/1480 train_time:24168ms step_avg:39.36ms
+step:615/1480 train_time:24226ms step_avg:39.39ms
+step:616/1480 train_time:24289ms step_avg:39.43ms
+step:617/1480 train_time:24346ms step_avg:39.46ms
+step:618/1480 train_time:24408ms step_avg:39.50ms
+step:619/1480 train_time:24465ms step_avg:39.52ms
+step:620/1480 train_time:24529ms step_avg:39.56ms
+step:621/1480 train_time:24587ms step_avg:39.59ms
+step:622/1480 train_time:24652ms step_avg:39.63ms
+step:623/1480 train_time:24710ms step_avg:39.66ms
+step:624/1480 train_time:24774ms step_avg:39.70ms
+step:625/1480 train_time:24832ms step_avg:39.73ms
+step:626/1480 train_time:24896ms step_avg:39.77ms
+step:627/1480 train_time:24953ms step_avg:39.80ms
+step:628/1480 train_time:25015ms step_avg:39.83ms
+step:629/1480 train_time:25071ms step_avg:39.86ms
+step:630/1480 train_time:25136ms step_avg:39.90ms
+step:631/1480 train_time:25194ms step_avg:39.93ms
+step:632/1480 train_time:25257ms step_avg:39.96ms
+step:633/1480 train_time:25317ms step_avg:40.00ms
+step:634/1480 train_time:25384ms step_avg:40.04ms
+step:635/1480 train_time:25443ms step_avg:40.07ms
+step:636/1480 train_time:25505ms step_avg:40.10ms
+step:637/1480 train_time:25563ms step_avg:40.13ms
+step:638/1480 train_time:25626ms step_avg:40.17ms
+step:639/1480 train_time:25684ms step_avg:40.19ms
+step:640/1480 train_time:25750ms step_avg:40.23ms
+step:641/1480 train_time:25808ms step_avg:40.26ms
+step:642/1480 train_time:25872ms step_avg:40.30ms
+step:643/1480 train_time:25928ms step_avg:40.32ms
+step:644/1480 train_time:25992ms step_avg:40.36ms
+step:645/1480 train_time:26050ms step_avg:40.39ms
+step:646/1480 train_time:26114ms step_avg:40.42ms
+step:647/1480 train_time:26171ms step_avg:40.45ms
+step:648/1480 train_time:26235ms step_avg:40.49ms
+step:649/1480 train_time:26293ms step_avg:40.51ms
+step:650/1480 train_time:26356ms step_avg:40.55ms
+step:651/1480 train_time:26414ms step_avg:40.57ms
+step:652/1480 train_time:26477ms step_avg:40.61ms
+step:653/1480 train_time:26536ms step_avg:40.64ms
+step:654/1480 train_time:26600ms step_avg:40.67ms
+step:655/1480 train_time:26658ms step_avg:40.70ms
+step:656/1480 train_time:26722ms step_avg:40.73ms
+step:657/1480 train_time:26782ms step_avg:40.76ms
+step:658/1480 train_time:26847ms step_avg:40.80ms
+step:659/1480 train_time:26906ms step_avg:40.83ms
+step:660/1480 train_time:26975ms step_avg:40.87ms
+step:661/1480 train_time:27036ms step_avg:40.90ms
+step:662/1480 train_time:27104ms step_avg:40.94ms
+step:663/1480 train_time:27164ms step_avg:40.97ms
+step:664/1480 train_time:27231ms step_avg:41.01ms
+step:665/1480 train_time:27291ms step_avg:41.04ms
+step:666/1480 train_time:27357ms step_avg:41.08ms
+step:667/1480 train_time:27417ms step_avg:41.11ms
+step:668/1480 train_time:27484ms step_avg:41.14ms
+step:669/1480 train_time:27544ms step_avg:41.17ms
+step:670/1480 train_time:27611ms step_avg:41.21ms
+step:671/1480 train_time:27670ms step_avg:41.24ms
+step:672/1480 train_time:27736ms step_avg:41.27ms
+step:673/1480 train_time:27796ms step_avg:41.30ms
+step:674/1480 train_time:27861ms step_avg:41.34ms
+step:675/1480 train_time:27920ms step_avg:41.36ms
+step:676/1480 train_time:27986ms step_avg:41.40ms
+step:677/1480 train_time:28046ms step_avg:41.43ms
+step:678/1480 train_time:28111ms step_avg:41.46ms
+step:679/1480 train_time:28170ms step_avg:41.49ms
+step:680/1480 train_time:28235ms step_avg:41.52ms
+step:681/1480 train_time:28294ms step_avg:41.55ms
+step:682/1480 train_time:28359ms step_avg:41.58ms
+step:683/1480 train_time:28417ms step_avg:41.61ms
+step:684/1480 train_time:28482ms step_avg:41.64ms
+step:685/1480 train_time:28541ms step_avg:41.67ms
+step:686/1480 train_time:28606ms step_avg:41.70ms
+step:687/1480 train_time:28665ms step_avg:41.72ms
+step:688/1480 train_time:28729ms step_avg:41.76ms
+step:689/1480 train_time:28788ms step_avg:41.78ms
+step:690/1480 train_time:28853ms step_avg:41.82ms
+step:691/1480 train_time:28910ms step_avg:41.84ms
+step:692/1480 train_time:28974ms step_avg:41.87ms
+step:693/1480 train_time:29032ms step_avg:41.89ms
+step:694/1480 train_time:29096ms step_avg:41.93ms
+step:695/1480 train_time:29154ms step_avg:41.95ms
+step:696/1480 train_time:29217ms step_avg:41.98ms
+step:697/1480 train_time:29275ms step_avg:42.00ms
+step:698/1480 train_time:29340ms step_avg:42.03ms
+step:699/1480 train_time:29398ms step_avg:42.06ms
+step:700/1480 train_time:29462ms step_avg:42.09ms
+step:701/1480 train_time:29520ms step_avg:42.11ms
+step:702/1480 train_time:29585ms step_avg:42.14ms
+step:703/1480 train_time:29645ms step_avg:42.17ms
+step:704/1480 train_time:29708ms step_avg:42.20ms
+step:705/1480 train_time:29766ms step_avg:42.22ms
+step:706/1480 train_time:29829ms step_avg:42.25ms
+step:707/1480 train_time:29888ms step_avg:42.27ms
+step:708/1480 train_time:29952ms step_avg:42.31ms
+step:709/1480 train_time:30010ms step_avg:42.33ms
+step:710/1480 train_time:30074ms step_avg:42.36ms
+step:711/1480 train_time:30131ms step_avg:42.38ms
+step:712/1480 train_time:30195ms step_avg:42.41ms
+step:713/1480 train_time:30255ms step_avg:42.43ms
+step:714/1480 train_time:30318ms step_avg:42.46ms
+step:715/1480 train_time:30376ms step_avg:42.48ms
+step:716/1480 train_time:30440ms step_avg:42.51ms
+step:717/1480 train_time:30498ms step_avg:42.54ms
+step:718/1480 train_time:30561ms step_avg:42.56ms
+step:719/1480 train_time:30619ms step_avg:42.59ms
+step:720/1480 train_time:30682ms step_avg:42.61ms
+step:721/1480 train_time:30741ms step_avg:42.64ms
+step:722/1480 train_time:30804ms step_avg:42.66ms
+step:723/1480 train_time:30861ms step_avg:42.68ms
+step:724/1480 train_time:30926ms step_avg:42.72ms
+step:725/1480 train_time:30987ms step_avg:42.74ms
+step:726/1480 train_time:31050ms step_avg:42.77ms
+step:727/1480 train_time:31108ms step_avg:42.79ms
+step:728/1480 train_time:31172ms step_avg:42.82ms
+step:729/1480 train_time:31231ms step_avg:42.84ms
+step:730/1480 train_time:31296ms step_avg:42.87ms
+step:731/1480 train_time:31354ms step_avg:42.89ms
+step:732/1480 train_time:31416ms step_avg:42.92ms
+step:733/1480 train_time:31474ms step_avg:42.94ms
+step:734/1480 train_time:31541ms step_avg:42.97ms
+step:735/1480 train_time:31601ms step_avg:42.99ms
+step:736/1480 train_time:31666ms step_avg:43.02ms
+step:737/1480 train_time:31724ms step_avg:43.05ms
+step:738/1480 train_time:31789ms step_avg:43.07ms
+step:739/1480 train_time:31848ms step_avg:43.10ms
+step:740/1480 train_time:31913ms step_avg:43.13ms
+step:741/1480 train_time:31971ms step_avg:43.15ms
+step:742/1480 train_time:32035ms step_avg:43.17ms
+step:743/1480 train_time:32094ms step_avg:43.19ms
+step:744/1480 train_time:32158ms step_avg:43.22ms
+step:745/1480 train_time:32216ms step_avg:43.24ms
+step:746/1480 train_time:32281ms step_avg:43.27ms
+step:747/1480 train_time:32340ms step_avg:43.29ms
+step:748/1480 train_time:32405ms step_avg:43.32ms
+step:749/1480 train_time:32464ms step_avg:43.34ms
+step:750/1480 train_time:32529ms step_avg:43.37ms
+step:750/1480 val_loss:3.7992 train_time:32612ms step_avg:43.48ms
+step:751/1480 train_time:32629ms step_avg:43.45ms
+step:752/1480 train_time:32654ms step_avg:43.42ms
+step:753/1480 train_time:32712ms step_avg:43.44ms
+step:754/1480 train_time:32775ms step_avg:43.47ms
+step:755/1480 train_time:32834ms step_avg:43.49ms
+step:756/1480 train_time:32898ms step_avg:43.52ms
+step:757/1480 train_time:32956ms step_avg:43.53ms
+step:758/1480 train_time:33020ms step_avg:43.56ms
+step:759/1480 train_time:33079ms step_avg:43.58ms
+step:760/1480 train_time:33144ms step_avg:43.61ms
+step:761/1480 train_time:33203ms step_avg:43.63ms
+step:762/1480 train_time:33268ms step_avg:43.66ms
+step:763/1480 train_time:33326ms step_avg:43.68ms
+step:764/1480 train_time:33390ms step_avg:43.70ms
+step:765/1480 train_time:33448ms step_avg:43.72ms
+step:766/1480 train_time:33511ms step_avg:43.75ms
+step:767/1480 train_time:33569ms step_avg:43.77ms
+step:768/1480 train_time:33632ms step_avg:43.79ms
+step:769/1480 train_time:33690ms step_avg:43.81ms
+step:770/1480 train_time:33754ms step_avg:43.84ms
+step:771/1480 train_time:33811ms step_avg:43.85ms
+step:772/1480 train_time:33874ms step_avg:43.88ms
+step:773/1480 train_time:33930ms step_avg:43.89ms
+step:774/1480 train_time:33993ms step_avg:43.92ms
+step:775/1480 train_time:34051ms step_avg:43.94ms
+step:776/1480 train_time:34116ms step_avg:43.96ms
+step:777/1480 train_time:34174ms step_avg:43.98ms
+step:778/1480 train_time:34239ms step_avg:44.01ms
+step:779/1480 train_time:34297ms step_avg:44.03ms
+step:780/1480 train_time:34361ms step_avg:44.05ms
+step:781/1480 train_time:34421ms step_avg:44.07ms
+step:782/1480 train_time:34488ms step_avg:44.10ms
+step:783/1480 train_time:34547ms step_avg:44.12ms
+step:784/1480 train_time:34612ms step_avg:44.15ms
+step:785/1480 train_time:34671ms step_avg:44.17ms
+step:786/1480 train_time:34736ms step_avg:44.19ms
+step:787/1480 train_time:34794ms step_avg:44.21ms
+step:788/1480 train_time:34859ms step_avg:44.24ms
+step:789/1480 train_time:34917ms step_avg:44.25ms
+step:790/1480 train_time:34982ms step_avg:44.28ms
+step:791/1480 train_time:35041ms step_avg:44.30ms
+step:792/1480 train_time:35106ms step_avg:44.33ms
+step:793/1480 train_time:35164ms step_avg:44.34ms
+step:794/1480 train_time:35229ms step_avg:44.37ms
+step:795/1480 train_time:35289ms step_avg:44.39ms
+step:796/1480 train_time:35355ms step_avg:44.42ms
+step:797/1480 train_time:35413ms step_avg:44.43ms
+step:798/1480 train_time:35477ms step_avg:44.46ms
+step:799/1480 train_time:35536ms step_avg:44.48ms
+step:800/1480 train_time:35602ms step_avg:44.50ms
+step:801/1480 train_time:35660ms step_avg:44.52ms
+step:802/1480 train_time:35725ms step_avg:44.55ms
+step:803/1480 train_time:35786ms step_avg:44.57ms
+step:804/1480 train_time:35850ms step_avg:44.59ms
+step:805/1480 train_time:35909ms step_avg:44.61ms
+step:806/1480 train_time:35973ms step_avg:44.63ms
+step:807/1480 train_time:36030ms step_avg:44.65ms
+step:808/1480 train_time:36095ms step_avg:44.67ms
+step:809/1480 train_time:36152ms step_avg:44.69ms
+step:810/1480 train_time:36216ms step_avg:44.71ms
+step:811/1480 train_time:36273ms step_avg:44.73ms
+step:812/1480 train_time:36337ms step_avg:44.75ms
+step:813/1480 train_time:36395ms step_avg:44.77ms
+step:814/1480 train_time:36459ms step_avg:44.79ms
+step:815/1480 train_time:36516ms step_avg:44.80ms
+step:816/1480 train_time:36579ms step_avg:44.83ms
+step:817/1480 train_time:36637ms step_avg:44.84ms
+step:818/1480 train_time:36700ms step_avg:44.87ms
+step:819/1480 train_time:36758ms step_avg:44.88ms
+step:820/1480 train_time:36821ms step_avg:44.90ms
+step:821/1480 train_time:36879ms step_avg:44.92ms
+step:822/1480 train_time:36944ms step_avg:44.94ms
+step:823/1480 train_time:37001ms step_avg:44.96ms
+step:824/1480 train_time:37064ms step_avg:44.98ms
+step:825/1480 train_time:37121ms step_avg:44.99ms
+step:826/1480 train_time:37184ms step_avg:45.02ms
+step:827/1480 train_time:37242ms step_avg:45.03ms
+step:828/1480 train_time:37306ms step_avg:45.06ms
+step:829/1480 train_time:37364ms step_avg:45.07ms
+step:830/1480 train_time:37431ms step_avg:45.10ms
+step:831/1480 train_time:37492ms step_avg:45.12ms
+step:832/1480 train_time:37557ms step_avg:45.14ms
+step:833/1480 train_time:37616ms step_avg:45.16ms
+step:834/1480 train_time:37683ms step_avg:45.18ms
+step:835/1480 train_time:37744ms step_avg:45.20ms
+step:836/1480 train_time:37810ms step_avg:45.23ms
+step:837/1480 train_time:37869ms step_avg:45.24ms
+step:838/1480 train_time:37935ms step_avg:45.27ms
+step:839/1480 train_time:37995ms step_avg:45.29ms
+step:840/1480 train_time:38060ms step_avg:45.31ms
+step:841/1480 train_time:38120ms step_avg:45.33ms
+step:842/1480 train_time:38186ms step_avg:45.35ms
+step:843/1480 train_time:38246ms step_avg:45.37ms
+step:844/1480 train_time:38312ms step_avg:45.39ms
+step:845/1480 train_time:38371ms step_avg:45.41ms
+step:846/1480 train_time:38437ms step_avg:45.43ms
+step:847/1480 train_time:38496ms step_avg:45.45ms
+step:848/1480 train_time:38560ms step_avg:45.47ms
+step:849/1480 train_time:38616ms step_avg:45.48ms
+step:850/1480 train_time:38676ms step_avg:45.50ms
+step:851/1480 train_time:38733ms step_avg:45.51ms
+step:852/1480 train_time:38800ms step_avg:45.54ms
+step:853/1480 train_time:38858ms step_avg:45.55ms
+step:854/1480 train_time:38924ms step_avg:45.58ms
+step:855/1480 train_time:38980ms step_avg:45.59ms
+step:856/1480 train_time:39044ms step_avg:45.61ms
+step:857/1480 train_time:39102ms step_avg:45.63ms
+step:858/1480 train_time:39166ms step_avg:45.65ms
+step:859/1480 train_time:39226ms step_avg:45.66ms
+step:860/1480 train_time:39293ms step_avg:45.69ms
+step:861/1480 train_time:39354ms step_avg:45.71ms
+step:862/1480 train_time:39419ms step_avg:45.73ms
+step:863/1480 train_time:39478ms step_avg:45.75ms
+step:864/1480 train_time:39545ms step_avg:45.77ms
+step:865/1480 train_time:39606ms step_avg:45.79ms
+step:866/1480 train_time:39671ms step_avg:45.81ms
+step:867/1480 train_time:39732ms step_avg:45.83ms
+step:868/1480 train_time:39798ms step_avg:45.85ms
+step:869/1480 train_time:39856ms step_avg:45.86ms
+step:870/1480 train_time:39923ms step_avg:45.89ms
+step:871/1480 train_time:39984ms step_avg:45.91ms
+step:872/1480 train_time:40050ms step_avg:45.93ms
+step:873/1480 train_time:40110ms step_avg:45.94ms
+step:874/1480 train_time:40176ms step_avg:45.97ms
+step:875/1480 train_time:40234ms step_avg:45.98ms
+step:876/1480 train_time:40300ms step_avg:46.00ms
+step:877/1480 train_time:40359ms step_avg:46.02ms
+step:878/1480 train_time:40425ms step_avg:46.04ms
+step:879/1480 train_time:40485ms step_avg:46.06ms
+step:880/1480 train_time:40552ms step_avg:46.08ms
+step:881/1480 train_time:40611ms step_avg:46.10ms
+step:882/1480 train_time:40676ms step_avg:46.12ms
+step:883/1480 train_time:40734ms step_avg:46.13ms
+step:884/1480 train_time:40800ms step_avg:46.15ms
+step:885/1480 train_time:40858ms step_avg:46.17ms
+step:886/1480 train_time:40923ms step_avg:46.19ms
+step:887/1480 train_time:40982ms step_avg:46.20ms
+step:888/1480 train_time:41048ms step_avg:46.23ms
+step:889/1480 train_time:41107ms step_avg:46.24ms
+step:890/1480 train_time:41171ms step_avg:46.26ms
+step:891/1480 train_time:41230ms step_avg:46.27ms
+step:892/1480 train_time:41295ms step_avg:46.29ms
+step:893/1480 train_time:41352ms step_avg:46.31ms
+step:894/1480 train_time:41416ms step_avg:46.33ms
+step:895/1480 train_time:41474ms step_avg:46.34ms
+step:896/1480 train_time:41538ms step_avg:46.36ms
+step:897/1480 train_time:41596ms step_avg:46.37ms
+step:898/1480 train_time:41659ms step_avg:46.39ms
+step:899/1480 train_time:41717ms step_avg:46.40ms
+step:900/1480 train_time:41780ms step_avg:46.42ms
+step:901/1480 train_time:41839ms step_avg:46.44ms
+step:902/1480 train_time:41902ms step_avg:46.45ms
+step:903/1480 train_time:41960ms step_avg:46.47ms
+step:904/1480 train_time:42024ms step_avg:46.49ms
+step:905/1480 train_time:42085ms step_avg:46.50ms
+step:906/1480 train_time:42150ms step_avg:46.52ms
+step:907/1480 train_time:42207ms step_avg:46.53ms
+step:908/1480 train_time:42271ms step_avg:46.55ms
+step:909/1480 train_time:42331ms step_avg:46.57ms
+step:910/1480 train_time:42397ms step_avg:46.59ms
+step:911/1480 train_time:42453ms step_avg:46.60ms
+step:912/1480 train_time:42517ms step_avg:46.62ms
+step:913/1480 train_time:42573ms step_avg:46.63ms
+step:914/1480 train_time:42637ms step_avg:46.65ms
+step:915/1480 train_time:42695ms step_avg:46.66ms
+step:916/1480 train_time:42758ms step_avg:46.68ms
+step:917/1480 train_time:42816ms step_avg:46.69ms
+step:918/1480 train_time:42879ms step_avg:46.71ms
+step:919/1480 train_time:42936ms step_avg:46.72ms
+step:920/1480 train_time:42999ms step_avg:46.74ms
+step:921/1480 train_time:43056ms step_avg:46.75ms
+step:922/1480 train_time:43119ms step_avg:46.77ms
+step:923/1480 train_time:43179ms step_avg:46.78ms
+step:924/1480 train_time:43245ms step_avg:46.80ms
+step:925/1480 train_time:43303ms step_avg:46.81ms
+step:926/1480 train_time:43368ms step_avg:46.83ms
+step:927/1480 train_time:43428ms step_avg:46.85ms
+step:928/1480 train_time:43493ms step_avg:46.87ms
+step:929/1480 train_time:43552ms step_avg:46.88ms
+step:930/1480 train_time:43617ms step_avg:46.90ms
+step:931/1480 train_time:43677ms step_avg:46.91ms
+step:932/1480 train_time:43741ms step_avg:46.93ms
+step:933/1480 train_time:43800ms step_avg:46.95ms
+step:934/1480 train_time:43864ms step_avg:46.96ms
+step:935/1480 train_time:43923ms step_avg:46.98ms
+step:936/1480 train_time:43990ms step_avg:47.00ms
+step:937/1480 train_time:44051ms step_avg:47.01ms
+step:938/1480 train_time:44116ms step_avg:47.03ms
+step:939/1480 train_time:44173ms step_avg:47.04ms
+step:940/1480 train_time:44238ms step_avg:47.06ms
+step:941/1480 train_time:44297ms step_avg:47.07ms
+step:942/1480 train_time:44361ms step_avg:47.09ms
+step:943/1480 train_time:44419ms step_avg:47.10ms
+step:944/1480 train_time:44484ms step_avg:47.12ms
+step:945/1480 train_time:44542ms step_avg:47.13ms
+step:946/1480 train_time:44606ms step_avg:47.15ms
+step:947/1480 train_time:44664ms step_avg:47.16ms
+step:948/1480 train_time:44728ms step_avg:47.18ms
+step:949/1480 train_time:44787ms step_avg:47.19ms
+step:950/1480 train_time:44851ms step_avg:47.21ms
+step:951/1480 train_time:44910ms step_avg:47.22ms
+step:952/1480 train_time:44976ms step_avg:47.24ms
+step:953/1480 train_time:45033ms step_avg:47.25ms
+step:954/1480 train_time:45097ms step_avg:47.27ms
+step:955/1480 train_time:45154ms step_avg:47.28ms
+step:956/1480 train_time:45217ms step_avg:47.30ms
+step:957/1480 train_time:45275ms step_avg:47.31ms
+step:958/1480 train_time:45339ms step_avg:47.33ms
+step:959/1480 train_time:45396ms step_avg:47.34ms
+step:960/1480 train_time:45459ms step_avg:47.35ms
+step:961/1480 train_time:45519ms step_avg:47.37ms
+step:962/1480 train_time:45606ms step_avg:47.41ms
+step:963/1480 train_time:45693ms step_avg:47.45ms
+step:964/1480 train_time:45789ms step_avg:47.50ms
+step:965/1480 train_time:45877ms step_avg:47.54ms
+step:966/1480 train_time:45972ms step_avg:47.59ms
+step:967/1480 train_time:46059ms step_avg:47.63ms
+step:968/1480 train_time:46154ms step_avg:47.68ms
+step:969/1480 train_time:46242ms step_avg:47.72ms
+step:970/1480 train_time:46336ms step_avg:47.77ms
+step:971/1480 train_time:46424ms step_avg:47.81ms
+step:972/1480 train_time:46517ms step_avg:47.86ms
+step:973/1480 train_time:46604ms step_avg:47.90ms
+step:974/1480 train_time:46693ms step_avg:47.94ms
+step:975/1480 train_time:46777ms step_avg:47.98ms
+step:976/1480 train_time:46867ms step_avg:48.02ms
+step:977/1480 train_time:46952ms step_avg:48.06ms
+step:978/1480 train_time:47043ms step_avg:48.10ms
+step:979/1480 train_time:47129ms step_avg:48.14ms
+step:980/1480 train_time:47222ms step_avg:48.19ms
+step:981/1480 train_time:47309ms step_avg:48.23ms
+step:982/1480 train_time:47400ms step_avg:48.27ms
+step:983/1480 train_time:47487ms step_avg:48.31ms
+step:984/1480 train_time:47577ms step_avg:48.35ms
+step:985/1480 train_time:47667ms step_avg:48.39ms
+step:986/1480 train_time:47768ms step_avg:48.45ms
+step:987/1480 train_time:47862ms step_avg:48.49ms
+step:988/1480 train_time:47961ms step_avg:48.54ms
+step:989/1480 train_time:48055ms step_avg:48.59ms
+step:990/1480 train_time:48154ms step_avg:48.64ms
+step:991/1480 train_time:48243ms step_avg:48.68ms
+step:992/1480 train_time:48328ms step_avg:48.72ms
+step:993/1480 train_time:48410ms step_avg:48.75ms
+step:994/1480 train_time:48501ms step_avg:48.79ms
+step:995/1480 train_time:48592ms step_avg:48.84ms
+step:996/1480 train_time:48686ms step_avg:48.88ms
+step:997/1480 train_time:48772ms step_avg:48.92ms
+step:998/1480 train_time:48865ms step_avg:48.96ms
+step:999/1480 train_time:48955ms step_avg:49.00ms
+step:1000/1480 train_time:49049ms step_avg:49.05ms
+step:1000/1480 val_loss:3.5114 train_time:49167ms step_avg:49.17ms
+step:1001/1480 train_time:49185ms step_avg:49.14ms
+step:1002/1480 train_time:49230ms step_avg:49.13ms
+step:1003/1480 train_time:49321ms step_avg:49.17ms
+step:1004/1480 train_time:49414ms step_avg:49.22ms
+step:1005/1480 train_time:49502ms step_avg:49.26ms
+step:1006/1480 train_time:49594ms step_avg:49.30ms
+step:1007/1480 train_time:49681ms step_avg:49.34ms
+step:1008/1480 train_time:49774ms step_avg:49.38ms
+step:1009/1480 train_time:49859ms step_avg:49.41ms
+step:1010/1480 train_time:49950ms step_avg:49.46ms
+step:1011/1480 train_time:50033ms step_avg:49.49ms
+step:1012/1480 train_time:50125ms step_avg:49.53ms
+step:1013/1480 train_time:50211ms step_avg:49.57ms
+step:1014/1480 train_time:50304ms step_avg:49.61ms
+step:1015/1480 train_time:50391ms step_avg:49.65ms
+step:1016/1480 train_time:50485ms step_avg:49.69ms
+step:1017/1480 train_time:50572ms step_avg:49.73ms
+step:1018/1480 train_time:50664ms step_avg:49.77ms
+step:1019/1480 train_time:50750ms step_avg:49.80ms
+step:1020/1480 train_time:50843ms step_avg:49.85ms
+step:1021/1480 train_time:50930ms step_avg:49.88ms
+step:1022/1480 train_time:51022ms step_avg:49.92ms
+step:1023/1480 train_time:51110ms step_avg:49.96ms
+step:1024/1480 train_time:51201ms step_avg:50.00ms
+step:1025/1480 train_time:51285ms step_avg:50.03ms
+step:1026/1480 train_time:51375ms step_avg:50.07ms
+step:1027/1480 train_time:51462ms step_avg:50.11ms
+step:1028/1480 train_time:51556ms step_avg:50.15ms
+step:1029/1480 train_time:51646ms step_avg:50.19ms
+step:1030/1480 train_time:51742ms step_avg:50.24ms
+step:1031/1480 train_time:51831ms step_avg:50.27ms
+step:1032/1480 train_time:51927ms step_avg:50.32ms
+step:1033/1480 train_time:52016ms step_avg:50.35ms
+step:1034/1480 train_time:52112ms step_avg:50.40ms
+step:1035/1480 train_time:52202ms step_avg:50.44ms
+step:1036/1480 train_time:52298ms step_avg:50.48ms
+step:1037/1480 train_time:52379ms step_avg:50.51ms
+step:1038/1480 train_time:52469ms step_avg:50.55ms
+step:1039/1480 train_time:52555ms step_avg:50.58ms
+step:1040/1480 train_time:52647ms step_avg:50.62ms
+step:1041/1480 train_time:52733ms step_avg:50.66ms
+step:1042/1480 train_time:52824ms step_avg:50.69ms
+step:1043/1480 train_time:52911ms step_avg:50.73ms
+step:1044/1480 train_time:53002ms step_avg:50.77ms
+step:1045/1480 train_time:53090ms step_avg:50.80ms
+step:1046/1480 train_time:53184ms step_avg:50.85ms
+step:1047/1480 train_time:53272ms step_avg:50.88ms
+step:1048/1480 train_time:53366ms step_avg:50.92ms
+step:1049/1480 train_time:53455ms step_avg:50.96ms
+step:1050/1480 train_time:53552ms step_avg:51.00ms
+step:1051/1480 train_time:53642ms step_avg:51.04ms
+step:1052/1480 train_time:53738ms step_avg:51.08ms
+step:1053/1480 train_time:53827ms step_avg:51.12ms
+step:1054/1480 train_time:53923ms step_avg:51.16ms
+step:1055/1480 train_time:54006ms step_avg:51.19ms
+step:1056/1480 train_time:54098ms step_avg:51.23ms
+step:1057/1480 train_time:54186ms step_avg:51.26ms
+step:1058/1480 train_time:54281ms step_avg:51.31ms
+step:1059/1480 train_time:54376ms step_avg:51.35ms
+step:1060/1480 train_time:54472ms step_avg:51.39ms
+step:1061/1480 train_time:54559ms step_avg:51.42ms
+step:1062/1480 train_time:54654ms step_avg:51.46ms
+step:1063/1480 train_time:54742ms step_avg:51.50ms
+step:1064/1480 train_time:54836ms step_avg:51.54ms
+step:1065/1480 train_time:54923ms step_avg:51.57ms
+step:1066/1480 train_time:55017ms step_avg:51.61ms
+step:1067/1480 train_time:55104ms step_avg:51.64ms
+step:1068/1480 train_time:55198ms step_avg:51.68ms
+step:1069/1480 train_time:55284ms step_avg:51.72ms
+step:1070/1480 train_time:55378ms step_avg:51.76ms
+step:1071/1480 train_time:55464ms step_avg:51.79ms
+step:1072/1480 train_time:55559ms step_avg:51.83ms
+step:1073/1480 train_time:55645ms step_avg:51.86ms
+step:1074/1480 train_time:55739ms step_avg:51.90ms
+step:1075/1480 train_time:55824ms step_avg:51.93ms
+step:1076/1480 train_time:55914ms step_avg:51.97ms
+step:1077/1480 train_time:55999ms step_avg:52.00ms
+step:1078/1480 train_time:56090ms step_avg:52.03ms
+step:1079/1480 train_time:56173ms step_avg:52.06ms
+step:1080/1480 train_time:56267ms step_avg:52.10ms
+step:1081/1480 train_time:56352ms step_avg:52.13ms
+step:1082/1480 train_time:56442ms step_avg:52.16ms
+step:1083/1480 train_time:56528ms step_avg:52.20ms
+step:1084/1480 train_time:56619ms step_avg:52.23ms
+step:1085/1480 train_time:56703ms step_avg:52.26ms
+step:1086/1480 train_time:56794ms step_avg:52.30ms
+step:1087/1480 train_time:56882ms step_avg:52.33ms
+step:1088/1480 train_time:56975ms step_avg:52.37ms
+step:1089/1480 train_time:57061ms step_avg:52.40ms
+step:1090/1480 train_time:57153ms step_avg:52.43ms
+step:1091/1480 train_time:57240ms step_avg:52.47ms
+step:1092/1480 train_time:57334ms step_avg:52.50ms
+step:1093/1480 train_time:57420ms step_avg:52.53ms
+step:1094/1480 train_time:57513ms step_avg:52.57ms
+step:1095/1480 train_time:57598ms step_avg:52.60ms
+step:1096/1480 train_time:57697ms step_avg:52.64ms
+step:1097/1480 train_time:57790ms step_avg:52.68ms
+step:1098/1480 train_time:57889ms step_avg:52.72ms
+step:1099/1480 train_time:57982ms step_avg:52.76ms
+step:1100/1480 train_time:58080ms step_avg:52.80ms
+step:1101/1480 train_time:58173ms step_avg:52.84ms
+step:1102/1480 train_time:58268ms step_avg:52.87ms
+step:1103/1480 train_time:58347ms step_avg:52.90ms
+step:1104/1480 train_time:58436ms step_avg:52.93ms
+step:1105/1480 train_time:58524ms step_avg:52.96ms
+step:1106/1480 train_time:58625ms step_avg:53.01ms
+step:1107/1480 train_time:58717ms step_avg:53.04ms
+step:1108/1480 train_time:58810ms step_avg:53.08ms
+step:1109/1480 train_time:58898ms step_avg:53.11ms
+step:1110/1480 train_time:58992ms step_avg:53.15ms
+step:1111/1480 train_time:59078ms step_avg:53.18ms
+step:1112/1480 train_time:59173ms step_avg:53.21ms
+step:1113/1480 train_time:59258ms step_avg:53.24ms
+step:1114/1480 train_time:59351ms step_avg:53.28ms
+step:1115/1480 train_time:59435ms step_avg:53.31ms
+step:1116/1480 train_time:59529ms step_avg:53.34ms
+step:1117/1480 train_time:59615ms step_avg:53.37ms
+step:1118/1480 train_time:59708ms step_avg:53.41ms
+step:1119/1480 train_time:59796ms step_avg:53.44ms
+step:1120/1480 train_time:59890ms step_avg:53.47ms
+step:1121/1480 train_time:59975ms step_avg:53.50ms
+step:1122/1480 train_time:60071ms step_avg:53.54ms
+step:1123/1480 train_time:60156ms step_avg:53.57ms
+step:1124/1480 train_time:60249ms step_avg:53.60ms
+step:1125/1480 train_time:60335ms step_avg:53.63ms
+step:1126/1480 train_time:60430ms step_avg:53.67ms
+step:1127/1480 train_time:60517ms step_avg:53.70ms
+step:1128/1480 train_time:60611ms step_avg:53.73ms
+step:1129/1480 train_time:60697ms step_avg:53.76ms
+step:1130/1480 train_time:60788ms step_avg:53.79ms
+step:1131/1480 train_time:60874ms step_avg:53.82ms
+step:1132/1480 train_time:60966ms step_avg:53.86ms
+step:1133/1480 train_time:61056ms step_avg:53.89ms
+step:1134/1480 train_time:61152ms step_avg:53.93ms
+step:1135/1480 train_time:61240ms step_avg:53.96ms
+step:1136/1480 train_time:61336ms step_avg:53.99ms
+step:1137/1480 train_time:61425ms step_avg:54.02ms
+step:1138/1480 train_time:61520ms step_avg:54.06ms
+step:1139/1480 train_time:61609ms step_avg:54.09ms
+step:1140/1480 train_time:61703ms step_avg:54.13ms
+step:1141/1480 train_time:61791ms step_avg:54.16ms
+step:1142/1480 train_time:61884ms step_avg:54.19ms
+step:1143/1480 train_time:61971ms step_avg:54.22ms
+step:1144/1480 train_time:62066ms step_avg:54.25ms
+step:1145/1480 train_time:62155ms step_avg:54.28ms
+step:1146/1480 train_time:62248ms step_avg:54.32ms
+step:1147/1480 train_time:62335ms step_avg:54.35ms
+step:1148/1480 train_time:62429ms step_avg:54.38ms
+step:1149/1480 train_time:62515ms step_avg:54.41ms
+step:1150/1480 train_time:62610ms step_avg:54.44ms
+step:1151/1480 train_time:62697ms step_avg:54.47ms
+step:1152/1480 train_time:62791ms step_avg:54.51ms
+step:1153/1480 train_time:62877ms step_avg:54.53ms
+step:1154/1480 train_time:62971ms step_avg:54.57ms
+step:1155/1480 train_time:63057ms step_avg:54.60ms
+step:1156/1480 train_time:63152ms step_avg:54.63ms
+step:1157/1480 train_time:63238ms step_avg:54.66ms
+step:1158/1480 train_time:63333ms step_avg:54.69ms
+step:1159/1480 train_time:63418ms step_avg:54.72ms
+step:1160/1480 train_time:63511ms step_avg:54.75ms
+step:1161/1480 train_time:63597ms step_avg:54.78ms
+step:1162/1480 train_time:63691ms step_avg:54.81ms
+step:1163/1480 train_time:63780ms step_avg:54.84ms
+step:1164/1480 train_time:63875ms step_avg:54.88ms
+step:1165/1480 train_time:63963ms step_avg:54.90ms
+step:1166/1480 train_time:64056ms step_avg:54.94ms
+step:1167/1480 train_time:64144ms step_avg:54.96ms
+step:1168/1480 train_time:64238ms step_avg:55.00ms
+step:1169/1480 train_time:64326ms step_avg:55.03ms
+step:1170/1480 train_time:64419ms step_avg:55.06ms
+step:1171/1480 train_time:64506ms step_avg:55.09ms
+step:1172/1480 train_time:64600ms step_avg:55.12ms
+step:1173/1480 train_time:64686ms step_avg:55.15ms
+step:1174/1480 train_time:64780ms step_avg:55.18ms
+step:1175/1480 train_time:64863ms step_avg:55.20ms
+step:1176/1480 train_time:64955ms step_avg:55.23ms
+step:1177/1480 train_time:65045ms step_avg:55.26ms
+step:1178/1480 train_time:65137ms step_avg:55.29ms
+step:1179/1480 train_time:65224ms step_avg:55.32ms
+step:1180/1480 train_time:65318ms step_avg:55.35ms
+step:1181/1480 train_time:65407ms step_avg:55.38ms
+step:1182/1480 train_time:65500ms step_avg:55.41ms
+step:1183/1480 train_time:65587ms step_avg:55.44ms
+step:1184/1480 train_time:65680ms step_avg:55.47ms
+step:1185/1480 train_time:65767ms step_avg:55.50ms
+step:1186/1480 train_time:65862ms step_avg:55.53ms
+step:1187/1480 train_time:65953ms step_avg:55.56ms
+step:1188/1480 train_time:66051ms step_avg:55.60ms
+step:1189/1480 train_time:66144ms step_avg:55.63ms
+step:1190/1480 train_time:66243ms step_avg:55.67ms
+step:1191/1480 train_time:66335ms step_avg:55.70ms
+step:1192/1480 train_time:66433ms step_avg:55.73ms
+step:1193/1480 train_time:66514ms step_avg:55.75ms
+step:1194/1480 train_time:66599ms step_avg:55.78ms
+step:1195/1480 train_time:66685ms step_avg:55.80ms
+step:1196/1480 train_time:66777ms step_avg:55.83ms
+step:1197/1480 train_time:66868ms step_avg:55.86ms
+step:1198/1480 train_time:66962ms step_avg:55.89ms
+step:1199/1480 train_time:67053ms step_avg:55.92ms
+step:1200/1480 train_time:67146ms step_avg:55.95ms
+step:1201/1480 train_time:67235ms step_avg:55.98ms
+step:1202/1480 train_time:67328ms step_avg:56.01ms
+step:1203/1480 train_time:67417ms step_avg:56.04ms
+step:1204/1480 train_time:67514ms step_avg:56.07ms
+step:1205/1480 train_time:67607ms step_avg:56.11ms
+step:1206/1480 train_time:67705ms step_avg:56.14ms
+step:1207/1480 train_time:67795ms step_avg:56.17ms
+step:1208/1480 train_time:67893ms step_avg:56.20ms
+step:1209/1480 train_time:67984ms step_avg:56.23ms
+step:1210/1480 train_time:68081ms step_avg:56.27ms
+step:1211/1480 train_time:68171ms step_avg:56.29ms
+step:1212/1480 train_time:68267ms step_avg:56.33ms
+step:1213/1480 train_time:68349ms step_avg:56.35ms
+step:1214/1480 train_time:68434ms step_avg:56.37ms
+step:1215/1480 train_time:68519ms step_avg:56.39ms
+step:1216/1480 train_time:68610ms step_avg:56.42ms
+step:1217/1480 train_time:68692ms step_avg:56.44ms
+step:1218/1480 train_time:68783ms step_avg:56.47ms
+step:1219/1480 train_time:68876ms step_avg:56.50ms
+step:1220/1480 train_time:68973ms step_avg:56.54ms
+step:1221/1480 train_time:69059ms step_avg:56.56ms
+step:1222/1480 train_time:69157ms step_avg:56.59ms
+step:1223/1480 train_time:69250ms step_avg:56.62ms
+step:1224/1480 train_time:69348ms step_avg:56.66ms
+step:1225/1480 train_time:69438ms step_avg:56.68ms
+step:1226/1480 train_time:69536ms step_avg:56.72ms
+step:1227/1480 train_time:69626ms step_avg:56.74ms
+step:1228/1480 train_time:69724ms step_avg:56.78ms
+step:1229/1480 train_time:69814ms step_avg:56.81ms
+step:1230/1480 train_time:69910ms step_avg:56.84ms
+step:1231/1480 train_time:69993ms step_avg:56.86ms
+step:1232/1480 train_time:70077ms step_avg:56.88ms
+step:1233/1480 train_time:70158ms step_avg:56.90ms
+step:1234/1480 train_time:70249ms step_avg:56.93ms
+step:1235/1480 train_time:70334ms step_avg:56.95ms
+step:1236/1480 train_time:70431ms step_avg:56.98ms
+step:1237/1480 train_time:70522ms step_avg:57.01ms
+step:1238/1480 train_time:70619ms step_avg:57.04ms
+step:1239/1480 train_time:70706ms step_avg:57.07ms
+step:1240/1480 train_time:70800ms step_avg:57.10ms
+step:1241/1480 train_time:70889ms step_avg:57.12ms
+step:1242/1480 train_time:70985ms step_avg:57.15ms
+step:1243/1480 train_time:71075ms step_avg:57.18ms
+step:1244/1480 train_time:71171ms step_avg:57.21ms
+step:1245/1480 train_time:71260ms step_avg:57.24ms
+step:1246/1480 train_time:71356ms step_avg:57.27ms
+step:1247/1480 train_time:71446ms step_avg:57.29ms
+step:1248/1480 train_time:71541ms step_avg:57.32ms
+step:1249/1480 train_time:71622ms step_avg:57.34ms
+step:1250/1480 train_time:71711ms step_avg:57.37ms
+step:1250/1480 val_loss:3.3696 train_time:71828ms step_avg:57.46ms
+step:1251/1480 train_time:71845ms step_avg:57.43ms
+step:1252/1480 train_time:71890ms step_avg:57.42ms
+step:1253/1480 train_time:71980ms step_avg:57.45ms
+step:1254/1480 train_time:72075ms step_avg:57.48ms
+step:1255/1480 train_time:72163ms step_avg:57.50ms
+step:1256/1480 train_time:72257ms step_avg:57.53ms
+step:1257/1480 train_time:72345ms step_avg:57.55ms
+step:1258/1480 train_time:72439ms step_avg:57.58ms
+step:1259/1480 train_time:72527ms step_avg:57.61ms
+step:1260/1480 train_time:72621ms step_avg:57.64ms
+step:1261/1480 train_time:72708ms step_avg:57.66ms
+step:1262/1480 train_time:72803ms step_avg:57.69ms
+step:1263/1480 train_time:72889ms step_avg:57.71ms
+step:1264/1480 train_time:72983ms step_avg:57.74ms
+step:1265/1480 train_time:73070ms step_avg:57.76ms
+step:1266/1480 train_time:73164ms step_avg:57.79ms
+step:1267/1480 train_time:73250ms step_avg:57.81ms
+step:1268/1480 train_time:73344ms step_avg:57.84ms
+step:1269/1480 train_time:73427ms step_avg:57.86ms
+step:1270/1480 train_time:73520ms step_avg:57.89ms
+step:1271/1480 train_time:73608ms step_avg:57.91ms
+step:1272/1480 train_time:73700ms step_avg:57.94ms
+step:1273/1480 train_time:73788ms step_avg:57.96ms
+step:1274/1480 train_time:73877ms step_avg:57.99ms
+step:1275/1480 train_time:73965ms step_avg:58.01ms
+step:1276/1480 train_time:74056ms step_avg:58.04ms
+step:1277/1480 train_time:74145ms step_avg:58.06ms
+step:1278/1480 train_time:74241ms step_avg:58.09ms
+step:1279/1480 train_time:74331ms step_avg:58.12ms
+step:1280/1480 train_time:74426ms step_avg:58.15ms
+step:1281/1480 train_time:74515ms step_avg:58.17ms
+step:1282/1480 train_time:74609ms step_avg:58.20ms
+step:1283/1480 train_time:74698ms step_avg:58.22ms
+step:1284/1480 train_time:74793ms step_avg:58.25ms
+step:1285/1480 train_time:74881ms step_avg:58.27ms
+step:1286/1480 train_time:74975ms step_avg:58.30ms
+step:1287/1480 train_time:75063ms step_avg:58.32ms
+step:1288/1480 train_time:75156ms step_avg:58.35ms
+step:1289/1480 train_time:75245ms step_avg:58.37ms
+step:1290/1480 train_time:75340ms step_avg:58.40ms
+step:1291/1480 train_time:75427ms step_avg:58.43ms
+step:1292/1480 train_time:75522ms step_avg:58.45ms
+step:1293/1480 train_time:75609ms step_avg:58.48ms
+step:1294/1480 train_time:75702ms step_avg:58.50ms
+step:1295/1480 train_time:75790ms step_avg:58.52ms
+step:1296/1480 train_time:75883ms step_avg:58.55ms
+step:1297/1480 train_time:75971ms step_avg:58.57ms
+step:1298/1480 train_time:76065ms step_avg:58.60ms
+step:1299/1480 train_time:76152ms step_avg:58.62ms
+step:1300/1480 train_time:76246ms step_avg:58.65ms
+step:1301/1480 train_time:76334ms step_avg:58.67ms
+step:1302/1480 train_time:76428ms step_avg:58.70ms
+step:1303/1480 train_time:76514ms step_avg:58.72ms
+step:1304/1480 train_time:76608ms step_avg:58.75ms
+step:1305/1480 train_time:76694ms step_avg:58.77ms
+step:1306/1480 train_time:76787ms step_avg:58.80ms
+step:1307/1480 train_time:76875ms step_avg:58.82ms
+step:1308/1480 train_time:76966ms step_avg:58.84ms
+step:1309/1480 train_time:77052ms step_avg:58.86ms
+step:1310/1480 train_time:77145ms step_avg:58.89ms
+step:1311/1480 train_time:77230ms step_avg:58.91ms
+step:1312/1480 train_time:77323ms step_avg:58.93ms
+step:1313/1480 train_time:77408ms step_avg:58.96ms
+step:1314/1480 train_time:77502ms step_avg:58.98ms
+step:1315/1480 train_time:77586ms step_avg:59.00ms
+step:1316/1480 train_time:77679ms step_avg:59.03ms
+step:1317/1480 train_time:77765ms step_avg:59.05ms
+step:1318/1480 train_time:77856ms step_avg:59.07ms
+step:1319/1480 train_time:77943ms step_avg:59.09ms
+step:1320/1480 train_time:78033ms step_avg:59.12ms
+step:1321/1480 train_time:78118ms step_avg:59.14ms
+step:1322/1480 train_time:78209ms step_avg:59.16ms
+step:1323/1480 train_time:78293ms step_avg:59.18ms
+step:1324/1480 train_time:78384ms step_avg:59.20ms
+step:1325/1480 train_time:78468ms step_avg:59.22ms
+step:1326/1480 train_time:78561ms step_avg:59.25ms
+step:1327/1480 train_time:78645ms step_avg:59.27ms
+step:1328/1480 train_time:78738ms step_avg:59.29ms
+step:1329/1480 train_time:78828ms step_avg:59.31ms
+step:1330/1480 train_time:78922ms step_avg:59.34ms
+step:1331/1480 train_time:79011ms step_avg:59.36ms
+step:1332/1480 train_time:79106ms step_avg:59.39ms
+step:1333/1480 train_time:79195ms step_avg:59.41ms
+step:1334/1480 train_time:79289ms step_avg:59.44ms
+step:1335/1480 train_time:79378ms step_avg:59.46ms
+step:1336/1480 train_time:79473ms step_avg:59.49ms
+step:1337/1480 train_time:79561ms step_avg:59.51ms
+step:1338/1480 train_time:79655ms step_avg:59.53ms
+step:1339/1480 train_time:79743ms step_avg:59.55ms
+step:1340/1480 train_time:79835ms step_avg:59.58ms
+step:1341/1480 train_time:79923ms step_avg:59.60ms
+step:1342/1480 train_time:80016ms step_avg:59.62ms
+step:1343/1480 train_time:80104ms step_avg:59.65ms
+step:1344/1480 train_time:80196ms step_avg:59.67ms
+step:1345/1480 train_time:80283ms step_avg:59.69ms
+step:1346/1480 train_time:80376ms step_avg:59.71ms
+step:1347/1480 train_time:80463ms step_avg:59.74ms
+step:1348/1480 train_time:80556ms step_avg:59.76ms
+step:1349/1480 train_time:80642ms step_avg:59.78ms
+step:1350/1480 train_time:80736ms step_avg:59.80ms
+step:1351/1480 train_time:80822ms step_avg:59.82ms
+step:1352/1480 train_time:80916ms step_avg:59.85ms
+step:1353/1480 train_time:81003ms step_avg:59.87ms
+step:1354/1480 train_time:81095ms step_avg:59.89ms
+step:1355/1480 train_time:81182ms step_avg:59.91ms
+step:1356/1480 train_time:81275ms step_avg:59.94ms
+step:1357/1480 train_time:81362ms step_avg:59.96ms
+step:1358/1480 train_time:81453ms step_avg:59.98ms
+step:1359/1480 train_time:81540ms step_avg:60.00ms
+step:1360/1480 train_time:81633ms step_avg:60.02ms
+step:1361/1480 train_time:81718ms step_avg:60.04ms
+step:1362/1480 train_time:81812ms step_avg:60.07ms
+step:1363/1480 train_time:81897ms step_avg:60.09ms
+step:1364/1480 train_time:81993ms step_avg:60.11ms
+step:1365/1480 train_time:82079ms step_avg:60.13ms
+step:1366/1480 train_time:82171ms step_avg:60.15ms
+step:1367/1480 train_time:82257ms step_avg:60.17ms
+step:1368/1480 train_time:82349ms step_avg:60.20ms
+step:1369/1480 train_time:82434ms step_avg:60.21ms
+step:1370/1480 train_time:82526ms step_avg:60.24ms
+step:1371/1480 train_time:82612ms step_avg:60.26ms
+step:1372/1480 train_time:82703ms step_avg:60.28ms
+step:1373/1480 train_time:82787ms step_avg:60.30ms
+step:1374/1480 train_time:82877ms step_avg:60.32ms
+step:1375/1480 train_time:82962ms step_avg:60.34ms
+step:1376/1480 train_time:83051ms step_avg:60.36ms
+step:1377/1480 train_time:83140ms step_avg:60.38ms
+step:1378/1480 train_time:83233ms step_avg:60.40ms
+step:1379/1480 train_time:83323ms step_avg:60.42ms
+step:1380/1480 train_time:83417ms step_avg:60.45ms
+step:1381/1480 train_time:83506ms step_avg:60.47ms
+step:1382/1480 train_time:83602ms step_avg:60.49ms
+step:1383/1480 train_time:83691ms step_avg:60.51ms
+step:1384/1480 train_time:83787ms step_avg:60.54ms
+step:1385/1480 train_time:83870ms step_avg:60.56ms
+step:1386/1480 train_time:83961ms step_avg:60.58ms
+step:1387/1480 train_time:84049ms step_avg:60.60ms
+step:1388/1480 train_time:84142ms step_avg:60.62ms
+step:1389/1480 train_time:84228ms step_avg:60.64ms
+step:1390/1480 train_time:84319ms step_avg:60.66ms
+step:1391/1480 train_time:84404ms step_avg:60.68ms
+step:1392/1480 train_time:84496ms step_avg:60.70ms
+step:1393/1480 train_time:84584ms step_avg:60.72ms
+step:1394/1480 train_time:84677ms step_avg:60.74ms
+step:1395/1480 train_time:84765ms step_avg:60.76ms
+step:1396/1480 train_time:84858ms step_avg:60.79ms
+step:1397/1480 train_time:84946ms step_avg:60.81ms
+step:1398/1480 train_time:85040ms step_avg:60.83ms
+step:1399/1480 train_time:85129ms step_avg:60.85ms
+step:1400/1480 train_time:85222ms step_avg:60.87ms
+step:1401/1480 train_time:85310ms step_avg:60.89ms
+step:1402/1480 train_time:85405ms step_avg:60.92ms
+step:1403/1480 train_time:85491ms step_avg:60.93ms
+step:1404/1480 train_time:85586ms step_avg:60.96ms
+step:1405/1480 train_time:85673ms step_avg:60.98ms
+step:1406/1480 train_time:85768ms step_avg:61.00ms
+step:1407/1480 train_time:85856ms step_avg:61.02ms
+step:1408/1480 train_time:85950ms step_avg:61.04ms
+step:1409/1480 train_time:86038ms step_avg:61.06ms
+step:1410/1480 train_time:86132ms step_avg:61.09ms
+step:1411/1480 train_time:86219ms step_avg:61.10ms
+step:1412/1480 train_time:86312ms step_avg:61.13ms
+step:1413/1480 train_time:86399ms step_avg:61.15ms
+step:1414/1480 train_time:86493ms step_avg:61.17ms
+step:1415/1480 train_time:86580ms step_avg:61.19ms
+step:1416/1480 train_time:86675ms step_avg:61.21ms
+step:1417/1480 train_time:86762ms step_avg:61.23ms
+step:1418/1480 train_time:86855ms step_avg:61.25ms
+step:1419/1480 train_time:86943ms step_avg:61.27ms
+step:1420/1480 train_time:87036ms step_avg:61.29ms
+step:1421/1480 train_time:87123ms step_avg:61.31ms
+step:1422/1480 train_time:87216ms step_avg:61.33ms
+step:1423/1480 train_time:87304ms step_avg:61.35ms
+step:1424/1480 train_time:87397ms step_avg:61.37ms
+step:1425/1480 train_time:87483ms step_avg:61.39ms
+step:1426/1480 train_time:87576ms step_avg:61.41ms
+step:1427/1480 train_time:87664ms step_avg:61.43ms
+step:1428/1480 train_time:87757ms step_avg:61.45ms
+step:1429/1480 train_time:87844ms step_avg:61.47ms
+step:1430/1480 train_time:87937ms step_avg:61.49ms
+step:1431/1480 train_time:88024ms step_avg:61.51ms
+step:1432/1480 train_time:88117ms step_avg:61.53ms
+step:1433/1480 train_time:88204ms step_avg:61.55ms
+step:1434/1480 train_time:88296ms step_avg:61.57ms
+step:1435/1480 train_time:88379ms step_avg:61.59ms
+step:1436/1480 train_time:88475ms step_avg:61.61ms
+step:1437/1480 train_time:88569ms step_avg:61.63ms
+step:1438/1480 train_time:88664ms step_avg:61.66ms
+step:1439/1480 train_time:88751ms step_avg:61.68ms
+step:1440/1480 train_time:88845ms step_avg:61.70ms
+step:1441/1480 train_time:88937ms step_avg:61.72ms
+step:1442/1480 train_time:89034ms step_avg:61.74ms
+step:1443/1480 train_time:89120ms step_avg:61.76ms
+step:1444/1480 train_time:89214ms step_avg:61.78ms
+step:1445/1480 train_time:89301ms step_avg:61.80ms
+step:1446/1480 train_time:89395ms step_avg:61.82ms
+step:1447/1480 train_time:89483ms step_avg:61.84ms
+step:1448/1480 train_time:89577ms step_avg:61.86ms
+step:1449/1480 train_time:89664ms step_avg:61.88ms
+step:1450/1480 train_time:89758ms step_avg:61.90ms
+step:1451/1480 train_time:89847ms step_avg:61.92ms
+step:1452/1480 train_time:89941ms step_avg:61.94ms
+step:1453/1480 train_time:90030ms step_avg:61.96ms
+step:1454/1480 train_time:90125ms step_avg:61.98ms
+step:1455/1480 train_time:90211ms step_avg:62.00ms
+step:1456/1480 train_time:90305ms step_avg:62.02ms
+step:1457/1480 train_time:90392ms step_avg:62.04ms
+step:1458/1480 train_time:90486ms step_avg:62.06ms
+step:1459/1480 train_time:90572ms step_avg:62.08ms
+step:1460/1480 train_time:90665ms step_avg:62.10ms
+step:1461/1480 train_time:90751ms step_avg:62.12ms
+step:1462/1480 train_time:90845ms step_avg:62.14ms
+step:1463/1480 train_time:90931ms step_avg:62.15ms
+step:1464/1480 train_time:91025ms step_avg:62.18ms
+step:1465/1480 train_time:91110ms step_avg:62.19ms
+step:1466/1480 train_time:91204ms step_avg:62.21ms
+step:1467/1480 train_time:91291ms step_avg:62.23ms
+step:1468/1480 train_time:91384ms step_avg:62.25ms
+step:1469/1480 train_time:91470ms step_avg:62.27ms
+step:1470/1480 train_time:91564ms step_avg:62.29ms
+step:1471/1480 train_time:91650ms step_avg:62.30ms
+step:1472/1480 train_time:91743ms step_avg:62.33ms
+step:1473/1480 train_time:91829ms step_avg:62.34ms
+step:1474/1480 train_time:91921ms step_avg:62.36ms
+step:1475/1480 train_time:92007ms step_avg:62.38ms
+step:1476/1480 train_time:92099ms step_avg:62.40ms
+step:1477/1480 train_time:92184ms step_avg:62.41ms
+step:1478/1480 train_time:92276ms step_avg:62.43ms
+step:1479/1480 train_time:92361ms step_avg:62.45ms
+step:1480/1480 train_time:92453ms step_avg:62.47ms
+step:1480/1480 val_loss:3.2804 train_time:92575ms step_avg:62.55ms
+peak memory allocated: 31277 MiB reserved: 47082 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline2-1490.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline2-1490.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:43:30 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   35C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   40C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   36C    P0            125W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   40C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   37C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   67C    P0            153W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          440671      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          440672      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          440673      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          440674      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          440675      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          440676      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          440677      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          440678      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8281 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:77ms step_avg:76.86ms
+step:2/1490 train_time:98ms step_avg:49.11ms
+step:3/1490 train_time:116ms step_avg:38.66ms
+step:4/1490 train_time:144ms step_avg:35.97ms
+step:5/1490 train_time:171ms step_avg:34.29ms
+step:6/1490 train_time:207ms step_avg:34.43ms
+step:7/1490 train_time:234ms step_avg:33.45ms
+step:8/1490 train_time:270ms step_avg:33.70ms
+step:9/1490 train_time:297ms step_avg:33.02ms
+step:10/1490 train_time:333ms step_avg:33.27ms
+step:11/1490 train_time:361ms step_avg:32.79ms
+step:12/1490 train_time:396ms step_avg:32.98ms
+step:13/1490 train_time:424ms step_avg:32.61ms
+step:14/1490 train_time:459ms step_avg:32.76ms
+step:15/1490 train_time:487ms step_avg:32.45ms
+step:16/1490 train_time:522ms step_avg:32.60ms
+step:17/1490 train_time:550ms step_avg:32.35ms
+step:18/1490 train_time:585ms step_avg:32.49ms
+step:19/1490 train_time:613ms step_avg:32.26ms
+step:20/1490 train_time:648ms step_avg:32.40ms
+step:21/1490 train_time:676ms step_avg:32.20ms
+step:22/1490 train_time:711ms step_avg:32.32ms
+step:23/1490 train_time:739ms step_avg:32.15ms
+step:24/1490 train_time:775ms step_avg:32.30ms
+step:25/1490 train_time:806ms step_avg:32.24ms
+step:26/1490 train_time:844ms step_avg:32.44ms
+step:27/1490 train_time:873ms step_avg:32.34ms
+step:28/1490 train_time:910ms step_avg:32.50ms
+step:29/1490 train_time:940ms step_avg:32.42ms
+step:30/1490 train_time:977ms step_avg:32.57ms
+step:31/1490 train_time:1007ms step_avg:32.49ms
+step:32/1490 train_time:1044ms step_avg:32.63ms
+step:33/1490 train_time:1074ms step_avg:32.54ms
+step:34/1490 train_time:1111ms step_avg:32.66ms
+step:35/1490 train_time:1141ms step_avg:32.59ms
+step:36/1490 train_time:1177ms step_avg:32.69ms
+step:37/1490 train_time:1207ms step_avg:32.63ms
+step:38/1490 train_time:1244ms step_avg:32.73ms
+step:39/1490 train_time:1273ms step_avg:32.65ms
+step:40/1490 train_time:1310ms step_avg:32.75ms
+step:41/1490 train_time:1340ms step_avg:32.68ms
+step:42/1490 train_time:1376ms step_avg:32.77ms
+step:43/1490 train_time:1407ms step_avg:32.71ms
+step:44/1490 train_time:1443ms step_avg:32.80ms
+step:45/1490 train_time:1472ms step_avg:32.72ms
+step:46/1490 train_time:1509ms step_avg:32.80ms
+step:47/1490 train_time:1538ms step_avg:32.73ms
+step:48/1490 train_time:1574ms step_avg:32.80ms
+step:49/1490 train_time:1605ms step_avg:32.75ms
+step:50/1490 train_time:1641ms step_avg:32.82ms
+step:51/1490 train_time:1670ms step_avg:32.75ms
+step:52/1490 train_time:1706ms step_avg:32.82ms
+step:53/1490 train_time:1736ms step_avg:32.75ms
+step:54/1490 train_time:1772ms step_avg:32.81ms
+step:55/1490 train_time:1802ms step_avg:32.77ms
+step:56/1490 train_time:1838ms step_avg:32.82ms
+step:57/1490 train_time:1868ms step_avg:32.76ms
+step:58/1490 train_time:1904ms step_avg:32.83ms
+step:59/1490 train_time:1933ms step_avg:32.76ms
+step:60/1490 train_time:1969ms step_avg:32.82ms
+step:61/1490 train_time:1999ms step_avg:32.77ms
+step:62/1490 train_time:2035ms step_avg:32.82ms
+step:63/1490 train_time:2064ms step_avg:32.76ms
+step:64/1490 train_time:2101ms step_avg:32.82ms
+step:65/1490 train_time:2129ms step_avg:32.76ms
+step:66/1490 train_time:2165ms step_avg:32.80ms
+step:67/1490 train_time:2194ms step_avg:32.75ms
+step:68/1490 train_time:2230ms step_avg:32.80ms
+step:69/1490 train_time:2260ms step_avg:32.75ms
+step:70/1490 train_time:2296ms step_avg:32.79ms
+step:71/1490 train_time:2325ms step_avg:32.75ms
+step:72/1490 train_time:2361ms step_avg:32.79ms
+step:73/1490 train_time:2390ms step_avg:32.74ms
+step:74/1490 train_time:2426ms step_avg:32.78ms
+step:75/1490 train_time:2455ms step_avg:32.73ms
+step:76/1490 train_time:2491ms step_avg:32.77ms
+step:77/1490 train_time:2520ms step_avg:32.72ms
+step:78/1490 train_time:2555ms step_avg:32.75ms
+step:79/1490 train_time:2584ms step_avg:32.71ms
+step:80/1490 train_time:2620ms step_avg:32.75ms
+step:81/1490 train_time:2649ms step_avg:32.70ms
+step:82/1490 train_time:2685ms step_avg:32.74ms
+step:83/1490 train_time:2714ms step_avg:32.70ms
+step:84/1490 train_time:2750ms step_avg:32.73ms
+step:85/1490 train_time:2779ms step_avg:32.69ms
+step:86/1490 train_time:2814ms step_avg:32.73ms
+step:87/1490 train_time:2844ms step_avg:32.69ms
+step:88/1490 train_time:2880ms step_avg:32.73ms
+step:89/1490 train_time:2909ms step_avg:32.69ms
+step:90/1490 train_time:2945ms step_avg:32.72ms
+step:91/1490 train_time:2974ms step_avg:32.68ms
+step:92/1490 train_time:3010ms step_avg:32.72ms
+step:93/1490 train_time:3039ms step_avg:32.68ms
+step:94/1490 train_time:3075ms step_avg:32.71ms
+step:95/1490 train_time:3105ms step_avg:32.68ms
+step:96/1490 train_time:3141ms step_avg:32.72ms
+step:97/1490 train_time:3170ms step_avg:32.68ms
+step:98/1490 train_time:3206ms step_avg:32.71ms
+step:99/1490 train_time:3235ms step_avg:32.68ms
+step:100/1490 train_time:3272ms step_avg:32.72ms
+step:101/1490 train_time:3303ms step_avg:32.70ms
+step:102/1490 train_time:3340ms step_avg:32.75ms
+step:103/1490 train_time:3370ms step_avg:32.72ms
+step:104/1490 train_time:3407ms step_avg:32.76ms
+step:105/1490 train_time:3437ms step_avg:32.73ms
+step:106/1490 train_time:3474ms step_avg:32.77ms
+step:107/1490 train_time:3505ms step_avg:32.75ms
+step:108/1490 train_time:3542ms step_avg:32.80ms
+step:109/1490 train_time:3572ms step_avg:32.77ms
+step:110/1490 train_time:3609ms step_avg:32.81ms
+step:111/1490 train_time:3640ms step_avg:32.79ms
+step:112/1490 train_time:3676ms step_avg:32.82ms
+step:113/1490 train_time:3707ms step_avg:32.80ms
+step:114/1490 train_time:3743ms step_avg:32.84ms
+step:115/1490 train_time:3773ms step_avg:32.81ms
+step:116/1490 train_time:3810ms step_avg:32.85ms
+step:117/1490 train_time:3840ms step_avg:32.82ms
+step:118/1490 train_time:3875ms step_avg:32.84ms
+step:119/1490 train_time:3903ms step_avg:32.80ms
+step:120/1490 train_time:3938ms step_avg:32.82ms
+step:121/1490 train_time:3967ms step_avg:32.78ms
+step:122/1490 train_time:4003ms step_avg:32.81ms
+step:123/1490 train_time:4033ms step_avg:32.79ms
+step:124/1490 train_time:4072ms step_avg:32.83ms
+step:125/1490 train_time:4103ms step_avg:32.83ms
+step:126/1490 train_time:4141ms step_avg:32.87ms
+step:127/1490 train_time:4171ms step_avg:32.85ms
+step:128/1490 train_time:4209ms step_avg:32.88ms
+step:129/1490 train_time:4240ms step_avg:32.87ms
+step:130/1490 train_time:4278ms step_avg:32.91ms
+step:131/1490 train_time:4310ms step_avg:32.90ms
+step:132/1490 train_time:4348ms step_avg:32.94ms
+step:133/1490 train_time:4378ms step_avg:32.92ms
+step:134/1490 train_time:4416ms step_avg:32.95ms
+step:135/1490 train_time:4446ms step_avg:32.94ms
+step:136/1490 train_time:4481ms step_avg:32.95ms
+step:137/1490 train_time:4509ms step_avg:32.91ms
+step:138/1490 train_time:4544ms step_avg:32.92ms
+step:139/1490 train_time:4571ms step_avg:32.89ms
+step:140/1490 train_time:4608ms step_avg:32.92ms
+step:141/1490 train_time:4637ms step_avg:32.89ms
+step:142/1490 train_time:4673ms step_avg:32.91ms
+step:143/1490 train_time:4702ms step_avg:32.88ms
+step:144/1490 train_time:4738ms step_avg:32.90ms
+step:145/1490 train_time:4767ms step_avg:32.88ms
+step:146/1490 train_time:4804ms step_avg:32.90ms
+step:147/1490 train_time:4832ms step_avg:32.87ms
+step:148/1490 train_time:4868ms step_avg:32.89ms
+step:149/1490 train_time:4898ms step_avg:32.87ms
+step:150/1490 train_time:4934ms step_avg:32.89ms
+step:151/1490 train_time:4963ms step_avg:32.87ms
+step:152/1490 train_time:5000ms step_avg:32.89ms
+step:153/1490 train_time:5028ms step_avg:32.87ms
+step:154/1490 train_time:5064ms step_avg:32.88ms
+step:155/1490 train_time:5093ms step_avg:32.86ms
+step:156/1490 train_time:5128ms step_avg:32.87ms
+step:157/1490 train_time:5157ms step_avg:32.85ms
+step:158/1490 train_time:5193ms step_avg:32.87ms
+step:159/1490 train_time:5222ms step_avg:32.84ms
+step:160/1490 train_time:5257ms step_avg:32.86ms
+step:161/1490 train_time:5287ms step_avg:32.84ms
+step:162/1490 train_time:5323ms step_avg:32.86ms
+step:163/1490 train_time:5352ms step_avg:32.83ms
+step:164/1490 train_time:5388ms step_avg:32.85ms
+step:165/1490 train_time:5417ms step_avg:32.83ms
+step:166/1490 train_time:5453ms step_avg:32.85ms
+step:167/1490 train_time:5482ms step_avg:32.83ms
+step:168/1490 train_time:5518ms step_avg:32.84ms
+step:169/1490 train_time:5547ms step_avg:32.82ms
+step:170/1490 train_time:5583ms step_avg:32.84ms
+step:171/1490 train_time:5613ms step_avg:32.82ms
+step:172/1490 train_time:5649ms step_avg:32.84ms
+step:173/1490 train_time:5679ms step_avg:32.83ms
+step:174/1490 train_time:5715ms step_avg:32.84ms
+step:175/1490 train_time:5744ms step_avg:32.82ms
+step:176/1490 train_time:5780ms step_avg:32.84ms
+step:177/1490 train_time:5809ms step_avg:32.82ms
+step:178/1490 train_time:5845ms step_avg:32.84ms
+step:179/1490 train_time:5875ms step_avg:32.82ms
+step:180/1490 train_time:5913ms step_avg:32.85ms
+step:181/1490 train_time:5945ms step_avg:32.85ms
+step:182/1490 train_time:5984ms step_avg:32.88ms
+step:183/1490 train_time:6015ms step_avg:32.87ms
+step:184/1490 train_time:6053ms step_avg:32.90ms
+step:185/1490 train_time:6084ms step_avg:32.89ms
+step:186/1490 train_time:6121ms step_avg:32.91ms
+step:187/1490 train_time:6152ms step_avg:32.90ms
+step:188/1490 train_time:6190ms step_avg:32.93ms
+step:189/1490 train_time:6222ms step_avg:32.92ms
+step:190/1490 train_time:6260ms step_avg:32.95ms
+step:191/1490 train_time:6290ms step_avg:32.93ms
+step:192/1490 train_time:6326ms step_avg:32.95ms
+step:193/1490 train_time:6354ms step_avg:32.92ms
+step:194/1490 train_time:6388ms step_avg:32.93ms
+step:195/1490 train_time:6416ms step_avg:32.90ms
+step:196/1490 train_time:6453ms step_avg:32.92ms
+step:197/1490 train_time:6483ms step_avg:32.91ms
+step:198/1490 train_time:6521ms step_avg:32.93ms
+step:199/1490 train_time:6550ms step_avg:32.92ms
+step:200/1490 train_time:6587ms step_avg:32.94ms
+step:201/1490 train_time:6618ms step_avg:32.93ms
+step:202/1490 train_time:6655ms step_avg:32.94ms
+step:203/1490 train_time:6686ms step_avg:32.93ms
+step:204/1490 train_time:6723ms step_avg:32.96ms
+step:205/1490 train_time:6753ms step_avg:32.94ms
+step:206/1490 train_time:6790ms step_avg:32.96ms
+step:207/1490 train_time:6821ms step_avg:32.95ms
+step:208/1490 train_time:6857ms step_avg:32.97ms
+step:209/1490 train_time:6888ms step_avg:32.95ms
+step:210/1490 train_time:6924ms step_avg:32.97ms
+step:211/1490 train_time:6954ms step_avg:32.96ms
+step:212/1490 train_time:6991ms step_avg:32.98ms
+step:213/1490 train_time:7021ms step_avg:32.96ms
+step:214/1490 train_time:7058ms step_avg:32.98ms
+step:215/1490 train_time:7088ms step_avg:32.97ms
+step:216/1490 train_time:7125ms step_avg:32.99ms
+step:217/1490 train_time:7155ms step_avg:32.97ms
+step:218/1490 train_time:7191ms step_avg:32.99ms
+step:219/1490 train_time:7222ms step_avg:32.98ms
+step:220/1490 train_time:7258ms step_avg:32.99ms
+step:221/1490 train_time:7288ms step_avg:32.98ms
+step:222/1490 train_time:7325ms step_avg:33.00ms
+step:223/1490 train_time:7355ms step_avg:32.98ms
+step:224/1490 train_time:7392ms step_avg:33.00ms
+step:225/1490 train_time:7422ms step_avg:32.98ms
+step:226/1490 train_time:7458ms step_avg:33.00ms
+step:227/1490 train_time:7488ms step_avg:32.99ms
+step:228/1490 train_time:7524ms step_avg:33.00ms
+step:229/1490 train_time:7554ms step_avg:32.99ms
+step:230/1490 train_time:7591ms step_avg:33.00ms
+step:231/1490 train_time:7621ms step_avg:32.99ms
+step:232/1490 train_time:7657ms step_avg:33.00ms
+step:233/1490 train_time:7687ms step_avg:32.99ms
+step:234/1490 train_time:7724ms step_avg:33.01ms
+step:235/1490 train_time:7753ms step_avg:32.99ms
+step:236/1490 train_time:7790ms step_avg:33.01ms
+step:237/1490 train_time:7820ms step_avg:32.99ms
+step:238/1490 train_time:7856ms step_avg:33.01ms
+step:239/1490 train_time:7886ms step_avg:33.00ms
+step:240/1490 train_time:7923ms step_avg:33.01ms
+step:241/1490 train_time:7952ms step_avg:33.00ms
+step:242/1490 train_time:7988ms step_avg:33.01ms
+step:243/1490 train_time:8018ms step_avg:33.00ms
+step:244/1490 train_time:8054ms step_avg:33.01ms
+step:245/1490 train_time:8084ms step_avg:33.00ms
+step:246/1490 train_time:8121ms step_avg:33.01ms
+step:247/1490 train_time:8151ms step_avg:33.00ms
+step:248/1490 train_time:8187ms step_avg:33.01ms
+step:249/1490 train_time:8217ms step_avg:33.00ms
+step:250/1490 train_time:8253ms step_avg:33.01ms
+step:250/1490 val_loss:4.5212 train_time:8300ms step_avg:33.20ms
+step:251/1490 train_time:8317ms step_avg:33.13ms
+step:252/1490 train_time:8335ms step_avg:33.07ms
+step:253/1490 train_time:8352ms step_avg:33.01ms
+step:254/1490 train_time:8390ms step_avg:33.03ms
+step:255/1490 train_time:8421ms step_avg:33.02ms
+step:256/1490 train_time:8459ms step_avg:33.04ms
+step:257/1490 train_time:8490ms step_avg:33.04ms
+step:258/1490 train_time:8529ms step_avg:33.06ms
+step:259/1490 train_time:8560ms step_avg:33.05ms
+step:260/1490 train_time:8597ms step_avg:33.06ms
+step:261/1490 train_time:8625ms step_avg:33.05ms
+step:262/1490 train_time:8660ms step_avg:33.05ms
+step:263/1490 train_time:8688ms step_avg:33.03ms
+step:264/1490 train_time:8722ms step_avg:33.04ms
+step:265/1490 train_time:8752ms step_avg:33.03ms
+step:266/1490 train_time:8789ms step_avg:33.04ms
+step:267/1490 train_time:8818ms step_avg:33.03ms
+step:268/1490 train_time:8854ms step_avg:33.04ms
+step:269/1490 train_time:8883ms step_avg:33.02ms
+step:270/1490 train_time:8918ms step_avg:33.03ms
+step:271/1490 train_time:8947ms step_avg:33.02ms
+step:272/1490 train_time:8983ms step_avg:33.02ms
+step:273/1490 train_time:9012ms step_avg:33.01ms
+step:274/1490 train_time:9048ms step_avg:33.02ms
+step:275/1490 train_time:9077ms step_avg:33.01ms
+step:276/1490 train_time:9114ms step_avg:33.02ms
+step:277/1490 train_time:9143ms step_avg:33.01ms
+step:278/1490 train_time:9180ms step_avg:33.02ms
+step:279/1490 train_time:9209ms step_avg:33.01ms
+step:280/1490 train_time:9245ms step_avg:33.02ms
+step:281/1490 train_time:9275ms step_avg:33.01ms
+step:282/1490 train_time:9311ms step_avg:33.02ms
+step:283/1490 train_time:9341ms step_avg:33.01ms
+step:284/1490 train_time:9377ms step_avg:33.02ms
+step:285/1490 train_time:9406ms step_avg:33.00ms
+step:286/1490 train_time:9443ms step_avg:33.02ms
+step:287/1490 train_time:9472ms step_avg:33.00ms
+step:288/1490 train_time:9508ms step_avg:33.02ms
+step:289/1490 train_time:9538ms step_avg:33.00ms
+step:290/1490 train_time:9575ms step_avg:33.02ms
+step:291/1490 train_time:9604ms step_avg:33.00ms
+step:292/1490 train_time:9640ms step_avg:33.01ms
+step:293/1490 train_time:9669ms step_avg:33.00ms
+step:294/1490 train_time:9706ms step_avg:33.01ms
+step:295/1490 train_time:9736ms step_avg:33.00ms
+step:296/1490 train_time:9772ms step_avg:33.01ms
+step:297/1490 train_time:9802ms step_avg:33.00ms
+step:298/1490 train_time:9840ms step_avg:33.02ms
+step:299/1490 train_time:9871ms step_avg:33.01ms
+step:300/1490 train_time:9909ms step_avg:33.03ms
+step:301/1490 train_time:9941ms step_avg:33.03ms
+step:302/1490 train_time:9979ms step_avg:33.04ms
+step:303/1490 train_time:10009ms step_avg:33.03ms
+step:304/1490 train_time:10046ms step_avg:33.05ms
+step:305/1490 train_time:10077ms step_avg:33.04ms
+step:306/1490 train_time:10114ms step_avg:33.05ms
+step:307/1490 train_time:10145ms step_avg:33.04ms
+step:308/1490 train_time:10182ms step_avg:33.06ms
+step:309/1490 train_time:10213ms step_avg:33.05ms
+step:310/1490 train_time:10250ms step_avg:33.06ms
+step:311/1490 train_time:10281ms step_avg:33.06ms
+step:312/1490 train_time:10318ms step_avg:33.07ms
+step:313/1490 train_time:10348ms step_avg:33.06ms
+step:314/1490 train_time:10386ms step_avg:33.07ms
+step:315/1490 train_time:10416ms step_avg:33.07ms
+step:316/1490 train_time:10454ms step_avg:33.08ms
+step:317/1490 train_time:10484ms step_avg:33.07ms
+step:318/1490 train_time:10521ms step_avg:33.09ms
+step:319/1490 train_time:10552ms step_avg:33.08ms
+step:320/1490 train_time:10589ms step_avg:33.09ms
+step:321/1490 train_time:10619ms step_avg:33.08ms
+step:322/1490 train_time:10656ms step_avg:33.09ms
+step:323/1490 train_time:10687ms step_avg:33.09ms
+step:324/1490 train_time:10724ms step_avg:33.10ms
+step:325/1490 train_time:10754ms step_avg:33.09ms
+step:326/1490 train_time:10792ms step_avg:33.10ms
+step:327/1490 train_time:10822ms step_avg:33.10ms
+step:328/1490 train_time:10860ms step_avg:33.11ms
+step:329/1490 train_time:10890ms step_avg:33.10ms
+step:330/1490 train_time:10927ms step_avg:33.11ms
+step:331/1490 train_time:10957ms step_avg:33.10ms
+step:332/1490 train_time:10994ms step_avg:33.12ms
+step:333/1490 train_time:11025ms step_avg:33.11ms
+step:334/1490 train_time:11062ms step_avg:33.12ms
+step:335/1490 train_time:11092ms step_avg:33.11ms
+step:336/1490 train_time:11129ms step_avg:33.12ms
+step:337/1490 train_time:11160ms step_avg:33.12ms
+step:338/1490 train_time:11197ms step_avg:33.13ms
+step:339/1490 train_time:11227ms step_avg:33.12ms
+step:340/1490 train_time:11264ms step_avg:33.13ms
+step:341/1490 train_time:11294ms step_avg:33.12ms
+step:342/1490 train_time:11332ms step_avg:33.13ms
+step:343/1490 train_time:11362ms step_avg:33.12ms
+step:344/1490 train_time:11399ms step_avg:33.14ms
+step:345/1490 train_time:11429ms step_avg:33.13ms
+step:346/1490 train_time:11466ms step_avg:33.14ms
+step:347/1490 train_time:11496ms step_avg:33.13ms
+step:348/1490 train_time:11533ms step_avg:33.14ms
+step:349/1490 train_time:11563ms step_avg:33.13ms
+step:350/1490 train_time:11600ms step_avg:33.14ms
+step:351/1490 train_time:11630ms step_avg:33.14ms
+step:352/1490 train_time:11668ms step_avg:33.15ms
+step:353/1490 train_time:11699ms step_avg:33.14ms
+step:354/1490 train_time:11736ms step_avg:33.15ms
+step:355/1490 train_time:11767ms step_avg:33.15ms
+step:356/1490 train_time:11804ms step_avg:33.16ms
+step:357/1490 train_time:11835ms step_avg:33.15ms
+step:358/1490 train_time:11872ms step_avg:33.16ms
+step:359/1490 train_time:11900ms step_avg:33.15ms
+step:360/1490 train_time:11935ms step_avg:33.15ms
+step:361/1490 train_time:11963ms step_avg:33.14ms
+step:362/1490 train_time:11997ms step_avg:33.14ms
+step:363/1490 train_time:12026ms step_avg:33.13ms
+step:364/1490 train_time:12061ms step_avg:33.13ms
+step:365/1490 train_time:12091ms step_avg:33.13ms
+step:366/1490 train_time:12127ms step_avg:33.13ms
+step:367/1490 train_time:12156ms step_avg:33.12ms
+step:368/1490 train_time:12192ms step_avg:33.13ms
+step:369/1490 train_time:12221ms step_avg:33.12ms
+step:370/1490 train_time:12258ms step_avg:33.13ms
+step:371/1490 train_time:12288ms step_avg:33.12ms
+step:372/1490 train_time:12324ms step_avg:33.13ms
+step:373/1490 train_time:12354ms step_avg:33.12ms
+step:374/1490 train_time:12391ms step_avg:33.13ms
+step:375/1490 train_time:12421ms step_avg:33.12ms
+step:376/1490 train_time:12456ms step_avg:33.13ms
+step:377/1490 train_time:12486ms step_avg:33.12ms
+step:378/1490 train_time:12523ms step_avg:33.13ms
+step:379/1490 train_time:12553ms step_avg:33.12ms
+step:380/1490 train_time:12589ms step_avg:33.13ms
+step:381/1490 train_time:12618ms step_avg:33.12ms
+step:382/1490 train_time:12656ms step_avg:33.13ms
+step:383/1490 train_time:12685ms step_avg:33.12ms
+step:384/1490 train_time:12720ms step_avg:33.13ms
+step:385/1490 train_time:12752ms step_avg:33.12ms
+step:386/1490 train_time:12788ms step_avg:33.13ms
+step:387/1490 train_time:12817ms step_avg:33.12ms
+step:388/1490 train_time:12855ms step_avg:33.13ms
+step:389/1490 train_time:12884ms step_avg:33.12ms
+step:390/1490 train_time:12922ms step_avg:33.13ms
+step:391/1490 train_time:12954ms step_avg:33.13ms
+step:392/1490 train_time:12994ms step_avg:33.15ms
+step:393/1490 train_time:13026ms step_avg:33.15ms
+step:394/1490 train_time:13065ms step_avg:33.16ms
+step:395/1490 train_time:13095ms step_avg:33.15ms
+step:396/1490 train_time:13133ms step_avg:33.16ms
+step:397/1490 train_time:13164ms step_avg:33.16ms
+step:398/1490 train_time:13202ms step_avg:33.17ms
+step:399/1490 train_time:13233ms step_avg:33.17ms
+step:400/1490 train_time:13270ms step_avg:33.18ms
+step:401/1490 train_time:13301ms step_avg:33.17ms
+step:402/1490 train_time:13335ms step_avg:33.17ms
+step:403/1490 train_time:13364ms step_avg:33.16ms
+step:404/1490 train_time:13399ms step_avg:33.17ms
+step:405/1490 train_time:13427ms step_avg:33.15ms
+step:406/1490 train_time:13462ms step_avg:33.16ms
+step:407/1490 train_time:13494ms step_avg:33.15ms
+step:408/1490 train_time:13532ms step_avg:33.17ms
+step:409/1490 train_time:13564ms step_avg:33.16ms
+step:410/1490 train_time:13603ms step_avg:33.18ms
+step:411/1490 train_time:13635ms step_avg:33.17ms
+step:412/1490 train_time:13673ms step_avg:33.19ms
+step:413/1490 train_time:13703ms step_avg:33.18ms
+step:414/1490 train_time:13740ms step_avg:33.19ms
+step:415/1490 train_time:13771ms step_avg:33.18ms
+step:416/1490 train_time:13808ms step_avg:33.19ms
+step:417/1490 train_time:13839ms step_avg:33.19ms
+step:418/1490 train_time:13876ms step_avg:33.20ms
+step:419/1490 train_time:13907ms step_avg:33.19ms
+step:420/1490 train_time:13943ms step_avg:33.20ms
+step:421/1490 train_time:13974ms step_avg:33.19ms
+step:422/1490 train_time:14011ms step_avg:33.20ms
+step:423/1490 train_time:14042ms step_avg:33.20ms
+step:424/1490 train_time:14080ms step_avg:33.21ms
+step:425/1490 train_time:14111ms step_avg:33.20ms
+step:426/1490 train_time:14146ms step_avg:33.21ms
+step:427/1490 train_time:14174ms step_avg:33.19ms
+step:428/1490 train_time:14208ms step_avg:33.20ms
+step:429/1490 train_time:14237ms step_avg:33.19ms
+step:430/1490 train_time:14273ms step_avg:33.19ms
+step:431/1490 train_time:14303ms step_avg:33.19ms
+step:432/1490 train_time:14341ms step_avg:33.20ms
+step:433/1490 train_time:14371ms step_avg:33.19ms
+step:434/1490 train_time:14408ms step_avg:33.20ms
+step:435/1490 train_time:14438ms step_avg:33.19ms
+step:436/1490 train_time:14476ms step_avg:33.20ms
+step:437/1490 train_time:14506ms step_avg:33.20ms
+step:438/1490 train_time:14543ms step_avg:33.20ms
+step:439/1490 train_time:14573ms step_avg:33.20ms
+step:440/1490 train_time:14610ms step_avg:33.21ms
+step:441/1490 train_time:14641ms step_avg:33.20ms
+step:442/1490 train_time:14677ms step_avg:33.21ms
+step:443/1490 train_time:14708ms step_avg:33.20ms
+step:444/1490 train_time:14745ms step_avg:33.21ms
+step:445/1490 train_time:14775ms step_avg:33.20ms
+step:446/1490 train_time:14812ms step_avg:33.21ms
+step:447/1490 train_time:14842ms step_avg:33.20ms
+step:448/1490 train_time:14878ms step_avg:33.21ms
+step:449/1490 train_time:14908ms step_avg:33.20ms
+step:450/1490 train_time:14946ms step_avg:33.21ms
+step:451/1490 train_time:14975ms step_avg:33.20ms
+step:452/1490 train_time:15012ms step_avg:33.21ms
+step:453/1490 train_time:15042ms step_avg:33.20ms
+step:454/1490 train_time:15078ms step_avg:33.21ms
+step:455/1490 train_time:15108ms step_avg:33.21ms
+step:456/1490 train_time:15145ms step_avg:33.21ms
+step:457/1490 train_time:15175ms step_avg:33.21ms
+step:458/1490 train_time:15211ms step_avg:33.21ms
+step:459/1490 train_time:15241ms step_avg:33.21ms
+step:460/1490 train_time:15277ms step_avg:33.21ms
+step:461/1490 train_time:15307ms step_avg:33.20ms
+step:462/1490 train_time:15344ms step_avg:33.21ms
+step:463/1490 train_time:15373ms step_avg:33.20ms
+step:464/1490 train_time:15410ms step_avg:33.21ms
+step:465/1490 train_time:15440ms step_avg:33.20ms
+step:466/1490 train_time:15476ms step_avg:33.21ms
+step:467/1490 train_time:15506ms step_avg:33.20ms
+step:468/1490 train_time:15543ms step_avg:33.21ms
+step:469/1490 train_time:15572ms step_avg:33.20ms
+step:470/1490 train_time:15609ms step_avg:33.21ms
+step:471/1490 train_time:15639ms step_avg:33.20ms
+step:472/1490 train_time:15675ms step_avg:33.21ms
+step:473/1490 train_time:15705ms step_avg:33.20ms
+step:474/1490 train_time:15742ms step_avg:33.21ms
+step:475/1490 train_time:15771ms step_avg:33.20ms
+step:476/1490 train_time:15807ms step_avg:33.21ms
+step:477/1490 train_time:15837ms step_avg:33.20ms
+step:478/1490 train_time:15874ms step_avg:33.21ms
+step:479/1490 train_time:15904ms step_avg:33.20ms
+step:480/1490 train_time:15940ms step_avg:33.21ms
+step:481/1490 train_time:15970ms step_avg:33.20ms
+step:482/1490 train_time:16006ms step_avg:33.21ms
+step:483/1490 train_time:16036ms step_avg:33.20ms
+step:484/1490 train_time:16075ms step_avg:33.21ms
+step:485/1490 train_time:16129ms step_avg:33.26ms
+step:486/1490 train_time:16192ms step_avg:33.32ms
+step:487/1490 train_time:16249ms step_avg:33.37ms
+step:488/1490 train_time:16312ms step_avg:33.43ms
+step:489/1490 train_time:16370ms step_avg:33.48ms
+step:490/1490 train_time:16434ms step_avg:33.54ms
+step:491/1490 train_time:16491ms step_avg:33.59ms
+step:492/1490 train_time:16554ms step_avg:33.65ms
+step:493/1490 train_time:16613ms step_avg:33.70ms
+step:494/1490 train_time:16681ms step_avg:33.77ms
+step:495/1490 train_time:16742ms step_avg:33.82ms
+step:496/1490 train_time:16808ms step_avg:33.89ms
+step:497/1490 train_time:16868ms step_avg:33.94ms
+step:498/1490 train_time:16935ms step_avg:34.01ms
+step:499/1490 train_time:16995ms step_avg:34.06ms
+step:500/1490 train_time:17061ms step_avg:34.12ms
+step:500/1490 val_loss:4.2239 train_time:17144ms step_avg:34.29ms
+step:501/1490 train_time:17161ms step_avg:34.25ms
+step:502/1490 train_time:17185ms step_avg:34.23ms
+step:503/1490 train_time:17245ms step_avg:34.28ms
+step:504/1490 train_time:17311ms step_avg:34.35ms
+step:505/1490 train_time:17370ms step_avg:34.40ms
+step:506/1490 train_time:17439ms step_avg:34.46ms
+step:507/1490 train_time:17495ms step_avg:34.51ms
+step:508/1490 train_time:17559ms step_avg:34.57ms
+step:509/1490 train_time:17618ms step_avg:34.61ms
+step:510/1490 train_time:17682ms step_avg:34.67ms
+step:511/1490 train_time:17741ms step_avg:34.72ms
+step:512/1490 train_time:17807ms step_avg:34.78ms
+step:513/1490 train_time:17866ms step_avg:34.83ms
+step:514/1490 train_time:17929ms step_avg:34.88ms
+step:515/1490 train_time:17986ms step_avg:34.92ms
+step:516/1490 train_time:18051ms step_avg:34.98ms
+step:517/1490 train_time:18111ms step_avg:35.03ms
+step:518/1490 train_time:18176ms step_avg:35.09ms
+step:519/1490 train_time:18234ms step_avg:35.13ms
+step:520/1490 train_time:18300ms step_avg:35.19ms
+step:521/1490 train_time:18360ms step_avg:35.24ms
+step:522/1490 train_time:18427ms step_avg:35.30ms
+step:523/1490 train_time:18486ms step_avg:35.35ms
+step:524/1490 train_time:18552ms step_avg:35.41ms
+step:525/1490 train_time:18611ms step_avg:35.45ms
+step:526/1490 train_time:18678ms step_avg:35.51ms
+step:527/1490 train_time:18737ms step_avg:35.55ms
+step:528/1490 train_time:18802ms step_avg:35.61ms
+step:529/1490 train_time:18861ms step_avg:35.65ms
+step:530/1490 train_time:18927ms step_avg:35.71ms
+step:531/1490 train_time:18987ms step_avg:35.76ms
+step:532/1490 train_time:19053ms step_avg:35.81ms
+step:533/1490 train_time:19112ms step_avg:35.86ms
+step:534/1490 train_time:19177ms step_avg:35.91ms
+step:535/1490 train_time:19234ms step_avg:35.95ms
+step:536/1490 train_time:19299ms step_avg:36.01ms
+step:537/1490 train_time:19358ms step_avg:36.05ms
+step:538/1490 train_time:19422ms step_avg:36.10ms
+step:539/1490 train_time:19480ms step_avg:36.14ms
+step:540/1490 train_time:19544ms step_avg:36.19ms
+step:541/1490 train_time:19605ms step_avg:36.24ms
+step:542/1490 train_time:19671ms step_avg:36.29ms
+step:543/1490 train_time:19730ms step_avg:36.33ms
+step:544/1490 train_time:19795ms step_avg:36.39ms
+step:545/1490 train_time:19853ms step_avg:36.43ms
+step:546/1490 train_time:19917ms step_avg:36.48ms
+step:547/1490 train_time:19974ms step_avg:36.52ms
+step:548/1490 train_time:20037ms step_avg:36.56ms
+step:549/1490 train_time:20095ms step_avg:36.60ms
+step:550/1490 train_time:20158ms step_avg:36.65ms
+step:551/1490 train_time:20216ms step_avg:36.69ms
+step:552/1490 train_time:20279ms step_avg:36.74ms
+step:553/1490 train_time:20336ms step_avg:36.77ms
+step:554/1490 train_time:20399ms step_avg:36.82ms
+step:555/1490 train_time:20456ms step_avg:36.86ms
+step:556/1490 train_time:20519ms step_avg:36.91ms
+step:557/1490 train_time:20576ms step_avg:36.94ms
+step:558/1490 train_time:20640ms step_avg:36.99ms
+step:559/1490 train_time:20697ms step_avg:37.02ms
+step:560/1490 train_time:20760ms step_avg:37.07ms
+step:561/1490 train_time:20817ms step_avg:37.11ms
+step:562/1490 train_time:20879ms step_avg:37.15ms
+step:563/1490 train_time:20936ms step_avg:37.19ms
+step:564/1490 train_time:20999ms step_avg:37.23ms
+step:565/1490 train_time:21056ms step_avg:37.27ms
+step:566/1490 train_time:21121ms step_avg:37.32ms
+step:567/1490 train_time:21180ms step_avg:37.35ms
+step:568/1490 train_time:21247ms step_avg:37.41ms
+step:569/1490 train_time:21306ms step_avg:37.45ms
+step:570/1490 train_time:21370ms step_avg:37.49ms
+step:571/1490 train_time:21429ms step_avg:37.53ms
+step:572/1490 train_time:21494ms step_avg:37.58ms
+step:573/1490 train_time:21552ms step_avg:37.61ms
+step:574/1490 train_time:21616ms step_avg:37.66ms
+step:575/1490 train_time:21674ms step_avg:37.69ms
+step:576/1490 train_time:21740ms step_avg:37.74ms
+step:577/1490 train_time:21798ms step_avg:37.78ms
+step:578/1490 train_time:21863ms step_avg:37.82ms
+step:579/1490 train_time:21921ms step_avg:37.86ms
+step:580/1490 train_time:21985ms step_avg:37.91ms
+step:581/1490 train_time:22045ms step_avg:37.94ms
+step:582/1490 train_time:22110ms step_avg:37.99ms
+step:583/1490 train_time:22168ms step_avg:38.02ms
+step:584/1490 train_time:22232ms step_avg:38.07ms
+step:585/1490 train_time:22290ms step_avg:38.10ms
+step:586/1490 train_time:22355ms step_avg:38.15ms
+step:587/1490 train_time:22413ms step_avg:38.18ms
+step:588/1490 train_time:22476ms step_avg:38.23ms
+step:589/1490 train_time:22534ms step_avg:38.26ms
+step:590/1490 train_time:22599ms step_avg:38.30ms
+step:591/1490 train_time:22658ms step_avg:38.34ms
+step:592/1490 train_time:22722ms step_avg:38.38ms
+step:593/1490 train_time:22780ms step_avg:38.42ms
+step:594/1490 train_time:22846ms step_avg:38.46ms
+step:595/1490 train_time:22905ms step_avg:38.50ms
+step:596/1490 train_time:22970ms step_avg:38.54ms
+step:597/1490 train_time:23028ms step_avg:38.57ms
+step:598/1490 train_time:23092ms step_avg:38.62ms
+step:599/1490 train_time:23151ms step_avg:38.65ms
+step:600/1490 train_time:23216ms step_avg:38.69ms
+step:601/1490 train_time:23274ms step_avg:38.73ms
+step:602/1490 train_time:23338ms step_avg:38.77ms
+step:603/1490 train_time:23396ms step_avg:38.80ms
+step:604/1490 train_time:23460ms step_avg:38.84ms
+step:605/1490 train_time:23518ms step_avg:38.87ms
+step:606/1490 train_time:23581ms step_avg:38.91ms
+step:607/1490 train_time:23640ms step_avg:38.95ms
+step:608/1490 train_time:23707ms step_avg:38.99ms
+step:609/1490 train_time:23768ms step_avg:39.03ms
+step:610/1490 train_time:23835ms step_avg:39.07ms
+step:611/1490 train_time:23894ms step_avg:39.11ms
+step:612/1490 train_time:23959ms step_avg:39.15ms
+step:613/1490 train_time:24018ms step_avg:39.18ms
+step:614/1490 train_time:24083ms step_avg:39.22ms
+step:615/1490 train_time:24142ms step_avg:39.26ms
+step:616/1490 train_time:24208ms step_avg:39.30ms
+step:617/1490 train_time:24268ms step_avg:39.33ms
+step:618/1490 train_time:24334ms step_avg:39.38ms
+step:619/1490 train_time:24393ms step_avg:39.41ms
+step:620/1490 train_time:24458ms step_avg:39.45ms
+step:621/1490 train_time:24517ms step_avg:39.48ms
+step:622/1490 train_time:24581ms step_avg:39.52ms
+step:623/1490 train_time:24638ms step_avg:39.55ms
+step:624/1490 train_time:24703ms step_avg:39.59ms
+step:625/1490 train_time:24762ms step_avg:39.62ms
+step:626/1490 train_time:24827ms step_avg:39.66ms
+step:627/1490 train_time:24887ms step_avg:39.69ms
+step:628/1490 train_time:24951ms step_avg:39.73ms
+step:629/1490 train_time:25010ms step_avg:39.76ms
+step:630/1490 train_time:25074ms step_avg:39.80ms
+step:631/1490 train_time:25132ms step_avg:39.83ms
+step:632/1490 train_time:25196ms step_avg:39.87ms
+step:633/1490 train_time:25254ms step_avg:39.90ms
+step:634/1490 train_time:25318ms step_avg:39.93ms
+step:635/1490 train_time:25374ms step_avg:39.96ms
+step:636/1490 train_time:25438ms step_avg:40.00ms
+step:637/1490 train_time:25495ms step_avg:40.02ms
+step:638/1490 train_time:25559ms step_avg:40.06ms
+step:639/1490 train_time:25618ms step_avg:40.09ms
+step:640/1490 train_time:25682ms step_avg:40.13ms
+step:641/1490 train_time:25739ms step_avg:40.15ms
+step:642/1490 train_time:25803ms step_avg:40.19ms
+step:643/1490 train_time:25861ms step_avg:40.22ms
+step:644/1490 train_time:25926ms step_avg:40.26ms
+step:645/1490 train_time:25984ms step_avg:40.29ms
+step:646/1490 train_time:26047ms step_avg:40.32ms
+step:647/1490 train_time:26106ms step_avg:40.35ms
+step:648/1490 train_time:26169ms step_avg:40.38ms
+step:649/1490 train_time:26227ms step_avg:40.41ms
+step:650/1490 train_time:26290ms step_avg:40.45ms
+step:651/1490 train_time:26349ms step_avg:40.48ms
+step:652/1490 train_time:26413ms step_avg:40.51ms
+step:653/1490 train_time:26471ms step_avg:40.54ms
+step:654/1490 train_time:26535ms step_avg:40.57ms
+step:655/1490 train_time:26592ms step_avg:40.60ms
+step:656/1490 train_time:26656ms step_avg:40.63ms
+step:657/1490 train_time:26713ms step_avg:40.66ms
+step:658/1490 train_time:26776ms step_avg:40.69ms
+step:659/1490 train_time:26834ms step_avg:40.72ms
+step:660/1490 train_time:26898ms step_avg:40.75ms
+step:661/1490 train_time:26957ms step_avg:40.78ms
+step:662/1490 train_time:27021ms step_avg:40.82ms
+step:663/1490 train_time:27079ms step_avg:40.84ms
+step:664/1490 train_time:27143ms step_avg:40.88ms
+step:665/1490 train_time:27201ms step_avg:40.90ms
+step:666/1490 train_time:27265ms step_avg:40.94ms
+step:667/1490 train_time:27324ms step_avg:40.97ms
+step:668/1490 train_time:27389ms step_avg:41.00ms
+step:669/1490 train_time:27449ms step_avg:41.03ms
+step:670/1490 train_time:27514ms step_avg:41.07ms
+step:671/1490 train_time:27572ms step_avg:41.09ms
+step:672/1490 train_time:27636ms step_avg:41.13ms
+step:673/1490 train_time:27694ms step_avg:41.15ms
+step:674/1490 train_time:27758ms step_avg:41.18ms
+step:675/1490 train_time:27816ms step_avg:41.21ms
+step:676/1490 train_time:27880ms step_avg:41.24ms
+step:677/1490 train_time:27938ms step_avg:41.27ms
+step:678/1490 train_time:28002ms step_avg:41.30ms
+step:679/1490 train_time:28060ms step_avg:41.33ms
+step:680/1490 train_time:28125ms step_avg:41.36ms
+step:681/1490 train_time:28184ms step_avg:41.39ms
+step:682/1490 train_time:28248ms step_avg:41.42ms
+step:683/1490 train_time:28308ms step_avg:41.45ms
+step:684/1490 train_time:28372ms step_avg:41.48ms
+step:685/1490 train_time:28430ms step_avg:41.50ms
+step:686/1490 train_time:28494ms step_avg:41.54ms
+step:687/1490 train_time:28553ms step_avg:41.56ms
+step:688/1490 train_time:28618ms step_avg:41.60ms
+step:689/1490 train_time:28675ms step_avg:41.62ms
+step:690/1490 train_time:28739ms step_avg:41.65ms
+step:691/1490 train_time:28797ms step_avg:41.67ms
+step:692/1490 train_time:28861ms step_avg:41.71ms
+step:693/1490 train_time:28919ms step_avg:41.73ms
+step:694/1490 train_time:28983ms step_avg:41.76ms
+step:695/1490 train_time:29041ms step_avg:41.79ms
+step:696/1490 train_time:29105ms step_avg:41.82ms
+step:697/1490 train_time:29163ms step_avg:41.84ms
+step:698/1490 train_time:29227ms step_avg:41.87ms
+step:699/1490 train_time:29286ms step_avg:41.90ms
+step:700/1490 train_time:29351ms step_avg:41.93ms
+step:701/1490 train_time:29409ms step_avg:41.95ms
+step:702/1490 train_time:29474ms step_avg:41.99ms
+step:703/1490 train_time:29532ms step_avg:42.01ms
+step:704/1490 train_time:29595ms step_avg:42.04ms
+step:705/1490 train_time:29654ms step_avg:42.06ms
+step:706/1490 train_time:29718ms step_avg:42.09ms
+step:707/1490 train_time:29774ms step_avg:42.11ms
+step:708/1490 train_time:29838ms step_avg:42.14ms
+step:709/1490 train_time:29895ms step_avg:42.16ms
+step:710/1490 train_time:29957ms step_avg:42.19ms
+step:711/1490 train_time:30014ms step_avg:42.21ms
+step:712/1490 train_time:30078ms step_avg:42.24ms
+step:713/1490 train_time:30134ms step_avg:42.26ms
+step:714/1490 train_time:30198ms step_avg:42.29ms
+step:715/1490 train_time:30255ms step_avg:42.31ms
+step:716/1490 train_time:30319ms step_avg:42.34ms
+step:717/1490 train_time:30377ms step_avg:42.37ms
+step:718/1490 train_time:30442ms step_avg:42.40ms
+step:719/1490 train_time:30501ms step_avg:42.42ms
+step:720/1490 train_time:30566ms step_avg:42.45ms
+step:721/1490 train_time:30624ms step_avg:42.47ms
+step:722/1490 train_time:30689ms step_avg:42.51ms
+step:723/1490 train_time:30750ms step_avg:42.53ms
+step:724/1490 train_time:30814ms step_avg:42.56ms
+step:725/1490 train_time:30871ms step_avg:42.58ms
+step:726/1490 train_time:30935ms step_avg:42.61ms
+step:727/1490 train_time:30992ms step_avg:42.63ms
+step:728/1490 train_time:31057ms step_avg:42.66ms
+step:729/1490 train_time:31115ms step_avg:42.68ms
+step:730/1490 train_time:31179ms step_avg:42.71ms
+step:731/1490 train_time:31237ms step_avg:42.73ms
+step:732/1490 train_time:31300ms step_avg:42.76ms
+step:733/1490 train_time:31359ms step_avg:42.78ms
+step:734/1490 train_time:31425ms step_avg:42.81ms
+step:735/1490 train_time:31484ms step_avg:42.83ms
+step:736/1490 train_time:31548ms step_avg:42.86ms
+step:737/1490 train_time:31607ms step_avg:42.89ms
+step:738/1490 train_time:31672ms step_avg:42.92ms
+step:739/1490 train_time:31730ms step_avg:42.94ms
+step:740/1490 train_time:31795ms step_avg:42.97ms
+step:741/1490 train_time:31853ms step_avg:42.99ms
+step:742/1490 train_time:31917ms step_avg:43.02ms
+step:743/1490 train_time:31975ms step_avg:43.03ms
+step:744/1490 train_time:32039ms step_avg:43.06ms
+step:745/1490 train_time:32096ms step_avg:43.08ms
+step:746/1490 train_time:32160ms step_avg:43.11ms
+step:747/1490 train_time:32221ms step_avg:43.13ms
+step:748/1490 train_time:32286ms step_avg:43.16ms
+step:749/1490 train_time:32347ms step_avg:43.19ms
+step:750/1490 train_time:32413ms step_avg:43.22ms
+step:750/1490 val_loss:3.8095 train_time:32500ms step_avg:43.33ms
+step:751/1490 train_time:32518ms step_avg:43.30ms
+step:752/1490 train_time:32542ms step_avg:43.27ms
+step:753/1490 train_time:32600ms step_avg:43.29ms
+step:754/1490 train_time:32667ms step_avg:43.33ms
+step:755/1490 train_time:32727ms step_avg:43.35ms
+step:756/1490 train_time:32792ms step_avg:43.38ms
+step:757/1490 train_time:32851ms step_avg:43.40ms
+step:758/1490 train_time:32918ms step_avg:43.43ms
+step:759/1490 train_time:32978ms step_avg:43.45ms
+step:760/1490 train_time:33045ms step_avg:43.48ms
+step:761/1490 train_time:33104ms step_avg:43.50ms
+step:762/1490 train_time:33169ms step_avg:43.53ms
+step:763/1490 train_time:33228ms step_avg:43.55ms
+step:764/1490 train_time:33294ms step_avg:43.58ms
+step:765/1490 train_time:33353ms step_avg:43.60ms
+step:766/1490 train_time:33419ms step_avg:43.63ms
+step:767/1490 train_time:33479ms step_avg:43.65ms
+step:768/1490 train_time:33544ms step_avg:43.68ms
+step:769/1490 train_time:33603ms step_avg:43.70ms
+step:770/1490 train_time:33667ms step_avg:43.72ms
+step:771/1490 train_time:33726ms step_avg:43.74ms
+step:772/1490 train_time:33790ms step_avg:43.77ms
+step:773/1490 train_time:33849ms step_avg:43.79ms
+step:774/1490 train_time:33915ms step_avg:43.82ms
+step:775/1490 train_time:33974ms step_avg:43.84ms
+step:776/1490 train_time:34039ms step_avg:43.86ms
+step:777/1490 train_time:34097ms step_avg:43.88ms
+step:778/1490 train_time:34163ms step_avg:43.91ms
+step:779/1490 train_time:34223ms step_avg:43.93ms
+step:780/1490 train_time:34287ms step_avg:43.96ms
+step:781/1490 train_time:34345ms step_avg:43.98ms
+step:782/1490 train_time:34409ms step_avg:44.00ms
+step:783/1490 train_time:34466ms step_avg:44.02ms
+step:784/1490 train_time:34530ms step_avg:44.04ms
+step:785/1490 train_time:34587ms step_avg:44.06ms
+step:786/1490 train_time:34650ms step_avg:44.08ms
+step:787/1490 train_time:34708ms step_avg:44.10ms
+step:788/1490 train_time:34772ms step_avg:44.13ms
+step:789/1490 train_time:34830ms step_avg:44.14ms
+step:790/1490 train_time:34895ms step_avg:44.17ms
+step:791/1490 train_time:34952ms step_avg:44.19ms
+step:792/1490 train_time:35016ms step_avg:44.21ms
+step:793/1490 train_time:35077ms step_avg:44.23ms
+step:794/1490 train_time:35142ms step_avg:44.26ms
+step:795/1490 train_time:35200ms step_avg:44.28ms
+step:796/1490 train_time:35265ms step_avg:44.30ms
+step:797/1490 train_time:35323ms step_avg:44.32ms
+step:798/1490 train_time:35387ms step_avg:44.34ms
+step:799/1490 train_time:35443ms step_avg:44.36ms
+step:800/1490 train_time:35507ms step_avg:44.38ms
+step:801/1490 train_time:35564ms step_avg:44.40ms
+step:802/1490 train_time:35628ms step_avg:44.42ms
+step:803/1490 train_time:35685ms step_avg:44.44ms
+step:804/1490 train_time:35747ms step_avg:44.46ms
+step:805/1490 train_time:35804ms step_avg:44.48ms
+step:806/1490 train_time:35868ms step_avg:44.50ms
+step:807/1490 train_time:35927ms step_avg:44.52ms
+step:808/1490 train_time:35990ms step_avg:44.54ms
+step:809/1490 train_time:36050ms step_avg:44.56ms
+step:810/1490 train_time:36116ms step_avg:44.59ms
+step:811/1490 train_time:36174ms step_avg:44.60ms
+step:812/1490 train_time:36238ms step_avg:44.63ms
+step:813/1490 train_time:36297ms step_avg:44.65ms
+step:814/1490 train_time:36360ms step_avg:44.67ms
+step:815/1490 train_time:36419ms step_avg:44.69ms
+step:816/1490 train_time:36483ms step_avg:44.71ms
+step:817/1490 train_time:36541ms step_avg:44.73ms
+step:818/1490 train_time:36605ms step_avg:44.75ms
+step:819/1490 train_time:36663ms step_avg:44.77ms
+step:820/1490 train_time:36727ms step_avg:44.79ms
+step:821/1490 train_time:36784ms step_avg:44.80ms
+step:822/1490 train_time:36848ms step_avg:44.83ms
+step:823/1490 train_time:36905ms step_avg:44.84ms
+step:824/1490 train_time:36969ms step_avg:44.86ms
+step:825/1490 train_time:37026ms step_avg:44.88ms
+step:826/1490 train_time:37091ms step_avg:44.90ms
+step:827/1490 train_time:37151ms step_avg:44.92ms
+step:828/1490 train_time:37218ms step_avg:44.95ms
+step:829/1490 train_time:37279ms step_avg:44.97ms
+step:830/1490 train_time:37346ms step_avg:45.00ms
+step:831/1490 train_time:37405ms step_avg:45.01ms
+step:832/1490 train_time:37471ms step_avg:45.04ms
+step:833/1490 train_time:37530ms step_avg:45.05ms
+step:834/1490 train_time:37597ms step_avg:45.08ms
+step:835/1490 train_time:37657ms step_avg:45.10ms
+step:836/1490 train_time:37723ms step_avg:45.12ms
+step:837/1490 train_time:37783ms step_avg:45.14ms
+step:838/1490 train_time:37847ms step_avg:45.16ms
+step:839/1490 train_time:37905ms step_avg:45.18ms
+step:840/1490 train_time:37970ms step_avg:45.20ms
+step:841/1490 train_time:38030ms step_avg:45.22ms
+step:842/1490 train_time:38096ms step_avg:45.24ms
+step:843/1490 train_time:38155ms step_avg:45.26ms
+step:844/1490 train_time:38221ms step_avg:45.29ms
+step:845/1490 train_time:38281ms step_avg:45.30ms
+step:846/1490 train_time:38347ms step_avg:45.33ms
+step:847/1490 train_time:38404ms step_avg:45.34ms
+step:848/1490 train_time:38469ms step_avg:45.36ms
+step:849/1490 train_time:38527ms step_avg:45.38ms
+step:850/1490 train_time:38592ms step_avg:45.40ms
+step:851/1490 train_time:38650ms step_avg:45.42ms
+step:852/1490 train_time:38714ms step_avg:45.44ms
+step:853/1490 train_time:38773ms step_avg:45.45ms
+step:854/1490 train_time:38838ms step_avg:45.48ms
+step:855/1490 train_time:38897ms step_avg:45.49ms
+step:856/1490 train_time:38962ms step_avg:45.52ms
+step:857/1490 train_time:39021ms step_avg:45.53ms
+step:858/1490 train_time:39085ms step_avg:45.55ms
+step:859/1490 train_time:39143ms step_avg:45.57ms
+step:860/1490 train_time:39207ms step_avg:45.59ms
+step:861/1490 train_time:39265ms step_avg:45.60ms
+step:862/1490 train_time:39329ms step_avg:45.63ms
+step:863/1490 train_time:39387ms step_avg:45.64ms
+step:864/1490 train_time:39451ms step_avg:45.66ms
+step:865/1490 train_time:39509ms step_avg:45.68ms
+step:866/1490 train_time:39573ms step_avg:45.70ms
+step:867/1490 train_time:39631ms step_avg:45.71ms
+step:868/1490 train_time:39695ms step_avg:45.73ms
+step:869/1490 train_time:39755ms step_avg:45.75ms
+step:870/1490 train_time:39822ms step_avg:45.77ms
+step:871/1490 train_time:39880ms step_avg:45.79ms
+step:872/1490 train_time:39945ms step_avg:45.81ms
+step:873/1490 train_time:40003ms step_avg:45.82ms
+step:874/1490 train_time:40066ms step_avg:45.84ms
+step:875/1490 train_time:40124ms step_avg:45.86ms
+step:876/1490 train_time:40188ms step_avg:45.88ms
+step:877/1490 train_time:40245ms step_avg:45.89ms
+step:878/1490 train_time:40309ms step_avg:45.91ms
+step:879/1490 train_time:40367ms step_avg:45.92ms
+step:880/1490 train_time:40431ms step_avg:45.94ms
+step:881/1490 train_time:40489ms step_avg:45.96ms
+step:882/1490 train_time:40552ms step_avg:45.98ms
+step:883/1490 train_time:40610ms step_avg:45.99ms
+step:884/1490 train_time:40674ms step_avg:46.01ms
+step:885/1490 train_time:40732ms step_avg:46.02ms
+step:886/1490 train_time:40796ms step_avg:46.05ms
+step:887/1490 train_time:40854ms step_avg:46.06ms
+step:888/1490 train_time:40918ms step_avg:46.08ms
+step:889/1490 train_time:40978ms step_avg:46.09ms
+step:890/1490 train_time:41046ms step_avg:46.12ms
+step:891/1490 train_time:41106ms step_avg:46.13ms
+step:892/1490 train_time:41173ms step_avg:46.16ms
+step:893/1490 train_time:41234ms step_avg:46.17ms
+step:894/1490 train_time:41302ms step_avg:46.20ms
+step:895/1490 train_time:41363ms step_avg:46.22ms
+step:896/1490 train_time:41431ms step_avg:46.24ms
+step:897/1490 train_time:41491ms step_avg:46.26ms
+step:898/1490 train_time:41558ms step_avg:46.28ms
+step:899/1490 train_time:41620ms step_avg:46.30ms
+step:900/1490 train_time:41687ms step_avg:46.32ms
+step:901/1490 train_time:41746ms step_avg:46.33ms
+step:902/1490 train_time:41810ms step_avg:46.35ms
+step:903/1490 train_time:41863ms step_avg:46.36ms
+step:904/1490 train_time:41923ms step_avg:46.37ms
+step:905/1490 train_time:41979ms step_avg:46.39ms
+step:906/1490 train_time:42041ms step_avg:46.40ms
+step:907/1490 train_time:42098ms step_avg:46.41ms
+step:908/1490 train_time:42163ms step_avg:46.43ms
+step:909/1490 train_time:42220ms step_avg:46.45ms
+step:910/1490 train_time:42288ms step_avg:46.47ms
+step:911/1490 train_time:42351ms step_avg:46.49ms
+step:912/1490 train_time:42419ms step_avg:46.51ms
+step:913/1490 train_time:42478ms step_avg:46.53ms
+step:914/1490 train_time:42541ms step_avg:46.54ms
+step:915/1490 train_time:42598ms step_avg:46.56ms
+step:916/1490 train_time:42662ms step_avg:46.57ms
+step:917/1490 train_time:42721ms step_avg:46.59ms
+step:918/1490 train_time:42785ms step_avg:46.61ms
+step:919/1490 train_time:42843ms step_avg:46.62ms
+step:920/1490 train_time:42908ms step_avg:46.64ms
+step:921/1490 train_time:42965ms step_avg:46.65ms
+step:922/1490 train_time:43030ms step_avg:46.67ms
+step:923/1490 train_time:43092ms step_avg:46.69ms
+step:924/1490 train_time:43158ms step_avg:46.71ms
+step:925/1490 train_time:43219ms step_avg:46.72ms
+step:926/1490 train_time:43286ms step_avg:46.75ms
+step:927/1490 train_time:43344ms step_avg:46.76ms
+step:928/1490 train_time:43410ms step_avg:46.78ms
+step:929/1490 train_time:43470ms step_avg:46.79ms
+step:930/1490 train_time:43536ms step_avg:46.81ms
+step:931/1490 train_time:43596ms step_avg:46.83ms
+step:932/1490 train_time:43662ms step_avg:46.85ms
+step:933/1490 train_time:43722ms step_avg:46.86ms
+step:934/1490 train_time:43787ms step_avg:46.88ms
+step:935/1490 train_time:43845ms step_avg:46.89ms
+step:936/1490 train_time:43910ms step_avg:46.91ms
+step:937/1490 train_time:43969ms step_avg:46.93ms
+step:938/1490 train_time:44035ms step_avg:46.95ms
+step:939/1490 train_time:44094ms step_avg:46.96ms
+step:940/1490 train_time:44159ms step_avg:46.98ms
+step:941/1490 train_time:44220ms step_avg:46.99ms
+step:942/1490 train_time:44285ms step_avg:47.01ms
+step:943/1490 train_time:44343ms step_avg:47.02ms
+step:944/1490 train_time:44409ms step_avg:47.04ms
+step:945/1490 train_time:44467ms step_avg:47.05ms
+step:946/1490 train_time:44531ms step_avg:47.07ms
+step:947/1490 train_time:44589ms step_avg:47.08ms
+step:948/1490 train_time:44654ms step_avg:47.10ms
+step:949/1490 train_time:44712ms step_avg:47.12ms
+step:950/1490 train_time:44777ms step_avg:47.13ms
+step:951/1490 train_time:44837ms step_avg:47.15ms
+step:952/1490 train_time:44901ms step_avg:47.17ms
+step:953/1490 train_time:44959ms step_avg:47.18ms
+step:954/1490 train_time:45024ms step_avg:47.19ms
+step:955/1490 train_time:45082ms step_avg:47.21ms
+step:956/1490 train_time:45145ms step_avg:47.22ms
+step:957/1490 train_time:45203ms step_avg:47.23ms
+step:958/1490 train_time:45267ms step_avg:47.25ms
+step:959/1490 train_time:45325ms step_avg:47.26ms
+step:960/1490 train_time:45389ms step_avg:47.28ms
+step:961/1490 train_time:45445ms step_avg:47.29ms
+step:962/1490 train_time:45508ms step_avg:47.31ms
+step:963/1490 train_time:45564ms step_avg:47.31ms
+step:964/1490 train_time:45626ms step_avg:47.33ms
+step:965/1490 train_time:45683ms step_avg:47.34ms
+step:966/1490 train_time:45747ms step_avg:47.36ms
+step:967/1490 train_time:45804ms step_avg:47.37ms
+step:968/1490 train_time:45873ms step_avg:47.39ms
+step:969/1490 train_time:45955ms step_avg:47.42ms
+step:970/1490 train_time:46046ms step_avg:47.47ms
+step:971/1490 train_time:46130ms step_avg:47.51ms
+step:972/1490 train_time:46223ms step_avg:47.55ms
+step:973/1490 train_time:46307ms step_avg:47.59ms
+step:974/1490 train_time:46400ms step_avg:47.64ms
+step:975/1490 train_time:46487ms step_avg:47.68ms
+step:976/1490 train_time:46580ms step_avg:47.73ms
+step:977/1490 train_time:46665ms step_avg:47.76ms
+step:978/1490 train_time:46757ms step_avg:47.81ms
+step:979/1490 train_time:46847ms step_avg:47.85ms
+step:980/1490 train_time:46938ms step_avg:47.90ms
+step:981/1490 train_time:47026ms step_avg:47.94ms
+step:982/1490 train_time:47119ms step_avg:47.98ms
+step:983/1490 train_time:47209ms step_avg:48.03ms
+step:984/1490 train_time:47301ms step_avg:48.07ms
+step:985/1490 train_time:47388ms step_avg:48.11ms
+step:986/1490 train_time:47481ms step_avg:48.16ms
+step:987/1490 train_time:47568ms step_avg:48.19ms
+step:988/1490 train_time:47661ms step_avg:48.24ms
+step:989/1490 train_time:47751ms step_avg:48.28ms
+step:990/1490 train_time:47845ms step_avg:48.33ms
+step:991/1490 train_time:47932ms step_avg:48.37ms
+step:992/1490 train_time:48027ms step_avg:48.41ms
+step:993/1490 train_time:48114ms step_avg:48.45ms
+step:994/1490 train_time:48209ms step_avg:48.50ms
+step:995/1490 train_time:48295ms step_avg:48.54ms
+step:996/1490 train_time:48390ms step_avg:48.58ms
+step:997/1490 train_time:48475ms step_avg:48.62ms
+step:998/1490 train_time:48569ms step_avg:48.67ms
+step:999/1490 train_time:48655ms step_avg:48.70ms
+step:1000/1490 train_time:48749ms step_avg:48.75ms
+step:1000/1490 val_loss:3.5180 train_time:48868ms step_avg:48.87ms
+step:1001/1490 train_time:48886ms step_avg:48.84ms
+step:1002/1490 train_time:48930ms step_avg:48.83ms
+step:1003/1490 train_time:49017ms step_avg:48.87ms
+step:1004/1490 train_time:49111ms step_avg:48.92ms
+step:1005/1490 train_time:49197ms step_avg:48.95ms
+step:1006/1490 train_time:49290ms step_avg:49.00ms
+step:1007/1490 train_time:49377ms step_avg:49.03ms
+step:1008/1490 train_time:49470ms step_avg:49.08ms
+step:1009/1490 train_time:49556ms step_avg:49.11ms
+step:1010/1490 train_time:49650ms step_avg:49.16ms
+step:1011/1490 train_time:49736ms step_avg:49.20ms
+step:1012/1490 train_time:49830ms step_avg:49.24ms
+step:1013/1490 train_time:49917ms step_avg:49.28ms
+step:1014/1490 train_time:50010ms step_avg:49.32ms
+step:1015/1490 train_time:50096ms step_avg:49.36ms
+step:1016/1490 train_time:50190ms step_avg:49.40ms
+step:1017/1490 train_time:50276ms step_avg:49.44ms
+step:1018/1490 train_time:50370ms step_avg:49.48ms
+step:1019/1490 train_time:50457ms step_avg:49.52ms
+step:1020/1490 train_time:50552ms step_avg:49.56ms
+step:1021/1490 train_time:50638ms step_avg:49.60ms
+step:1022/1490 train_time:50732ms step_avg:49.64ms
+step:1023/1490 train_time:50818ms step_avg:49.68ms
+step:1024/1490 train_time:50913ms step_avg:49.72ms
+step:1025/1490 train_time:51001ms step_avg:49.76ms
+step:1026/1490 train_time:51095ms step_avg:49.80ms
+step:1027/1490 train_time:51183ms step_avg:49.84ms
+step:1028/1490 train_time:51276ms step_avg:49.88ms
+step:1029/1490 train_time:51365ms step_avg:49.92ms
+step:1030/1490 train_time:51457ms step_avg:49.96ms
+step:1031/1490 train_time:51545ms step_avg:49.99ms
+step:1032/1490 train_time:51638ms step_avg:50.04ms
+step:1033/1490 train_time:51726ms step_avg:50.07ms
+step:1034/1490 train_time:51818ms step_avg:50.11ms
+step:1035/1490 train_time:51904ms step_avg:50.15ms
+step:1036/1490 train_time:51998ms step_avg:50.19ms
+step:1037/1490 train_time:52081ms step_avg:50.22ms
+step:1038/1490 train_time:52174ms step_avg:50.26ms
+step:1039/1490 train_time:52264ms step_avg:50.30ms
+step:1040/1490 train_time:52356ms step_avg:50.34ms
+step:1041/1490 train_time:52445ms step_avg:50.38ms
+step:1042/1490 train_time:52536ms step_avg:50.42ms
+step:1043/1490 train_time:52624ms step_avg:50.45ms
+step:1044/1490 train_time:52717ms step_avg:50.50ms
+step:1045/1490 train_time:52805ms step_avg:50.53ms
+step:1046/1490 train_time:52900ms step_avg:50.57ms
+step:1047/1490 train_time:52991ms step_avg:50.61ms
+step:1048/1490 train_time:53087ms step_avg:50.66ms
+step:1049/1490 train_time:53176ms step_avg:50.69ms
+step:1050/1490 train_time:53273ms step_avg:50.74ms
+step:1051/1490 train_time:53364ms step_avg:50.77ms
+step:1052/1490 train_time:53460ms step_avg:50.82ms
+step:1053/1490 train_time:53551ms step_avg:50.86ms
+step:1054/1490 train_time:53646ms step_avg:50.90ms
+step:1055/1490 train_time:53729ms step_avg:50.93ms
+step:1056/1490 train_time:53814ms step_avg:50.96ms
+step:1057/1490 train_time:53900ms step_avg:50.99ms
+step:1058/1490 train_time:53991ms step_avg:51.03ms
+step:1059/1490 train_time:54076ms step_avg:51.06ms
+step:1060/1490 train_time:54170ms step_avg:51.10ms
+step:1061/1490 train_time:54254ms step_avg:51.13ms
+step:1062/1490 train_time:54349ms step_avg:51.18ms
+step:1063/1490 train_time:54435ms step_avg:51.21ms
+step:1064/1490 train_time:54529ms step_avg:51.25ms
+step:1065/1490 train_time:54616ms step_avg:51.28ms
+step:1066/1490 train_time:54712ms step_avg:51.32ms
+step:1067/1490 train_time:54800ms step_avg:51.36ms
+step:1068/1490 train_time:54895ms step_avg:51.40ms
+step:1069/1490 train_time:54982ms step_avg:51.43ms
+step:1070/1490 train_time:55078ms step_avg:51.47ms
+step:1071/1490 train_time:55167ms step_avg:51.51ms
+step:1072/1490 train_time:55261ms step_avg:51.55ms
+step:1073/1490 train_time:55349ms step_avg:51.58ms
+step:1074/1490 train_time:55443ms step_avg:51.62ms
+step:1075/1490 train_time:55531ms step_avg:51.66ms
+step:1076/1490 train_time:55625ms step_avg:51.70ms
+step:1077/1490 train_time:55713ms step_avg:51.73ms
+step:1078/1490 train_time:55807ms step_avg:51.77ms
+step:1079/1490 train_time:55893ms step_avg:51.80ms
+step:1080/1490 train_time:55987ms step_avg:51.84ms
+step:1081/1490 train_time:56073ms step_avg:51.87ms
+step:1082/1490 train_time:56166ms step_avg:51.91ms
+step:1083/1490 train_time:56253ms step_avg:51.94ms
+step:1084/1490 train_time:56347ms step_avg:51.98ms
+step:1085/1490 train_time:56433ms step_avg:52.01ms
+step:1086/1490 train_time:56527ms step_avg:52.05ms
+step:1087/1490 train_time:56612ms step_avg:52.08ms
+step:1088/1490 train_time:56705ms step_avg:52.12ms
+step:1089/1490 train_time:56790ms step_avg:52.15ms
+step:1090/1490 train_time:56884ms step_avg:52.19ms
+step:1091/1490 train_time:56971ms step_avg:52.22ms
+step:1092/1490 train_time:57063ms step_avg:52.26ms
+step:1093/1490 train_time:57149ms step_avg:52.29ms
+step:1094/1490 train_time:57242ms step_avg:52.32ms
+step:1095/1490 train_time:57328ms step_avg:52.35ms
+step:1096/1490 train_time:57419ms step_avg:52.39ms
+step:1097/1490 train_time:57506ms step_avg:52.42ms
+step:1098/1490 train_time:57598ms step_avg:52.46ms
+step:1099/1490 train_time:57685ms step_avg:52.49ms
+step:1100/1490 train_time:57778ms step_avg:52.53ms
+step:1101/1490 train_time:57866ms step_avg:52.56ms
+step:1102/1490 train_time:57958ms step_avg:52.59ms
+step:1103/1490 train_time:58044ms step_avg:52.62ms
+step:1104/1490 train_time:58138ms step_avg:52.66ms
+step:1105/1490 train_time:58225ms step_avg:52.69ms
+step:1106/1490 train_time:58316ms step_avg:52.73ms
+step:1107/1490 train_time:58403ms step_avg:52.76ms
+step:1108/1490 train_time:58495ms step_avg:52.79ms
+step:1109/1490 train_time:58583ms step_avg:52.82ms
+step:1110/1490 train_time:58672ms step_avg:52.86ms
+step:1111/1490 train_time:58755ms step_avg:52.89ms
+step:1112/1490 train_time:58847ms step_avg:52.92ms
+step:1113/1490 train_time:58932ms step_avg:52.95ms
+step:1114/1490 train_time:59022ms step_avg:52.98ms
+step:1115/1490 train_time:59107ms step_avg:53.01ms
+step:1116/1490 train_time:59198ms step_avg:53.04ms
+step:1117/1490 train_time:59286ms step_avg:53.08ms
+step:1118/1490 train_time:59377ms step_avg:53.11ms
+step:1119/1490 train_time:59463ms step_avg:53.14ms
+step:1120/1490 train_time:59554ms step_avg:53.17ms
+step:1121/1490 train_time:59642ms step_avg:53.20ms
+step:1122/1490 train_time:59737ms step_avg:53.24ms
+step:1123/1490 train_time:59827ms step_avg:53.27ms
+step:1124/1490 train_time:59922ms step_avg:53.31ms
+step:1125/1490 train_time:60011ms step_avg:53.34ms
+step:1126/1490 train_time:60107ms step_avg:53.38ms
+step:1127/1490 train_time:60195ms step_avg:53.41ms
+step:1128/1490 train_time:60291ms step_avg:53.45ms
+step:1129/1490 train_time:60379ms step_avg:53.48ms
+step:1130/1490 train_time:60474ms step_avg:53.52ms
+step:1131/1490 train_time:60561ms step_avg:53.55ms
+step:1132/1490 train_time:60657ms step_avg:53.58ms
+step:1133/1490 train_time:60744ms step_avg:53.61ms
+step:1134/1490 train_time:60839ms step_avg:53.65ms
+step:1135/1490 train_time:60927ms step_avg:53.68ms
+step:1136/1490 train_time:61021ms step_avg:53.72ms
+step:1137/1490 train_time:61110ms step_avg:53.75ms
+step:1138/1490 train_time:61204ms step_avg:53.78ms
+step:1139/1490 train_time:61291ms step_avg:53.81ms
+step:1140/1490 train_time:61386ms step_avg:53.85ms
+step:1141/1490 train_time:61473ms step_avg:53.88ms
+step:1142/1490 train_time:61568ms step_avg:53.91ms
+step:1143/1490 train_time:61654ms step_avg:53.94ms
+step:1144/1490 train_time:61748ms step_avg:53.98ms
+step:1145/1490 train_time:61834ms step_avg:54.00ms
+step:1146/1490 train_time:61928ms step_avg:54.04ms
+step:1147/1490 train_time:62014ms step_avg:54.07ms
+step:1148/1490 train_time:62107ms step_avg:54.10ms
+step:1149/1490 train_time:62192ms step_avg:54.13ms
+step:1150/1490 train_time:62285ms step_avg:54.16ms
+step:1151/1490 train_time:62370ms step_avg:54.19ms
+step:1152/1490 train_time:62462ms step_avg:54.22ms
+step:1153/1490 train_time:62549ms step_avg:54.25ms
+step:1154/1490 train_time:62641ms step_avg:54.28ms
+step:1155/1490 train_time:62727ms step_avg:54.31ms
+step:1156/1490 train_time:62819ms step_avg:54.34ms
+step:1157/1490 train_time:62906ms step_avg:54.37ms
+step:1158/1490 train_time:62999ms step_avg:54.40ms
+step:1159/1490 train_time:63087ms step_avg:54.43ms
+step:1160/1490 train_time:63179ms step_avg:54.46ms
+step:1161/1490 train_time:63268ms step_avg:54.49ms
+step:1162/1490 train_time:63361ms step_avg:54.53ms
+step:1163/1490 train_time:63448ms step_avg:54.56ms
+step:1164/1490 train_time:63540ms step_avg:54.59ms
+step:1165/1490 train_time:63628ms step_avg:54.62ms
+step:1166/1490 train_time:63720ms step_avg:54.65ms
+step:1167/1490 train_time:63807ms step_avg:54.68ms
+step:1168/1490 train_time:63901ms step_avg:54.71ms
+step:1169/1490 train_time:63988ms step_avg:54.74ms
+step:1170/1490 train_time:64081ms step_avg:54.77ms
+step:1171/1490 train_time:64168ms step_avg:54.80ms
+step:1172/1490 train_time:64260ms step_avg:54.83ms
+step:1173/1490 train_time:64347ms step_avg:54.86ms
+step:1174/1490 train_time:64439ms step_avg:54.89ms
+step:1175/1490 train_time:64526ms step_avg:54.92ms
+step:1176/1490 train_time:64617ms step_avg:54.95ms
+step:1177/1490 train_time:64703ms step_avg:54.97ms
+step:1178/1490 train_time:64794ms step_avg:55.00ms
+step:1179/1490 train_time:64880ms step_avg:55.03ms
+step:1180/1490 train_time:64972ms step_avg:55.06ms
+step:1181/1490 train_time:65058ms step_avg:55.09ms
+step:1182/1490 train_time:65152ms step_avg:55.12ms
+step:1183/1490 train_time:65238ms step_avg:55.15ms
+step:1184/1490 train_time:65331ms step_avg:55.18ms
+step:1185/1490 train_time:65416ms step_avg:55.20ms
+step:1186/1490 train_time:65511ms step_avg:55.24ms
+step:1187/1490 train_time:65595ms step_avg:55.26ms
+step:1188/1490 train_time:65689ms step_avg:55.29ms
+step:1189/1490 train_time:65774ms step_avg:55.32ms
+step:1190/1490 train_time:65868ms step_avg:55.35ms
+step:1191/1490 train_time:65954ms step_avg:55.38ms
+step:1192/1490 train_time:66048ms step_avg:55.41ms
+step:1193/1490 train_time:66134ms step_avg:55.43ms
+step:1194/1490 train_time:66227ms step_avg:55.47ms
+step:1195/1490 train_time:66313ms step_avg:55.49ms
+step:1196/1490 train_time:66405ms step_avg:55.52ms
+step:1197/1490 train_time:66494ms step_avg:55.55ms
+step:1198/1490 train_time:66588ms step_avg:55.58ms
+step:1199/1490 train_time:66673ms step_avg:55.61ms
+step:1200/1490 train_time:66767ms step_avg:55.64ms
+step:1201/1490 train_time:66852ms step_avg:55.66ms
+step:1202/1490 train_time:66945ms step_avg:55.69ms
+step:1203/1490 train_time:67032ms step_avg:55.72ms
+step:1204/1490 train_time:67125ms step_avg:55.75ms
+step:1205/1490 train_time:67210ms step_avg:55.78ms
+step:1206/1490 train_time:67303ms step_avg:55.81ms
+step:1207/1490 train_time:67389ms step_avg:55.83ms
+step:1208/1490 train_time:67479ms step_avg:55.86ms
+step:1209/1490 train_time:67566ms step_avg:55.89ms
+step:1210/1490 train_time:67656ms step_avg:55.91ms
+step:1211/1490 train_time:67741ms step_avg:55.94ms
+step:1212/1490 train_time:67833ms step_avg:55.97ms
+step:1213/1490 train_time:67920ms step_avg:55.99ms
+step:1214/1490 train_time:68014ms step_avg:56.02ms
+step:1215/1490 train_time:68099ms step_avg:56.05ms
+step:1216/1490 train_time:68194ms step_avg:56.08ms
+step:1217/1490 train_time:68279ms step_avg:56.10ms
+step:1218/1490 train_time:68374ms step_avg:56.14ms
+step:1219/1490 train_time:68460ms step_avg:56.16ms
+step:1220/1490 train_time:68553ms step_avg:56.19ms
+step:1221/1490 train_time:68639ms step_avg:56.22ms
+step:1222/1490 train_time:68732ms step_avg:56.25ms
+step:1223/1490 train_time:68817ms step_avg:56.27ms
+step:1224/1490 train_time:68909ms step_avg:56.30ms
+step:1225/1490 train_time:68991ms step_avg:56.32ms
+step:1226/1490 train_time:69085ms step_avg:56.35ms
+step:1227/1490 train_time:69172ms step_avg:56.38ms
+step:1228/1490 train_time:69265ms step_avg:56.40ms
+step:1229/1490 train_time:69351ms step_avg:56.43ms
+step:1230/1490 train_time:69445ms step_avg:56.46ms
+step:1231/1490 train_time:69531ms step_avg:56.48ms
+step:1232/1490 train_time:69623ms step_avg:56.51ms
+step:1233/1490 train_time:69709ms step_avg:56.54ms
+step:1234/1490 train_time:69800ms step_avg:56.56ms
+step:1235/1490 train_time:69886ms step_avg:56.59ms
+step:1236/1490 train_time:69978ms step_avg:56.62ms
+step:1237/1490 train_time:70065ms step_avg:56.64ms
+step:1238/1490 train_time:70157ms step_avg:56.67ms
+step:1239/1490 train_time:70244ms step_avg:56.69ms
+step:1240/1490 train_time:70337ms step_avg:56.72ms
+step:1241/1490 train_time:70424ms step_avg:56.75ms
+step:1242/1490 train_time:70516ms step_avg:56.78ms
+step:1243/1490 train_time:70604ms step_avg:56.80ms
+step:1244/1490 train_time:70698ms step_avg:56.83ms
+step:1245/1490 train_time:70784ms step_avg:56.85ms
+step:1246/1490 train_time:70878ms step_avg:56.88ms
+step:1247/1490 train_time:70966ms step_avg:56.91ms
+step:1248/1490 train_time:71058ms step_avg:56.94ms
+step:1249/1490 train_time:71145ms step_avg:56.96ms
+step:1250/1490 train_time:71238ms step_avg:56.99ms
+step:1250/1490 val_loss:3.3721 train_time:71356ms step_avg:57.08ms
+step:1251/1490 train_time:71374ms step_avg:57.05ms
+step:1252/1490 train_time:71418ms step_avg:57.04ms
+step:1253/1490 train_time:71503ms step_avg:57.07ms
+step:1254/1490 train_time:71598ms step_avg:57.10ms
+step:1255/1490 train_time:71685ms step_avg:57.12ms
+step:1256/1490 train_time:71777ms step_avg:57.15ms
+step:1257/1490 train_time:71864ms step_avg:57.17ms
+step:1258/1490 train_time:71958ms step_avg:57.20ms
+step:1259/1490 train_time:72046ms step_avg:57.22ms
+step:1260/1490 train_time:72136ms step_avg:57.25ms
+step:1261/1490 train_time:72221ms step_avg:57.27ms
+step:1262/1490 train_time:72312ms step_avg:57.30ms
+step:1263/1490 train_time:72396ms step_avg:57.32ms
+step:1264/1490 train_time:72492ms step_avg:57.35ms
+step:1265/1490 train_time:72578ms step_avg:57.37ms
+step:1266/1490 train_time:72672ms step_avg:57.40ms
+step:1267/1490 train_time:72757ms step_avg:57.42ms
+step:1268/1490 train_time:72850ms step_avg:57.45ms
+step:1269/1490 train_time:72936ms step_avg:57.48ms
+step:1270/1490 train_time:73031ms step_avg:57.51ms
+step:1271/1490 train_time:73117ms step_avg:57.53ms
+step:1272/1490 train_time:73213ms step_avg:57.56ms
+step:1273/1490 train_time:73299ms step_avg:57.58ms
+step:1274/1490 train_time:73395ms step_avg:57.61ms
+step:1275/1490 train_time:73480ms step_avg:57.63ms
+step:1276/1490 train_time:73572ms step_avg:57.66ms
+step:1277/1490 train_time:73657ms step_avg:57.68ms
+step:1278/1490 train_time:73750ms step_avg:57.71ms
+step:1279/1490 train_time:73834ms step_avg:57.73ms
+step:1280/1490 train_time:73928ms step_avg:57.76ms
+step:1281/1490 train_time:74012ms step_avg:57.78ms
+step:1282/1490 train_time:74103ms step_avg:57.80ms
+step:1283/1490 train_time:74189ms step_avg:57.82ms
+step:1284/1490 train_time:74278ms step_avg:57.85ms
+step:1285/1490 train_time:74363ms step_avg:57.87ms
+step:1286/1490 train_time:74455ms step_avg:57.90ms
+step:1287/1490 train_time:74540ms step_avg:57.92ms
+step:1288/1490 train_time:74634ms step_avg:57.95ms
+step:1289/1490 train_time:74719ms step_avg:57.97ms
+step:1290/1490 train_time:74809ms step_avg:57.99ms
+step:1291/1490 train_time:74893ms step_avg:58.01ms
+step:1292/1490 train_time:74988ms step_avg:58.04ms
+step:1293/1490 train_time:75073ms step_avg:58.06ms
+step:1294/1490 train_time:75168ms step_avg:58.09ms
+step:1295/1490 train_time:75257ms step_avg:58.11ms
+step:1296/1490 train_time:75352ms step_avg:58.14ms
+step:1297/1490 train_time:75439ms step_avg:58.16ms
+step:1298/1490 train_time:75536ms step_avg:58.19ms
+step:1299/1490 train_time:75624ms step_avg:58.22ms
+step:1300/1490 train_time:75719ms step_avg:58.25ms
+step:1301/1490 train_time:75807ms step_avg:58.27ms
+step:1302/1490 train_time:75903ms step_avg:58.30ms
+step:1303/1490 train_time:75985ms step_avg:58.32ms
+step:1304/1490 train_time:76074ms step_avg:58.34ms
+step:1305/1490 train_time:76165ms step_avg:58.36ms
+step:1306/1490 train_time:76258ms step_avg:58.39ms
+step:1307/1490 train_time:76345ms step_avg:58.41ms
+step:1308/1490 train_time:76435ms step_avg:58.44ms
+step:1309/1490 train_time:76522ms step_avg:58.46ms
+step:1310/1490 train_time:76615ms step_avg:58.48ms
+step:1311/1490 train_time:76709ms step_avg:58.51ms
+step:1312/1490 train_time:76808ms step_avg:58.54ms
+step:1313/1490 train_time:76900ms step_avg:58.57ms
+step:1314/1490 train_time:76999ms step_avg:58.60ms
+step:1315/1490 train_time:77091ms step_avg:58.62ms
+step:1316/1490 train_time:77189ms step_avg:58.65ms
+step:1317/1490 train_time:77281ms step_avg:58.68ms
+step:1318/1490 train_time:77380ms step_avg:58.71ms
+step:1319/1490 train_time:77472ms step_avg:58.74ms
+step:1320/1490 train_time:77569ms step_avg:58.76ms
+step:1321/1490 train_time:77648ms step_avg:58.78ms
+step:1322/1490 train_time:77736ms step_avg:58.80ms
+step:1323/1490 train_time:77822ms step_avg:58.82ms
+step:1324/1490 train_time:77914ms step_avg:58.85ms
+step:1325/1490 train_time:78000ms step_avg:58.87ms
+step:1326/1490 train_time:78094ms step_avg:58.89ms
+step:1327/1490 train_time:78180ms step_avg:58.91ms
+step:1328/1490 train_time:78270ms step_avg:58.94ms
+step:1329/1490 train_time:78354ms step_avg:58.96ms
+step:1330/1490 train_time:78446ms step_avg:58.98ms
+step:1331/1490 train_time:78532ms step_avg:59.00ms
+step:1332/1490 train_time:78623ms step_avg:59.03ms
+step:1333/1490 train_time:78708ms step_avg:59.05ms
+step:1334/1490 train_time:78802ms step_avg:59.07ms
+step:1335/1490 train_time:78892ms step_avg:59.09ms
+step:1336/1490 train_time:78984ms step_avg:59.12ms
+step:1337/1490 train_time:79070ms step_avg:59.14ms
+step:1338/1490 train_time:79162ms step_avg:59.16ms
+step:1339/1490 train_time:79249ms step_avg:59.19ms
+step:1340/1490 train_time:79341ms step_avg:59.21ms
+step:1341/1490 train_time:79428ms step_avg:59.23ms
+step:1342/1490 train_time:79518ms step_avg:59.25ms
+step:1343/1490 train_time:79603ms step_avg:59.27ms
+step:1344/1490 train_time:79694ms step_avg:59.30ms
+step:1345/1490 train_time:79777ms step_avg:59.31ms
+step:1346/1490 train_time:79870ms step_avg:59.34ms
+step:1347/1490 train_time:79957ms step_avg:59.36ms
+step:1348/1490 train_time:80052ms step_avg:59.39ms
+step:1349/1490 train_time:80142ms step_avg:59.41ms
+step:1350/1490 train_time:80240ms step_avg:59.44ms
+step:1351/1490 train_time:80332ms step_avg:59.46ms
+step:1352/1490 train_time:80427ms step_avg:59.49ms
+step:1353/1490 train_time:80517ms step_avg:59.51ms
+step:1354/1490 train_time:80614ms step_avg:59.54ms
+step:1355/1490 train_time:80695ms step_avg:59.55ms
+step:1356/1490 train_time:80789ms step_avg:59.58ms
+step:1357/1490 train_time:80877ms step_avg:59.60ms
+step:1358/1490 train_time:80969ms step_avg:59.62ms
+step:1359/1490 train_time:81055ms step_avg:59.64ms
+step:1360/1490 train_time:81148ms step_avg:59.67ms
+step:1361/1490 train_time:81236ms step_avg:59.69ms
+step:1362/1490 train_time:81330ms step_avg:59.71ms
+step:1363/1490 train_time:81419ms step_avg:59.74ms
+step:1364/1490 train_time:81515ms step_avg:59.76ms
+step:1365/1490 train_time:81602ms step_avg:59.78ms
+step:1366/1490 train_time:81693ms step_avg:59.80ms
+step:1367/1490 train_time:81782ms step_avg:59.83ms
+step:1368/1490 train_time:81874ms step_avg:59.85ms
+step:1369/1490 train_time:81959ms step_avg:59.87ms
+step:1370/1490 train_time:82053ms step_avg:59.89ms
+step:1371/1490 train_time:82140ms step_avg:59.91ms
+step:1372/1490 train_time:82233ms step_avg:59.94ms
+step:1373/1490 train_time:82319ms step_avg:59.96ms
+step:1374/1490 train_time:82412ms step_avg:59.98ms
+step:1375/1490 train_time:82498ms step_avg:60.00ms
+step:1376/1490 train_time:82593ms step_avg:60.02ms
+step:1377/1490 train_time:82677ms step_avg:60.04ms
+step:1378/1490 train_time:82769ms step_avg:60.06ms
+step:1379/1490 train_time:82854ms step_avg:60.08ms
+step:1380/1490 train_time:82949ms step_avg:60.11ms
+step:1381/1490 train_time:83035ms step_avg:60.13ms
+step:1382/1490 train_time:83130ms step_avg:60.15ms
+step:1383/1490 train_time:83218ms step_avg:60.17ms
+step:1384/1490 train_time:83314ms step_avg:60.20ms
+step:1385/1490 train_time:83403ms step_avg:60.22ms
+step:1386/1490 train_time:83498ms step_avg:60.24ms
+step:1387/1490 train_time:83588ms step_avg:60.27ms
+step:1388/1490 train_time:83683ms step_avg:60.29ms
+step:1389/1490 train_time:83772ms step_avg:60.31ms
+step:1390/1490 train_time:83868ms step_avg:60.34ms
+step:1391/1490 train_time:83956ms step_avg:60.36ms
+step:1392/1490 train_time:84052ms step_avg:60.38ms
+step:1393/1490 train_time:84140ms step_avg:60.40ms
+step:1394/1490 train_time:84234ms step_avg:60.43ms
+step:1395/1490 train_time:84322ms step_avg:60.45ms
+step:1396/1490 train_time:84416ms step_avg:60.47ms
+step:1397/1490 train_time:84504ms step_avg:60.49ms
+step:1398/1490 train_time:84593ms step_avg:60.51ms
+step:1399/1490 train_time:84675ms step_avg:60.53ms
+step:1400/1490 train_time:84772ms step_avg:60.55ms
+step:1401/1490 train_time:84859ms step_avg:60.57ms
+step:1402/1490 train_time:84953ms step_avg:60.59ms
+step:1403/1490 train_time:85037ms step_avg:60.61ms
+step:1404/1490 train_time:85129ms step_avg:60.63ms
+step:1405/1490 train_time:85214ms step_avg:60.65ms
+step:1406/1490 train_time:85307ms step_avg:60.67ms
+step:1407/1490 train_time:85399ms step_avg:60.70ms
+step:1408/1490 train_time:85503ms step_avg:60.73ms
+step:1409/1490 train_time:85599ms step_avg:60.75ms
+step:1410/1490 train_time:85703ms step_avg:60.78ms
+step:1411/1490 train_time:85792ms step_avg:60.80ms
+step:1412/1490 train_time:85877ms step_avg:60.82ms
+step:1413/1490 train_time:85958ms step_avg:60.83ms
+step:1414/1490 train_time:86045ms step_avg:60.85ms
+step:1415/1490 train_time:86131ms step_avg:60.87ms
+step:1416/1490 train_time:86228ms step_avg:60.90ms
+step:1417/1490 train_time:86316ms step_avg:60.91ms
+step:1418/1490 train_time:86409ms step_avg:60.94ms
+step:1419/1490 train_time:86497ms step_avg:60.96ms
+step:1420/1490 train_time:86592ms step_avg:60.98ms
+step:1421/1490 train_time:86677ms step_avg:61.00ms
+step:1422/1490 train_time:86772ms step_avg:61.02ms
+step:1423/1490 train_time:86859ms step_avg:61.04ms
+step:1424/1490 train_time:86954ms step_avg:61.06ms
+step:1425/1490 train_time:87039ms step_avg:61.08ms
+step:1426/1490 train_time:87135ms step_avg:61.10ms
+step:1427/1490 train_time:87221ms step_avg:61.12ms
+step:1428/1490 train_time:87315ms step_avg:61.15ms
+step:1429/1490 train_time:87402ms step_avg:61.16ms
+step:1430/1490 train_time:87496ms step_avg:61.19ms
+step:1431/1490 train_time:87582ms step_avg:61.20ms
+step:1432/1490 train_time:87673ms step_avg:61.22ms
+step:1433/1490 train_time:87759ms step_avg:61.24ms
+step:1434/1490 train_time:87853ms step_avg:61.26ms
+step:1435/1490 train_time:87937ms step_avg:61.28ms
+step:1436/1490 train_time:88031ms step_avg:61.30ms
+step:1437/1490 train_time:88116ms step_avg:61.32ms
+step:1438/1490 train_time:88213ms step_avg:61.34ms
+step:1439/1490 train_time:88299ms step_avg:61.36ms
+step:1440/1490 train_time:88392ms step_avg:61.38ms
+step:1441/1490 train_time:88479ms step_avg:61.40ms
+step:1442/1490 train_time:88574ms step_avg:61.42ms
+step:1443/1490 train_time:88659ms step_avg:61.44ms
+step:1444/1490 train_time:88753ms step_avg:61.46ms
+step:1445/1490 train_time:88838ms step_avg:61.48ms
+step:1446/1490 train_time:88930ms step_avg:61.50ms
+step:1447/1490 train_time:89013ms step_avg:61.52ms
+step:1448/1490 train_time:89102ms step_avg:61.53ms
+step:1449/1490 train_time:89189ms step_avg:61.55ms
+step:1450/1490 train_time:89280ms step_avg:61.57ms
+step:1451/1490 train_time:89371ms step_avg:61.59ms
+step:1452/1490 train_time:89466ms step_avg:61.62ms
+step:1453/1490 train_time:89553ms step_avg:61.63ms
+step:1454/1490 train_time:89647ms step_avg:61.66ms
+step:1455/1490 train_time:89732ms step_avg:61.67ms
+step:1456/1490 train_time:89827ms step_avg:61.69ms
+step:1457/1490 train_time:89914ms step_avg:61.71ms
+step:1458/1490 train_time:90009ms step_avg:61.73ms
+step:1459/1490 train_time:90096ms step_avg:61.75ms
+step:1460/1490 train_time:90191ms step_avg:61.77ms
+step:1461/1490 train_time:90277ms step_avg:61.79ms
+step:1462/1490 train_time:90367ms step_avg:61.81ms
+step:1463/1490 train_time:90450ms step_avg:61.83ms
+step:1464/1490 train_time:90540ms step_avg:61.84ms
+step:1465/1490 train_time:90627ms step_avg:61.86ms
+step:1466/1490 train_time:90722ms step_avg:61.88ms
+step:1467/1490 train_time:90811ms step_avg:61.90ms
+step:1468/1490 train_time:90907ms step_avg:61.93ms
+step:1469/1490 train_time:90995ms step_avg:61.94ms
+step:1470/1490 train_time:91091ms step_avg:61.97ms
+step:1471/1490 train_time:91180ms step_avg:61.98ms
+step:1472/1490 train_time:91275ms step_avg:62.01ms
+step:1473/1490 train_time:91366ms step_avg:62.03ms
+step:1474/1490 train_time:91461ms step_avg:62.05ms
+step:1475/1490 train_time:91551ms step_avg:62.07ms
+step:1476/1490 train_time:91647ms step_avg:62.09ms
+step:1477/1490 train_time:91735ms step_avg:62.11ms
+step:1478/1490 train_time:91831ms step_avg:62.13ms
+step:1479/1490 train_time:91919ms step_avg:62.15ms
+step:1480/1490 train_time:92014ms step_avg:62.17ms
+step:1481/1490 train_time:92101ms step_avg:62.19ms
+step:1482/1490 train_time:92195ms step_avg:62.21ms
+step:1483/1490 train_time:92284ms step_avg:62.23ms
+step:1484/1490 train_time:92378ms step_avg:62.25ms
+step:1485/1490 train_time:92464ms step_avg:62.27ms
+step:1486/1490 train_time:92559ms step_avg:62.29ms
+step:1487/1490 train_time:92647ms step_avg:62.30ms
+step:1488/1490 train_time:92740ms step_avg:62.33ms
+step:1489/1490 train_time:92829ms step_avg:62.34ms
+step:1490/1490 train_time:92922ms step_avg:62.36ms
+step:1490/1490 val_loss:3.2796 train_time:93043ms step_avg:62.44ms
+peak memory allocated: 31296 MiB reserved: 47162 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline3-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline3-1480.txt
@@ -1,0 +1,4447 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:23:53 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   41C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   35C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   40C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   35C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   40C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   37C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   67C    P0            152W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          338878      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          338879      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          338880      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          338881      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          338882      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          338883      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          338884      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          338885      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8293 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:100ms step_avg:100.38ms
+step:2/1480 train_time:127ms step_avg:63.62ms
+step:3/1480 train_time:144ms step_avg:47.96ms
+step:4/1480 train_time:162ms step_avg:40.49ms
+step:5/1480 train_time:185ms step_avg:37.00ms
+step:6/1480 train_time:219ms step_avg:36.56ms
+step:7/1480 train_time:247ms step_avg:35.31ms
+step:8/1480 train_time:281ms step_avg:35.18ms
+step:9/1480 train_time:310ms step_avg:34.43ms
+step:10/1480 train_time:345ms step_avg:34.50ms
+step:11/1480 train_time:373ms step_avg:33.91ms
+step:12/1480 train_time:408ms step_avg:34.01ms
+step:13/1480 train_time:436ms step_avg:33.54ms
+step:14/1480 train_time:471ms step_avg:33.65ms
+step:15/1480 train_time:499ms step_avg:33.25ms
+step:16/1480 train_time:533ms step_avg:33.34ms
+step:17/1480 train_time:562ms step_avg:33.04ms
+step:18/1480 train_time:598ms step_avg:33.20ms
+step:19/1480 train_time:626ms step_avg:32.93ms
+step:20/1480 train_time:661ms step_avg:33.05ms
+step:21/1480 train_time:689ms step_avg:32.82ms
+step:22/1480 train_time:724ms step_avg:32.90ms
+step:23/1480 train_time:753ms step_avg:32.75ms
+step:24/1480 train_time:789ms step_avg:32.87ms
+step:25/1480 train_time:817ms step_avg:32.69ms
+step:26/1480 train_time:853ms step_avg:32.80ms
+step:27/1480 train_time:881ms step_avg:32.64ms
+step:28/1480 train_time:918ms step_avg:32.78ms
+step:29/1480 train_time:947ms step_avg:32.65ms
+step:30/1480 train_time:983ms step_avg:32.78ms
+step:31/1480 train_time:1014ms step_avg:32.71ms
+step:32/1480 train_time:1051ms step_avg:32.84ms
+step:33/1480 train_time:1080ms step_avg:32.73ms
+step:34/1480 train_time:1116ms step_avg:32.82ms
+step:35/1480 train_time:1145ms step_avg:32.71ms
+step:36/1480 train_time:1180ms step_avg:32.77ms
+step:37/1480 train_time:1208ms step_avg:32.66ms
+step:38/1480 train_time:1244ms step_avg:32.75ms
+step:39/1480 train_time:1273ms step_avg:32.64ms
+step:40/1480 train_time:1308ms step_avg:32.71ms
+step:41/1480 train_time:1337ms step_avg:32.60ms
+step:42/1480 train_time:1372ms step_avg:32.67ms
+step:43/1480 train_time:1401ms step_avg:32.59ms
+step:44/1480 train_time:1437ms step_avg:32.65ms
+step:45/1480 train_time:1466ms step_avg:32.58ms
+step:46/1480 train_time:1502ms step_avg:32.64ms
+step:47/1480 train_time:1530ms step_avg:32.56ms
+step:48/1480 train_time:1566ms step_avg:32.62ms
+step:49/1480 train_time:1594ms step_avg:32.53ms
+step:50/1480 train_time:1629ms step_avg:32.58ms
+step:51/1480 train_time:1658ms step_avg:32.51ms
+step:52/1480 train_time:1694ms step_avg:32.57ms
+step:53/1480 train_time:1724ms step_avg:32.52ms
+step:54/1480 train_time:1759ms step_avg:32.58ms
+step:55/1480 train_time:1789ms step_avg:32.53ms
+step:56/1480 train_time:1825ms step_avg:32.59ms
+step:57/1480 train_time:1854ms step_avg:32.53ms
+step:58/1480 train_time:1891ms step_avg:32.61ms
+step:59/1480 train_time:1921ms step_avg:32.56ms
+step:60/1480 train_time:1958ms step_avg:32.63ms
+step:61/1480 train_time:1988ms step_avg:32.60ms
+step:62/1480 train_time:2025ms step_avg:32.66ms
+step:63/1480 train_time:2055ms step_avg:32.61ms
+step:64/1480 train_time:2092ms step_avg:32.69ms
+step:65/1480 train_time:2122ms step_avg:32.64ms
+step:66/1480 train_time:2156ms step_avg:32.67ms
+step:67/1480 train_time:2185ms step_avg:32.61ms
+step:68/1480 train_time:2221ms step_avg:32.66ms
+step:69/1480 train_time:2249ms step_avg:32.60ms
+step:70/1480 train_time:2285ms step_avg:32.65ms
+step:71/1480 train_time:2316ms step_avg:32.61ms
+step:72/1480 train_time:2355ms step_avg:32.71ms
+step:73/1480 train_time:2388ms step_avg:32.72ms
+step:74/1480 train_time:2427ms step_avg:32.80ms
+step:75/1480 train_time:2458ms step_avg:32.78ms
+step:76/1480 train_time:2497ms step_avg:32.85ms
+step:77/1480 train_time:2527ms step_avg:32.82ms
+step:78/1480 train_time:2561ms step_avg:32.84ms
+step:79/1480 train_time:2590ms step_avg:32.78ms
+step:80/1480 train_time:2624ms step_avg:32.80ms
+step:81/1480 train_time:2652ms step_avg:32.75ms
+step:82/1480 train_time:2687ms step_avg:32.77ms
+step:83/1480 train_time:2718ms step_avg:32.74ms
+step:84/1480 train_time:2755ms step_avg:32.80ms
+step:85/1480 train_time:2787ms step_avg:32.79ms
+step:86/1480 train_time:2825ms step_avg:32.84ms
+step:87/1480 train_time:2855ms step_avg:32.81ms
+step:88/1480 train_time:2893ms step_avg:32.87ms
+step:89/1480 train_time:2924ms step_avg:32.85ms
+step:90/1480 train_time:2960ms step_avg:32.89ms
+step:91/1480 train_time:2991ms step_avg:32.87ms
+step:92/1480 train_time:3028ms step_avg:32.92ms
+step:93/1480 train_time:3059ms step_avg:32.89ms
+step:94/1480 train_time:3096ms step_avg:32.94ms
+step:95/1480 train_time:3127ms step_avg:32.92ms
+step:96/1480 train_time:3162ms step_avg:32.94ms
+step:97/1480 train_time:3190ms step_avg:32.89ms
+step:98/1480 train_time:3225ms step_avg:32.91ms
+step:99/1480 train_time:3254ms step_avg:32.87ms
+step:100/1480 train_time:3289ms step_avg:32.89ms
+step:101/1480 train_time:3318ms step_avg:32.85ms
+step:102/1480 train_time:3353ms step_avg:32.87ms
+step:103/1480 train_time:3382ms step_avg:32.84ms
+step:104/1480 train_time:3418ms step_avg:32.86ms
+step:105/1480 train_time:3447ms step_avg:32.83ms
+step:106/1480 train_time:3483ms step_avg:32.85ms
+step:107/1480 train_time:3512ms step_avg:32.82ms
+step:108/1480 train_time:3548ms step_avg:32.85ms
+step:109/1480 train_time:3577ms step_avg:32.82ms
+step:110/1480 train_time:3613ms step_avg:32.85ms
+step:111/1480 train_time:3643ms step_avg:32.82ms
+step:112/1480 train_time:3679ms step_avg:32.84ms
+step:113/1480 train_time:3709ms step_avg:32.82ms
+step:114/1480 train_time:3745ms step_avg:32.85ms
+step:115/1480 train_time:3774ms step_avg:32.82ms
+step:116/1480 train_time:3811ms step_avg:32.85ms
+step:117/1480 train_time:3840ms step_avg:32.82ms
+step:118/1480 train_time:3876ms step_avg:32.84ms
+step:119/1480 train_time:3906ms step_avg:32.82ms
+step:120/1480 train_time:3941ms step_avg:32.85ms
+step:121/1480 train_time:3971ms step_avg:32.82ms
+step:122/1480 train_time:4007ms step_avg:32.85ms
+step:123/1480 train_time:4037ms step_avg:32.82ms
+step:124/1480 train_time:4073ms step_avg:32.85ms
+step:125/1480 train_time:4103ms step_avg:32.83ms
+step:126/1480 train_time:4139ms step_avg:32.85ms
+step:127/1480 train_time:4169ms step_avg:32.83ms
+step:128/1480 train_time:4205ms step_avg:32.85ms
+step:129/1480 train_time:4235ms step_avg:32.83ms
+step:130/1480 train_time:4271ms step_avg:32.85ms
+step:131/1480 train_time:4301ms step_avg:32.83ms
+step:132/1480 train_time:4337ms step_avg:32.85ms
+step:133/1480 train_time:4367ms step_avg:32.83ms
+step:134/1480 train_time:4403ms step_avg:32.86ms
+step:135/1480 train_time:4432ms step_avg:32.83ms
+step:136/1480 train_time:4468ms step_avg:32.86ms
+step:137/1480 train_time:4497ms step_avg:32.83ms
+step:138/1480 train_time:4534ms step_avg:32.85ms
+step:139/1480 train_time:4564ms step_avg:32.83ms
+step:140/1480 train_time:4599ms step_avg:32.85ms
+step:141/1480 train_time:4628ms step_avg:32.83ms
+step:142/1480 train_time:4665ms step_avg:32.85ms
+step:143/1480 train_time:4694ms step_avg:32.82ms
+step:144/1480 train_time:4730ms step_avg:32.85ms
+step:145/1480 train_time:4759ms step_avg:32.82ms
+step:146/1480 train_time:4796ms step_avg:32.85ms
+step:147/1480 train_time:4826ms step_avg:32.83ms
+step:148/1480 train_time:4862ms step_avg:32.85ms
+step:149/1480 train_time:4892ms step_avg:32.83ms
+step:150/1480 train_time:4929ms step_avg:32.86ms
+step:151/1480 train_time:4958ms step_avg:32.84ms
+step:152/1480 train_time:4995ms step_avg:32.86ms
+step:153/1480 train_time:5026ms step_avg:32.85ms
+step:154/1480 train_time:5062ms step_avg:32.87ms
+step:155/1480 train_time:5092ms step_avg:32.85ms
+step:156/1480 train_time:5128ms step_avg:32.87ms
+step:157/1480 train_time:5158ms step_avg:32.85ms
+step:158/1480 train_time:5195ms step_avg:32.88ms
+step:159/1480 train_time:5225ms step_avg:32.86ms
+step:160/1480 train_time:5261ms step_avg:32.88ms
+step:161/1480 train_time:5291ms step_avg:32.87ms
+step:162/1480 train_time:5328ms step_avg:32.89ms
+step:163/1480 train_time:5358ms step_avg:32.87ms
+step:164/1480 train_time:5394ms step_avg:32.89ms
+step:165/1480 train_time:5425ms step_avg:32.88ms
+step:166/1480 train_time:5461ms step_avg:32.90ms
+step:167/1480 train_time:5491ms step_avg:32.88ms
+step:168/1480 train_time:5528ms step_avg:32.90ms
+step:169/1480 train_time:5558ms step_avg:32.88ms
+step:170/1480 train_time:5594ms step_avg:32.91ms
+step:171/1480 train_time:5625ms step_avg:32.89ms
+step:172/1480 train_time:5661ms step_avg:32.91ms
+step:173/1480 train_time:5691ms step_avg:32.90ms
+step:174/1480 train_time:5728ms step_avg:32.92ms
+step:175/1480 train_time:5757ms step_avg:32.90ms
+step:176/1480 train_time:5794ms step_avg:32.92ms
+step:177/1480 train_time:5824ms step_avg:32.91ms
+step:178/1480 train_time:5861ms step_avg:32.92ms
+step:179/1480 train_time:5891ms step_avg:32.91ms
+step:180/1480 train_time:5927ms step_avg:32.93ms
+step:181/1480 train_time:5957ms step_avg:32.91ms
+step:182/1480 train_time:5994ms step_avg:32.93ms
+step:183/1480 train_time:6024ms step_avg:32.92ms
+step:184/1480 train_time:6060ms step_avg:32.94ms
+step:185/1480 train_time:6090ms step_avg:32.92ms
+step:186/1480 train_time:6127ms step_avg:32.94ms
+step:187/1480 train_time:6156ms step_avg:32.92ms
+step:188/1480 train_time:6193ms step_avg:32.94ms
+step:189/1480 train_time:6223ms step_avg:32.93ms
+step:190/1480 train_time:6259ms step_avg:32.94ms
+step:191/1480 train_time:6289ms step_avg:32.93ms
+step:192/1480 train_time:6326ms step_avg:32.95ms
+step:193/1480 train_time:6356ms step_avg:32.93ms
+step:194/1480 train_time:6393ms step_avg:32.95ms
+step:195/1480 train_time:6422ms step_avg:32.93ms
+step:196/1480 train_time:6456ms step_avg:32.94ms
+step:197/1480 train_time:6485ms step_avg:32.92ms
+step:198/1480 train_time:6521ms step_avg:32.93ms
+step:199/1480 train_time:6550ms step_avg:32.92ms
+step:200/1480 train_time:6587ms step_avg:32.93ms
+step:201/1480 train_time:6617ms step_avg:32.92ms
+step:202/1480 train_time:6656ms step_avg:32.95ms
+step:203/1480 train_time:6689ms step_avg:32.95ms
+step:204/1480 train_time:6728ms step_avg:32.98ms
+step:205/1480 train_time:6759ms step_avg:32.97ms
+step:206/1480 train_time:6796ms step_avg:32.99ms
+step:207/1480 train_time:6827ms step_avg:32.98ms
+step:208/1480 train_time:6866ms step_avg:33.01ms
+step:209/1480 train_time:6898ms step_avg:33.01ms
+step:210/1480 train_time:6937ms step_avg:33.03ms
+step:211/1480 train_time:6968ms step_avg:33.02ms
+step:212/1480 train_time:7006ms step_avg:33.05ms
+step:213/1480 train_time:7036ms step_avg:33.03ms
+step:214/1480 train_time:7074ms step_avg:33.06ms
+step:215/1480 train_time:7105ms step_avg:33.05ms
+step:216/1480 train_time:7143ms step_avg:33.07ms
+step:217/1480 train_time:7174ms step_avg:33.06ms
+step:218/1480 train_time:7212ms step_avg:33.08ms
+step:219/1480 train_time:7242ms step_avg:33.07ms
+step:220/1480 train_time:7277ms step_avg:33.08ms
+step:221/1480 train_time:7305ms step_avg:33.05ms
+step:222/1480 train_time:7339ms step_avg:33.06ms
+step:223/1480 train_time:7367ms step_avg:33.04ms
+step:224/1480 train_time:7402ms step_avg:33.05ms
+step:225/1480 train_time:7432ms step_avg:33.03ms
+step:226/1480 train_time:7469ms step_avg:33.05ms
+step:227/1480 train_time:7499ms step_avg:33.04ms
+step:228/1480 train_time:7539ms step_avg:33.06ms
+step:229/1480 train_time:7569ms step_avg:33.05ms
+step:230/1480 train_time:7609ms step_avg:33.08ms
+step:231/1480 train_time:7641ms step_avg:33.08ms
+step:232/1480 train_time:7679ms step_avg:33.10ms
+step:233/1480 train_time:7711ms step_avg:33.09ms
+step:234/1480 train_time:7749ms step_avg:33.12ms
+step:235/1480 train_time:7781ms step_avg:33.11ms
+step:236/1480 train_time:7819ms step_avg:33.13ms
+step:237/1480 train_time:7849ms step_avg:33.12ms
+step:238/1480 train_time:7883ms step_avg:33.12ms
+step:239/1480 train_time:7915ms step_avg:33.12ms
+step:240/1480 train_time:7951ms step_avg:33.13ms
+step:241/1480 train_time:7980ms step_avg:33.11ms
+step:242/1480 train_time:8019ms step_avg:33.14ms
+step:243/1480 train_time:8049ms step_avg:33.12ms
+step:244/1480 train_time:8084ms step_avg:33.13ms
+step:245/1480 train_time:8114ms step_avg:33.12ms
+step:246/1480 train_time:8150ms step_avg:33.13ms
+step:247/1480 train_time:8179ms step_avg:33.12ms
+step:248/1480 train_time:8215ms step_avg:33.13ms
+step:249/1480 train_time:8245ms step_avg:33.11ms
+step:250/1480 train_time:8281ms step_avg:33.12ms
+step:250/1480 val_loss:4.4947 train_time:8331ms step_avg:33.32ms
+step:251/1480 train_time:8347ms step_avg:33.25ms
+step:252/1480 train_time:8365ms step_avg:33.19ms
+step:253/1480 train_time:8382ms step_avg:33.13ms
+step:254/1480 train_time:8419ms step_avg:33.15ms
+step:255/1480 train_time:8449ms step_avg:33.13ms
+step:256/1480 train_time:8486ms step_avg:33.15ms
+step:257/1480 train_time:8518ms step_avg:33.14ms
+step:258/1480 train_time:8555ms step_avg:33.16ms
+step:259/1480 train_time:8585ms step_avg:33.15ms
+step:260/1480 train_time:8622ms step_avg:33.16ms
+step:261/1480 train_time:8653ms step_avg:33.15ms
+step:262/1480 train_time:8689ms step_avg:33.17ms
+step:263/1480 train_time:8720ms step_avg:33.15ms
+step:264/1480 train_time:8757ms step_avg:33.17ms
+step:265/1480 train_time:8787ms step_avg:33.16ms
+step:266/1480 train_time:8824ms step_avg:33.17ms
+step:267/1480 train_time:8854ms step_avg:33.16ms
+step:268/1480 train_time:8891ms step_avg:33.18ms
+step:269/1480 train_time:8921ms step_avg:33.16ms
+step:270/1480 train_time:8958ms step_avg:33.18ms
+step:271/1480 train_time:8988ms step_avg:33.17ms
+step:272/1480 train_time:9025ms step_avg:33.18ms
+step:273/1480 train_time:9056ms step_avg:33.17ms
+step:274/1480 train_time:9092ms step_avg:33.18ms
+step:275/1480 train_time:9122ms step_avg:33.17ms
+step:276/1480 train_time:9159ms step_avg:33.18ms
+step:277/1480 train_time:9189ms step_avg:33.17ms
+step:278/1480 train_time:9225ms step_avg:33.18ms
+step:279/1480 train_time:9255ms step_avg:33.17ms
+step:280/1480 train_time:9291ms step_avg:33.18ms
+step:281/1480 train_time:9322ms step_avg:33.17ms
+step:282/1480 train_time:9358ms step_avg:33.19ms
+step:283/1480 train_time:9388ms step_avg:33.17ms
+step:284/1480 train_time:9425ms step_avg:33.18ms
+step:285/1480 train_time:9455ms step_avg:33.17ms
+step:286/1480 train_time:9491ms step_avg:33.18ms
+step:287/1480 train_time:9521ms step_avg:33.17ms
+step:288/1480 train_time:9557ms step_avg:33.18ms
+step:289/1480 train_time:9587ms step_avg:33.17ms
+step:290/1480 train_time:9623ms step_avg:33.18ms
+step:291/1480 train_time:9653ms step_avg:33.17ms
+step:292/1480 train_time:9689ms step_avg:33.18ms
+step:293/1480 train_time:9719ms step_avg:33.17ms
+step:294/1480 train_time:9756ms step_avg:33.18ms
+step:295/1480 train_time:9785ms step_avg:33.17ms
+step:296/1480 train_time:9822ms step_avg:33.18ms
+step:297/1480 train_time:9852ms step_avg:33.17ms
+step:298/1480 train_time:9888ms step_avg:33.18ms
+step:299/1480 train_time:9918ms step_avg:33.17ms
+step:300/1480 train_time:9954ms step_avg:33.18ms
+step:301/1480 train_time:9983ms step_avg:33.17ms
+step:302/1480 train_time:10020ms step_avg:33.18ms
+step:303/1480 train_time:10050ms step_avg:33.17ms
+step:304/1480 train_time:10086ms step_avg:33.18ms
+step:305/1480 train_time:10117ms step_avg:33.17ms
+step:306/1480 train_time:10153ms step_avg:33.18ms
+step:307/1480 train_time:10182ms step_avg:33.17ms
+step:308/1480 train_time:10219ms step_avg:33.18ms
+step:309/1480 train_time:10249ms step_avg:33.17ms
+step:310/1480 train_time:10286ms step_avg:33.18ms
+step:311/1480 train_time:10316ms step_avg:33.17ms
+step:312/1480 train_time:10352ms step_avg:33.18ms
+step:313/1480 train_time:10381ms step_avg:33.17ms
+step:314/1480 train_time:10417ms step_avg:33.18ms
+step:315/1480 train_time:10447ms step_avg:33.17ms
+step:316/1480 train_time:10484ms step_avg:33.18ms
+step:317/1480 train_time:10514ms step_avg:33.17ms
+step:318/1480 train_time:10549ms step_avg:33.17ms
+step:319/1480 train_time:10580ms step_avg:33.16ms
+step:320/1480 train_time:10616ms step_avg:33.18ms
+step:321/1480 train_time:10646ms step_avg:33.16ms
+step:322/1480 train_time:10682ms step_avg:33.17ms
+step:323/1480 train_time:10712ms step_avg:33.16ms
+step:324/1480 train_time:10748ms step_avg:33.17ms
+step:325/1480 train_time:10778ms step_avg:33.16ms
+step:326/1480 train_time:10815ms step_avg:33.17ms
+step:327/1480 train_time:10844ms step_avg:33.16ms
+step:328/1480 train_time:10881ms step_avg:33.17ms
+step:329/1480 train_time:10910ms step_avg:33.16ms
+step:330/1480 train_time:10946ms step_avg:33.17ms
+step:331/1480 train_time:10976ms step_avg:33.16ms
+step:332/1480 train_time:11012ms step_avg:33.17ms
+step:333/1480 train_time:11042ms step_avg:33.16ms
+step:334/1480 train_time:11078ms step_avg:33.17ms
+step:335/1480 train_time:11107ms step_avg:33.16ms
+step:336/1480 train_time:11143ms step_avg:33.16ms
+step:337/1480 train_time:11174ms step_avg:33.16ms
+step:338/1480 train_time:11209ms step_avg:33.16ms
+step:339/1480 train_time:11239ms step_avg:33.15ms
+step:340/1480 train_time:11275ms step_avg:33.16ms
+step:341/1480 train_time:11304ms step_avg:33.15ms
+step:342/1480 train_time:11340ms step_avg:33.16ms
+step:343/1480 train_time:11370ms step_avg:33.15ms
+step:344/1480 train_time:11406ms step_avg:33.16ms
+step:345/1480 train_time:11437ms step_avg:33.15ms
+step:346/1480 train_time:11473ms step_avg:33.16ms
+step:347/1480 train_time:11503ms step_avg:33.15ms
+step:348/1480 train_time:11540ms step_avg:33.16ms
+step:349/1480 train_time:11570ms step_avg:33.15ms
+step:350/1480 train_time:11607ms step_avg:33.16ms
+step:351/1480 train_time:11637ms step_avg:33.15ms
+step:352/1480 train_time:11674ms step_avg:33.17ms
+step:353/1480 train_time:11704ms step_avg:33.16ms
+step:354/1480 train_time:11741ms step_avg:33.17ms
+step:355/1480 train_time:11771ms step_avg:33.16ms
+step:356/1480 train_time:11807ms step_avg:33.17ms
+step:357/1480 train_time:11838ms step_avg:33.16ms
+step:358/1480 train_time:11875ms step_avg:33.17ms
+step:359/1480 train_time:11905ms step_avg:33.16ms
+step:360/1480 train_time:11942ms step_avg:33.17ms
+step:361/1480 train_time:11973ms step_avg:33.17ms
+step:362/1480 train_time:12009ms step_avg:33.17ms
+step:363/1480 train_time:12040ms step_avg:33.17ms
+step:364/1480 train_time:12077ms step_avg:33.18ms
+step:365/1480 train_time:12107ms step_avg:33.17ms
+step:366/1480 train_time:12144ms step_avg:33.18ms
+step:367/1480 train_time:12175ms step_avg:33.17ms
+step:368/1480 train_time:12210ms step_avg:33.18ms
+step:369/1480 train_time:12240ms step_avg:33.17ms
+step:370/1480 train_time:12277ms step_avg:33.18ms
+step:371/1480 train_time:12307ms step_avg:33.17ms
+step:372/1480 train_time:12344ms step_avg:33.18ms
+step:373/1480 train_time:12374ms step_avg:33.17ms
+step:374/1480 train_time:12410ms step_avg:33.18ms
+step:375/1480 train_time:12441ms step_avg:33.18ms
+step:376/1480 train_time:12478ms step_avg:33.19ms
+step:377/1480 train_time:12508ms step_avg:33.18ms
+step:378/1480 train_time:12544ms step_avg:33.19ms
+step:379/1480 train_time:12574ms step_avg:33.18ms
+step:380/1480 train_time:12610ms step_avg:33.18ms
+step:381/1480 train_time:12641ms step_avg:33.18ms
+step:382/1480 train_time:12678ms step_avg:33.19ms
+step:383/1480 train_time:12707ms step_avg:33.18ms
+step:384/1480 train_time:12744ms step_avg:33.19ms
+step:385/1480 train_time:12774ms step_avg:33.18ms
+step:386/1480 train_time:12809ms step_avg:33.18ms
+step:387/1480 train_time:12840ms step_avg:33.18ms
+step:388/1480 train_time:12876ms step_avg:33.19ms
+step:389/1480 train_time:12906ms step_avg:33.18ms
+step:390/1480 train_time:12942ms step_avg:33.19ms
+step:391/1480 train_time:12972ms step_avg:33.18ms
+step:392/1480 train_time:13008ms step_avg:33.18ms
+step:393/1480 train_time:13039ms step_avg:33.18ms
+step:394/1480 train_time:13076ms step_avg:33.19ms
+step:395/1480 train_time:13105ms step_avg:33.18ms
+step:396/1480 train_time:13142ms step_avg:33.19ms
+step:397/1480 train_time:13172ms step_avg:33.18ms
+step:398/1480 train_time:13208ms step_avg:33.19ms
+step:399/1480 train_time:13239ms step_avg:33.18ms
+step:400/1480 train_time:13275ms step_avg:33.19ms
+step:401/1480 train_time:13305ms step_avg:33.18ms
+step:402/1480 train_time:13342ms step_avg:33.19ms
+step:403/1480 train_time:13372ms step_avg:33.18ms
+step:404/1480 train_time:13408ms step_avg:33.19ms
+step:405/1480 train_time:13439ms step_avg:33.18ms
+step:406/1480 train_time:13476ms step_avg:33.19ms
+step:407/1480 train_time:13505ms step_avg:33.18ms
+step:408/1480 train_time:13541ms step_avg:33.19ms
+step:409/1480 train_time:13571ms step_avg:33.18ms
+step:410/1480 train_time:13608ms step_avg:33.19ms
+step:411/1480 train_time:13638ms step_avg:33.18ms
+step:412/1480 train_time:13675ms step_avg:33.19ms
+step:413/1480 train_time:13705ms step_avg:33.18ms
+step:414/1480 train_time:13741ms step_avg:33.19ms
+step:415/1480 train_time:13771ms step_avg:33.18ms
+step:416/1480 train_time:13807ms step_avg:33.19ms
+step:417/1480 train_time:13837ms step_avg:33.18ms
+step:418/1480 train_time:13873ms step_avg:33.19ms
+step:419/1480 train_time:13903ms step_avg:33.18ms
+step:420/1480 train_time:13939ms step_avg:33.19ms
+step:421/1480 train_time:13969ms step_avg:33.18ms
+step:422/1480 train_time:14005ms step_avg:33.19ms
+step:423/1480 train_time:14035ms step_avg:33.18ms
+step:424/1480 train_time:14071ms step_avg:33.19ms
+step:425/1480 train_time:14101ms step_avg:33.18ms
+step:426/1480 train_time:14137ms step_avg:33.19ms
+step:427/1480 train_time:14166ms step_avg:33.18ms
+step:428/1480 train_time:14203ms step_avg:33.18ms
+step:429/1480 train_time:14233ms step_avg:33.18ms
+step:430/1480 train_time:14268ms step_avg:33.18ms
+step:431/1480 train_time:14298ms step_avg:33.17ms
+step:432/1480 train_time:14334ms step_avg:33.18ms
+step:433/1480 train_time:14363ms step_avg:33.17ms
+step:434/1480 train_time:14400ms step_avg:33.18ms
+step:435/1480 train_time:14429ms step_avg:33.17ms
+step:436/1480 train_time:14466ms step_avg:33.18ms
+step:437/1480 train_time:14496ms step_avg:33.17ms
+step:438/1480 train_time:14533ms step_avg:33.18ms
+step:439/1480 train_time:14562ms step_avg:33.17ms
+step:440/1480 train_time:14599ms step_avg:33.18ms
+step:441/1480 train_time:14629ms step_avg:33.17ms
+step:442/1480 train_time:14666ms step_avg:33.18ms
+step:443/1480 train_time:14696ms step_avg:33.17ms
+step:444/1480 train_time:14732ms step_avg:33.18ms
+step:445/1480 train_time:14763ms step_avg:33.17ms
+step:446/1480 train_time:14800ms step_avg:33.18ms
+step:447/1480 train_time:14830ms step_avg:33.18ms
+step:448/1480 train_time:14866ms step_avg:33.18ms
+step:449/1480 train_time:14897ms step_avg:33.18ms
+step:450/1480 train_time:14934ms step_avg:33.19ms
+step:451/1480 train_time:14964ms step_avg:33.18ms
+step:452/1480 train_time:15001ms step_avg:33.19ms
+step:453/1480 train_time:15030ms step_avg:33.18ms
+step:454/1480 train_time:15067ms step_avg:33.19ms
+step:455/1480 train_time:15097ms step_avg:33.18ms
+step:456/1480 train_time:15134ms step_avg:33.19ms
+step:457/1480 train_time:15164ms step_avg:33.18ms
+step:458/1480 train_time:15201ms step_avg:33.19ms
+step:459/1480 train_time:15231ms step_avg:33.18ms
+step:460/1480 train_time:15267ms step_avg:33.19ms
+step:461/1480 train_time:15298ms step_avg:33.18ms
+step:462/1480 train_time:15335ms step_avg:33.19ms
+step:463/1480 train_time:15364ms step_avg:33.18ms
+step:464/1480 train_time:15401ms step_avg:33.19ms
+step:465/1480 train_time:15431ms step_avg:33.19ms
+step:466/1480 train_time:15468ms step_avg:33.19ms
+step:467/1480 train_time:15498ms step_avg:33.19ms
+step:468/1480 train_time:15535ms step_avg:33.19ms
+step:469/1480 train_time:15564ms step_avg:33.19ms
+step:470/1480 train_time:15602ms step_avg:33.20ms
+step:471/1480 train_time:15632ms step_avg:33.19ms
+step:472/1480 train_time:15669ms step_avg:33.20ms
+step:473/1480 train_time:15699ms step_avg:33.19ms
+step:474/1480 train_time:15735ms step_avg:33.20ms
+step:475/1480 train_time:15765ms step_avg:33.19ms
+step:476/1480 train_time:15802ms step_avg:33.20ms
+step:477/1480 train_time:15833ms step_avg:33.19ms
+step:478/1480 train_time:15869ms step_avg:33.20ms
+step:479/1480 train_time:15900ms step_avg:33.19ms
+step:480/1480 train_time:15936ms step_avg:33.20ms
+step:481/1480 train_time:15969ms step_avg:33.20ms
+step:482/1480 train_time:16029ms step_avg:33.25ms
+step:483/1480 train_time:16088ms step_avg:33.31ms
+step:484/1480 train_time:16154ms step_avg:33.38ms
+step:485/1480 train_time:16211ms step_avg:33.42ms
+step:486/1480 train_time:16276ms step_avg:33.49ms
+step:487/1480 train_time:16332ms step_avg:33.54ms
+step:488/1480 train_time:16397ms step_avg:33.60ms
+step:489/1480 train_time:16455ms step_avg:33.65ms
+step:490/1480 train_time:16518ms step_avg:33.71ms
+step:491/1480 train_time:16576ms step_avg:33.76ms
+step:492/1480 train_time:16640ms step_avg:33.82ms
+step:493/1480 train_time:16699ms step_avg:33.87ms
+step:494/1480 train_time:16763ms step_avg:33.93ms
+step:495/1480 train_time:16822ms step_avg:33.98ms
+step:496/1480 train_time:16887ms step_avg:34.05ms
+step:497/1480 train_time:16946ms step_avg:34.10ms
+step:498/1480 train_time:17010ms step_avg:34.16ms
+step:499/1480 train_time:17068ms step_avg:34.21ms
+step:500/1480 train_time:17132ms step_avg:34.26ms
+step:500/1480 val_loss:4.2219 train_time:17213ms step_avg:34.43ms
+step:501/1480 train_time:17230ms step_avg:34.39ms
+step:502/1480 train_time:17255ms step_avg:34.37ms
+step:503/1480 train_time:17311ms step_avg:34.42ms
+step:504/1480 train_time:17375ms step_avg:34.47ms
+step:505/1480 train_time:17434ms step_avg:34.52ms
+step:506/1480 train_time:17499ms step_avg:34.58ms
+step:507/1480 train_time:17555ms step_avg:34.62ms
+step:508/1480 train_time:17617ms step_avg:34.68ms
+step:509/1480 train_time:17677ms step_avg:34.73ms
+step:510/1480 train_time:17740ms step_avg:34.78ms
+step:511/1480 train_time:17799ms step_avg:34.83ms
+step:512/1480 train_time:17864ms step_avg:34.89ms
+step:513/1480 train_time:17922ms step_avg:34.94ms
+step:514/1480 train_time:17986ms step_avg:34.99ms
+step:515/1480 train_time:18044ms step_avg:35.04ms
+step:516/1480 train_time:18108ms step_avg:35.09ms
+step:517/1480 train_time:18165ms step_avg:35.14ms
+step:518/1480 train_time:18229ms step_avg:35.19ms
+step:519/1480 train_time:18285ms step_avg:35.23ms
+step:520/1480 train_time:18349ms step_avg:35.29ms
+step:521/1480 train_time:18405ms step_avg:35.33ms
+step:522/1480 train_time:18469ms step_avg:35.38ms
+step:523/1480 train_time:18528ms step_avg:35.43ms
+step:524/1480 train_time:18598ms step_avg:35.49ms
+step:525/1480 train_time:18661ms step_avg:35.54ms
+step:526/1480 train_time:18729ms step_avg:35.61ms
+step:527/1480 train_time:18790ms step_avg:35.65ms
+step:528/1480 train_time:18858ms step_avg:35.72ms
+step:529/1480 train_time:18921ms step_avg:35.77ms
+step:530/1480 train_time:18988ms step_avg:35.83ms
+step:531/1480 train_time:19049ms step_avg:35.87ms
+step:532/1480 train_time:19117ms step_avg:35.93ms
+step:533/1480 train_time:19179ms step_avg:35.98ms
+step:534/1480 train_time:19247ms step_avg:36.04ms
+step:535/1480 train_time:19308ms step_avg:36.09ms
+step:536/1480 train_time:19369ms step_avg:36.14ms
+step:537/1480 train_time:19422ms step_avg:36.17ms
+step:538/1480 train_time:19482ms step_avg:36.21ms
+step:539/1480 train_time:19538ms step_avg:36.25ms
+step:540/1480 train_time:19604ms step_avg:36.30ms
+step:541/1480 train_time:19664ms step_avg:36.35ms
+step:542/1480 train_time:19728ms step_avg:36.40ms
+step:543/1480 train_time:19785ms step_avg:36.44ms
+step:544/1480 train_time:19849ms step_avg:36.49ms
+step:545/1480 train_time:19906ms step_avg:36.53ms
+step:546/1480 train_time:19970ms step_avg:36.58ms
+step:547/1480 train_time:20026ms step_avg:36.61ms
+step:548/1480 train_time:20090ms step_avg:36.66ms
+step:549/1480 train_time:20146ms step_avg:36.70ms
+step:550/1480 train_time:20210ms step_avg:36.75ms
+step:551/1480 train_time:20267ms step_avg:36.78ms
+step:552/1480 train_time:20331ms step_avg:36.83ms
+step:553/1480 train_time:20388ms step_avg:36.87ms
+step:554/1480 train_time:20451ms step_avg:36.92ms
+step:555/1480 train_time:20509ms step_avg:36.95ms
+step:556/1480 train_time:20572ms step_avg:37.00ms
+step:557/1480 train_time:20629ms step_avg:37.04ms
+step:558/1480 train_time:20693ms step_avg:37.08ms
+step:559/1480 train_time:20751ms step_avg:37.12ms
+step:560/1480 train_time:20814ms step_avg:37.17ms
+step:561/1480 train_time:20872ms step_avg:37.20ms
+step:562/1480 train_time:20935ms step_avg:37.25ms
+step:563/1480 train_time:20993ms step_avg:37.29ms
+step:564/1480 train_time:21056ms step_avg:37.33ms
+step:565/1480 train_time:21113ms step_avg:37.37ms
+step:566/1480 train_time:21176ms step_avg:37.41ms
+step:567/1480 train_time:21233ms step_avg:37.45ms
+step:568/1480 train_time:21297ms step_avg:37.50ms
+step:569/1480 train_time:21355ms step_avg:37.53ms
+step:570/1480 train_time:21419ms step_avg:37.58ms
+step:571/1480 train_time:21475ms step_avg:37.61ms
+step:572/1480 train_time:21537ms step_avg:37.65ms
+step:573/1480 train_time:21595ms step_avg:37.69ms
+step:574/1480 train_time:21664ms step_avg:37.74ms
+step:575/1480 train_time:21723ms step_avg:37.78ms
+step:576/1480 train_time:21788ms step_avg:37.83ms
+step:577/1480 train_time:21846ms step_avg:37.86ms
+step:578/1480 train_time:21910ms step_avg:37.91ms
+step:579/1480 train_time:21967ms step_avg:37.94ms
+step:580/1480 train_time:22029ms step_avg:37.98ms
+step:581/1480 train_time:22085ms step_avg:38.01ms
+step:582/1480 train_time:22149ms step_avg:38.06ms
+step:583/1480 train_time:22209ms step_avg:38.09ms
+step:584/1480 train_time:22280ms step_avg:38.15ms
+step:585/1480 train_time:22344ms step_avg:38.19ms
+step:586/1480 train_time:22413ms step_avg:38.25ms
+step:587/1480 train_time:22475ms step_avg:38.29ms
+step:588/1480 train_time:22544ms step_avg:38.34ms
+step:589/1480 train_time:22607ms step_avg:38.38ms
+step:590/1480 train_time:22676ms step_avg:38.43ms
+step:591/1480 train_time:22738ms step_avg:38.47ms
+step:592/1480 train_time:22807ms step_avg:38.52ms
+step:593/1480 train_time:22861ms step_avg:38.55ms
+step:594/1480 train_time:22919ms step_avg:38.59ms
+step:595/1480 train_time:22974ms step_avg:38.61ms
+step:596/1480 train_time:23034ms step_avg:38.65ms
+step:597/1480 train_time:23088ms step_avg:38.67ms
+step:598/1480 train_time:23149ms step_avg:38.71ms
+step:599/1480 train_time:23205ms step_avg:38.74ms
+step:600/1480 train_time:23267ms step_avg:38.78ms
+step:601/1480 train_time:23325ms step_avg:38.81ms
+step:602/1480 train_time:23387ms step_avg:38.85ms
+step:603/1480 train_time:23449ms step_avg:38.89ms
+step:604/1480 train_time:23518ms step_avg:38.94ms
+step:605/1480 train_time:23581ms step_avg:38.98ms
+step:606/1480 train_time:23649ms step_avg:39.02ms
+step:607/1480 train_time:23710ms step_avg:39.06ms
+step:608/1480 train_time:23777ms step_avg:39.11ms
+step:609/1480 train_time:23838ms step_avg:39.14ms
+step:610/1480 train_time:23905ms step_avg:39.19ms
+step:611/1480 train_time:23967ms step_avg:39.23ms
+step:612/1480 train_time:24033ms step_avg:39.27ms
+step:613/1480 train_time:24093ms step_avg:39.30ms
+step:614/1480 train_time:24161ms step_avg:39.35ms
+step:615/1480 train_time:24222ms step_avg:39.39ms
+step:616/1480 train_time:24289ms step_avg:39.43ms
+step:617/1480 train_time:24348ms step_avg:39.46ms
+step:618/1480 train_time:24414ms step_avg:39.51ms
+step:619/1480 train_time:24470ms step_avg:39.53ms
+step:620/1480 train_time:24530ms step_avg:39.56ms
+step:621/1480 train_time:24585ms step_avg:39.59ms
+step:622/1480 train_time:24644ms step_avg:39.62ms
+step:623/1480 train_time:24700ms step_avg:39.65ms
+step:624/1480 train_time:24761ms step_avg:39.68ms
+step:625/1480 train_time:24818ms step_avg:39.71ms
+step:626/1480 train_time:24884ms step_avg:39.75ms
+step:627/1480 train_time:24943ms step_avg:39.78ms
+step:628/1480 train_time:25009ms step_avg:39.82ms
+step:629/1480 train_time:25066ms step_avg:39.85ms
+step:630/1480 train_time:25132ms step_avg:39.89ms
+step:631/1480 train_time:25192ms step_avg:39.92ms
+step:632/1480 train_time:25256ms step_avg:39.96ms
+step:633/1480 train_time:25314ms step_avg:39.99ms
+step:634/1480 train_time:25378ms step_avg:40.03ms
+step:635/1480 train_time:25437ms step_avg:40.06ms
+step:636/1480 train_time:25503ms step_avg:40.10ms
+step:637/1480 train_time:25561ms step_avg:40.13ms
+step:638/1480 train_time:25624ms step_avg:40.16ms
+step:639/1480 train_time:25682ms step_avg:40.19ms
+step:640/1480 train_time:25745ms step_avg:40.23ms
+step:641/1480 train_time:25803ms step_avg:40.25ms
+step:642/1480 train_time:25866ms step_avg:40.29ms
+step:643/1480 train_time:25923ms step_avg:40.32ms
+step:644/1480 train_time:25986ms step_avg:40.35ms
+step:645/1480 train_time:26043ms step_avg:40.38ms
+step:646/1480 train_time:26107ms step_avg:40.41ms
+step:647/1480 train_time:26166ms step_avg:40.44ms
+step:648/1480 train_time:26231ms step_avg:40.48ms
+step:649/1480 train_time:26291ms step_avg:40.51ms
+step:650/1480 train_time:26357ms step_avg:40.55ms
+step:651/1480 train_time:26417ms step_avg:40.58ms
+step:652/1480 train_time:26482ms step_avg:40.62ms
+step:653/1480 train_time:26542ms step_avg:40.65ms
+step:654/1480 train_time:26608ms step_avg:40.68ms
+step:655/1480 train_time:26667ms step_avg:40.71ms
+step:656/1480 train_time:26731ms step_avg:40.75ms
+step:657/1480 train_time:26789ms step_avg:40.77ms
+step:658/1480 train_time:26854ms step_avg:40.81ms
+step:659/1480 train_time:26913ms step_avg:40.84ms
+step:660/1480 train_time:26978ms step_avg:40.88ms
+step:661/1480 train_time:27037ms step_avg:40.90ms
+step:662/1480 train_time:27103ms step_avg:40.94ms
+step:663/1480 train_time:27162ms step_avg:40.97ms
+step:664/1480 train_time:27227ms step_avg:41.00ms
+step:665/1480 train_time:27285ms step_avg:41.03ms
+step:666/1480 train_time:27349ms step_avg:41.07ms
+step:667/1480 train_time:27408ms step_avg:41.09ms
+step:668/1480 train_time:27472ms step_avg:41.13ms
+step:669/1480 train_time:27530ms step_avg:41.15ms
+step:670/1480 train_time:27594ms step_avg:41.19ms
+step:671/1480 train_time:27653ms step_avg:41.21ms
+step:672/1480 train_time:27718ms step_avg:41.25ms
+step:673/1480 train_time:27776ms step_avg:41.27ms
+step:674/1480 train_time:27841ms step_avg:41.31ms
+step:675/1480 train_time:27900ms step_avg:41.33ms
+step:676/1480 train_time:27965ms step_avg:41.37ms
+step:677/1480 train_time:28023ms step_avg:41.39ms
+step:678/1480 train_time:28090ms step_avg:41.43ms
+step:679/1480 train_time:28148ms step_avg:41.45ms
+step:680/1480 train_time:28212ms step_avg:41.49ms
+step:681/1480 train_time:28269ms step_avg:41.51ms
+step:682/1480 train_time:28332ms step_avg:41.54ms
+step:683/1480 train_time:28389ms step_avg:41.57ms
+step:684/1480 train_time:28452ms step_avg:41.60ms
+step:685/1480 train_time:28510ms step_avg:41.62ms
+step:686/1480 train_time:28573ms step_avg:41.65ms
+step:687/1480 train_time:28629ms step_avg:41.67ms
+step:688/1480 train_time:28693ms step_avg:41.70ms
+step:689/1480 train_time:28750ms step_avg:41.73ms
+step:690/1480 train_time:28814ms step_avg:41.76ms
+step:691/1480 train_time:28873ms step_avg:41.79ms
+step:692/1480 train_time:28939ms step_avg:41.82ms
+step:693/1480 train_time:29000ms step_avg:41.85ms
+step:694/1480 train_time:29063ms step_avg:41.88ms
+step:695/1480 train_time:29121ms step_avg:41.90ms
+step:696/1480 train_time:29186ms step_avg:41.93ms
+step:697/1480 train_time:29244ms step_avg:41.96ms
+step:698/1480 train_time:29308ms step_avg:41.99ms
+step:699/1480 train_time:29366ms step_avg:42.01ms
+step:700/1480 train_time:29429ms step_avg:42.04ms
+step:701/1480 train_time:29486ms step_avg:42.06ms
+step:702/1480 train_time:29549ms step_avg:42.09ms
+step:703/1480 train_time:29606ms step_avg:42.11ms
+step:704/1480 train_time:29669ms step_avg:42.14ms
+step:705/1480 train_time:29726ms step_avg:42.16ms
+step:706/1480 train_time:29789ms step_avg:42.19ms
+step:707/1480 train_time:29847ms step_avg:42.22ms
+step:708/1480 train_time:29912ms step_avg:42.25ms
+step:709/1480 train_time:29971ms step_avg:42.27ms
+step:710/1480 train_time:30035ms step_avg:42.30ms
+step:711/1480 train_time:30093ms step_avg:42.33ms
+step:712/1480 train_time:30158ms step_avg:42.36ms
+step:713/1480 train_time:30215ms step_avg:42.38ms
+step:714/1480 train_time:30278ms step_avg:42.41ms
+step:715/1480 train_time:30336ms step_avg:42.43ms
+step:716/1480 train_time:30400ms step_avg:42.46ms
+step:717/1480 train_time:30460ms step_avg:42.48ms
+step:718/1480 train_time:30525ms step_avg:42.51ms
+step:719/1480 train_time:30583ms step_avg:42.54ms
+step:720/1480 train_time:30647ms step_avg:42.57ms
+step:721/1480 train_time:30706ms step_avg:42.59ms
+step:722/1480 train_time:30770ms step_avg:42.62ms
+step:723/1480 train_time:30826ms step_avg:42.64ms
+step:724/1480 train_time:30890ms step_avg:42.67ms
+step:725/1480 train_time:30947ms step_avg:42.69ms
+step:726/1480 train_time:31011ms step_avg:42.71ms
+step:727/1480 train_time:31070ms step_avg:42.74ms
+step:728/1480 train_time:31134ms step_avg:42.77ms
+step:729/1480 train_time:31192ms step_avg:42.79ms
+step:730/1480 train_time:31255ms step_avg:42.82ms
+step:731/1480 train_time:31313ms step_avg:42.84ms
+step:732/1480 train_time:31375ms step_avg:42.86ms
+step:733/1480 train_time:31434ms step_avg:42.88ms
+step:734/1480 train_time:31501ms step_avg:42.92ms
+step:735/1480 train_time:31563ms step_avg:42.94ms
+step:736/1480 train_time:31630ms step_avg:42.98ms
+step:737/1480 train_time:31689ms step_avg:43.00ms
+step:738/1480 train_time:31756ms step_avg:43.03ms
+step:739/1480 train_time:31817ms step_avg:43.05ms
+step:740/1480 train_time:31883ms step_avg:43.09ms
+step:741/1480 train_time:31944ms step_avg:43.11ms
+step:742/1480 train_time:32010ms step_avg:43.14ms
+step:743/1480 train_time:32069ms step_avg:43.16ms
+step:744/1480 train_time:32135ms step_avg:43.19ms
+step:745/1480 train_time:32194ms step_avg:43.21ms
+step:746/1480 train_time:32261ms step_avg:43.25ms
+step:747/1480 train_time:32321ms step_avg:43.27ms
+step:748/1480 train_time:32387ms step_avg:43.30ms
+step:749/1480 train_time:32446ms step_avg:43.32ms
+step:750/1480 train_time:32512ms step_avg:43.35ms
+step:750/1480 val_loss:3.7984 train_time:32597ms step_avg:43.46ms
+step:751/1480 train_time:32614ms step_avg:43.43ms
+step:752/1480 train_time:32638ms step_avg:43.40ms
+step:753/1480 train_time:32697ms step_avg:43.42ms
+step:754/1480 train_time:32761ms step_avg:43.45ms
+step:755/1480 train_time:32819ms step_avg:43.47ms
+step:756/1480 train_time:32884ms step_avg:43.50ms
+step:757/1480 train_time:32943ms step_avg:43.52ms
+step:758/1480 train_time:33007ms step_avg:43.54ms
+step:759/1480 train_time:33064ms step_avg:43.56ms
+step:760/1480 train_time:33129ms step_avg:43.59ms
+step:761/1480 train_time:33186ms step_avg:43.61ms
+step:762/1480 train_time:33250ms step_avg:43.64ms
+step:763/1480 train_time:33308ms step_avg:43.65ms
+step:764/1480 train_time:33371ms step_avg:43.68ms
+step:765/1480 train_time:33428ms step_avg:43.70ms
+step:766/1480 train_time:33492ms step_avg:43.72ms
+step:767/1480 train_time:33549ms step_avg:43.74ms
+step:768/1480 train_time:33612ms step_avg:43.77ms
+step:769/1480 train_time:33669ms step_avg:43.78ms
+step:770/1480 train_time:33731ms step_avg:43.81ms
+step:771/1480 train_time:33789ms step_avg:43.82ms
+step:772/1480 train_time:33852ms step_avg:43.85ms
+step:773/1480 train_time:33909ms step_avg:43.87ms
+step:774/1480 train_time:33972ms step_avg:43.89ms
+step:775/1480 train_time:34030ms step_avg:43.91ms
+step:776/1480 train_time:34094ms step_avg:43.93ms
+step:777/1480 train_time:34153ms step_avg:43.95ms
+step:778/1480 train_time:34218ms step_avg:43.98ms
+step:779/1480 train_time:34278ms step_avg:44.00ms
+step:780/1480 train_time:34342ms step_avg:44.03ms
+step:781/1480 train_time:34401ms step_avg:44.05ms
+step:782/1480 train_time:34467ms step_avg:44.08ms
+step:783/1480 train_time:34525ms step_avg:44.09ms
+step:784/1480 train_time:34589ms step_avg:44.12ms
+step:785/1480 train_time:34646ms step_avg:44.14ms
+step:786/1480 train_time:34711ms step_avg:44.16ms
+step:787/1480 train_time:34768ms step_avg:44.18ms
+step:788/1480 train_time:34833ms step_avg:44.20ms
+step:789/1480 train_time:34893ms step_avg:44.22ms
+step:790/1480 train_time:34957ms step_avg:44.25ms
+step:791/1480 train_time:35016ms step_avg:44.27ms
+step:792/1480 train_time:35081ms step_avg:44.29ms
+step:793/1480 train_time:35140ms step_avg:44.31ms
+step:794/1480 train_time:35205ms step_avg:44.34ms
+step:795/1480 train_time:35264ms step_avg:44.36ms
+step:796/1480 train_time:35329ms step_avg:44.38ms
+step:797/1480 train_time:35388ms step_avg:44.40ms
+step:798/1480 train_time:35452ms step_avg:44.43ms
+step:799/1480 train_time:35511ms step_avg:44.44ms
+step:800/1480 train_time:35575ms step_avg:44.47ms
+step:801/1480 train_time:35635ms step_avg:44.49ms
+step:802/1480 train_time:35700ms step_avg:44.51ms
+step:803/1480 train_time:35759ms step_avg:44.53ms
+step:804/1480 train_time:35824ms step_avg:44.56ms
+step:805/1480 train_time:35884ms step_avg:44.58ms
+step:806/1480 train_time:35949ms step_avg:44.60ms
+step:807/1480 train_time:36006ms step_avg:44.62ms
+step:808/1480 train_time:36071ms step_avg:44.64ms
+step:809/1480 train_time:36129ms step_avg:44.66ms
+step:810/1480 train_time:36193ms step_avg:44.68ms
+step:811/1480 train_time:36251ms step_avg:44.70ms
+step:812/1480 train_time:36315ms step_avg:44.72ms
+step:813/1480 train_time:36374ms step_avg:44.74ms
+step:814/1480 train_time:36439ms step_avg:44.77ms
+step:815/1480 train_time:36498ms step_avg:44.78ms
+step:816/1480 train_time:36563ms step_avg:44.81ms
+step:817/1480 train_time:36621ms step_avg:44.82ms
+step:818/1480 train_time:36686ms step_avg:44.85ms
+step:819/1480 train_time:36744ms step_avg:44.86ms
+step:820/1480 train_time:36808ms step_avg:44.89ms
+step:821/1480 train_time:36866ms step_avg:44.90ms
+step:822/1480 train_time:36930ms step_avg:44.93ms
+step:823/1480 train_time:36988ms step_avg:44.94ms
+step:824/1480 train_time:37052ms step_avg:44.97ms
+step:825/1480 train_time:37109ms step_avg:44.98ms
+step:826/1480 train_time:37174ms step_avg:45.00ms
+step:827/1480 train_time:37232ms step_avg:45.02ms
+step:828/1480 train_time:37297ms step_avg:45.04ms
+step:829/1480 train_time:37355ms step_avg:45.06ms
+step:830/1480 train_time:37420ms step_avg:45.08ms
+step:831/1480 train_time:37478ms step_avg:45.10ms
+step:832/1480 train_time:37543ms step_avg:45.12ms
+step:833/1480 train_time:37601ms step_avg:45.14ms
+step:834/1480 train_time:37665ms step_avg:45.16ms
+step:835/1480 train_time:37723ms step_avg:45.18ms
+step:836/1480 train_time:37789ms step_avg:45.20ms
+step:837/1480 train_time:37846ms step_avg:45.22ms
+step:838/1480 train_time:37910ms step_avg:45.24ms
+step:839/1480 train_time:37967ms step_avg:45.25ms
+step:840/1480 train_time:38032ms step_avg:45.28ms
+step:841/1480 train_time:38090ms step_avg:45.29ms
+step:842/1480 train_time:38154ms step_avg:45.31ms
+step:843/1480 train_time:38212ms step_avg:45.33ms
+step:844/1480 train_time:38277ms step_avg:45.35ms
+step:845/1480 train_time:38336ms step_avg:45.37ms
+step:846/1480 train_time:38400ms step_avg:45.39ms
+step:847/1480 train_time:38459ms step_avg:45.41ms
+step:848/1480 train_time:38523ms step_avg:45.43ms
+step:849/1480 train_time:38583ms step_avg:45.45ms
+step:850/1480 train_time:38648ms step_avg:45.47ms
+step:851/1480 train_time:38705ms step_avg:45.48ms
+step:852/1480 train_time:38769ms step_avg:45.50ms
+step:853/1480 train_time:38827ms step_avg:45.52ms
+step:854/1480 train_time:38892ms step_avg:45.54ms
+step:855/1480 train_time:38950ms step_avg:45.56ms
+step:856/1480 train_time:39014ms step_avg:45.58ms
+step:857/1480 train_time:39072ms step_avg:45.59ms
+step:858/1480 train_time:39137ms step_avg:45.61ms
+step:859/1480 train_time:39196ms step_avg:45.63ms
+step:860/1480 train_time:39261ms step_avg:45.65ms
+step:861/1480 train_time:39319ms step_avg:45.67ms
+step:862/1480 train_time:39383ms step_avg:45.69ms
+step:863/1480 train_time:39443ms step_avg:45.70ms
+step:864/1480 train_time:39507ms step_avg:45.73ms
+step:865/1480 train_time:39565ms step_avg:45.74ms
+step:866/1480 train_time:39629ms step_avg:45.76ms
+step:867/1480 train_time:39687ms step_avg:45.77ms
+step:868/1480 train_time:39751ms step_avg:45.80ms
+step:869/1480 train_time:39808ms step_avg:45.81ms
+step:870/1480 train_time:39872ms step_avg:45.83ms
+step:871/1480 train_time:39930ms step_avg:45.84ms
+step:872/1480 train_time:39993ms step_avg:45.86ms
+step:873/1480 train_time:40051ms step_avg:45.88ms
+step:874/1480 train_time:40114ms step_avg:45.90ms
+step:875/1480 train_time:40172ms step_avg:45.91ms
+step:876/1480 train_time:40237ms step_avg:45.93ms
+step:877/1480 train_time:40294ms step_avg:45.95ms
+step:878/1480 train_time:40358ms step_avg:45.97ms
+step:879/1480 train_time:40416ms step_avg:45.98ms
+step:880/1480 train_time:40480ms step_avg:46.00ms
+step:881/1480 train_time:40539ms step_avg:46.01ms
+step:882/1480 train_time:40600ms step_avg:46.03ms
+step:883/1480 train_time:40658ms step_avg:46.04ms
+step:884/1480 train_time:40721ms step_avg:46.06ms
+step:885/1480 train_time:40779ms step_avg:46.08ms
+step:886/1480 train_time:40843ms step_avg:46.10ms
+step:887/1480 train_time:40902ms step_avg:46.11ms
+step:888/1480 train_time:40967ms step_avg:46.13ms
+step:889/1480 train_time:41026ms step_avg:46.15ms
+step:890/1480 train_time:41091ms step_avg:46.17ms
+step:891/1480 train_time:41148ms step_avg:46.18ms
+step:892/1480 train_time:41212ms step_avg:46.20ms
+step:893/1480 train_time:41269ms step_avg:46.21ms
+step:894/1480 train_time:41332ms step_avg:46.23ms
+step:895/1480 train_time:41391ms step_avg:46.25ms
+step:896/1480 train_time:41455ms step_avg:46.27ms
+step:897/1480 train_time:41513ms step_avg:46.28ms
+step:898/1480 train_time:41578ms step_avg:46.30ms
+step:899/1480 train_time:41639ms step_avg:46.32ms
+step:900/1480 train_time:41704ms step_avg:46.34ms
+step:901/1480 train_time:41762ms step_avg:46.35ms
+step:902/1480 train_time:41827ms step_avg:46.37ms
+step:903/1480 train_time:41886ms step_avg:46.38ms
+step:904/1480 train_time:41950ms step_avg:46.40ms
+step:905/1480 train_time:42007ms step_avg:46.42ms
+step:906/1480 train_time:42070ms step_avg:46.44ms
+step:907/1480 train_time:42129ms step_avg:46.45ms
+step:908/1480 train_time:42194ms step_avg:46.47ms
+step:909/1480 train_time:42253ms step_avg:46.48ms
+step:910/1480 train_time:42318ms step_avg:46.50ms
+step:911/1480 train_time:42376ms step_avg:46.52ms
+step:912/1480 train_time:42441ms step_avg:46.54ms
+step:913/1480 train_time:42499ms step_avg:46.55ms
+step:914/1480 train_time:42565ms step_avg:46.57ms
+step:915/1480 train_time:42623ms step_avg:46.58ms
+step:916/1480 train_time:42687ms step_avg:46.60ms
+step:917/1480 train_time:42745ms step_avg:46.61ms
+step:918/1480 train_time:42808ms step_avg:46.63ms
+step:919/1480 train_time:42864ms step_avg:46.64ms
+step:920/1480 train_time:42927ms step_avg:46.66ms
+step:921/1480 train_time:42983ms step_avg:46.67ms
+step:922/1480 train_time:43046ms step_avg:46.69ms
+step:923/1480 train_time:43104ms step_avg:46.70ms
+step:924/1480 train_time:43172ms step_avg:46.72ms
+step:925/1480 train_time:43234ms step_avg:46.74ms
+step:926/1480 train_time:43302ms step_avg:46.76ms
+step:927/1480 train_time:43363ms step_avg:46.78ms
+step:928/1480 train_time:43431ms step_avg:46.80ms
+step:929/1480 train_time:43491ms step_avg:46.82ms
+step:930/1480 train_time:43559ms step_avg:46.84ms
+step:931/1480 train_time:43621ms step_avg:46.85ms
+step:932/1480 train_time:43689ms step_avg:46.88ms
+step:933/1480 train_time:43749ms step_avg:46.89ms
+step:934/1480 train_time:43815ms step_avg:46.91ms
+step:935/1480 train_time:43876ms step_avg:46.93ms
+step:936/1480 train_time:43939ms step_avg:46.94ms
+step:937/1480 train_time:43993ms step_avg:46.95ms
+step:938/1480 train_time:44052ms step_avg:46.96ms
+step:939/1480 train_time:44110ms step_avg:46.98ms
+step:940/1480 train_time:44172ms step_avg:46.99ms
+step:941/1480 train_time:44227ms step_avg:47.00ms
+step:942/1480 train_time:44290ms step_avg:47.02ms
+step:943/1480 train_time:44349ms step_avg:47.03ms
+step:944/1480 train_time:44410ms step_avg:47.04ms
+step:945/1480 train_time:44471ms step_avg:47.06ms
+step:946/1480 train_time:44539ms step_avg:47.08ms
+step:947/1480 train_time:44599ms step_avg:47.09ms
+step:948/1480 train_time:44665ms step_avg:47.12ms
+step:949/1480 train_time:44723ms step_avg:47.13ms
+step:950/1480 train_time:44786ms step_avg:47.14ms
+step:951/1480 train_time:44844ms step_avg:47.15ms
+step:952/1480 train_time:44907ms step_avg:47.17ms
+step:953/1480 train_time:44965ms step_avg:47.18ms
+step:954/1480 train_time:45029ms step_avg:47.20ms
+step:955/1480 train_time:45086ms step_avg:47.21ms
+step:956/1480 train_time:45150ms step_avg:47.23ms
+step:957/1480 train_time:45206ms step_avg:47.24ms
+step:958/1480 train_time:45270ms step_avg:47.25ms
+step:959/1480 train_time:45327ms step_avg:47.26ms
+step:960/1480 train_time:45390ms step_avg:47.28ms
+step:961/1480 train_time:45455ms step_avg:47.30ms
+step:962/1480 train_time:45544ms step_avg:47.34ms
+step:963/1480 train_time:45629ms step_avg:47.38ms
+step:964/1480 train_time:45721ms step_avg:47.43ms
+step:965/1480 train_time:45809ms step_avg:47.47ms
+step:966/1480 train_time:45907ms step_avg:47.52ms
+step:967/1480 train_time:45995ms step_avg:47.56ms
+step:968/1480 train_time:46089ms step_avg:47.61ms
+step:969/1480 train_time:46176ms step_avg:47.65ms
+step:970/1480 train_time:46269ms step_avg:47.70ms
+step:971/1480 train_time:46356ms step_avg:47.74ms
+step:972/1480 train_time:46450ms step_avg:47.79ms
+step:973/1480 train_time:46537ms step_avg:47.83ms
+step:974/1480 train_time:46629ms step_avg:47.87ms
+step:975/1480 train_time:46717ms step_avg:47.91ms
+step:976/1480 train_time:46812ms step_avg:47.96ms
+step:977/1480 train_time:46900ms step_avg:48.00ms
+step:978/1480 train_time:46994ms step_avg:48.05ms
+step:979/1480 train_time:47082ms step_avg:48.09ms
+step:980/1480 train_time:47176ms step_avg:48.14ms
+step:981/1480 train_time:47263ms step_avg:48.18ms
+step:982/1480 train_time:47357ms step_avg:48.23ms
+step:983/1480 train_time:47444ms step_avg:48.26ms
+step:984/1480 train_time:47538ms step_avg:48.31ms
+step:985/1480 train_time:47626ms step_avg:48.35ms
+step:986/1480 train_time:47720ms step_avg:48.40ms
+step:987/1480 train_time:47808ms step_avg:48.44ms
+step:988/1480 train_time:47901ms step_avg:48.48ms
+step:989/1480 train_time:47988ms step_avg:48.52ms
+step:990/1480 train_time:48081ms step_avg:48.57ms
+step:991/1480 train_time:48168ms step_avg:48.61ms
+step:992/1480 train_time:48261ms step_avg:48.65ms
+step:993/1480 train_time:48348ms step_avg:48.69ms
+step:994/1480 train_time:48441ms step_avg:48.73ms
+step:995/1480 train_time:48528ms step_avg:48.77ms
+step:996/1480 train_time:48622ms step_avg:48.82ms
+step:997/1480 train_time:48709ms step_avg:48.86ms
+step:998/1480 train_time:48802ms step_avg:48.90ms
+step:999/1480 train_time:48888ms step_avg:48.94ms
+step:1000/1480 train_time:48980ms step_avg:48.98ms
+step:1000/1480 val_loss:3.5103 train_time:49100ms step_avg:49.10ms
+step:1001/1480 train_time:49117ms step_avg:49.07ms
+step:1002/1480 train_time:49162ms step_avg:49.06ms
+step:1003/1480 train_time:49249ms step_avg:49.10ms
+step:1004/1480 train_time:49342ms step_avg:49.15ms
+step:1005/1480 train_time:49429ms step_avg:49.18ms
+step:1006/1480 train_time:49523ms step_avg:49.23ms
+step:1007/1480 train_time:49611ms step_avg:49.27ms
+step:1008/1480 train_time:49703ms step_avg:49.31ms
+step:1009/1480 train_time:49789ms step_avg:49.34ms
+step:1010/1480 train_time:49885ms step_avg:49.39ms
+step:1011/1480 train_time:49970ms step_avg:49.43ms
+step:1012/1480 train_time:50062ms step_avg:49.47ms
+step:1013/1480 train_time:50147ms step_avg:49.50ms
+step:1014/1480 train_time:50239ms step_avg:49.55ms
+step:1015/1480 train_time:50324ms step_avg:49.58ms
+step:1016/1480 train_time:50416ms step_avg:49.62ms
+step:1017/1480 train_time:50502ms step_avg:49.66ms
+step:1018/1480 train_time:50591ms step_avg:49.70ms
+step:1019/1480 train_time:50674ms step_avg:49.73ms
+step:1020/1480 train_time:50764ms step_avg:49.77ms
+step:1021/1480 train_time:50848ms step_avg:49.80ms
+step:1022/1480 train_time:50945ms step_avg:49.85ms
+step:1023/1480 train_time:51033ms step_avg:49.89ms
+step:1024/1480 train_time:51126ms step_avg:49.93ms
+step:1025/1480 train_time:51212ms step_avg:49.96ms
+step:1026/1480 train_time:51305ms step_avg:50.00ms
+step:1027/1480 train_time:51390ms step_avg:50.04ms
+step:1028/1480 train_time:51482ms step_avg:50.08ms
+step:1029/1480 train_time:51565ms step_avg:50.11ms
+step:1030/1480 train_time:51656ms step_avg:50.15ms
+step:1031/1480 train_time:51740ms step_avg:50.18ms
+step:1032/1480 train_time:51832ms step_avg:50.22ms
+step:1033/1480 train_time:51919ms step_avg:50.26ms
+step:1034/1480 train_time:52010ms step_avg:50.30ms
+step:1035/1480 train_time:52096ms step_avg:50.33ms
+step:1036/1480 train_time:52189ms step_avg:50.38ms
+step:1037/1480 train_time:52273ms step_avg:50.41ms
+step:1038/1480 train_time:52365ms step_avg:50.45ms
+step:1039/1480 train_time:52452ms step_avg:50.48ms
+step:1040/1480 train_time:52544ms step_avg:50.52ms
+step:1041/1480 train_time:52629ms step_avg:50.56ms
+step:1042/1480 train_time:52718ms step_avg:50.59ms
+step:1043/1480 train_time:52803ms step_avg:50.63ms
+step:1044/1480 train_time:52893ms step_avg:50.66ms
+step:1045/1480 train_time:52980ms step_avg:50.70ms
+step:1046/1480 train_time:53074ms step_avg:50.74ms
+step:1047/1480 train_time:53158ms step_avg:50.77ms
+step:1048/1480 train_time:53251ms step_avg:50.81ms
+step:1049/1480 train_time:53335ms step_avg:50.84ms
+step:1050/1480 train_time:53428ms step_avg:50.88ms
+step:1051/1480 train_time:53515ms step_avg:50.92ms
+step:1052/1480 train_time:53612ms step_avg:50.96ms
+step:1053/1480 train_time:53697ms step_avg:50.99ms
+step:1054/1480 train_time:53792ms step_avg:51.04ms
+step:1055/1480 train_time:53879ms step_avg:51.07ms
+step:1056/1480 train_time:53970ms step_avg:51.11ms
+step:1057/1480 train_time:54054ms step_avg:51.14ms
+step:1058/1480 train_time:54147ms step_avg:51.18ms
+step:1059/1480 train_time:54232ms step_avg:51.21ms
+step:1060/1480 train_time:54324ms step_avg:51.25ms
+step:1061/1480 train_time:54410ms step_avg:51.28ms
+step:1062/1480 train_time:54503ms step_avg:51.32ms
+step:1063/1480 train_time:54591ms step_avg:51.36ms
+step:1064/1480 train_time:54683ms step_avg:51.39ms
+step:1065/1480 train_time:54769ms step_avg:51.43ms
+step:1066/1480 train_time:54860ms step_avg:51.46ms
+step:1067/1480 train_time:54945ms step_avg:51.49ms
+step:1068/1480 train_time:55038ms step_avg:51.53ms
+step:1069/1480 train_time:55128ms step_avg:51.57ms
+step:1070/1480 train_time:55223ms step_avg:51.61ms
+step:1071/1480 train_time:55314ms step_avg:51.65ms
+step:1072/1480 train_time:55410ms step_avg:51.69ms
+step:1073/1480 train_time:55499ms step_avg:51.72ms
+step:1074/1480 train_time:55595ms step_avg:51.76ms
+step:1075/1480 train_time:55684ms step_avg:51.80ms
+step:1076/1480 train_time:55779ms step_avg:51.84ms
+step:1077/1480 train_time:55861ms step_avg:51.87ms
+step:1078/1480 train_time:55952ms step_avg:51.90ms
+step:1079/1480 train_time:56044ms step_avg:51.94ms
+step:1080/1480 train_time:56141ms step_avg:51.98ms
+step:1081/1480 train_time:56235ms step_avg:52.02ms
+step:1082/1480 train_time:56330ms step_avg:52.06ms
+step:1083/1480 train_time:56416ms step_avg:52.09ms
+step:1084/1480 train_time:56507ms step_avg:52.13ms
+step:1085/1480 train_time:56593ms step_avg:52.16ms
+step:1086/1480 train_time:56690ms step_avg:52.20ms
+step:1087/1480 train_time:56780ms step_avg:52.24ms
+step:1088/1480 train_time:56877ms step_avg:52.28ms
+step:1089/1480 train_time:56969ms step_avg:52.31ms
+step:1090/1480 train_time:57067ms step_avg:52.35ms
+step:1091/1480 train_time:57158ms step_avg:52.39ms
+step:1092/1480 train_time:57255ms step_avg:52.43ms
+step:1093/1480 train_time:57346ms step_avg:52.47ms
+step:1094/1480 train_time:57442ms step_avg:52.51ms
+step:1095/1480 train_time:57532ms step_avg:52.54ms
+step:1096/1480 train_time:57628ms step_avg:52.58ms
+step:1097/1480 train_time:57710ms step_avg:52.61ms
+step:1098/1480 train_time:57797ms step_avg:52.64ms
+step:1099/1480 train_time:57882ms step_avg:52.67ms
+step:1100/1480 train_time:57972ms step_avg:52.70ms
+step:1101/1480 train_time:58056ms step_avg:52.73ms
+step:1102/1480 train_time:58148ms step_avg:52.77ms
+step:1103/1480 train_time:58235ms step_avg:52.80ms
+step:1104/1480 train_time:58330ms step_avg:52.83ms
+step:1105/1480 train_time:58417ms step_avg:52.87ms
+step:1106/1480 train_time:58513ms step_avg:52.91ms
+step:1107/1480 train_time:58602ms step_avg:52.94ms
+step:1108/1480 train_time:58696ms step_avg:52.97ms
+step:1109/1480 train_time:58786ms step_avg:53.01ms
+step:1110/1480 train_time:58881ms step_avg:53.05ms
+step:1111/1480 train_time:58970ms step_avg:53.08ms
+step:1112/1480 train_time:59065ms step_avg:53.12ms
+step:1113/1480 train_time:59154ms step_avg:53.15ms
+step:1114/1480 train_time:59250ms step_avg:53.19ms
+step:1115/1480 train_time:59337ms step_avg:53.22ms
+step:1116/1480 train_time:59432ms step_avg:53.25ms
+step:1117/1480 train_time:59520ms step_avg:53.29ms
+step:1118/1480 train_time:59614ms step_avg:53.32ms
+step:1119/1480 train_time:59700ms step_avg:53.35ms
+step:1120/1480 train_time:59794ms step_avg:53.39ms
+step:1121/1480 train_time:59880ms step_avg:53.42ms
+step:1122/1480 train_time:59972ms step_avg:53.45ms
+step:1123/1480 train_time:60059ms step_avg:53.48ms
+step:1124/1480 train_time:60152ms step_avg:53.52ms
+step:1125/1480 train_time:60238ms step_avg:53.54ms
+step:1126/1480 train_time:60332ms step_avg:53.58ms
+step:1127/1480 train_time:60419ms step_avg:53.61ms
+step:1128/1480 train_time:60512ms step_avg:53.65ms
+step:1129/1480 train_time:60598ms step_avg:53.67ms
+step:1130/1480 train_time:60691ms step_avg:53.71ms
+step:1131/1480 train_time:60778ms step_avg:53.74ms
+step:1132/1480 train_time:60871ms step_avg:53.77ms
+step:1133/1480 train_time:60957ms step_avg:53.80ms
+step:1134/1480 train_time:61051ms step_avg:53.84ms
+step:1135/1480 train_time:61136ms step_avg:53.86ms
+step:1136/1480 train_time:61227ms step_avg:53.90ms
+step:1137/1480 train_time:61310ms step_avg:53.92ms
+step:1138/1480 train_time:61401ms step_avg:53.95ms
+step:1139/1480 train_time:61485ms step_avg:53.98ms
+step:1140/1480 train_time:61578ms step_avg:54.02ms
+step:1141/1480 train_time:61665ms step_avg:54.04ms
+step:1142/1480 train_time:61756ms step_avg:54.08ms
+step:1143/1480 train_time:61843ms step_avg:54.11ms
+step:1144/1480 train_time:61936ms step_avg:54.14ms
+step:1145/1480 train_time:62024ms step_avg:54.17ms
+step:1146/1480 train_time:62118ms step_avg:54.20ms
+step:1147/1480 train_time:62206ms step_avg:54.23ms
+step:1148/1480 train_time:62303ms step_avg:54.27ms
+step:1149/1480 train_time:62392ms step_avg:54.30ms
+step:1150/1480 train_time:62488ms step_avg:54.34ms
+step:1151/1480 train_time:62578ms step_avg:54.37ms
+step:1152/1480 train_time:62674ms step_avg:54.40ms
+step:1153/1480 train_time:62763ms step_avg:54.43ms
+step:1154/1480 train_time:62858ms step_avg:54.47ms
+step:1155/1480 train_time:62947ms step_avg:54.50ms
+step:1156/1480 train_time:63043ms step_avg:54.54ms
+step:1157/1480 train_time:63132ms step_avg:54.57ms
+step:1158/1480 train_time:63228ms step_avg:54.60ms
+step:1159/1480 train_time:63316ms step_avg:54.63ms
+step:1160/1480 train_time:63412ms step_avg:54.67ms
+step:1161/1480 train_time:63499ms step_avg:54.69ms
+step:1162/1480 train_time:63593ms step_avg:54.73ms
+step:1163/1480 train_time:63682ms step_avg:54.76ms
+step:1164/1480 train_time:63775ms step_avg:54.79ms
+step:1165/1480 train_time:63856ms step_avg:54.81ms
+step:1166/1480 train_time:63949ms step_avg:54.84ms
+step:1167/1480 train_time:64039ms step_avg:54.87ms
+step:1168/1480 train_time:64129ms step_avg:54.91ms
+step:1169/1480 train_time:64217ms step_avg:54.93ms
+step:1170/1480 train_time:64310ms step_avg:54.97ms
+step:1171/1480 train_time:64403ms step_avg:55.00ms
+step:1172/1480 train_time:64495ms step_avg:55.03ms
+step:1173/1480 train_time:64584ms step_avg:55.06ms
+step:1174/1480 train_time:64683ms step_avg:55.10ms
+step:1175/1480 train_time:64773ms step_avg:55.13ms
+step:1176/1480 train_time:64871ms step_avg:55.16ms
+step:1177/1480 train_time:64962ms step_avg:55.19ms
+step:1178/1480 train_time:65059ms step_avg:55.23ms
+step:1179/1480 train_time:65150ms step_avg:55.26ms
+step:1180/1480 train_time:65246ms step_avg:55.29ms
+step:1181/1480 train_time:65336ms step_avg:55.32ms
+step:1182/1480 train_time:65432ms step_avg:55.36ms
+step:1183/1480 train_time:65522ms step_avg:55.39ms
+step:1184/1480 train_time:65617ms step_avg:55.42ms
+step:1185/1480 train_time:65699ms step_avg:55.44ms
+step:1186/1480 train_time:65786ms step_avg:55.47ms
+step:1187/1480 train_time:65868ms step_avg:55.49ms
+step:1188/1480 train_time:65961ms step_avg:55.52ms
+step:1189/1480 train_time:66045ms step_avg:55.55ms
+step:1190/1480 train_time:66136ms step_avg:55.58ms
+step:1191/1480 train_time:66224ms step_avg:55.60ms
+step:1192/1480 train_time:66316ms step_avg:55.63ms
+step:1193/1480 train_time:66403ms step_avg:55.66ms
+step:1194/1480 train_time:66496ms step_avg:55.69ms
+step:1195/1480 train_time:66585ms step_avg:55.72ms
+step:1196/1480 train_time:66678ms step_avg:55.75ms
+step:1197/1480 train_time:66765ms step_avg:55.78ms
+step:1198/1480 train_time:66858ms step_avg:55.81ms
+step:1199/1480 train_time:66946ms step_avg:55.83ms
+step:1200/1480 train_time:67042ms step_avg:55.87ms
+step:1201/1480 train_time:67130ms step_avg:55.89ms
+step:1202/1480 train_time:67224ms step_avg:55.93ms
+step:1203/1480 train_time:67312ms step_avg:55.95ms
+step:1204/1480 train_time:67406ms step_avg:55.98ms
+step:1205/1480 train_time:67493ms step_avg:56.01ms
+step:1206/1480 train_time:67587ms step_avg:56.04ms
+step:1207/1480 train_time:67675ms step_avg:56.07ms
+step:1208/1480 train_time:67770ms step_avg:56.10ms
+step:1209/1480 train_time:67857ms step_avg:56.13ms
+step:1210/1480 train_time:67953ms step_avg:56.16ms
+step:1211/1480 train_time:68040ms step_avg:56.19ms
+step:1212/1480 train_time:68133ms step_avg:56.22ms
+step:1213/1480 train_time:68221ms step_avg:56.24ms
+step:1214/1480 train_time:68314ms step_avg:56.27ms
+step:1215/1480 train_time:68401ms step_avg:56.30ms
+step:1216/1480 train_time:68495ms step_avg:56.33ms
+step:1217/1480 train_time:68582ms step_avg:56.35ms
+step:1218/1480 train_time:68675ms step_avg:56.38ms
+step:1219/1480 train_time:68761ms step_avg:56.41ms
+step:1220/1480 train_time:68855ms step_avg:56.44ms
+step:1221/1480 train_time:68941ms step_avg:56.46ms
+step:1222/1480 train_time:69034ms step_avg:56.49ms
+step:1223/1480 train_time:69120ms step_avg:56.52ms
+step:1224/1480 train_time:69212ms step_avg:56.55ms
+step:1225/1480 train_time:69297ms step_avg:56.57ms
+step:1226/1480 train_time:69389ms step_avg:56.60ms
+step:1227/1480 train_time:69472ms step_avg:56.62ms
+step:1228/1480 train_time:69564ms step_avg:56.65ms
+step:1229/1480 train_time:69648ms step_avg:56.67ms
+step:1230/1480 train_time:69739ms step_avg:56.70ms
+step:1231/1480 train_time:69824ms step_avg:56.72ms
+step:1232/1480 train_time:69915ms step_avg:56.75ms
+step:1233/1480 train_time:70002ms step_avg:56.77ms
+step:1234/1480 train_time:70092ms step_avg:56.80ms
+step:1235/1480 train_time:70176ms step_avg:56.82ms
+step:1236/1480 train_time:70266ms step_avg:56.85ms
+step:1237/1480 train_time:70353ms step_avg:56.87ms
+step:1238/1480 train_time:70445ms step_avg:56.90ms
+step:1239/1480 train_time:70530ms step_avg:56.92ms
+step:1240/1480 train_time:70623ms step_avg:56.95ms
+step:1241/1480 train_time:70708ms step_avg:56.98ms
+step:1242/1480 train_time:70801ms step_avg:57.01ms
+step:1243/1480 train_time:70888ms step_avg:57.03ms
+step:1244/1480 train_time:70983ms step_avg:57.06ms
+step:1245/1480 train_time:71069ms step_avg:57.08ms
+step:1246/1480 train_time:71162ms step_avg:57.11ms
+step:1247/1480 train_time:71249ms step_avg:57.14ms
+step:1248/1480 train_time:71342ms step_avg:57.17ms
+step:1249/1480 train_time:71427ms step_avg:57.19ms
+step:1250/1480 train_time:71520ms step_avg:57.22ms
+step:1250/1480 val_loss:3.3694 train_time:71639ms step_avg:57.31ms
+step:1251/1480 train_time:71656ms step_avg:57.28ms
+step:1252/1480 train_time:71701ms step_avg:57.27ms
+step:1253/1480 train_time:71788ms step_avg:57.29ms
+step:1254/1480 train_time:71881ms step_avg:57.32ms
+step:1255/1480 train_time:71967ms step_avg:57.34ms
+step:1256/1480 train_time:72062ms step_avg:57.37ms
+step:1257/1480 train_time:72148ms step_avg:57.40ms
+step:1258/1480 train_time:72242ms step_avg:57.43ms
+step:1259/1480 train_time:72330ms step_avg:57.45ms
+step:1260/1480 train_time:72425ms step_avg:57.48ms
+step:1261/1480 train_time:72511ms step_avg:57.50ms
+step:1262/1480 train_time:72607ms step_avg:57.53ms
+step:1263/1480 train_time:72693ms step_avg:57.56ms
+step:1264/1480 train_time:72787ms step_avg:57.58ms
+step:1265/1480 train_time:72873ms step_avg:57.61ms
+step:1266/1480 train_time:72967ms step_avg:57.64ms
+step:1267/1480 train_time:73054ms step_avg:57.66ms
+step:1268/1480 train_time:73147ms step_avg:57.69ms
+step:1269/1480 train_time:73234ms step_avg:57.71ms
+step:1270/1480 train_time:73328ms step_avg:57.74ms
+step:1271/1480 train_time:73414ms step_avg:57.76ms
+step:1272/1480 train_time:73507ms step_avg:57.79ms
+step:1273/1480 train_time:73593ms step_avg:57.81ms
+step:1274/1480 train_time:73682ms step_avg:57.84ms
+step:1275/1480 train_time:73767ms step_avg:57.86ms
+step:1276/1480 train_time:73859ms step_avg:57.88ms
+step:1277/1480 train_time:73944ms step_avg:57.90ms
+step:1278/1480 train_time:74033ms step_avg:57.93ms
+step:1279/1480 train_time:74119ms step_avg:57.95ms
+step:1280/1480 train_time:74211ms step_avg:57.98ms
+step:1281/1480 train_time:74297ms step_avg:58.00ms
+step:1282/1480 train_time:74391ms step_avg:58.03ms
+step:1283/1480 train_time:74477ms step_avg:58.05ms
+step:1284/1480 train_time:74568ms step_avg:58.08ms
+step:1285/1480 train_time:74665ms step_avg:58.10ms
+step:1286/1480 train_time:74770ms step_avg:58.14ms
+step:1287/1480 train_time:74860ms step_avg:58.17ms
+step:1288/1480 train_time:74944ms step_avg:58.19ms
+step:1289/1480 train_time:75029ms step_avg:58.21ms
+step:1290/1480 train_time:75121ms step_avg:58.23ms
+step:1291/1480 train_time:75212ms step_avg:58.26ms
+step:1292/1480 train_time:75305ms step_avg:58.29ms
+step:1293/1480 train_time:75393ms step_avg:58.31ms
+step:1294/1480 train_time:75486ms step_avg:58.34ms
+step:1295/1480 train_time:75577ms step_avg:58.36ms
+step:1296/1480 train_time:75671ms step_avg:58.39ms
+step:1297/1480 train_time:75759ms step_avg:58.41ms
+step:1298/1480 train_time:75851ms step_avg:58.44ms
+step:1299/1480 train_time:75938ms step_avg:58.46ms
+step:1300/1480 train_time:76031ms step_avg:58.49ms
+step:1301/1480 train_time:76119ms step_avg:58.51ms
+step:1302/1480 train_time:76214ms step_avg:58.54ms
+step:1303/1480 train_time:76303ms step_avg:58.56ms
+step:1304/1480 train_time:76398ms step_avg:58.59ms
+step:1305/1480 train_time:76485ms step_avg:58.61ms
+step:1306/1480 train_time:76579ms step_avg:58.64ms
+step:1307/1480 train_time:76667ms step_avg:58.66ms
+step:1308/1480 train_time:76761ms step_avg:58.69ms
+step:1309/1480 train_time:76849ms step_avg:58.71ms
+step:1310/1480 train_time:76943ms step_avg:58.74ms
+step:1311/1480 train_time:77030ms step_avg:58.76ms
+step:1312/1480 train_time:77124ms step_avg:58.78ms
+step:1313/1480 train_time:77211ms step_avg:58.81ms
+step:1314/1480 train_time:77307ms step_avg:58.83ms
+step:1315/1480 train_time:77393ms step_avg:58.85ms
+step:1316/1480 train_time:77488ms step_avg:58.88ms
+step:1317/1480 train_time:77575ms step_avg:58.90ms
+step:1318/1480 train_time:77668ms step_avg:58.93ms
+step:1319/1480 train_time:77756ms step_avg:58.95ms
+step:1320/1480 train_time:77849ms step_avg:58.98ms
+step:1321/1480 train_time:77935ms step_avg:59.00ms
+step:1322/1480 train_time:78029ms step_avg:59.02ms
+step:1323/1480 train_time:78115ms step_avg:59.04ms
+step:1324/1480 train_time:78208ms step_avg:59.07ms
+step:1325/1480 train_time:78294ms step_avg:59.09ms
+step:1326/1480 train_time:78389ms step_avg:59.12ms
+step:1327/1480 train_time:78475ms step_avg:59.14ms
+step:1328/1480 train_time:78569ms step_avg:59.16ms
+step:1329/1480 train_time:78655ms step_avg:59.18ms
+step:1330/1480 train_time:78749ms step_avg:59.21ms
+step:1331/1480 train_time:78834ms step_avg:59.23ms
+step:1332/1480 train_time:78928ms step_avg:59.26ms
+step:1333/1480 train_time:79014ms step_avg:59.28ms
+step:1334/1480 train_time:79106ms step_avg:59.30ms
+step:1335/1480 train_time:79192ms step_avg:59.32ms
+step:1336/1480 train_time:79287ms step_avg:59.35ms
+step:1337/1480 train_time:79372ms step_avg:59.37ms
+step:1338/1480 train_time:79466ms step_avg:59.39ms
+step:1339/1480 train_time:79552ms step_avg:59.41ms
+step:1340/1480 train_time:79646ms step_avg:59.44ms
+step:1341/1480 train_time:79730ms step_avg:59.46ms
+step:1342/1480 train_time:79820ms step_avg:59.48ms
+step:1343/1480 train_time:79907ms step_avg:59.50ms
+step:1344/1480 train_time:79997ms step_avg:59.52ms
+step:1345/1480 train_time:80083ms step_avg:59.54ms
+step:1346/1480 train_time:80176ms step_avg:59.57ms
+step:1347/1480 train_time:80261ms step_avg:59.58ms
+step:1348/1480 train_time:80350ms step_avg:59.61ms
+step:1349/1480 train_time:80434ms step_avg:59.62ms
+step:1350/1480 train_time:80526ms step_avg:59.65ms
+step:1351/1480 train_time:80612ms step_avg:59.67ms
+step:1352/1480 train_time:80702ms step_avg:59.69ms
+step:1353/1480 train_time:80789ms step_avg:59.71ms
+step:1354/1480 train_time:80882ms step_avg:59.74ms
+step:1355/1480 train_time:80968ms step_avg:59.75ms
+step:1356/1480 train_time:81064ms step_avg:59.78ms
+step:1357/1480 train_time:81149ms step_avg:59.80ms
+step:1358/1480 train_time:81241ms step_avg:59.82ms
+step:1359/1480 train_time:81328ms step_avg:59.84ms
+step:1360/1480 train_time:81427ms step_avg:59.87ms
+step:1361/1480 train_time:81518ms step_avg:59.90ms
+step:1362/1480 train_time:81616ms step_avg:59.92ms
+step:1363/1480 train_time:81708ms step_avg:59.95ms
+step:1364/1480 train_time:81806ms step_avg:59.98ms
+step:1365/1480 train_time:81897ms step_avg:60.00ms
+step:1366/1480 train_time:81994ms step_avg:60.02ms
+step:1367/1480 train_time:82087ms step_avg:60.05ms
+step:1368/1480 train_time:82185ms step_avg:60.08ms
+step:1369/1480 train_time:82275ms step_avg:60.10ms
+step:1370/1480 train_time:82373ms step_avg:60.13ms
+step:1371/1480 train_time:82455ms step_avg:60.14ms
+step:1372/1480 train_time:82539ms step_avg:60.16ms
+step:1373/1480 train_time:82625ms step_avg:60.18ms
+step:1374/1480 train_time:82719ms step_avg:60.20ms
+step:1375/1480 train_time:82803ms step_avg:60.22ms
+step:1376/1480 train_time:82892ms step_avg:60.24ms
+step:1377/1480 train_time:82980ms step_avg:60.26ms
+step:1378/1480 train_time:83070ms step_avg:60.28ms
+step:1379/1480 train_time:83154ms step_avg:60.30ms
+step:1380/1480 train_time:83245ms step_avg:60.32ms
+step:1381/1480 train_time:83329ms step_avg:60.34ms
+step:1382/1480 train_time:83421ms step_avg:60.36ms
+step:1383/1480 train_time:83508ms step_avg:60.38ms
+step:1384/1480 train_time:83603ms step_avg:60.41ms
+step:1385/1480 train_time:83689ms step_avg:60.43ms
+step:1386/1480 train_time:83780ms step_avg:60.45ms
+step:1387/1480 train_time:83868ms step_avg:60.47ms
+step:1388/1480 train_time:83965ms step_avg:60.49ms
+step:1389/1480 train_time:84058ms step_avg:60.52ms
+step:1390/1480 train_time:84156ms step_avg:60.54ms
+step:1391/1480 train_time:84249ms step_avg:60.57ms
+step:1392/1480 train_time:84346ms step_avg:60.59ms
+step:1393/1480 train_time:84437ms step_avg:60.62ms
+step:1394/1480 train_time:84534ms step_avg:60.64ms
+step:1395/1480 train_time:84626ms step_avg:60.66ms
+step:1396/1480 train_time:84712ms step_avg:60.68ms
+step:1397/1480 train_time:84790ms step_avg:60.69ms
+step:1398/1480 train_time:84884ms step_avg:60.72ms
+step:1399/1480 train_time:84975ms step_avg:60.74ms
+step:1400/1480 train_time:85077ms step_avg:60.77ms
+step:1401/1480 train_time:85165ms step_avg:60.79ms
+step:1402/1480 train_time:85257ms step_avg:60.81ms
+step:1403/1480 train_time:85341ms step_avg:60.83ms
+step:1404/1480 train_time:85435ms step_avg:60.85ms
+step:1405/1480 train_time:85525ms step_avg:60.87ms
+step:1406/1480 train_time:85625ms step_avg:60.90ms
+step:1407/1480 train_time:85716ms step_avg:60.92ms
+step:1408/1480 train_time:85812ms step_avg:60.95ms
+step:1409/1480 train_time:85903ms step_avg:60.97ms
+step:1410/1480 train_time:85999ms step_avg:60.99ms
+step:1411/1480 train_time:86089ms step_avg:61.01ms
+step:1412/1480 train_time:86185ms step_avg:61.04ms
+step:1413/1480 train_time:86277ms step_avg:61.06ms
+step:1414/1480 train_time:86372ms step_avg:61.08ms
+step:1415/1480 train_time:86461ms step_avg:61.10ms
+step:1416/1480 train_time:86549ms step_avg:61.12ms
+step:1417/1480 train_time:86631ms step_avg:61.14ms
+step:1418/1480 train_time:86722ms step_avg:61.16ms
+step:1419/1480 train_time:86805ms step_avg:61.17ms
+step:1420/1480 train_time:86896ms step_avg:61.19ms
+step:1421/1480 train_time:86983ms step_avg:61.21ms
+step:1422/1480 train_time:87073ms step_avg:61.23ms
+step:1423/1480 train_time:87164ms step_avg:61.25ms
+step:1424/1480 train_time:87262ms step_avg:61.28ms
+step:1425/1480 train_time:87354ms step_avg:61.30ms
+step:1426/1480 train_time:87452ms step_avg:61.33ms
+step:1427/1480 train_time:87544ms step_avg:61.35ms
+step:1428/1480 train_time:87641ms step_avg:61.37ms
+step:1429/1480 train_time:87732ms step_avg:61.39ms
+step:1430/1480 train_time:87829ms step_avg:61.42ms
+step:1431/1480 train_time:87919ms step_avg:61.44ms
+step:1432/1480 train_time:88003ms step_avg:61.45ms
+step:1433/1480 train_time:88085ms step_avg:61.47ms
+step:1434/1480 train_time:88179ms step_avg:61.49ms
+step:1435/1480 train_time:88264ms step_avg:61.51ms
+step:1436/1480 train_time:88353ms step_avg:61.53ms
+step:1437/1480 train_time:88437ms step_avg:61.54ms
+step:1438/1480 train_time:88530ms step_avg:61.56ms
+step:1439/1480 train_time:88617ms step_avg:61.58ms
+step:1440/1480 train_time:88707ms step_avg:61.60ms
+step:1441/1480 train_time:88805ms step_avg:61.63ms
+step:1442/1480 train_time:88908ms step_avg:61.66ms
+step:1443/1480 train_time:89004ms step_avg:61.68ms
+step:1444/1480 train_time:89106ms step_avg:61.71ms
+step:1445/1480 train_time:89194ms step_avg:61.73ms
+step:1446/1480 train_time:89281ms step_avg:61.74ms
+step:1447/1480 train_time:89363ms step_avg:61.76ms
+step:1448/1480 train_time:89457ms step_avg:61.78ms
+step:1449/1480 train_time:89548ms step_avg:61.80ms
+step:1450/1480 train_time:89640ms step_avg:61.82ms
+step:1451/1480 train_time:89727ms step_avg:61.84ms
+step:1452/1480 train_time:89823ms step_avg:61.86ms
+step:1453/1480 train_time:89912ms step_avg:61.88ms
+step:1454/1480 train_time:90008ms step_avg:61.90ms
+step:1455/1480 train_time:90099ms step_avg:61.92ms
+step:1456/1480 train_time:90196ms step_avg:61.95ms
+step:1457/1480 train_time:90287ms step_avg:61.97ms
+step:1458/1480 train_time:90383ms step_avg:61.99ms
+step:1459/1480 train_time:90474ms step_avg:62.01ms
+step:1460/1480 train_time:90571ms step_avg:62.03ms
+step:1461/1480 train_time:90661ms step_avg:62.05ms
+step:1462/1480 train_time:90757ms step_avg:62.08ms
+step:1463/1480 train_time:90840ms step_avg:62.09ms
+step:1464/1480 train_time:90929ms step_avg:62.11ms
+step:1465/1480 train_time:91016ms step_avg:62.13ms
+step:1466/1480 train_time:91109ms step_avg:62.15ms
+step:1467/1480 train_time:91202ms step_avg:62.17ms
+step:1468/1480 train_time:91296ms step_avg:62.19ms
+step:1469/1480 train_time:91385ms step_avg:62.21ms
+step:1470/1480 train_time:91481ms step_avg:62.23ms
+step:1471/1480 train_time:91567ms step_avg:62.25ms
+step:1472/1480 train_time:91665ms step_avg:62.27ms
+step:1473/1480 train_time:91758ms step_avg:62.29ms
+step:1474/1480 train_time:91857ms step_avg:62.32ms
+step:1475/1480 train_time:91950ms step_avg:62.34ms
+step:1476/1480 train_time:92048ms step_avg:62.36ms
+step:1477/1480 train_time:92140ms step_avg:62.38ms
+step:1478/1480 train_time:92237ms step_avg:62.41ms
+step:1479/1480 train_time:92328ms step_avg:62.43ms
+step:1480/1480 train_time:92426ms step_avg:62.45ms
+step:1480/1480 val_loss:3.2795 train_time:92550ms step_avg:62.53ms
+peak memory allocated: 30504 MiB reserved: 47182 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline3-1490.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline3-1490.txt
@@ -1,0 +1,4457 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:46:37 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   35C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   41C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   36C    P0            126W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   41C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   37C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   67C    P0            153W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          457912      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          457913      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          457914      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          457915      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          457916      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          457917      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          457918      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          457919      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8301 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:79ms step_avg:79.34ms
+step:2/1490 train_time:101ms step_avg:50.39ms
+step:3/1490 train_time:118ms step_avg:39.48ms
+step:4/1490 train_time:146ms step_avg:36.45ms
+step:5/1490 train_time:173ms step_avg:34.61ms
+step:6/1490 train_time:208ms step_avg:34.63ms
+step:7/1490 train_time:236ms step_avg:33.69ms
+step:8/1490 train_time:271ms step_avg:33.88ms
+step:9/1490 train_time:299ms step_avg:33.23ms
+step:10/1490 train_time:334ms step_avg:33.38ms
+step:11/1490 train_time:362ms step_avg:32.89ms
+step:12/1490 train_time:396ms step_avg:33.04ms
+step:13/1490 train_time:425ms step_avg:32.68ms
+step:14/1490 train_time:460ms step_avg:32.83ms
+step:15/1490 train_time:488ms step_avg:32.54ms
+step:16/1490 train_time:523ms step_avg:32.67ms
+step:17/1490 train_time:551ms step_avg:32.42ms
+step:18/1490 train_time:586ms step_avg:32.58ms
+step:19/1490 train_time:615ms step_avg:32.36ms
+step:20/1490 train_time:650ms step_avg:32.48ms
+step:21/1490 train_time:678ms step_avg:32.28ms
+step:22/1490 train_time:713ms step_avg:32.39ms
+step:23/1490 train_time:743ms step_avg:32.32ms
+step:24/1490 train_time:780ms step_avg:32.50ms
+step:25/1490 train_time:810ms step_avg:32.40ms
+step:26/1490 train_time:847ms step_avg:32.57ms
+step:27/1490 train_time:877ms step_avg:32.47ms
+step:28/1490 train_time:913ms step_avg:32.61ms
+step:29/1490 train_time:943ms step_avg:32.51ms
+step:30/1490 train_time:980ms step_avg:32.66ms
+step:31/1490 train_time:1010ms step_avg:32.57ms
+step:32/1490 train_time:1046ms step_avg:32.69ms
+step:33/1490 train_time:1076ms step_avg:32.60ms
+step:34/1490 train_time:1112ms step_avg:32.70ms
+step:35/1490 train_time:1141ms step_avg:32.61ms
+step:36/1490 train_time:1178ms step_avg:32.72ms
+step:37/1490 train_time:1208ms step_avg:32.64ms
+step:38/1490 train_time:1244ms step_avg:32.74ms
+step:39/1490 train_time:1274ms step_avg:32.66ms
+step:40/1490 train_time:1310ms step_avg:32.75ms
+step:41/1490 train_time:1339ms step_avg:32.67ms
+step:42/1490 train_time:1376ms step_avg:32.76ms
+step:43/1490 train_time:1406ms step_avg:32.69ms
+step:44/1490 train_time:1442ms step_avg:32.78ms
+step:45/1490 train_time:1473ms step_avg:32.72ms
+step:46/1490 train_time:1509ms step_avg:32.80ms
+step:47/1490 train_time:1539ms step_avg:32.74ms
+step:48/1490 train_time:1575ms step_avg:32.81ms
+step:49/1490 train_time:1605ms step_avg:32.75ms
+step:50/1490 train_time:1641ms step_avg:32.82ms
+step:51/1490 train_time:1671ms step_avg:32.77ms
+step:52/1490 train_time:1707ms step_avg:32.83ms
+step:53/1490 train_time:1737ms step_avg:32.77ms
+step:54/1490 train_time:1773ms step_avg:32.83ms
+step:55/1490 train_time:1803ms step_avg:32.77ms
+step:56/1490 train_time:1840ms step_avg:32.86ms
+step:57/1490 train_time:1869ms step_avg:32.79ms
+step:58/1490 train_time:1905ms step_avg:32.85ms
+step:59/1490 train_time:1935ms step_avg:32.80ms
+step:60/1490 train_time:1971ms step_avg:32.85ms
+step:61/1490 train_time:2000ms step_avg:32.79ms
+step:62/1490 train_time:2036ms step_avg:32.84ms
+step:63/1490 train_time:2066ms step_avg:32.80ms
+step:64/1490 train_time:2103ms step_avg:32.85ms
+step:65/1490 train_time:2132ms step_avg:32.80ms
+step:66/1490 train_time:2168ms step_avg:32.85ms
+step:67/1490 train_time:2198ms step_avg:32.80ms
+step:68/1490 train_time:2234ms step_avg:32.85ms
+step:69/1490 train_time:2263ms step_avg:32.80ms
+step:70/1490 train_time:2299ms step_avg:32.84ms
+step:71/1490 train_time:2329ms step_avg:32.80ms
+step:72/1490 train_time:2364ms step_avg:32.84ms
+step:73/1490 train_time:2394ms step_avg:32.80ms
+step:74/1490 train_time:2430ms step_avg:32.84ms
+step:75/1490 train_time:2459ms step_avg:32.79ms
+step:76/1490 train_time:2495ms step_avg:32.83ms
+step:77/1490 train_time:2525ms step_avg:32.79ms
+step:78/1490 train_time:2561ms step_avg:32.83ms
+step:79/1490 train_time:2590ms step_avg:32.79ms
+step:80/1490 train_time:2626ms step_avg:32.82ms
+step:81/1490 train_time:2655ms step_avg:32.78ms
+step:82/1490 train_time:2691ms step_avg:32.82ms
+step:83/1490 train_time:2720ms step_avg:32.77ms
+step:84/1490 train_time:2756ms step_avg:32.81ms
+step:85/1490 train_time:2785ms step_avg:32.77ms
+step:86/1490 train_time:2821ms step_avg:32.80ms
+step:87/1490 train_time:2850ms step_avg:32.76ms
+step:88/1490 train_time:2886ms step_avg:32.79ms
+step:89/1490 train_time:2915ms step_avg:32.75ms
+step:90/1490 train_time:2951ms step_avg:32.78ms
+step:91/1490 train_time:2980ms step_avg:32.74ms
+step:92/1490 train_time:3015ms step_avg:32.77ms
+step:93/1490 train_time:3045ms step_avg:32.74ms
+step:94/1490 train_time:3081ms step_avg:32.77ms
+step:95/1490 train_time:3110ms step_avg:32.74ms
+step:96/1490 train_time:3146ms step_avg:32.77ms
+step:97/1490 train_time:3175ms step_avg:32.73ms
+step:98/1490 train_time:3211ms step_avg:32.76ms
+step:99/1490 train_time:3240ms step_avg:32.73ms
+step:100/1490 train_time:3276ms step_avg:32.76ms
+step:101/1490 train_time:3306ms step_avg:32.73ms
+step:102/1490 train_time:3341ms step_avg:32.76ms
+step:103/1490 train_time:3371ms step_avg:32.73ms
+step:104/1490 train_time:3407ms step_avg:32.76ms
+step:105/1490 train_time:3436ms step_avg:32.73ms
+step:106/1490 train_time:3472ms step_avg:32.76ms
+step:107/1490 train_time:3502ms step_avg:32.73ms
+step:108/1490 train_time:3537ms step_avg:32.75ms
+step:109/1490 train_time:3567ms step_avg:32.73ms
+step:110/1490 train_time:3603ms step_avg:32.76ms
+step:111/1490 train_time:3633ms step_avg:32.73ms
+step:112/1490 train_time:3669ms step_avg:32.76ms
+step:113/1490 train_time:3699ms step_avg:32.73ms
+step:114/1490 train_time:3734ms step_avg:32.76ms
+step:115/1490 train_time:3764ms step_avg:32.73ms
+step:116/1490 train_time:3800ms step_avg:32.76ms
+step:117/1490 train_time:3830ms step_avg:32.73ms
+step:118/1490 train_time:3866ms step_avg:32.76ms
+step:119/1490 train_time:3895ms step_avg:32.73ms
+step:120/1490 train_time:3932ms step_avg:32.76ms
+step:121/1490 train_time:3961ms step_avg:32.74ms
+step:122/1490 train_time:3997ms step_avg:32.76ms
+step:123/1490 train_time:4027ms step_avg:32.74ms
+step:124/1490 train_time:4062ms step_avg:32.76ms
+step:125/1490 train_time:4092ms step_avg:32.74ms
+step:126/1490 train_time:4128ms step_avg:32.76ms
+step:127/1490 train_time:4157ms step_avg:32.73ms
+step:128/1490 train_time:4193ms step_avg:32.76ms
+step:129/1490 train_time:4223ms step_avg:32.73ms
+step:130/1490 train_time:4260ms step_avg:32.77ms
+step:131/1490 train_time:4292ms step_avg:32.76ms
+step:132/1490 train_time:4330ms step_avg:32.80ms
+step:133/1490 train_time:4360ms step_avg:32.78ms
+step:134/1490 train_time:4398ms step_avg:32.82ms
+step:135/1490 train_time:4429ms step_avg:32.81ms
+step:136/1490 train_time:4467ms step_avg:32.85ms
+step:137/1490 train_time:4498ms step_avg:32.83ms
+step:138/1490 train_time:4536ms step_avg:32.87ms
+step:139/1490 train_time:4568ms step_avg:32.86ms
+step:140/1490 train_time:4605ms step_avg:32.89ms
+step:141/1490 train_time:4636ms step_avg:32.88ms
+step:142/1490 train_time:4671ms step_avg:32.89ms
+step:143/1490 train_time:4699ms step_avg:32.86ms
+step:144/1490 train_time:4734ms step_avg:32.87ms
+step:145/1490 train_time:4762ms step_avg:32.84ms
+step:146/1490 train_time:4799ms step_avg:32.87ms
+step:147/1490 train_time:4828ms step_avg:32.84ms
+step:148/1490 train_time:4864ms step_avg:32.87ms
+step:149/1490 train_time:4895ms step_avg:32.85ms
+step:150/1490 train_time:4932ms step_avg:32.88ms
+step:151/1490 train_time:4962ms step_avg:32.86ms
+step:152/1490 train_time:4999ms step_avg:32.89ms
+step:153/1490 train_time:5030ms step_avg:32.88ms
+step:154/1490 train_time:5067ms step_avg:32.90ms
+step:155/1490 train_time:5098ms step_avg:32.89ms
+step:156/1490 train_time:5135ms step_avg:32.92ms
+step:157/1490 train_time:5166ms step_avg:32.91ms
+step:158/1490 train_time:5203ms step_avg:32.93ms
+step:159/1490 train_time:5234ms step_avg:32.92ms
+step:160/1490 train_time:5270ms step_avg:32.94ms
+step:161/1490 train_time:5301ms step_avg:32.92ms
+step:162/1490 train_time:5338ms step_avg:32.95ms
+step:163/1490 train_time:5369ms step_avg:32.94ms
+step:164/1490 train_time:5405ms step_avg:32.96ms
+step:165/1490 train_time:5436ms step_avg:32.94ms
+step:166/1490 train_time:5473ms step_avg:32.97ms
+step:167/1490 train_time:5503ms step_avg:32.95ms
+step:168/1490 train_time:5539ms step_avg:32.97ms
+step:169/1490 train_time:5570ms step_avg:32.96ms
+step:170/1490 train_time:5607ms step_avg:32.98ms
+step:171/1490 train_time:5637ms step_avg:32.96ms
+step:172/1490 train_time:5673ms step_avg:32.99ms
+step:173/1490 train_time:5704ms step_avg:32.97ms
+step:174/1490 train_time:5740ms step_avg:32.99ms
+step:175/1490 train_time:5771ms step_avg:32.98ms
+step:176/1490 train_time:5808ms step_avg:33.00ms
+step:177/1490 train_time:5838ms step_avg:32.98ms
+step:178/1490 train_time:5874ms step_avg:33.00ms
+step:179/1490 train_time:5905ms step_avg:32.99ms
+step:180/1490 train_time:5942ms step_avg:33.01ms
+step:181/1490 train_time:5972ms step_avg:33.00ms
+step:182/1490 train_time:6009ms step_avg:33.02ms
+step:183/1490 train_time:6039ms step_avg:33.00ms
+step:184/1490 train_time:6076ms step_avg:33.02ms
+step:185/1490 train_time:6105ms step_avg:33.00ms
+step:186/1490 train_time:6142ms step_avg:33.02ms
+step:187/1490 train_time:6172ms step_avg:33.00ms
+step:188/1490 train_time:6208ms step_avg:33.02ms
+step:189/1490 train_time:6239ms step_avg:33.01ms
+step:190/1490 train_time:6275ms step_avg:33.03ms
+step:191/1490 train_time:6305ms step_avg:33.01ms
+step:192/1490 train_time:6341ms step_avg:33.03ms
+step:193/1490 train_time:6371ms step_avg:33.01ms
+step:194/1490 train_time:6408ms step_avg:33.03ms
+step:195/1490 train_time:6438ms step_avg:33.01ms
+step:196/1490 train_time:6474ms step_avg:33.03ms
+step:197/1490 train_time:6504ms step_avg:33.01ms
+step:198/1490 train_time:6540ms step_avg:33.03ms
+step:199/1490 train_time:6570ms step_avg:33.01ms
+step:200/1490 train_time:6606ms step_avg:33.03ms
+step:201/1490 train_time:6636ms step_avg:33.01ms
+step:202/1490 train_time:6672ms step_avg:33.03ms
+step:203/1490 train_time:6702ms step_avg:33.01ms
+step:204/1490 train_time:6738ms step_avg:33.03ms
+step:205/1490 train_time:6769ms step_avg:33.02ms
+step:206/1490 train_time:6805ms step_avg:33.04ms
+step:207/1490 train_time:6835ms step_avg:33.02ms
+step:208/1490 train_time:6872ms step_avg:33.04ms
+step:209/1490 train_time:6902ms step_avg:33.02ms
+step:210/1490 train_time:6938ms step_avg:33.04ms
+step:211/1490 train_time:6969ms step_avg:33.03ms
+step:212/1490 train_time:7005ms step_avg:33.04ms
+step:213/1490 train_time:7035ms step_avg:33.03ms
+step:214/1490 train_time:7072ms step_avg:33.04ms
+step:215/1490 train_time:7102ms step_avg:33.03ms
+step:216/1490 train_time:7138ms step_avg:33.05ms
+step:217/1490 train_time:7168ms step_avg:33.03ms
+step:218/1490 train_time:7204ms step_avg:33.05ms
+step:219/1490 train_time:7234ms step_avg:33.03ms
+step:220/1490 train_time:7270ms step_avg:33.05ms
+step:221/1490 train_time:7300ms step_avg:33.03ms
+step:222/1490 train_time:7337ms step_avg:33.05ms
+step:223/1490 train_time:7367ms step_avg:33.03ms
+step:224/1490 train_time:7403ms step_avg:33.05ms
+step:225/1490 train_time:7433ms step_avg:33.03ms
+step:226/1490 train_time:7469ms step_avg:33.05ms
+step:227/1490 train_time:7499ms step_avg:33.04ms
+step:228/1490 train_time:7535ms step_avg:33.05ms
+step:229/1490 train_time:7565ms step_avg:33.04ms
+step:230/1490 train_time:7601ms step_avg:33.05ms
+step:231/1490 train_time:7631ms step_avg:33.04ms
+step:232/1490 train_time:7667ms step_avg:33.05ms
+step:233/1490 train_time:7697ms step_avg:33.03ms
+step:234/1490 train_time:7733ms step_avg:33.05ms
+step:235/1490 train_time:7763ms step_avg:33.03ms
+step:236/1490 train_time:7799ms step_avg:33.05ms
+step:237/1490 train_time:7829ms step_avg:33.03ms
+step:238/1490 train_time:7865ms step_avg:33.05ms
+step:239/1490 train_time:7895ms step_avg:33.03ms
+step:240/1490 train_time:7931ms step_avg:33.05ms
+step:241/1490 train_time:7961ms step_avg:33.03ms
+step:242/1490 train_time:7997ms step_avg:33.05ms
+step:243/1490 train_time:8028ms step_avg:33.04ms
+step:244/1490 train_time:8064ms step_avg:33.05ms
+step:245/1490 train_time:8094ms step_avg:33.04ms
+step:246/1490 train_time:8131ms step_avg:33.05ms
+step:247/1490 train_time:8162ms step_avg:33.04ms
+step:248/1490 train_time:8198ms step_avg:33.06ms
+step:249/1490 train_time:8229ms step_avg:33.05ms
+step:250/1490 train_time:8265ms step_avg:33.06ms
+step:250/1490 val_loss:4.5192 train_time:8313ms step_avg:33.25ms
+step:251/1490 train_time:8330ms step_avg:33.19ms
+step:252/1490 train_time:8348ms step_avg:33.13ms
+step:253/1490 train_time:8369ms step_avg:33.08ms
+step:254/1490 train_time:8409ms step_avg:33.11ms
+step:255/1490 train_time:8439ms step_avg:33.09ms
+step:256/1490 train_time:8475ms step_avg:33.11ms
+step:257/1490 train_time:8504ms step_avg:33.09ms
+step:258/1490 train_time:8543ms step_avg:33.11ms
+step:259/1490 train_time:8572ms step_avg:33.10ms
+step:260/1490 train_time:8609ms step_avg:33.11ms
+step:261/1490 train_time:8639ms step_avg:33.10ms
+step:262/1490 train_time:8675ms step_avg:33.11ms
+step:263/1490 train_time:8706ms step_avg:33.10ms
+step:264/1490 train_time:8742ms step_avg:33.11ms
+step:265/1490 train_time:8773ms step_avg:33.10ms
+step:266/1490 train_time:8809ms step_avg:33.12ms
+step:267/1490 train_time:8839ms step_avg:33.11ms
+step:268/1490 train_time:8876ms step_avg:33.12ms
+step:269/1490 train_time:8906ms step_avg:33.11ms
+step:270/1490 train_time:8943ms step_avg:33.12ms
+step:271/1490 train_time:8973ms step_avg:33.11ms
+step:272/1490 train_time:9010ms step_avg:33.12ms
+step:273/1490 train_time:9040ms step_avg:33.11ms
+step:274/1490 train_time:9076ms step_avg:33.13ms
+step:275/1490 train_time:9107ms step_avg:33.12ms
+step:276/1490 train_time:9144ms step_avg:33.13ms
+step:277/1490 train_time:9174ms step_avg:33.12ms
+step:278/1490 train_time:9211ms step_avg:33.13ms
+step:279/1490 train_time:9241ms step_avg:33.12ms
+step:280/1490 train_time:9277ms step_avg:33.13ms
+step:281/1490 train_time:9307ms step_avg:33.12ms
+step:282/1490 train_time:9343ms step_avg:33.13ms
+step:283/1490 train_time:9374ms step_avg:33.12ms
+step:284/1490 train_time:9410ms step_avg:33.13ms
+step:285/1490 train_time:9439ms step_avg:33.12ms
+step:286/1490 train_time:9476ms step_avg:33.13ms
+step:287/1490 train_time:9506ms step_avg:33.12ms
+step:288/1490 train_time:9542ms step_avg:33.13ms
+step:289/1490 train_time:9573ms step_avg:33.12ms
+step:290/1490 train_time:9609ms step_avg:33.13ms
+step:291/1490 train_time:9639ms step_avg:33.12ms
+step:292/1490 train_time:9675ms step_avg:33.13ms
+step:293/1490 train_time:9706ms step_avg:33.13ms
+step:294/1490 train_time:9742ms step_avg:33.14ms
+step:295/1490 train_time:9772ms step_avg:33.13ms
+step:296/1490 train_time:9808ms step_avg:33.14ms
+step:297/1490 train_time:9838ms step_avg:33.12ms
+step:298/1490 train_time:9874ms step_avg:33.13ms
+step:299/1490 train_time:9904ms step_avg:33.12ms
+step:300/1490 train_time:9941ms step_avg:33.14ms
+step:301/1490 train_time:9971ms step_avg:33.13ms
+step:302/1490 train_time:10007ms step_avg:33.14ms
+step:303/1490 train_time:10037ms step_avg:33.12ms
+step:304/1490 train_time:10073ms step_avg:33.13ms
+step:305/1490 train_time:10103ms step_avg:33.12ms
+step:306/1490 train_time:10139ms step_avg:33.14ms
+step:307/1490 train_time:10170ms step_avg:33.13ms
+step:308/1490 train_time:10206ms step_avg:33.14ms
+step:309/1490 train_time:10236ms step_avg:33.13ms
+step:310/1490 train_time:10272ms step_avg:33.14ms
+step:311/1490 train_time:10303ms step_avg:33.13ms
+step:312/1490 train_time:10339ms step_avg:33.14ms
+step:313/1490 train_time:10369ms step_avg:33.13ms
+step:314/1490 train_time:10406ms step_avg:33.14ms
+step:315/1490 train_time:10436ms step_avg:33.13ms
+step:316/1490 train_time:10473ms step_avg:33.14ms
+step:317/1490 train_time:10503ms step_avg:33.13ms
+step:318/1490 train_time:10539ms step_avg:33.14ms
+step:319/1490 train_time:10569ms step_avg:33.13ms
+step:320/1490 train_time:10606ms step_avg:33.14ms
+step:321/1490 train_time:10636ms step_avg:33.13ms
+step:322/1490 train_time:10672ms step_avg:33.14ms
+step:323/1490 train_time:10702ms step_avg:33.13ms
+step:324/1490 train_time:10739ms step_avg:33.14ms
+step:325/1490 train_time:10769ms step_avg:33.13ms
+step:326/1490 train_time:10805ms step_avg:33.15ms
+step:327/1490 train_time:10835ms step_avg:33.13ms
+step:328/1490 train_time:10871ms step_avg:33.14ms
+step:329/1490 train_time:10901ms step_avg:33.13ms
+step:330/1490 train_time:10937ms step_avg:33.14ms
+step:331/1490 train_time:10967ms step_avg:33.13ms
+step:332/1490 train_time:11004ms step_avg:33.14ms
+step:333/1490 train_time:11034ms step_avg:33.13ms
+step:334/1490 train_time:11070ms step_avg:33.14ms
+step:335/1490 train_time:11101ms step_avg:33.14ms
+step:336/1490 train_time:11137ms step_avg:33.14ms
+step:337/1490 train_time:11167ms step_avg:33.14ms
+step:338/1490 train_time:11203ms step_avg:33.15ms
+step:339/1490 train_time:11233ms step_avg:33.14ms
+step:340/1490 train_time:11270ms step_avg:33.15ms
+step:341/1490 train_time:11300ms step_avg:33.14ms
+step:342/1490 train_time:11336ms step_avg:33.15ms
+step:343/1490 train_time:11366ms step_avg:33.14ms
+step:344/1490 train_time:11403ms step_avg:33.15ms
+step:345/1490 train_time:11433ms step_avg:33.14ms
+step:346/1490 train_time:11469ms step_avg:33.15ms
+step:347/1490 train_time:11500ms step_avg:33.14ms
+step:348/1490 train_time:11536ms step_avg:33.15ms
+step:349/1490 train_time:11567ms step_avg:33.14ms
+step:350/1490 train_time:11603ms step_avg:33.15ms
+step:351/1490 train_time:11633ms step_avg:33.14ms
+step:352/1490 train_time:11669ms step_avg:33.15ms
+step:353/1490 train_time:11700ms step_avg:33.14ms
+step:354/1490 train_time:11737ms step_avg:33.15ms
+step:355/1490 train_time:11766ms step_avg:33.14ms
+step:356/1490 train_time:11803ms step_avg:33.15ms
+step:357/1490 train_time:11833ms step_avg:33.14ms
+step:358/1490 train_time:11869ms step_avg:33.15ms
+step:359/1490 train_time:11898ms step_avg:33.14ms
+step:360/1490 train_time:11934ms step_avg:33.15ms
+step:361/1490 train_time:11964ms step_avg:33.14ms
+step:362/1490 train_time:12001ms step_avg:33.15ms
+step:363/1490 train_time:12031ms step_avg:33.14ms
+step:364/1490 train_time:12067ms step_avg:33.15ms
+step:365/1490 train_time:12097ms step_avg:33.14ms
+step:366/1490 train_time:12133ms step_avg:33.15ms
+step:367/1490 train_time:12162ms step_avg:33.14ms
+step:368/1490 train_time:12198ms step_avg:33.15ms
+step:369/1490 train_time:12228ms step_avg:33.14ms
+step:370/1490 train_time:12264ms step_avg:33.15ms
+step:371/1490 train_time:12294ms step_avg:33.14ms
+step:372/1490 train_time:12330ms step_avg:33.15ms
+step:373/1490 train_time:12360ms step_avg:33.14ms
+step:374/1490 train_time:12396ms step_avg:33.15ms
+step:375/1490 train_time:12426ms step_avg:33.14ms
+step:376/1490 train_time:12463ms step_avg:33.15ms
+step:377/1490 train_time:12494ms step_avg:33.14ms
+step:378/1490 train_time:12532ms step_avg:33.15ms
+step:379/1490 train_time:12563ms step_avg:33.15ms
+step:380/1490 train_time:12601ms step_avg:33.16ms
+step:381/1490 train_time:12632ms step_avg:33.16ms
+step:382/1490 train_time:12670ms step_avg:33.17ms
+step:383/1490 train_time:12701ms step_avg:33.16ms
+step:384/1490 train_time:12739ms step_avg:33.17ms
+step:385/1490 train_time:12770ms step_avg:33.17ms
+step:386/1490 train_time:12808ms step_avg:33.18ms
+step:387/1490 train_time:12839ms step_avg:33.18ms
+step:388/1490 train_time:12876ms step_avg:33.19ms
+step:389/1490 train_time:12907ms step_avg:33.18ms
+step:390/1490 train_time:12944ms step_avg:33.19ms
+step:391/1490 train_time:12974ms step_avg:33.18ms
+step:392/1490 train_time:13011ms step_avg:33.19ms
+step:393/1490 train_time:13042ms step_avg:33.19ms
+step:394/1490 train_time:13080ms step_avg:33.20ms
+step:395/1490 train_time:13111ms step_avg:33.19ms
+step:396/1490 train_time:13148ms step_avg:33.20ms
+step:397/1490 train_time:13178ms step_avg:33.19ms
+step:398/1490 train_time:13215ms step_avg:33.20ms
+step:399/1490 train_time:13246ms step_avg:33.20ms
+step:400/1490 train_time:13283ms step_avg:33.21ms
+step:401/1490 train_time:13313ms step_avg:33.20ms
+step:402/1490 train_time:13351ms step_avg:33.21ms
+step:403/1490 train_time:13381ms step_avg:33.20ms
+step:404/1490 train_time:13417ms step_avg:33.21ms
+step:405/1490 train_time:13448ms step_avg:33.21ms
+step:406/1490 train_time:13485ms step_avg:33.21ms
+step:407/1490 train_time:13516ms step_avg:33.21ms
+step:408/1490 train_time:13552ms step_avg:33.22ms
+step:409/1490 train_time:13582ms step_avg:33.21ms
+step:410/1490 train_time:13619ms step_avg:33.22ms
+step:411/1490 train_time:13650ms step_avg:33.21ms
+step:412/1490 train_time:13687ms step_avg:33.22ms
+step:413/1490 train_time:13717ms step_avg:33.21ms
+step:414/1490 train_time:13753ms step_avg:33.22ms
+step:415/1490 train_time:13784ms step_avg:33.21ms
+step:416/1490 train_time:13821ms step_avg:33.22ms
+step:417/1490 train_time:13851ms step_avg:33.22ms
+step:418/1490 train_time:13888ms step_avg:33.22ms
+step:419/1490 train_time:13918ms step_avg:33.22ms
+step:420/1490 train_time:13954ms step_avg:33.22ms
+step:421/1490 train_time:13985ms step_avg:33.22ms
+step:422/1490 train_time:14021ms step_avg:33.23ms
+step:423/1490 train_time:14052ms step_avg:33.22ms
+step:424/1490 train_time:14088ms step_avg:33.23ms
+step:425/1490 train_time:14118ms step_avg:33.22ms
+step:426/1490 train_time:14155ms step_avg:33.23ms
+step:427/1490 train_time:14186ms step_avg:33.22ms
+step:428/1490 train_time:14222ms step_avg:33.23ms
+step:429/1490 train_time:14252ms step_avg:33.22ms
+step:430/1490 train_time:14289ms step_avg:33.23ms
+step:431/1490 train_time:14319ms step_avg:33.22ms
+step:432/1490 train_time:14355ms step_avg:33.23ms
+step:433/1490 train_time:14386ms step_avg:33.22ms
+step:434/1490 train_time:14423ms step_avg:33.23ms
+step:435/1490 train_time:14453ms step_avg:33.22ms
+step:436/1490 train_time:14490ms step_avg:33.23ms
+step:437/1490 train_time:14520ms step_avg:33.23ms
+step:438/1490 train_time:14556ms step_avg:33.23ms
+step:439/1490 train_time:14587ms step_avg:33.23ms
+step:440/1490 train_time:14624ms step_avg:33.24ms
+step:441/1490 train_time:14654ms step_avg:33.23ms
+step:442/1490 train_time:14691ms step_avg:33.24ms
+step:443/1490 train_time:14721ms step_avg:33.23ms
+step:444/1490 train_time:14757ms step_avg:33.24ms
+step:445/1490 train_time:14788ms step_avg:33.23ms
+step:446/1490 train_time:14825ms step_avg:33.24ms
+step:447/1490 train_time:14855ms step_avg:33.23ms
+step:448/1490 train_time:14891ms step_avg:33.24ms
+step:449/1490 train_time:14921ms step_avg:33.23ms
+step:450/1490 train_time:14958ms step_avg:33.24ms
+step:451/1490 train_time:14988ms step_avg:33.23ms
+step:452/1490 train_time:15025ms step_avg:33.24ms
+step:453/1490 train_time:15055ms step_avg:33.23ms
+step:454/1490 train_time:15092ms step_avg:33.24ms
+step:455/1490 train_time:15121ms step_avg:33.23ms
+step:456/1490 train_time:15158ms step_avg:33.24ms
+step:457/1490 train_time:15189ms step_avg:33.24ms
+step:458/1490 train_time:15225ms step_avg:33.24ms
+step:459/1490 train_time:15255ms step_avg:33.24ms
+step:460/1490 train_time:15291ms step_avg:33.24ms
+step:461/1490 train_time:15321ms step_avg:33.23ms
+step:462/1490 train_time:15357ms step_avg:33.24ms
+step:463/1490 train_time:15388ms step_avg:33.24ms
+step:464/1490 train_time:15424ms step_avg:33.24ms
+step:465/1490 train_time:15455ms step_avg:33.24ms
+step:466/1490 train_time:15491ms step_avg:33.24ms
+step:467/1490 train_time:15522ms step_avg:33.24ms
+step:468/1490 train_time:15558ms step_avg:33.24ms
+step:469/1490 train_time:15589ms step_avg:33.24ms
+step:470/1490 train_time:15626ms step_avg:33.25ms
+step:471/1490 train_time:15656ms step_avg:33.24ms
+step:472/1490 train_time:15692ms step_avg:33.25ms
+step:473/1490 train_time:15721ms step_avg:33.24ms
+step:474/1490 train_time:15757ms step_avg:33.24ms
+step:475/1490 train_time:15788ms step_avg:33.24ms
+step:476/1490 train_time:15824ms step_avg:33.24ms
+step:477/1490 train_time:15854ms step_avg:33.24ms
+step:478/1490 train_time:15890ms step_avg:33.24ms
+step:479/1490 train_time:15920ms step_avg:33.24ms
+step:480/1490 train_time:15956ms step_avg:33.24ms
+step:481/1490 train_time:15986ms step_avg:33.23ms
+step:482/1490 train_time:16022ms step_avg:33.24ms
+step:483/1490 train_time:16052ms step_avg:33.23ms
+step:484/1490 train_time:16091ms step_avg:33.25ms
+step:485/1490 train_time:16144ms step_avg:33.29ms
+step:486/1490 train_time:16214ms step_avg:33.36ms
+step:487/1490 train_time:16276ms step_avg:33.42ms
+step:488/1490 train_time:16347ms step_avg:33.50ms
+step:489/1490 train_time:16409ms step_avg:33.56ms
+step:490/1490 train_time:16477ms step_avg:33.63ms
+step:491/1490 train_time:16541ms step_avg:33.69ms
+step:492/1490 train_time:16604ms step_avg:33.75ms
+step:493/1490 train_time:16657ms step_avg:33.79ms
+step:494/1490 train_time:16717ms step_avg:33.84ms
+step:495/1490 train_time:16773ms step_avg:33.88ms
+step:496/1490 train_time:16837ms step_avg:33.95ms
+step:497/1490 train_time:16896ms step_avg:34.00ms
+step:498/1490 train_time:16960ms step_avg:34.06ms
+step:499/1490 train_time:17019ms step_avg:34.11ms
+step:500/1490 train_time:17083ms step_avg:34.17ms
+step:500/1490 val_loss:4.2341 train_time:17166ms step_avg:34.33ms
+step:501/1490 train_time:17183ms step_avg:34.30ms
+step:502/1490 train_time:17207ms step_avg:34.28ms
+step:503/1490 train_time:17266ms step_avg:34.33ms
+step:504/1490 train_time:17332ms step_avg:34.39ms
+step:505/1490 train_time:17392ms step_avg:34.44ms
+step:506/1490 train_time:17458ms step_avg:34.50ms
+step:507/1490 train_time:17517ms step_avg:34.55ms
+step:508/1490 train_time:17582ms step_avg:34.61ms
+step:509/1490 train_time:17640ms step_avg:34.66ms
+step:510/1490 train_time:17701ms step_avg:34.71ms
+step:511/1490 train_time:17756ms step_avg:34.75ms
+step:512/1490 train_time:17819ms step_avg:34.80ms
+step:513/1490 train_time:17874ms step_avg:34.84ms
+step:514/1490 train_time:17937ms step_avg:34.90ms
+step:515/1490 train_time:17993ms step_avg:34.94ms
+step:516/1490 train_time:18057ms step_avg:34.99ms
+step:517/1490 train_time:18116ms step_avg:35.04ms
+step:518/1490 train_time:18181ms step_avg:35.10ms
+step:519/1490 train_time:18242ms step_avg:35.15ms
+step:520/1490 train_time:18308ms step_avg:35.21ms
+step:521/1490 train_time:18365ms step_avg:35.25ms
+step:522/1490 train_time:18430ms step_avg:35.31ms
+step:523/1490 train_time:18488ms step_avg:35.35ms
+step:524/1490 train_time:18552ms step_avg:35.41ms
+step:525/1490 train_time:18611ms step_avg:35.45ms
+step:526/1490 train_time:18675ms step_avg:35.50ms
+step:527/1490 train_time:18733ms step_avg:35.55ms
+step:528/1490 train_time:18797ms step_avg:35.60ms
+step:529/1490 train_time:18856ms step_avg:35.64ms
+step:530/1490 train_time:18920ms step_avg:35.70ms
+step:531/1490 train_time:18979ms step_avg:35.74ms
+step:532/1490 train_time:19044ms step_avg:35.80ms
+step:533/1490 train_time:19104ms step_avg:35.84ms
+step:534/1490 train_time:19168ms step_avg:35.90ms
+step:535/1490 train_time:19226ms step_avg:35.94ms
+step:536/1490 train_time:19291ms step_avg:35.99ms
+step:537/1490 train_time:19348ms step_avg:36.03ms
+step:538/1490 train_time:19413ms step_avg:36.08ms
+step:539/1490 train_time:19470ms step_avg:36.12ms
+step:540/1490 train_time:19535ms step_avg:36.18ms
+step:541/1490 train_time:19593ms step_avg:36.22ms
+step:542/1490 train_time:19658ms step_avg:36.27ms
+step:543/1490 train_time:19717ms step_avg:36.31ms
+step:544/1490 train_time:19782ms step_avg:36.36ms
+step:545/1490 train_time:19843ms step_avg:36.41ms
+step:546/1490 train_time:19910ms step_avg:36.46ms
+step:547/1490 train_time:19967ms step_avg:36.50ms
+step:548/1490 train_time:20032ms step_avg:36.56ms
+step:549/1490 train_time:20090ms step_avg:36.59ms
+step:550/1490 train_time:20155ms step_avg:36.64ms
+step:551/1490 train_time:20214ms step_avg:36.69ms
+step:552/1490 train_time:20278ms step_avg:36.74ms
+step:553/1490 train_time:20338ms step_avg:36.78ms
+step:554/1490 train_time:20403ms step_avg:36.83ms
+step:555/1490 train_time:20462ms step_avg:36.87ms
+step:556/1490 train_time:20527ms step_avg:36.92ms
+step:557/1490 train_time:20585ms step_avg:36.96ms
+step:558/1490 train_time:20651ms step_avg:37.01ms
+step:559/1490 train_time:20708ms step_avg:37.04ms
+step:560/1490 train_time:20772ms step_avg:37.09ms
+step:561/1490 train_time:20829ms step_avg:37.13ms
+step:562/1490 train_time:20894ms step_avg:37.18ms
+step:563/1490 train_time:20952ms step_avg:37.22ms
+step:564/1490 train_time:21018ms step_avg:37.27ms
+step:565/1490 train_time:21076ms step_avg:37.30ms
+step:566/1490 train_time:21141ms step_avg:37.35ms
+step:567/1490 train_time:21201ms step_avg:37.39ms
+step:568/1490 train_time:21265ms step_avg:37.44ms
+step:569/1490 train_time:21323ms step_avg:37.47ms
+step:570/1490 train_time:21388ms step_avg:37.52ms
+step:571/1490 train_time:21447ms step_avg:37.56ms
+step:572/1490 train_time:21512ms step_avg:37.61ms
+step:573/1490 train_time:21568ms step_avg:37.64ms
+step:574/1490 train_time:21632ms step_avg:37.69ms
+step:575/1490 train_time:21690ms step_avg:37.72ms
+step:576/1490 train_time:21754ms step_avg:37.77ms
+step:577/1490 train_time:21811ms step_avg:37.80ms
+step:578/1490 train_time:21874ms step_avg:37.84ms
+step:579/1490 train_time:21933ms step_avg:37.88ms
+step:580/1490 train_time:22003ms step_avg:37.94ms
+step:581/1490 train_time:22067ms step_avg:37.98ms
+step:582/1490 train_time:22136ms step_avg:38.03ms
+step:583/1490 train_time:22197ms step_avg:38.07ms
+step:584/1490 train_time:22265ms step_avg:38.13ms
+step:585/1490 train_time:22327ms step_avg:38.17ms
+step:586/1490 train_time:22394ms step_avg:38.22ms
+step:587/1490 train_time:22455ms step_avg:38.25ms
+step:588/1490 train_time:22524ms step_avg:38.31ms
+step:589/1490 train_time:22586ms step_avg:38.35ms
+step:590/1490 train_time:22653ms step_avg:38.39ms
+step:591/1490 train_time:22714ms step_avg:38.43ms
+step:592/1490 train_time:22773ms step_avg:38.47ms
+step:593/1490 train_time:22827ms step_avg:38.49ms
+step:594/1490 train_time:22886ms step_avg:38.53ms
+step:595/1490 train_time:22941ms step_avg:38.56ms
+step:596/1490 train_time:23002ms step_avg:38.59ms
+step:597/1490 train_time:23059ms step_avg:38.62ms
+step:598/1490 train_time:23121ms step_avg:38.66ms
+step:599/1490 train_time:23178ms step_avg:38.70ms
+step:600/1490 train_time:23243ms step_avg:38.74ms
+step:601/1490 train_time:23302ms step_avg:38.77ms
+step:602/1490 train_time:23368ms step_avg:38.82ms
+step:603/1490 train_time:23428ms step_avg:38.85ms
+step:604/1490 train_time:23492ms step_avg:38.89ms
+step:605/1490 train_time:23552ms step_avg:38.93ms
+step:606/1490 train_time:23617ms step_avg:38.97ms
+step:607/1490 train_time:23676ms step_avg:39.00ms
+step:608/1490 train_time:23743ms step_avg:39.05ms
+step:609/1490 train_time:23803ms step_avg:39.08ms
+step:610/1490 train_time:23869ms step_avg:39.13ms
+step:611/1490 train_time:23928ms step_avg:39.16ms
+step:612/1490 train_time:23994ms step_avg:39.21ms
+step:613/1490 train_time:24054ms step_avg:39.24ms
+step:614/1490 train_time:24120ms step_avg:39.28ms
+step:615/1490 train_time:24180ms step_avg:39.32ms
+step:616/1490 train_time:24247ms step_avg:39.36ms
+step:617/1490 train_time:24306ms step_avg:39.39ms
+step:618/1490 train_time:24371ms step_avg:39.44ms
+step:619/1490 train_time:24429ms step_avg:39.46ms
+step:620/1490 train_time:24493ms step_avg:39.51ms
+step:621/1490 train_time:24553ms step_avg:39.54ms
+step:622/1490 train_time:24619ms step_avg:39.58ms
+step:623/1490 train_time:24677ms step_avg:39.61ms
+step:624/1490 train_time:24743ms step_avg:39.65ms
+step:625/1490 train_time:24803ms step_avg:39.69ms
+step:626/1490 train_time:24868ms step_avg:39.73ms
+step:627/1490 train_time:24926ms step_avg:39.75ms
+step:628/1490 train_time:24991ms step_avg:39.79ms
+step:629/1490 train_time:25049ms step_avg:39.82ms
+step:630/1490 train_time:25113ms step_avg:39.86ms
+step:631/1490 train_time:25171ms step_avg:39.89ms
+step:632/1490 train_time:25235ms step_avg:39.93ms
+step:633/1490 train_time:25293ms step_avg:39.96ms
+step:634/1490 train_time:25357ms step_avg:39.99ms
+step:635/1490 train_time:25415ms step_avg:40.02ms
+step:636/1490 train_time:25479ms step_avg:40.06ms
+step:637/1490 train_time:25537ms step_avg:40.09ms
+step:638/1490 train_time:25602ms step_avg:40.13ms
+step:639/1490 train_time:25661ms step_avg:40.16ms
+step:640/1490 train_time:25724ms step_avg:40.19ms
+step:641/1490 train_time:25783ms step_avg:40.22ms
+step:642/1490 train_time:25848ms step_avg:40.26ms
+step:643/1490 train_time:25907ms step_avg:40.29ms
+step:644/1490 train_time:25970ms step_avg:40.33ms
+step:645/1490 train_time:26028ms step_avg:40.35ms
+step:646/1490 train_time:26091ms step_avg:40.39ms
+step:647/1490 train_time:26149ms step_avg:40.42ms
+step:648/1490 train_time:26213ms step_avg:40.45ms
+step:649/1490 train_time:26271ms step_avg:40.48ms
+step:650/1490 train_time:26336ms step_avg:40.52ms
+step:651/1490 train_time:26395ms step_avg:40.55ms
+step:652/1490 train_time:26461ms step_avg:40.58ms
+step:653/1490 train_time:26520ms step_avg:40.61ms
+step:654/1490 train_time:26585ms step_avg:40.65ms
+step:655/1490 train_time:26645ms step_avg:40.68ms
+step:656/1490 train_time:26710ms step_avg:40.72ms
+step:657/1490 train_time:26768ms step_avg:40.74ms
+step:658/1490 train_time:26832ms step_avg:40.78ms
+step:659/1490 train_time:26890ms step_avg:40.80ms
+step:660/1490 train_time:26954ms step_avg:40.84ms
+step:661/1490 train_time:27013ms step_avg:40.87ms
+step:662/1490 train_time:27077ms step_avg:40.90ms
+step:663/1490 train_time:27135ms step_avg:40.93ms
+step:664/1490 train_time:27200ms step_avg:40.96ms
+step:665/1490 train_time:27259ms step_avg:40.99ms
+step:666/1490 train_time:27323ms step_avg:41.03ms
+step:667/1490 train_time:27382ms step_avg:41.05ms
+step:668/1490 train_time:27447ms step_avg:41.09ms
+step:669/1490 train_time:27506ms step_avg:41.11ms
+step:670/1490 train_time:27570ms step_avg:41.15ms
+step:671/1490 train_time:27628ms step_avg:41.17ms
+step:672/1490 train_time:27691ms step_avg:41.21ms
+step:673/1490 train_time:27749ms step_avg:41.23ms
+step:674/1490 train_time:27814ms step_avg:41.27ms
+step:675/1490 train_time:27871ms step_avg:41.29ms
+step:676/1490 train_time:27935ms step_avg:41.32ms
+step:677/1490 train_time:27992ms step_avg:41.35ms
+step:678/1490 train_time:28057ms step_avg:41.38ms
+step:679/1490 train_time:28114ms step_avg:41.40ms
+step:680/1490 train_time:28177ms step_avg:41.44ms
+step:681/1490 train_time:28235ms step_avg:41.46ms
+step:682/1490 train_time:28298ms step_avg:41.49ms
+step:683/1490 train_time:28356ms step_avg:41.52ms
+step:684/1490 train_time:28420ms step_avg:41.55ms
+step:685/1490 train_time:28479ms step_avg:41.57ms
+step:686/1490 train_time:28546ms step_avg:41.61ms
+step:687/1490 train_time:28607ms step_avg:41.64ms
+step:688/1490 train_time:28673ms step_avg:41.68ms
+step:689/1490 train_time:28732ms step_avg:41.70ms
+step:690/1490 train_time:28798ms step_avg:41.74ms
+step:691/1490 train_time:28859ms step_avg:41.76ms
+step:692/1490 train_time:28926ms step_avg:41.80ms
+step:693/1490 train_time:28985ms step_avg:41.83ms
+step:694/1490 train_time:29051ms step_avg:41.86ms
+step:695/1490 train_time:29107ms step_avg:41.88ms
+step:696/1490 train_time:29167ms step_avg:41.91ms
+step:697/1490 train_time:29223ms step_avg:41.93ms
+step:698/1490 train_time:29289ms step_avg:41.96ms
+step:699/1490 train_time:29345ms step_avg:41.98ms
+step:700/1490 train_time:29409ms step_avg:42.01ms
+step:701/1490 train_time:29467ms step_avg:42.04ms
+step:702/1490 train_time:29532ms step_avg:42.07ms
+step:703/1490 train_time:29590ms step_avg:42.09ms
+step:704/1490 train_time:29655ms step_avg:42.12ms
+step:705/1490 train_time:29716ms step_avg:42.15ms
+step:706/1490 train_time:29784ms step_avg:42.19ms
+step:707/1490 train_time:29847ms step_avg:42.22ms
+step:708/1490 train_time:29914ms step_avg:42.25ms
+step:709/1490 train_time:29975ms step_avg:42.28ms
+step:710/1490 train_time:30044ms step_avg:42.32ms
+step:711/1490 train_time:30107ms step_avg:42.34ms
+step:712/1490 train_time:30174ms step_avg:42.38ms
+step:713/1490 train_time:30235ms step_avg:42.41ms
+step:714/1490 train_time:30303ms step_avg:42.44ms
+step:715/1490 train_time:30358ms step_avg:42.46ms
+step:716/1490 train_time:30418ms step_avg:42.48ms
+step:717/1490 train_time:30471ms step_avg:42.50ms
+step:718/1490 train_time:30534ms step_avg:42.53ms
+step:719/1490 train_time:30591ms step_avg:42.55ms
+step:720/1490 train_time:30654ms step_avg:42.58ms
+step:721/1490 train_time:30711ms step_avg:42.59ms
+step:722/1490 train_time:30774ms step_avg:42.62ms
+step:723/1490 train_time:30831ms step_avg:42.64ms
+step:724/1490 train_time:30893ms step_avg:42.67ms
+step:725/1490 train_time:30951ms step_avg:42.69ms
+step:726/1490 train_time:31014ms step_avg:42.72ms
+step:727/1490 train_time:31071ms step_avg:42.74ms
+step:728/1490 train_time:31135ms step_avg:42.77ms
+step:729/1490 train_time:31194ms step_avg:42.79ms
+step:730/1490 train_time:31259ms step_avg:42.82ms
+step:731/1490 train_time:31317ms step_avg:42.84ms
+step:732/1490 train_time:31382ms step_avg:42.87ms
+step:733/1490 train_time:31442ms step_avg:42.90ms
+step:734/1490 train_time:31506ms step_avg:42.92ms
+step:735/1490 train_time:31563ms step_avg:42.94ms
+step:736/1490 train_time:31626ms step_avg:42.97ms
+step:737/1490 train_time:31683ms step_avg:42.99ms
+step:738/1490 train_time:31747ms step_avg:43.02ms
+step:739/1490 train_time:31806ms step_avg:43.04ms
+step:740/1490 train_time:31870ms step_avg:43.07ms
+step:741/1490 train_time:31927ms step_avg:43.09ms
+step:742/1490 train_time:31990ms step_avg:43.11ms
+step:743/1490 train_time:32047ms step_avg:43.13ms
+step:744/1490 train_time:32111ms step_avg:43.16ms
+step:745/1490 train_time:32173ms step_avg:43.18ms
+step:746/1490 train_time:32243ms step_avg:43.22ms
+step:747/1490 train_time:32306ms step_avg:43.25ms
+step:748/1490 train_time:32374ms step_avg:43.28ms
+step:749/1490 train_time:32435ms step_avg:43.30ms
+step:750/1490 train_time:32504ms step_avg:43.34ms
+step:750/1490 val_loss:3.7983 train_time:32594ms step_avg:43.46ms
+step:751/1490 train_time:32611ms step_avg:43.42ms
+step:752/1490 train_time:32635ms step_avg:43.40ms
+step:753/1490 train_time:32695ms step_avg:43.42ms
+step:754/1490 train_time:32762ms step_avg:43.45ms
+step:755/1490 train_time:32821ms step_avg:43.47ms
+step:756/1490 train_time:32888ms step_avg:43.50ms
+step:757/1490 train_time:32948ms step_avg:43.52ms
+step:758/1490 train_time:33015ms step_avg:43.56ms
+step:759/1490 train_time:33074ms step_avg:43.58ms
+step:760/1490 train_time:33140ms step_avg:43.60ms
+step:761/1490 train_time:33199ms step_avg:43.62ms
+step:762/1490 train_time:33264ms step_avg:43.65ms
+step:763/1490 train_time:33324ms step_avg:43.68ms
+step:764/1490 train_time:33390ms step_avg:43.70ms
+step:765/1490 train_time:33451ms step_avg:43.73ms
+step:766/1490 train_time:33516ms step_avg:43.76ms
+step:767/1490 train_time:33575ms step_avg:43.77ms
+step:768/1490 train_time:33639ms step_avg:43.80ms
+step:769/1490 train_time:33697ms step_avg:43.82ms
+step:770/1490 train_time:33761ms step_avg:43.85ms
+step:771/1490 train_time:33819ms step_avg:43.86ms
+step:772/1490 train_time:33884ms step_avg:43.89ms
+step:773/1490 train_time:33942ms step_avg:43.91ms
+step:774/1490 train_time:34007ms step_avg:43.94ms
+step:775/1490 train_time:34066ms step_avg:43.96ms
+step:776/1490 train_time:34130ms step_avg:43.98ms
+step:777/1490 train_time:34189ms step_avg:44.00ms
+step:778/1490 train_time:34254ms step_avg:44.03ms
+step:779/1490 train_time:34312ms step_avg:44.05ms
+step:780/1490 train_time:34376ms step_avg:44.07ms
+step:781/1490 train_time:34435ms step_avg:44.09ms
+step:782/1490 train_time:34499ms step_avg:44.12ms
+step:783/1490 train_time:34556ms step_avg:44.13ms
+step:784/1490 train_time:34620ms step_avg:44.16ms
+step:785/1490 train_time:34678ms step_avg:44.18ms
+step:786/1490 train_time:34742ms step_avg:44.20ms
+step:787/1490 train_time:34800ms step_avg:44.22ms
+step:788/1490 train_time:34864ms step_avg:44.24ms
+step:789/1490 train_time:34922ms step_avg:44.26ms
+step:790/1490 train_time:34986ms step_avg:44.29ms
+step:791/1490 train_time:35044ms step_avg:44.30ms
+step:792/1490 train_time:35108ms step_avg:44.33ms
+step:793/1490 train_time:35166ms step_avg:44.35ms
+step:794/1490 train_time:35230ms step_avg:44.37ms
+step:795/1490 train_time:35289ms step_avg:44.39ms
+step:796/1490 train_time:35353ms step_avg:44.41ms
+step:797/1490 train_time:35412ms step_avg:44.43ms
+step:798/1490 train_time:35475ms step_avg:44.46ms
+step:799/1490 train_time:35533ms step_avg:44.47ms
+step:800/1490 train_time:35597ms step_avg:44.50ms
+step:801/1490 train_time:35654ms step_avg:44.51ms
+step:802/1490 train_time:35717ms step_avg:44.54ms
+step:803/1490 train_time:35773ms step_avg:44.55ms
+step:804/1490 train_time:35837ms step_avg:44.57ms
+step:805/1490 train_time:35895ms step_avg:44.59ms
+step:806/1490 train_time:35958ms step_avg:44.61ms
+step:807/1490 train_time:36015ms step_avg:44.63ms
+step:808/1490 train_time:36081ms step_avg:44.65ms
+step:809/1490 train_time:36142ms step_avg:44.67ms
+step:810/1490 train_time:36207ms step_avg:44.70ms
+step:811/1490 train_time:36267ms step_avg:44.72ms
+step:812/1490 train_time:36333ms step_avg:44.74ms
+step:813/1490 train_time:36392ms step_avg:44.76ms
+step:814/1490 train_time:36458ms step_avg:44.79ms
+step:815/1490 train_time:36517ms step_avg:44.81ms
+step:816/1490 train_time:36582ms step_avg:44.83ms
+step:817/1490 train_time:36641ms step_avg:44.85ms
+step:818/1490 train_time:36707ms step_avg:44.87ms
+step:819/1490 train_time:36767ms step_avg:44.89ms
+step:820/1490 train_time:36832ms step_avg:44.92ms
+step:821/1490 train_time:36891ms step_avg:44.93ms
+step:822/1490 train_time:36956ms step_avg:44.96ms
+step:823/1490 train_time:37015ms step_avg:44.98ms
+step:824/1490 train_time:37079ms step_avg:45.00ms
+step:825/1490 train_time:37138ms step_avg:45.02ms
+step:826/1490 train_time:37202ms step_avg:45.04ms
+step:827/1490 train_time:37259ms step_avg:45.05ms
+step:828/1490 train_time:37323ms step_avg:45.08ms
+step:829/1490 train_time:37383ms step_avg:45.09ms
+step:830/1490 train_time:37449ms step_avg:45.12ms
+step:831/1490 train_time:37507ms step_avg:45.13ms
+step:832/1490 train_time:37572ms step_avg:45.16ms
+step:833/1490 train_time:37632ms step_avg:45.18ms
+step:834/1490 train_time:37696ms step_avg:45.20ms
+step:835/1490 train_time:37753ms step_avg:45.21ms
+step:836/1490 train_time:37816ms step_avg:45.23ms
+step:837/1490 train_time:37874ms step_avg:45.25ms
+step:838/1490 train_time:37937ms step_avg:45.27ms
+step:839/1490 train_time:37995ms step_avg:45.29ms
+step:840/1490 train_time:38058ms step_avg:45.31ms
+step:841/1490 train_time:38117ms step_avg:45.32ms
+step:842/1490 train_time:38187ms step_avg:45.35ms
+step:843/1490 train_time:38254ms step_avg:45.38ms
+step:844/1490 train_time:38324ms step_avg:45.41ms
+step:845/1490 train_time:38378ms step_avg:45.42ms
+step:846/1490 train_time:38438ms step_avg:45.43ms
+step:847/1490 train_time:38495ms step_avg:45.45ms
+step:848/1490 train_time:38558ms step_avg:45.47ms
+step:849/1490 train_time:38617ms step_avg:45.49ms
+step:850/1490 train_time:38680ms step_avg:45.51ms
+step:851/1490 train_time:38741ms step_avg:45.52ms
+step:852/1490 train_time:38810ms step_avg:45.55ms
+step:853/1490 train_time:38873ms step_avg:45.57ms
+step:854/1490 train_time:38940ms step_avg:45.60ms
+step:855/1490 train_time:39000ms step_avg:45.61ms
+step:856/1490 train_time:39067ms step_avg:45.64ms
+step:857/1490 train_time:39129ms step_avg:45.66ms
+step:858/1490 train_time:39197ms step_avg:45.68ms
+step:859/1490 train_time:39256ms step_avg:45.70ms
+step:860/1490 train_time:39323ms step_avg:45.72ms
+step:861/1490 train_time:39383ms step_avg:45.74ms
+step:862/1490 train_time:39450ms step_avg:45.77ms
+step:863/1490 train_time:39511ms step_avg:45.78ms
+step:864/1490 train_time:39572ms step_avg:45.80ms
+step:865/1490 train_time:39625ms step_avg:45.81ms
+step:866/1490 train_time:39686ms step_avg:45.83ms
+step:867/1490 train_time:39743ms step_avg:45.84ms
+step:868/1490 train_time:39807ms step_avg:45.86ms
+step:869/1490 train_time:39866ms step_avg:45.88ms
+step:870/1490 train_time:39930ms step_avg:45.90ms
+step:871/1490 train_time:39990ms step_avg:45.91ms
+step:872/1490 train_time:40055ms step_avg:45.93ms
+step:873/1490 train_time:40112ms step_avg:45.95ms
+step:874/1490 train_time:40176ms step_avg:45.97ms
+step:875/1490 train_time:40234ms step_avg:45.98ms
+step:876/1490 train_time:40297ms step_avg:46.00ms
+step:877/1490 train_time:40354ms step_avg:46.01ms
+step:878/1490 train_time:40417ms step_avg:46.03ms
+step:879/1490 train_time:40474ms step_avg:46.05ms
+step:880/1490 train_time:40538ms step_avg:46.07ms
+step:881/1490 train_time:40594ms step_avg:46.08ms
+step:882/1490 train_time:40657ms step_avg:46.10ms
+step:883/1490 train_time:40714ms step_avg:46.11ms
+step:884/1490 train_time:40777ms step_avg:46.13ms
+step:885/1490 train_time:40834ms step_avg:46.14ms
+step:886/1490 train_time:40899ms step_avg:46.16ms
+step:887/1490 train_time:40956ms step_avg:46.17ms
+step:888/1490 train_time:41019ms step_avg:46.19ms
+step:889/1490 train_time:41075ms step_avg:46.20ms
+step:890/1490 train_time:41138ms step_avg:46.22ms
+step:891/1490 train_time:41201ms step_avg:46.24ms
+step:892/1490 train_time:41272ms step_avg:46.27ms
+step:893/1490 train_time:41339ms step_avg:46.29ms
+step:894/1490 train_time:41409ms step_avg:46.32ms
+step:895/1490 train_time:41473ms step_avg:46.34ms
+step:896/1490 train_time:41544ms step_avg:46.37ms
+step:897/1490 train_time:41606ms step_avg:46.38ms
+step:898/1490 train_time:41665ms step_avg:46.40ms
+step:899/1490 train_time:41718ms step_avg:46.41ms
+step:900/1490 train_time:41778ms step_avg:46.42ms
+step:901/1490 train_time:41834ms step_avg:46.43ms
+step:902/1490 train_time:41899ms step_avg:46.45ms
+step:903/1490 train_time:41960ms step_avg:46.47ms
+step:904/1490 train_time:42025ms step_avg:46.49ms
+step:905/1490 train_time:42085ms step_avg:46.50ms
+step:906/1490 train_time:42151ms step_avg:46.52ms
+step:907/1490 train_time:42211ms step_avg:46.54ms
+step:908/1490 train_time:42279ms step_avg:46.56ms
+step:909/1490 train_time:42341ms step_avg:46.58ms
+step:910/1490 train_time:42410ms step_avg:46.60ms
+step:911/1490 train_time:42473ms step_avg:46.62ms
+step:912/1490 train_time:42541ms step_avg:46.65ms
+step:913/1490 train_time:42602ms step_avg:46.66ms
+step:914/1490 train_time:42670ms step_avg:46.68ms
+step:915/1490 train_time:42733ms step_avg:46.70ms
+step:916/1490 train_time:42801ms step_avg:46.73ms
+step:917/1490 train_time:42856ms step_avg:46.73ms
+step:918/1490 train_time:42915ms step_avg:46.75ms
+step:919/1490 train_time:42969ms step_avg:46.76ms
+step:920/1490 train_time:43031ms step_avg:46.77ms
+step:921/1490 train_time:43087ms step_avg:46.78ms
+step:922/1490 train_time:43147ms step_avg:46.80ms
+step:923/1490 train_time:43205ms step_avg:46.81ms
+step:924/1490 train_time:43268ms step_avg:46.83ms
+step:925/1490 train_time:43325ms step_avg:46.84ms
+step:926/1490 train_time:43388ms step_avg:46.86ms
+step:927/1490 train_time:43447ms step_avg:46.87ms
+step:928/1490 train_time:43515ms step_avg:46.89ms
+step:929/1490 train_time:43573ms step_avg:46.90ms
+step:930/1490 train_time:43640ms step_avg:46.92ms
+step:931/1490 train_time:43701ms step_avg:46.94ms
+step:932/1490 train_time:43768ms step_avg:46.96ms
+step:933/1490 train_time:43831ms step_avg:46.98ms
+step:934/1490 train_time:43897ms step_avg:47.00ms
+step:935/1490 train_time:43955ms step_avg:47.01ms
+step:936/1490 train_time:44020ms step_avg:47.03ms
+step:937/1490 train_time:44080ms step_avg:47.04ms
+step:938/1490 train_time:44146ms step_avg:47.06ms
+step:939/1490 train_time:44206ms step_avg:47.08ms
+step:940/1490 train_time:44271ms step_avg:47.10ms
+step:941/1490 train_time:44332ms step_avg:47.11ms
+step:942/1490 train_time:44397ms step_avg:47.13ms
+step:943/1490 train_time:44455ms step_avg:47.14ms
+step:944/1490 train_time:44520ms step_avg:47.16ms
+step:945/1490 train_time:44578ms step_avg:47.17ms
+step:946/1490 train_time:44644ms step_avg:47.19ms
+step:947/1490 train_time:44702ms step_avg:47.20ms
+step:948/1490 train_time:44767ms step_avg:47.22ms
+step:949/1490 train_time:44827ms step_avg:47.24ms
+step:950/1490 train_time:44893ms step_avg:47.26ms
+step:951/1490 train_time:44951ms step_avg:47.27ms
+step:952/1490 train_time:45015ms step_avg:47.28ms
+step:953/1490 train_time:45073ms step_avg:47.30ms
+step:954/1490 train_time:45137ms step_avg:47.31ms
+step:955/1490 train_time:45195ms step_avg:47.32ms
+step:956/1490 train_time:45258ms step_avg:47.34ms
+step:957/1490 train_time:45316ms step_avg:47.35ms
+step:958/1490 train_time:45381ms step_avg:47.37ms
+step:959/1490 train_time:45439ms step_avg:47.38ms
+step:960/1490 train_time:45504ms step_avg:47.40ms
+step:961/1490 train_time:45562ms step_avg:47.41ms
+step:962/1490 train_time:45627ms step_avg:47.43ms
+step:963/1490 train_time:45685ms step_avg:47.44ms
+step:964/1490 train_time:45750ms step_avg:47.46ms
+step:965/1490 train_time:45808ms step_avg:47.47ms
+step:966/1490 train_time:45872ms step_avg:47.49ms
+step:967/1490 train_time:45931ms step_avg:47.50ms
+step:968/1490 train_time:46000ms step_avg:47.52ms
+step:969/1490 train_time:46081ms step_avg:47.55ms
+step:970/1490 train_time:46173ms step_avg:47.60ms
+step:971/1490 train_time:46259ms step_avg:47.64ms
+step:972/1490 train_time:46351ms step_avg:47.69ms
+step:973/1490 train_time:46438ms step_avg:47.73ms
+step:974/1490 train_time:46529ms step_avg:47.77ms
+step:975/1490 train_time:46614ms step_avg:47.81ms
+step:976/1490 train_time:46705ms step_avg:47.85ms
+step:977/1490 train_time:46788ms step_avg:47.89ms
+step:978/1490 train_time:46879ms step_avg:47.93ms
+step:979/1490 train_time:46965ms step_avg:47.97ms
+step:980/1490 train_time:47058ms step_avg:48.02ms
+step:981/1490 train_time:47145ms step_avg:48.06ms
+step:982/1490 train_time:47238ms step_avg:48.10ms
+step:983/1490 train_time:47325ms step_avg:48.14ms
+step:984/1490 train_time:47419ms step_avg:48.19ms
+step:985/1490 train_time:47504ms step_avg:48.23ms
+step:986/1490 train_time:47598ms step_avg:48.27ms
+step:987/1490 train_time:47687ms step_avg:48.32ms
+step:988/1490 train_time:47782ms step_avg:48.36ms
+step:989/1490 train_time:47869ms step_avg:48.40ms
+step:990/1490 train_time:47965ms step_avg:48.45ms
+step:991/1490 train_time:48054ms step_avg:48.49ms
+step:992/1490 train_time:48148ms step_avg:48.54ms
+step:993/1490 train_time:48236ms step_avg:48.58ms
+step:994/1490 train_time:48329ms step_avg:48.62ms
+step:995/1490 train_time:48419ms step_avg:48.66ms
+step:996/1490 train_time:48511ms step_avg:48.71ms
+step:997/1490 train_time:48599ms step_avg:48.74ms
+step:998/1490 train_time:48693ms step_avg:48.79ms
+step:999/1490 train_time:48782ms step_avg:48.83ms
+step:1000/1490 train_time:48875ms step_avg:48.88ms
+step:1000/1490 val_loss:3.5152 train_time:48995ms step_avg:48.99ms
+step:1001/1490 train_time:49013ms step_avg:48.96ms
+step:1002/1490 train_time:49057ms step_avg:48.96ms
+step:1003/1490 train_time:49142ms step_avg:49.00ms
+step:1004/1490 train_time:49237ms step_avg:49.04ms
+step:1005/1490 train_time:49323ms step_avg:49.08ms
+step:1006/1490 train_time:49416ms step_avg:49.12ms
+step:1007/1490 train_time:49505ms step_avg:49.16ms
+step:1008/1490 train_time:49596ms step_avg:49.20ms
+step:1009/1490 train_time:49684ms step_avg:49.24ms
+step:1010/1490 train_time:49776ms step_avg:49.28ms
+step:1011/1490 train_time:49862ms step_avg:49.32ms
+step:1012/1490 train_time:49952ms step_avg:49.36ms
+step:1013/1490 train_time:50039ms step_avg:49.40ms
+step:1014/1490 train_time:50130ms step_avg:49.44ms
+step:1015/1490 train_time:50215ms step_avg:49.47ms
+step:1016/1490 train_time:50306ms step_avg:49.51ms
+step:1017/1490 train_time:50389ms step_avg:49.55ms
+step:1018/1490 train_time:50481ms step_avg:49.59ms
+step:1019/1490 train_time:50571ms step_avg:49.63ms
+step:1020/1490 train_time:50663ms step_avg:49.67ms
+step:1021/1490 train_time:50749ms step_avg:49.71ms
+step:1022/1490 train_time:50842ms step_avg:49.75ms
+step:1023/1490 train_time:50929ms step_avg:49.78ms
+step:1024/1490 train_time:51023ms step_avg:49.83ms
+step:1025/1490 train_time:51110ms step_avg:49.86ms
+step:1026/1490 train_time:51203ms step_avg:49.91ms
+step:1027/1490 train_time:51290ms step_avg:49.94ms
+step:1028/1490 train_time:51384ms step_avg:49.98ms
+step:1029/1490 train_time:51471ms step_avg:50.02ms
+step:1030/1490 train_time:51565ms step_avg:50.06ms
+step:1031/1490 train_time:51650ms step_avg:50.10ms
+step:1032/1490 train_time:51741ms step_avg:50.14ms
+step:1033/1490 train_time:51829ms step_avg:50.17ms
+step:1034/1490 train_time:51918ms step_avg:50.21ms
+step:1035/1490 train_time:52003ms step_avg:50.24ms
+step:1036/1490 train_time:52092ms step_avg:50.28ms
+step:1037/1490 train_time:52178ms step_avg:50.32ms
+step:1038/1490 train_time:52271ms step_avg:50.36ms
+step:1039/1490 train_time:52358ms step_avg:50.39ms
+step:1040/1490 train_time:52450ms step_avg:50.43ms
+step:1041/1490 train_time:52534ms step_avg:50.47ms
+step:1042/1490 train_time:52625ms step_avg:50.50ms
+step:1043/1490 train_time:52712ms step_avg:50.54ms
+step:1044/1490 train_time:52806ms step_avg:50.58ms
+step:1045/1490 train_time:52890ms step_avg:50.61ms
+step:1046/1490 train_time:52983ms step_avg:50.65ms
+step:1047/1490 train_time:53070ms step_avg:50.69ms
+step:1048/1490 train_time:53163ms step_avg:50.73ms
+step:1049/1490 train_time:53249ms step_avg:50.76ms
+step:1050/1490 train_time:53346ms step_avg:50.81ms
+step:1051/1490 train_time:53433ms step_avg:50.84ms
+step:1052/1490 train_time:53529ms step_avg:50.88ms
+step:1053/1490 train_time:53617ms step_avg:50.92ms
+step:1054/1490 train_time:53713ms step_avg:50.96ms
+step:1055/1490 train_time:53802ms step_avg:51.00ms
+step:1056/1490 train_time:53896ms step_avg:51.04ms
+step:1057/1490 train_time:53986ms step_avg:51.07ms
+step:1058/1490 train_time:54080ms step_avg:51.12ms
+step:1059/1490 train_time:54163ms step_avg:51.15ms
+step:1060/1490 train_time:54254ms step_avg:51.18ms
+step:1061/1490 train_time:54345ms step_avg:51.22ms
+step:1062/1490 train_time:54438ms step_avg:51.26ms
+step:1063/1490 train_time:54524ms step_avg:51.29ms
+step:1064/1490 train_time:54614ms step_avg:51.33ms
+step:1065/1490 train_time:54699ms step_avg:51.36ms
+step:1066/1490 train_time:54792ms step_avg:51.40ms
+step:1067/1490 train_time:54879ms step_avg:51.43ms
+step:1068/1490 train_time:54973ms step_avg:51.47ms
+step:1069/1490 train_time:55062ms step_avg:51.51ms
+step:1070/1490 train_time:55157ms step_avg:51.55ms
+step:1071/1490 train_time:55248ms step_avg:51.59ms
+step:1072/1490 train_time:55343ms step_avg:51.63ms
+step:1073/1490 train_time:55432ms step_avg:51.66ms
+step:1074/1490 train_time:55528ms step_avg:51.70ms
+step:1075/1490 train_time:55617ms step_avg:51.74ms
+step:1076/1490 train_time:55711ms step_avg:51.78ms
+step:1077/1490 train_time:55799ms step_avg:51.81ms
+step:1078/1490 train_time:55896ms step_avg:51.85ms
+step:1079/1490 train_time:55981ms step_avg:51.88ms
+step:1080/1490 train_time:56066ms step_avg:51.91ms
+step:1081/1490 train_time:56156ms step_avg:51.95ms
+step:1082/1490 train_time:56249ms step_avg:51.99ms
+step:1083/1490 train_time:56336ms step_avg:52.02ms
+step:1084/1490 train_time:56429ms step_avg:52.06ms
+step:1085/1490 train_time:56516ms step_avg:52.09ms
+step:1086/1490 train_time:56610ms step_avg:52.13ms
+step:1087/1490 train_time:56696ms step_avg:52.16ms
+step:1088/1490 train_time:56790ms step_avg:52.20ms
+step:1089/1490 train_time:56876ms step_avg:52.23ms
+step:1090/1490 train_time:56971ms step_avg:52.27ms
+step:1091/1490 train_time:57057ms step_avg:52.30ms
+step:1092/1490 train_time:57152ms step_avg:52.34ms
+step:1093/1490 train_time:57239ms step_avg:52.37ms
+step:1094/1490 train_time:57333ms step_avg:52.41ms
+step:1095/1490 train_time:57420ms step_avg:52.44ms
+step:1096/1490 train_time:57514ms step_avg:52.48ms
+step:1097/1490 train_time:57602ms step_avg:52.51ms
+step:1098/1490 train_time:57695ms step_avg:52.55ms
+step:1099/1490 train_time:57783ms step_avg:52.58ms
+step:1100/1490 train_time:57877ms step_avg:52.62ms
+step:1101/1490 train_time:57966ms step_avg:52.65ms
+step:1102/1490 train_time:58058ms step_avg:52.68ms
+step:1103/1490 train_time:58146ms step_avg:52.72ms
+step:1104/1490 train_time:58240ms step_avg:52.75ms
+step:1105/1490 train_time:58326ms step_avg:52.78ms
+step:1106/1490 train_time:58421ms step_avg:52.82ms
+step:1107/1490 train_time:58507ms step_avg:52.85ms
+step:1108/1490 train_time:58600ms step_avg:52.89ms
+step:1109/1490 train_time:58688ms step_avg:52.92ms
+step:1110/1490 train_time:58780ms step_avg:52.96ms
+step:1111/1490 train_time:58867ms step_avg:52.99ms
+step:1112/1490 train_time:58959ms step_avg:53.02ms
+step:1113/1490 train_time:59045ms step_avg:53.05ms
+step:1114/1490 train_time:59134ms step_avg:53.08ms
+step:1115/1490 train_time:59218ms step_avg:53.11ms
+step:1116/1490 train_time:59310ms step_avg:53.14ms
+step:1117/1490 train_time:59394ms step_avg:53.17ms
+step:1118/1490 train_time:59487ms step_avg:53.21ms
+step:1119/1490 train_time:59572ms step_avg:53.24ms
+step:1120/1490 train_time:59666ms step_avg:53.27ms
+step:1121/1490 train_time:59754ms step_avg:53.30ms
+step:1122/1490 train_time:59849ms step_avg:53.34ms
+step:1123/1490 train_time:59936ms step_avg:53.37ms
+step:1124/1490 train_time:60031ms step_avg:53.41ms
+step:1125/1490 train_time:60119ms step_avg:53.44ms
+step:1126/1490 train_time:60215ms step_avg:53.48ms
+step:1127/1490 train_time:60304ms step_avg:53.51ms
+step:1128/1490 train_time:60399ms step_avg:53.54ms
+step:1129/1490 train_time:60489ms step_avg:53.58ms
+step:1130/1490 train_time:60583ms step_avg:53.61ms
+step:1131/1490 train_time:60671ms step_avg:53.64ms
+step:1132/1490 train_time:60766ms step_avg:53.68ms
+step:1133/1490 train_time:60852ms step_avg:53.71ms
+step:1134/1490 train_time:60948ms step_avg:53.75ms
+step:1135/1490 train_time:61033ms step_avg:53.77ms
+step:1136/1490 train_time:61127ms step_avg:53.81ms
+step:1137/1490 train_time:61214ms step_avg:53.84ms
+step:1138/1490 train_time:61309ms step_avg:53.87ms
+step:1139/1490 train_time:61396ms step_avg:53.90ms
+step:1140/1490 train_time:61490ms step_avg:53.94ms
+step:1141/1490 train_time:61576ms step_avg:53.97ms
+step:1142/1490 train_time:61669ms step_avg:54.00ms
+step:1143/1490 train_time:61754ms step_avg:54.03ms
+step:1144/1490 train_time:61848ms step_avg:54.06ms
+step:1145/1490 train_time:61933ms step_avg:54.09ms
+step:1146/1490 train_time:62027ms step_avg:54.12ms
+step:1147/1490 train_time:62112ms step_avg:54.15ms
+step:1148/1490 train_time:62206ms step_avg:54.19ms
+step:1149/1490 train_time:62291ms step_avg:54.21ms
+step:1150/1490 train_time:62385ms step_avg:54.25ms
+step:1151/1490 train_time:62471ms step_avg:54.28ms
+step:1152/1490 train_time:62564ms step_avg:54.31ms
+step:1153/1490 train_time:62650ms step_avg:54.34ms
+step:1154/1490 train_time:62745ms step_avg:54.37ms
+step:1155/1490 train_time:62828ms step_avg:54.40ms
+step:1156/1490 train_time:62923ms step_avg:54.43ms
+step:1157/1490 train_time:63010ms step_avg:54.46ms
+step:1158/1490 train_time:63103ms step_avg:54.49ms
+step:1159/1490 train_time:63190ms step_avg:54.52ms
+step:1160/1490 train_time:63282ms step_avg:54.55ms
+step:1161/1490 train_time:63368ms step_avg:54.58ms
+step:1162/1490 train_time:63460ms step_avg:54.61ms
+step:1163/1490 train_time:63546ms step_avg:54.64ms
+step:1164/1490 train_time:63635ms step_avg:54.67ms
+step:1165/1490 train_time:63719ms step_avg:54.69ms
+step:1166/1490 train_time:63810ms step_avg:54.73ms
+step:1167/1490 train_time:63895ms step_avg:54.75ms
+step:1168/1490 train_time:63991ms step_avg:54.79ms
+step:1169/1490 train_time:64078ms step_avg:54.81ms
+step:1170/1490 train_time:64173ms step_avg:54.85ms
+step:1171/1490 train_time:64261ms step_avg:54.88ms
+step:1172/1490 train_time:64356ms step_avg:54.91ms
+step:1173/1490 train_time:64446ms step_avg:54.94ms
+step:1174/1490 train_time:64539ms step_avg:54.97ms
+step:1175/1490 train_time:64628ms step_avg:55.00ms
+step:1176/1490 train_time:64723ms step_avg:55.04ms
+step:1177/1490 train_time:64811ms step_avg:55.06ms
+step:1178/1490 train_time:64905ms step_avg:55.10ms
+step:1179/1490 train_time:64991ms step_avg:55.12ms
+step:1180/1490 train_time:65086ms step_avg:55.16ms
+step:1181/1490 train_time:65172ms step_avg:55.18ms
+step:1182/1490 train_time:65267ms step_avg:55.22ms
+step:1183/1490 train_time:65353ms step_avg:55.24ms
+step:1184/1490 train_time:65447ms step_avg:55.28ms
+step:1185/1490 train_time:65533ms step_avg:55.30ms
+step:1186/1490 train_time:65626ms step_avg:55.33ms
+step:1187/1490 train_time:65712ms step_avg:55.36ms
+step:1188/1490 train_time:65806ms step_avg:55.39ms
+step:1189/1490 train_time:65890ms step_avg:55.42ms
+step:1190/1490 train_time:65984ms step_avg:55.45ms
+step:1191/1490 train_time:66071ms step_avg:55.48ms
+step:1192/1490 train_time:66164ms step_avg:55.51ms
+step:1193/1490 train_time:66251ms step_avg:55.53ms
+step:1194/1490 train_time:66346ms step_avg:55.57ms
+step:1195/1490 train_time:66430ms step_avg:55.59ms
+step:1196/1490 train_time:66520ms step_avg:55.62ms
+step:1197/1490 train_time:66606ms step_avg:55.64ms
+step:1198/1490 train_time:66696ms step_avg:55.67ms
+step:1199/1490 train_time:66781ms step_avg:55.70ms
+step:1200/1490 train_time:66872ms step_avg:55.73ms
+step:1201/1490 train_time:66957ms step_avg:55.75ms
+step:1202/1490 train_time:67050ms step_avg:55.78ms
+step:1203/1490 train_time:67136ms step_avg:55.81ms
+step:1204/1490 train_time:67229ms step_avg:55.84ms
+step:1205/1490 train_time:67316ms step_avg:55.86ms
+step:1206/1490 train_time:67410ms step_avg:55.90ms
+step:1207/1490 train_time:67498ms step_avg:55.92ms
+step:1208/1490 train_time:67592ms step_avg:55.95ms
+step:1209/1490 train_time:67680ms step_avg:55.98ms
+step:1210/1490 train_time:67775ms step_avg:56.01ms
+step:1211/1490 train_time:67864ms step_avg:56.04ms
+step:1212/1490 train_time:67957ms step_avg:56.07ms
+step:1213/1490 train_time:68047ms step_avg:56.10ms
+step:1214/1490 train_time:68141ms step_avg:56.13ms
+step:1215/1490 train_time:68229ms step_avg:56.16ms
+step:1216/1490 train_time:68324ms step_avg:56.19ms
+step:1217/1490 train_time:68411ms step_avg:56.21ms
+step:1218/1490 train_time:68506ms step_avg:56.24ms
+step:1219/1490 train_time:68593ms step_avg:56.27ms
+step:1220/1490 train_time:68686ms step_avg:56.30ms
+step:1221/1490 train_time:68773ms step_avg:56.33ms
+step:1222/1490 train_time:68866ms step_avg:56.36ms
+step:1223/1490 train_time:68954ms step_avg:56.38ms
+step:1224/1490 train_time:69048ms step_avg:56.41ms
+step:1225/1490 train_time:69134ms step_avg:56.44ms
+step:1226/1490 train_time:69229ms step_avg:56.47ms
+step:1227/1490 train_time:69315ms step_avg:56.49ms
+step:1228/1490 train_time:69409ms step_avg:56.52ms
+step:1229/1490 train_time:69495ms step_avg:56.55ms
+step:1230/1490 train_time:69587ms step_avg:56.58ms
+step:1231/1490 train_time:69675ms step_avg:56.60ms
+step:1232/1490 train_time:69768ms step_avg:56.63ms
+step:1233/1490 train_time:69853ms step_avg:56.65ms
+step:1234/1490 train_time:69948ms step_avg:56.68ms
+step:1235/1490 train_time:70032ms step_avg:56.71ms
+step:1236/1490 train_time:70127ms step_avg:56.74ms
+step:1237/1490 train_time:70213ms step_avg:56.76ms
+step:1238/1490 train_time:70306ms step_avg:56.79ms
+step:1239/1490 train_time:70391ms step_avg:56.81ms
+step:1240/1490 train_time:70485ms step_avg:56.84ms
+step:1241/1490 train_time:70571ms step_avg:56.87ms
+step:1242/1490 train_time:70664ms step_avg:56.89ms
+step:1243/1490 train_time:70750ms step_avg:56.92ms
+step:1244/1490 train_time:70846ms step_avg:56.95ms
+step:1245/1490 train_time:70930ms step_avg:56.97ms
+step:1246/1490 train_time:71024ms step_avg:57.00ms
+step:1247/1490 train_time:71111ms step_avg:57.03ms
+step:1248/1490 train_time:71202ms step_avg:57.05ms
+step:1249/1490 train_time:71284ms step_avg:57.07ms
+step:1250/1490 train_time:71378ms step_avg:57.10ms
+step:1250/1490 val_loss:3.3705 train_time:71503ms step_avg:57.20ms
+step:1251/1490 train_time:71520ms step_avg:57.17ms
+step:1252/1490 train_time:71565ms step_avg:57.16ms
+step:1253/1490 train_time:71654ms step_avg:57.19ms
+step:1254/1490 train_time:71748ms step_avg:57.22ms
+step:1255/1490 train_time:71835ms step_avg:57.24ms
+step:1256/1490 train_time:71929ms step_avg:57.27ms
+step:1257/1490 train_time:72016ms step_avg:57.29ms
+step:1258/1490 train_time:72111ms step_avg:57.32ms
+step:1259/1490 train_time:72196ms step_avg:57.34ms
+step:1260/1490 train_time:72290ms step_avg:57.37ms
+step:1261/1490 train_time:72376ms step_avg:57.40ms
+step:1262/1490 train_time:72469ms step_avg:57.42ms
+step:1263/1490 train_time:72555ms step_avg:57.45ms
+step:1264/1490 train_time:72647ms step_avg:57.47ms
+step:1265/1490 train_time:72734ms step_avg:57.50ms
+step:1266/1490 train_time:72825ms step_avg:57.52ms
+step:1267/1490 train_time:72911ms step_avg:57.55ms
+step:1268/1490 train_time:73003ms step_avg:57.57ms
+step:1269/1490 train_time:73089ms step_avg:57.60ms
+step:1270/1490 train_time:73181ms step_avg:57.62ms
+step:1271/1490 train_time:73267ms step_avg:57.65ms
+step:1272/1490 train_time:73359ms step_avg:57.67ms
+step:1273/1490 train_time:73444ms step_avg:57.69ms
+step:1274/1490 train_time:73537ms step_avg:57.72ms
+step:1275/1490 train_time:73621ms step_avg:57.74ms
+step:1276/1490 train_time:73713ms step_avg:57.77ms
+step:1277/1490 train_time:73798ms step_avg:57.79ms
+step:1278/1490 train_time:73889ms step_avg:57.82ms
+step:1279/1490 train_time:73974ms step_avg:57.84ms
+step:1280/1490 train_time:74064ms step_avg:57.86ms
+step:1281/1490 train_time:74148ms step_avg:57.88ms
+step:1282/1490 train_time:74242ms step_avg:57.91ms
+step:1283/1490 train_time:74328ms step_avg:57.93ms
+step:1284/1490 train_time:74422ms step_avg:57.96ms
+step:1285/1490 train_time:74513ms step_avg:57.99ms
+step:1286/1490 train_time:74604ms step_avg:58.01ms
+step:1287/1490 train_time:74691ms step_avg:58.04ms
+step:1288/1490 train_time:74783ms step_avg:58.06ms
+step:1289/1490 train_time:74870ms step_avg:58.08ms
+step:1290/1490 train_time:74961ms step_avg:58.11ms
+step:1291/1490 train_time:75048ms step_avg:58.13ms
+step:1292/1490 train_time:75139ms step_avg:58.16ms
+step:1293/1490 train_time:75228ms step_avg:58.18ms
+step:1294/1490 train_time:75324ms step_avg:58.21ms
+step:1295/1490 train_time:75414ms step_avg:58.23ms
+step:1296/1490 train_time:75509ms step_avg:58.26ms
+step:1297/1490 train_time:75599ms step_avg:58.29ms
+step:1298/1490 train_time:75696ms step_avg:58.32ms
+step:1299/1490 train_time:75785ms step_avg:58.34ms
+step:1300/1490 train_time:75882ms step_avg:58.37ms
+step:1301/1490 train_time:75972ms step_avg:58.39ms
+step:1302/1490 train_time:76067ms step_avg:58.42ms
+step:1303/1490 train_time:76157ms step_avg:58.45ms
+step:1304/1490 train_time:76252ms step_avg:58.48ms
+step:1305/1490 train_time:76341ms step_avg:58.50ms
+step:1306/1490 train_time:76437ms step_avg:58.53ms
+step:1307/1490 train_time:76524ms step_avg:58.55ms
+step:1308/1490 train_time:76618ms step_avg:58.58ms
+step:1309/1490 train_time:76706ms step_avg:58.60ms
+step:1310/1490 train_time:76800ms step_avg:58.63ms
+step:1311/1490 train_time:76882ms step_avg:58.64ms
+step:1312/1490 train_time:76977ms step_avg:58.67ms
+step:1313/1490 train_time:77064ms step_avg:58.69ms
+step:1314/1490 train_time:77154ms step_avg:58.72ms
+step:1315/1490 train_time:77244ms step_avg:58.74ms
+step:1316/1490 train_time:77338ms step_avg:58.77ms
+step:1317/1490 train_time:77425ms step_avg:58.79ms
+step:1318/1490 train_time:77519ms step_avg:58.82ms
+step:1319/1490 train_time:77605ms step_avg:58.84ms
+step:1320/1490 train_time:77701ms step_avg:58.86ms
+step:1321/1490 train_time:77792ms step_avg:58.89ms
+step:1322/1490 train_time:77888ms step_avg:58.92ms
+step:1323/1490 train_time:77978ms step_avg:58.94ms
+step:1324/1490 train_time:78075ms step_avg:58.97ms
+step:1325/1490 train_time:78164ms step_avg:58.99ms
+step:1326/1490 train_time:78260ms step_avg:59.02ms
+step:1327/1490 train_time:78350ms step_avg:59.04ms
+step:1328/1490 train_time:78446ms step_avg:59.07ms
+step:1329/1490 train_time:78530ms step_avg:59.09ms
+step:1330/1490 train_time:78614ms step_avg:59.11ms
+step:1331/1490 train_time:78703ms step_avg:59.13ms
+step:1332/1490 train_time:78798ms step_avg:59.16ms
+step:1333/1490 train_time:78891ms step_avg:59.18ms
+step:1334/1490 train_time:78986ms step_avg:59.21ms
+step:1335/1490 train_time:79075ms step_avg:59.23ms
+step:1336/1490 train_time:79171ms step_avg:59.26ms
+step:1337/1490 train_time:79256ms step_avg:59.28ms
+step:1338/1490 train_time:79350ms step_avg:59.31ms
+step:1339/1490 train_time:79439ms step_avg:59.33ms
+step:1340/1490 train_time:79535ms step_avg:59.35ms
+step:1341/1490 train_time:79624ms step_avg:59.38ms
+step:1342/1490 train_time:79720ms step_avg:59.40ms
+step:1343/1490 train_time:79810ms step_avg:59.43ms
+step:1344/1490 train_time:79906ms step_avg:59.45ms
+step:1345/1490 train_time:79996ms step_avg:59.48ms
+step:1346/1490 train_time:80092ms step_avg:59.50ms
+step:1347/1490 train_time:80180ms step_avg:59.52ms
+step:1348/1490 train_time:80278ms step_avg:59.55ms
+step:1349/1490 train_time:80358ms step_avg:59.57ms
+step:1350/1490 train_time:80444ms step_avg:59.59ms
+step:1351/1490 train_time:80532ms step_avg:59.61ms
+step:1352/1490 train_time:80623ms step_avg:59.63ms
+step:1353/1490 train_time:80709ms step_avg:59.65ms
+step:1354/1490 train_time:80801ms step_avg:59.68ms
+step:1355/1490 train_time:80887ms step_avg:59.70ms
+step:1356/1490 train_time:80982ms step_avg:59.72ms
+step:1357/1490 train_time:81070ms step_avg:59.74ms
+step:1358/1490 train_time:81164ms step_avg:59.77ms
+step:1359/1490 train_time:81254ms step_avg:59.79ms
+step:1360/1490 train_time:81348ms step_avg:59.81ms
+step:1361/1490 train_time:81436ms step_avg:59.84ms
+step:1362/1490 train_time:81530ms step_avg:59.86ms
+step:1363/1490 train_time:81617ms step_avg:59.88ms
+step:1364/1490 train_time:81711ms step_avg:59.91ms
+step:1365/1490 train_time:81797ms step_avg:59.92ms
+step:1366/1490 train_time:81893ms step_avg:59.95ms
+step:1367/1490 train_time:81979ms step_avg:59.97ms
+step:1368/1490 train_time:82071ms step_avg:59.99ms
+step:1369/1490 train_time:82157ms step_avg:60.01ms
+step:1370/1490 train_time:82251ms step_avg:60.04ms
+step:1371/1490 train_time:82338ms step_avg:60.06ms
+step:1372/1490 train_time:82431ms step_avg:60.08ms
+step:1373/1490 train_time:82517ms step_avg:60.10ms
+step:1374/1490 train_time:82611ms step_avg:60.12ms
+step:1375/1490 train_time:82697ms step_avg:60.14ms
+step:1376/1490 train_time:82790ms step_avg:60.17ms
+step:1377/1490 train_time:82876ms step_avg:60.19ms
+step:1378/1490 train_time:82968ms step_avg:60.21ms
+step:1379/1490 train_time:83055ms step_avg:60.23ms
+step:1380/1490 train_time:83148ms step_avg:60.25ms
+step:1381/1490 train_time:83234ms step_avg:60.27ms
+step:1382/1490 train_time:83326ms step_avg:60.29ms
+step:1383/1490 train_time:83412ms step_avg:60.31ms
+step:1384/1490 train_time:83503ms step_avg:60.33ms
+step:1385/1490 train_time:83590ms step_avg:60.35ms
+step:1386/1490 train_time:83680ms step_avg:60.38ms
+step:1387/1490 train_time:83764ms step_avg:60.39ms
+step:1388/1490 train_time:83856ms step_avg:60.41ms
+step:1389/1490 train_time:83940ms step_avg:60.43ms
+step:1390/1490 train_time:84033ms step_avg:60.46ms
+step:1391/1490 train_time:84120ms step_avg:60.47ms
+step:1392/1490 train_time:84216ms step_avg:60.50ms
+step:1393/1490 train_time:84302ms step_avg:60.52ms
+step:1394/1490 train_time:84396ms step_avg:60.54ms
+step:1395/1490 train_time:84483ms step_avg:60.56ms
+step:1396/1490 train_time:84578ms step_avg:60.59ms
+step:1397/1490 train_time:84665ms step_avg:60.60ms
+step:1398/1490 train_time:84759ms step_avg:60.63ms
+step:1399/1490 train_time:84846ms step_avg:60.65ms
+step:1400/1490 train_time:84941ms step_avg:60.67ms
+step:1401/1490 train_time:85029ms step_avg:60.69ms
+step:1402/1490 train_time:85124ms step_avg:60.72ms
+step:1403/1490 train_time:85211ms step_avg:60.74ms
+step:1404/1490 train_time:85304ms step_avg:60.76ms
+step:1405/1490 train_time:85392ms step_avg:60.78ms
+step:1406/1490 train_time:85484ms step_avg:60.80ms
+step:1407/1490 train_time:85572ms step_avg:60.82ms
+step:1408/1490 train_time:85665ms step_avg:60.84ms
+step:1409/1490 train_time:85752ms step_avg:60.86ms
+step:1410/1490 train_time:85844ms step_avg:60.88ms
+step:1411/1490 train_time:85933ms step_avg:60.90ms
+step:1412/1490 train_time:86025ms step_avg:60.92ms
+step:1413/1490 train_time:86113ms step_avg:60.94ms
+step:1414/1490 train_time:86205ms step_avg:60.97ms
+step:1415/1490 train_time:86292ms step_avg:60.98ms
+step:1416/1490 train_time:86385ms step_avg:61.01ms
+step:1417/1490 train_time:86473ms step_avg:61.03ms
+step:1418/1490 train_time:86564ms step_avg:61.05ms
+step:1419/1490 train_time:86652ms step_avg:61.07ms
+step:1420/1490 train_time:86744ms step_avg:61.09ms
+step:1421/1490 train_time:86831ms step_avg:61.11ms
+step:1422/1490 train_time:86924ms step_avg:61.13ms
+step:1423/1490 train_time:87011ms step_avg:61.15ms
+step:1424/1490 train_time:87104ms step_avg:61.17ms
+step:1425/1490 train_time:87190ms step_avg:61.19ms
+step:1426/1490 train_time:87284ms step_avg:61.21ms
+step:1427/1490 train_time:87372ms step_avg:61.23ms
+step:1428/1490 train_time:87464ms step_avg:61.25ms
+step:1429/1490 train_time:87551ms step_avg:61.27ms
+step:1430/1490 train_time:87642ms step_avg:61.29ms
+step:1431/1490 train_time:87730ms step_avg:61.31ms
+step:1432/1490 train_time:87822ms step_avg:61.33ms
+step:1433/1490 train_time:87909ms step_avg:61.35ms
+step:1434/1490 train_time:88004ms step_avg:61.37ms
+step:1435/1490 train_time:88093ms step_avg:61.39ms
+step:1436/1490 train_time:88187ms step_avg:61.41ms
+step:1437/1490 train_time:88276ms step_avg:61.43ms
+step:1438/1490 train_time:88370ms step_avg:61.45ms
+step:1439/1490 train_time:88457ms step_avg:61.47ms
+step:1440/1490 train_time:88552ms step_avg:61.49ms
+step:1441/1490 train_time:88639ms step_avg:61.51ms
+step:1442/1490 train_time:88734ms step_avg:61.54ms
+step:1443/1490 train_time:88819ms step_avg:61.55ms
+step:1444/1490 train_time:88914ms step_avg:61.57ms
+step:1445/1490 train_time:88999ms step_avg:61.59ms
+step:1446/1490 train_time:89093ms step_avg:61.61ms
+step:1447/1490 train_time:89177ms step_avg:61.63ms
+step:1448/1490 train_time:89278ms step_avg:61.66ms
+step:1449/1490 train_time:89373ms step_avg:61.68ms
+step:1450/1490 train_time:89465ms step_avg:61.70ms
+step:1451/1490 train_time:89556ms step_avg:61.72ms
+step:1452/1490 train_time:89651ms step_avg:61.74ms
+step:1453/1490 train_time:89742ms step_avg:61.76ms
+step:1454/1490 train_time:89839ms step_avg:61.79ms
+step:1455/1490 train_time:89925ms step_avg:61.80ms
+step:1456/1490 train_time:90020ms step_avg:61.83ms
+step:1457/1490 train_time:90109ms step_avg:61.85ms
+step:1458/1490 train_time:90202ms step_avg:61.87ms
+step:1459/1490 train_time:90289ms step_avg:61.88ms
+step:1460/1490 train_time:90383ms step_avg:61.91ms
+step:1461/1490 train_time:90471ms step_avg:61.92ms
+step:1462/1490 train_time:90563ms step_avg:61.94ms
+step:1463/1490 train_time:90650ms step_avg:61.96ms
+step:1464/1490 train_time:90742ms step_avg:61.98ms
+step:1465/1490 train_time:90831ms step_avg:62.00ms
+step:1466/1490 train_time:90926ms step_avg:62.02ms
+step:1467/1490 train_time:91016ms step_avg:62.04ms
+step:1468/1490 train_time:91111ms step_avg:62.06ms
+step:1469/1490 train_time:91199ms step_avg:62.08ms
+step:1470/1490 train_time:91294ms step_avg:62.10ms
+step:1471/1490 train_time:91382ms step_avg:62.12ms
+step:1472/1490 train_time:91477ms step_avg:62.14ms
+step:1473/1490 train_time:91565ms step_avg:62.16ms
+step:1474/1490 train_time:91660ms step_avg:62.18ms
+step:1475/1490 train_time:91747ms step_avg:62.20ms
+step:1476/1490 train_time:91843ms step_avg:62.22ms
+step:1477/1490 train_time:91932ms step_avg:62.24ms
+step:1478/1490 train_time:92026ms step_avg:62.26ms
+step:1479/1490 train_time:92116ms step_avg:62.28ms
+step:1480/1490 train_time:92211ms step_avg:62.30ms
+step:1481/1490 train_time:92298ms step_avg:62.32ms
+step:1482/1490 train_time:92392ms step_avg:62.34ms
+step:1483/1490 train_time:92479ms step_avg:62.36ms
+step:1484/1490 train_time:92573ms step_avg:62.38ms
+step:1485/1490 train_time:92656ms step_avg:62.39ms
+step:1486/1490 train_time:92752ms step_avg:62.42ms
+step:1487/1490 train_time:92843ms step_avg:62.44ms
+step:1488/1490 train_time:92934ms step_avg:62.46ms
+step:1489/1490 train_time:93024ms step_avg:62.47ms
+step:1490/1490 train_time:93118ms step_avg:62.50ms
+step:1490/1490 val_loss:3.2781 train_time:93240ms step_avg:62.58ms
+peak memory allocated: 31296 MiB reserved: 47082 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline4-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline4-1480.txt
@@ -1,0 +1,4447 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:27:03 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   35C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   40C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   36C    P0            126W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   40C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   37C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   67C    P0            153W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          355867      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          355868      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          355869      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          355870      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          355871      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          355872      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          355873      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          355874      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8283 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:89ms step_avg:88.72ms
+step:2/1480 train_time:112ms step_avg:56.17ms
+step:3/1480 train_time:132ms step_avg:43.87ms
+step:4/1480 train_time:155ms step_avg:38.63ms
+step:5/1480 train_time:179ms step_avg:35.89ms
+step:6/1480 train_time:214ms step_avg:35.67ms
+step:7/1480 train_time:243ms step_avg:34.65ms
+step:8/1480 train_time:277ms step_avg:34.65ms
+step:9/1480 train_time:305ms step_avg:33.88ms
+step:10/1480 train_time:340ms step_avg:33.96ms
+step:11/1480 train_time:368ms step_avg:33.43ms
+step:12/1480 train_time:403ms step_avg:33.56ms
+step:13/1480 train_time:431ms step_avg:33.14ms
+step:14/1480 train_time:466ms step_avg:33.26ms
+step:15/1480 train_time:494ms step_avg:32.95ms
+step:16/1480 train_time:529ms step_avg:33.06ms
+step:17/1480 train_time:557ms step_avg:32.77ms
+step:18/1480 train_time:592ms step_avg:32.87ms
+step:19/1480 train_time:622ms step_avg:32.72ms
+step:20/1480 train_time:657ms step_avg:32.85ms
+step:21/1480 train_time:686ms step_avg:32.69ms
+step:22/1480 train_time:722ms step_avg:32.84ms
+step:23/1480 train_time:751ms step_avg:32.67ms
+step:24/1480 train_time:787ms step_avg:32.80ms
+step:25/1480 train_time:816ms step_avg:32.66ms
+step:26/1480 train_time:852ms step_avg:32.77ms
+step:27/1480 train_time:882ms step_avg:32.65ms
+step:28/1480 train_time:917ms step_avg:32.74ms
+step:29/1480 train_time:946ms step_avg:32.62ms
+step:30/1480 train_time:982ms step_avg:32.73ms
+step:31/1480 train_time:1011ms step_avg:32.61ms
+step:32/1480 train_time:1047ms step_avg:32.71ms
+step:33/1480 train_time:1075ms step_avg:32.59ms
+step:34/1480 train_time:1111ms step_avg:32.67ms
+step:35/1480 train_time:1140ms step_avg:32.58ms
+step:36/1480 train_time:1175ms step_avg:32.65ms
+step:37/1480 train_time:1205ms step_avg:32.55ms
+step:38/1480 train_time:1240ms step_avg:32.64ms
+step:39/1480 train_time:1269ms step_avg:32.53ms
+step:40/1480 train_time:1304ms step_avg:32.60ms
+step:41/1480 train_time:1333ms step_avg:32.50ms
+step:42/1480 train_time:1368ms step_avg:32.57ms
+step:43/1480 train_time:1397ms step_avg:32.49ms
+step:44/1480 train_time:1432ms step_avg:32.55ms
+step:45/1480 train_time:1462ms step_avg:32.49ms
+step:46/1480 train_time:1497ms step_avg:32.54ms
+step:47/1480 train_time:1526ms step_avg:32.46ms
+step:48/1480 train_time:1561ms step_avg:32.53ms
+step:49/1480 train_time:1590ms step_avg:32.46ms
+step:50/1480 train_time:1627ms step_avg:32.53ms
+step:51/1480 train_time:1656ms step_avg:32.47ms
+step:52/1480 train_time:1691ms step_avg:32.53ms
+step:53/1480 train_time:1721ms step_avg:32.47ms
+step:54/1480 train_time:1757ms step_avg:32.53ms
+step:55/1480 train_time:1787ms step_avg:32.48ms
+step:56/1480 train_time:1823ms step_avg:32.55ms
+step:57/1480 train_time:1852ms step_avg:32.49ms
+step:58/1480 train_time:1888ms step_avg:32.55ms
+step:59/1480 train_time:1917ms step_avg:32.49ms
+step:60/1480 train_time:1953ms step_avg:32.55ms
+step:61/1480 train_time:1982ms step_avg:32.50ms
+step:62/1480 train_time:2018ms step_avg:32.55ms
+step:63/1480 train_time:2047ms step_avg:32.50ms
+step:64/1480 train_time:2083ms step_avg:32.55ms
+step:65/1480 train_time:2112ms step_avg:32.50ms
+step:66/1480 train_time:2149ms step_avg:32.55ms
+step:67/1480 train_time:2178ms step_avg:32.51ms
+step:68/1480 train_time:2213ms step_avg:32.55ms
+step:69/1480 train_time:2243ms step_avg:32.51ms
+step:70/1480 train_time:2279ms step_avg:32.55ms
+step:71/1480 train_time:2308ms step_avg:32.50ms
+step:72/1480 train_time:2343ms step_avg:32.55ms
+step:73/1480 train_time:2372ms step_avg:32.50ms
+step:74/1480 train_time:2408ms step_avg:32.54ms
+step:75/1480 train_time:2437ms step_avg:32.50ms
+step:76/1480 train_time:2473ms step_avg:32.54ms
+step:77/1480 train_time:2502ms step_avg:32.50ms
+step:78/1480 train_time:2538ms step_avg:32.53ms
+step:79/1480 train_time:2567ms step_avg:32.49ms
+step:80/1480 train_time:2602ms step_avg:32.52ms
+step:81/1480 train_time:2631ms step_avg:32.48ms
+step:82/1480 train_time:2667ms step_avg:32.53ms
+step:83/1480 train_time:2696ms step_avg:32.48ms
+step:84/1480 train_time:2732ms step_avg:32.52ms
+step:85/1480 train_time:2761ms step_avg:32.49ms
+step:86/1480 train_time:2796ms step_avg:32.52ms
+step:87/1480 train_time:2826ms step_avg:32.48ms
+step:88/1480 train_time:2865ms step_avg:32.55ms
+step:89/1480 train_time:2897ms step_avg:32.55ms
+step:90/1480 train_time:2936ms step_avg:32.62ms
+step:91/1480 train_time:2969ms step_avg:32.62ms
+step:92/1480 train_time:3007ms step_avg:32.69ms
+step:93/1480 train_time:3038ms step_avg:32.67ms
+step:94/1480 train_time:3076ms step_avg:32.72ms
+step:95/1480 train_time:3107ms step_avg:32.70ms
+step:96/1480 train_time:3144ms step_avg:32.75ms
+step:97/1480 train_time:3175ms step_avg:32.73ms
+step:98/1480 train_time:3212ms step_avg:32.78ms
+step:99/1480 train_time:3244ms step_avg:32.77ms
+step:100/1480 train_time:3279ms step_avg:32.79ms
+step:101/1480 train_time:3307ms step_avg:32.74ms
+step:102/1480 train_time:3343ms step_avg:32.77ms
+step:103/1480 train_time:3371ms step_avg:32.72ms
+step:104/1480 train_time:3405ms step_avg:32.74ms
+step:105/1480 train_time:3433ms step_avg:32.70ms
+step:106/1480 train_time:3469ms step_avg:32.72ms
+step:107/1480 train_time:3498ms step_avg:32.69ms
+step:108/1480 train_time:3533ms step_avg:32.71ms
+step:109/1480 train_time:3562ms step_avg:32.68ms
+step:110/1480 train_time:3597ms step_avg:32.70ms
+step:111/1480 train_time:3626ms step_avg:32.67ms
+step:112/1480 train_time:3662ms step_avg:32.70ms
+step:113/1480 train_time:3691ms step_avg:32.67ms
+step:114/1480 train_time:3727ms step_avg:32.69ms
+step:115/1480 train_time:3756ms step_avg:32.66ms
+step:116/1480 train_time:3792ms step_avg:32.69ms
+step:117/1480 train_time:3821ms step_avg:32.66ms
+step:118/1480 train_time:3857ms step_avg:32.69ms
+step:119/1480 train_time:3888ms step_avg:32.67ms
+step:120/1480 train_time:3926ms step_avg:32.72ms
+step:121/1480 train_time:3957ms step_avg:32.70ms
+step:122/1480 train_time:3995ms step_avg:32.74ms
+step:123/1480 train_time:4026ms step_avg:32.73ms
+step:124/1480 train_time:4064ms step_avg:32.77ms
+step:125/1480 train_time:4095ms step_avg:32.76ms
+step:126/1480 train_time:4132ms step_avg:32.80ms
+step:127/1480 train_time:4164ms step_avg:32.78ms
+step:128/1480 train_time:4201ms step_avg:32.82ms
+step:129/1480 train_time:4231ms step_avg:32.80ms
+step:130/1480 train_time:4269ms step_avg:32.84ms
+step:131/1480 train_time:4300ms step_avg:32.82ms
+step:132/1480 train_time:4336ms step_avg:32.85ms
+step:133/1480 train_time:4367ms step_avg:32.83ms
+step:134/1480 train_time:4404ms step_avg:32.86ms
+step:135/1480 train_time:4434ms step_avg:32.84ms
+step:136/1480 train_time:4471ms step_avg:32.88ms
+step:137/1480 train_time:4502ms step_avg:32.86ms
+step:138/1480 train_time:4539ms step_avg:32.89ms
+step:139/1480 train_time:4569ms step_avg:32.87ms
+step:140/1480 train_time:4606ms step_avg:32.90ms
+step:141/1480 train_time:4636ms step_avg:32.88ms
+step:142/1480 train_time:4673ms step_avg:32.91ms
+step:143/1480 train_time:4703ms step_avg:32.89ms
+step:144/1480 train_time:4739ms step_avg:32.91ms
+step:145/1480 train_time:4769ms step_avg:32.89ms
+step:146/1480 train_time:4806ms step_avg:32.92ms
+step:147/1480 train_time:4836ms step_avg:32.90ms
+step:148/1480 train_time:4872ms step_avg:32.92ms
+step:149/1480 train_time:4903ms step_avg:32.90ms
+step:150/1480 train_time:4939ms step_avg:32.93ms
+step:151/1480 train_time:4969ms step_avg:32.91ms
+step:152/1480 train_time:5005ms step_avg:32.93ms
+step:153/1480 train_time:5035ms step_avg:32.91ms
+step:154/1480 train_time:5071ms step_avg:32.93ms
+step:155/1480 train_time:5101ms step_avg:32.91ms
+step:156/1480 train_time:5138ms step_avg:32.93ms
+step:157/1480 train_time:5168ms step_avg:32.92ms
+step:158/1480 train_time:5204ms step_avg:32.94ms
+step:159/1480 train_time:5233ms step_avg:32.91ms
+step:160/1480 train_time:5270ms step_avg:32.94ms
+step:161/1480 train_time:5300ms step_avg:32.92ms
+step:162/1480 train_time:5336ms step_avg:32.94ms
+step:163/1480 train_time:5366ms step_avg:32.92ms
+step:164/1480 train_time:5402ms step_avg:32.94ms
+step:165/1480 train_time:5431ms step_avg:32.92ms
+step:166/1480 train_time:5468ms step_avg:32.94ms
+step:167/1480 train_time:5498ms step_avg:32.92ms
+step:168/1480 train_time:5534ms step_avg:32.94ms
+step:169/1480 train_time:5564ms step_avg:32.92ms
+step:170/1480 train_time:5600ms step_avg:32.94ms
+step:171/1480 train_time:5629ms step_avg:32.92ms
+step:172/1480 train_time:5666ms step_avg:32.94ms
+step:173/1480 train_time:5695ms step_avg:32.92ms
+step:174/1480 train_time:5731ms step_avg:32.94ms
+step:175/1480 train_time:5762ms step_avg:32.93ms
+step:176/1480 train_time:5798ms step_avg:32.94ms
+step:177/1480 train_time:5828ms step_avg:32.92ms
+step:178/1480 train_time:5864ms step_avg:32.94ms
+step:179/1480 train_time:5894ms step_avg:32.93ms
+step:180/1480 train_time:5930ms step_avg:32.95ms
+step:181/1480 train_time:5960ms step_avg:32.93ms
+step:182/1480 train_time:5996ms step_avg:32.94ms
+step:183/1480 train_time:6026ms step_avg:32.93ms
+step:184/1480 train_time:6062ms step_avg:32.95ms
+step:185/1480 train_time:6092ms step_avg:32.93ms
+step:186/1480 train_time:6129ms step_avg:32.95ms
+step:187/1480 train_time:6158ms step_avg:32.93ms
+step:188/1480 train_time:6194ms step_avg:32.95ms
+step:189/1480 train_time:6224ms step_avg:32.93ms
+step:190/1480 train_time:6261ms step_avg:32.95ms
+step:191/1480 train_time:6290ms step_avg:32.93ms
+step:192/1480 train_time:6327ms step_avg:32.95ms
+step:193/1480 train_time:6356ms step_avg:32.93ms
+step:194/1480 train_time:6393ms step_avg:32.95ms
+step:195/1480 train_time:6423ms step_avg:32.94ms
+step:196/1480 train_time:6459ms step_avg:32.95ms
+step:197/1480 train_time:6489ms step_avg:32.94ms
+step:198/1480 train_time:6525ms step_avg:32.96ms
+step:199/1480 train_time:6555ms step_avg:32.94ms
+step:200/1480 train_time:6592ms step_avg:32.96ms
+step:201/1480 train_time:6621ms step_avg:32.94ms
+step:202/1480 train_time:6657ms step_avg:32.95ms
+step:203/1480 train_time:6687ms step_avg:32.94ms
+step:204/1480 train_time:6723ms step_avg:32.96ms
+step:205/1480 train_time:6753ms step_avg:32.94ms
+step:206/1480 train_time:6789ms step_avg:32.96ms
+step:207/1480 train_time:6819ms step_avg:32.94ms
+step:208/1480 train_time:6855ms step_avg:32.96ms
+step:209/1480 train_time:6885ms step_avg:32.94ms
+step:210/1480 train_time:6922ms step_avg:32.96ms
+step:211/1480 train_time:6951ms step_avg:32.94ms
+step:212/1480 train_time:6987ms step_avg:32.96ms
+step:213/1480 train_time:7017ms step_avg:32.94ms
+step:214/1480 train_time:7053ms step_avg:32.96ms
+step:215/1480 train_time:7083ms step_avg:32.95ms
+step:216/1480 train_time:7119ms step_avg:32.96ms
+step:217/1480 train_time:7149ms step_avg:32.94ms
+step:218/1480 train_time:7185ms step_avg:32.96ms
+step:219/1480 train_time:7215ms step_avg:32.94ms
+step:220/1480 train_time:7251ms step_avg:32.96ms
+step:221/1480 train_time:7281ms step_avg:32.95ms
+step:222/1480 train_time:7317ms step_avg:32.96ms
+step:223/1480 train_time:7346ms step_avg:32.94ms
+step:224/1480 train_time:7383ms step_avg:32.96ms
+step:225/1480 train_time:7412ms step_avg:32.94ms
+step:226/1480 train_time:7448ms step_avg:32.96ms
+step:227/1480 train_time:7478ms step_avg:32.94ms
+step:228/1480 train_time:7513ms step_avg:32.95ms
+step:229/1480 train_time:7543ms step_avg:32.94ms
+step:230/1480 train_time:7579ms step_avg:32.95ms
+step:231/1480 train_time:7608ms step_avg:32.94ms
+step:232/1480 train_time:7645ms step_avg:32.95ms
+step:233/1480 train_time:7674ms step_avg:32.94ms
+step:234/1480 train_time:7710ms step_avg:32.95ms
+step:235/1480 train_time:7740ms step_avg:32.94ms
+step:236/1480 train_time:7776ms step_avg:32.95ms
+step:237/1480 train_time:7805ms step_avg:32.93ms
+step:238/1480 train_time:7842ms step_avg:32.95ms
+step:239/1480 train_time:7871ms step_avg:32.93ms
+step:240/1480 train_time:7907ms step_avg:32.95ms
+step:241/1480 train_time:7937ms step_avg:32.93ms
+step:242/1480 train_time:7973ms step_avg:32.95ms
+step:243/1480 train_time:8004ms step_avg:32.94ms
+step:244/1480 train_time:8042ms step_avg:32.96ms
+step:245/1480 train_time:8073ms step_avg:32.95ms
+step:246/1480 train_time:8110ms step_avg:32.97ms
+step:247/1480 train_time:8142ms step_avg:32.96ms
+step:248/1480 train_time:8179ms step_avg:32.98ms
+step:249/1480 train_time:8209ms step_avg:32.97ms
+step:250/1480 train_time:8247ms step_avg:32.99ms
+step:250/1480 val_loss:4.5116 train_time:8295ms step_avg:33.18ms
+step:251/1480 train_time:8311ms step_avg:33.11ms
+step:252/1480 train_time:8329ms step_avg:33.05ms
+step:253/1480 train_time:8346ms step_avg:32.99ms
+step:254/1480 train_time:8386ms step_avg:33.01ms
+step:255/1480 train_time:8419ms step_avg:33.02ms
+step:256/1480 train_time:8459ms step_avg:33.04ms
+step:257/1480 train_time:8493ms step_avg:33.04ms
+step:258/1480 train_time:8533ms step_avg:33.07ms
+step:259/1480 train_time:8564ms step_avg:33.07ms
+step:260/1480 train_time:8599ms step_avg:33.07ms
+step:261/1480 train_time:8627ms step_avg:33.05ms
+step:262/1480 train_time:8662ms step_avg:33.06ms
+step:263/1480 train_time:8690ms step_avg:33.04ms
+step:264/1480 train_time:8727ms step_avg:33.06ms
+step:265/1480 train_time:8755ms step_avg:33.04ms
+step:266/1480 train_time:8791ms step_avg:33.05ms
+step:267/1480 train_time:8822ms step_avg:33.04ms
+step:268/1480 train_time:8858ms step_avg:33.05ms
+step:269/1480 train_time:8888ms step_avg:33.04ms
+step:270/1480 train_time:8925ms step_avg:33.05ms
+step:271/1480 train_time:8955ms step_avg:33.04ms
+step:272/1480 train_time:8991ms step_avg:33.06ms
+step:273/1480 train_time:9021ms step_avg:33.05ms
+step:274/1480 train_time:9057ms step_avg:33.06ms
+step:275/1480 train_time:9088ms step_avg:33.05ms
+step:276/1480 train_time:9124ms step_avg:33.06ms
+step:277/1480 train_time:9154ms step_avg:33.05ms
+step:278/1480 train_time:9190ms step_avg:33.06ms
+step:279/1480 train_time:9221ms step_avg:33.05ms
+step:280/1480 train_time:9257ms step_avg:33.06ms
+step:281/1480 train_time:9287ms step_avg:33.05ms
+step:282/1480 train_time:9323ms step_avg:33.06ms
+step:283/1480 train_time:9353ms step_avg:33.05ms
+step:284/1480 train_time:9391ms step_avg:33.07ms
+step:285/1480 train_time:9420ms step_avg:33.05ms
+step:286/1480 train_time:9457ms step_avg:33.07ms
+step:287/1480 train_time:9486ms step_avg:33.05ms
+step:288/1480 train_time:9523ms step_avg:33.07ms
+step:289/1480 train_time:9553ms step_avg:33.06ms
+step:290/1480 train_time:9589ms step_avg:33.07ms
+step:291/1480 train_time:9619ms step_avg:33.06ms
+step:292/1480 train_time:9655ms step_avg:33.07ms
+step:293/1480 train_time:9685ms step_avg:33.06ms
+step:294/1480 train_time:9722ms step_avg:33.07ms
+step:295/1480 train_time:9751ms step_avg:33.06ms
+step:296/1480 train_time:9788ms step_avg:33.07ms
+step:297/1480 train_time:9818ms step_avg:33.06ms
+step:298/1480 train_time:9854ms step_avg:33.07ms
+step:299/1480 train_time:9884ms step_avg:33.06ms
+step:300/1480 train_time:9920ms step_avg:33.07ms
+step:301/1480 train_time:9950ms step_avg:33.06ms
+step:302/1480 train_time:9986ms step_avg:33.07ms
+step:303/1480 train_time:10016ms step_avg:33.05ms
+step:304/1480 train_time:10052ms step_avg:33.07ms
+step:305/1480 train_time:10082ms step_avg:33.06ms
+step:306/1480 train_time:10118ms step_avg:33.07ms
+step:307/1480 train_time:10148ms step_avg:33.06ms
+step:308/1480 train_time:10184ms step_avg:33.07ms
+step:309/1480 train_time:10214ms step_avg:33.06ms
+step:310/1480 train_time:10250ms step_avg:33.06ms
+step:311/1480 train_time:10280ms step_avg:33.06ms
+step:312/1480 train_time:10316ms step_avg:33.06ms
+step:313/1480 train_time:10346ms step_avg:33.06ms
+step:314/1480 train_time:10383ms step_avg:33.07ms
+step:315/1480 train_time:10413ms step_avg:33.06ms
+step:316/1480 train_time:10449ms step_avg:33.07ms
+step:317/1480 train_time:10479ms step_avg:33.06ms
+step:318/1480 train_time:10514ms step_avg:33.06ms
+step:319/1480 train_time:10545ms step_avg:33.06ms
+step:320/1480 train_time:10581ms step_avg:33.07ms
+step:321/1480 train_time:10610ms step_avg:33.05ms
+step:322/1480 train_time:10647ms step_avg:33.06ms
+step:323/1480 train_time:10676ms step_avg:33.05ms
+step:324/1480 train_time:10712ms step_avg:33.06ms
+step:325/1480 train_time:10742ms step_avg:33.05ms
+step:326/1480 train_time:10778ms step_avg:33.06ms
+step:327/1480 train_time:10808ms step_avg:33.05ms
+step:328/1480 train_time:10844ms step_avg:33.06ms
+step:329/1480 train_time:10873ms step_avg:33.05ms
+step:330/1480 train_time:10910ms step_avg:33.06ms
+step:331/1480 train_time:10940ms step_avg:33.05ms
+step:332/1480 train_time:10975ms step_avg:33.06ms
+step:333/1480 train_time:11005ms step_avg:33.05ms
+step:334/1480 train_time:11042ms step_avg:33.06ms
+step:335/1480 train_time:11071ms step_avg:33.05ms
+step:336/1480 train_time:11107ms step_avg:33.06ms
+step:337/1480 train_time:11137ms step_avg:33.05ms
+step:338/1480 train_time:11173ms step_avg:33.06ms
+step:339/1480 train_time:11203ms step_avg:33.05ms
+step:340/1480 train_time:11241ms step_avg:33.06ms
+step:341/1480 train_time:11272ms step_avg:33.05ms
+step:342/1480 train_time:11310ms step_avg:33.07ms
+step:343/1480 train_time:11342ms step_avg:33.07ms
+step:344/1480 train_time:11380ms step_avg:33.08ms
+step:345/1480 train_time:11411ms step_avg:33.07ms
+step:346/1480 train_time:11449ms step_avg:33.09ms
+step:347/1480 train_time:11481ms step_avg:33.09ms
+step:348/1480 train_time:11518ms step_avg:33.10ms
+step:349/1480 train_time:11550ms step_avg:33.10ms
+step:350/1480 train_time:11589ms step_avg:33.11ms
+step:351/1480 train_time:11620ms step_avg:33.11ms
+step:352/1480 train_time:11657ms step_avg:33.12ms
+step:353/1480 train_time:11685ms step_avg:33.10ms
+step:354/1480 train_time:11720ms step_avg:33.11ms
+step:355/1480 train_time:11748ms step_avg:33.09ms
+step:356/1480 train_time:11783ms step_avg:33.10ms
+step:357/1480 train_time:11813ms step_avg:33.09ms
+step:358/1480 train_time:11852ms step_avg:33.11ms
+step:359/1480 train_time:11881ms step_avg:33.10ms
+step:360/1480 train_time:11918ms step_avg:33.10ms
+step:361/1480 train_time:11947ms step_avg:33.09ms
+step:362/1480 train_time:11982ms step_avg:33.10ms
+step:363/1480 train_time:12013ms step_avg:33.09ms
+step:364/1480 train_time:12050ms step_avg:33.10ms
+step:365/1480 train_time:12079ms step_avg:33.09ms
+step:366/1480 train_time:12117ms step_avg:33.11ms
+step:367/1480 train_time:12146ms step_avg:33.10ms
+step:368/1480 train_time:12185ms step_avg:33.11ms
+step:369/1480 train_time:12216ms step_avg:33.10ms
+step:370/1480 train_time:12253ms step_avg:33.12ms
+step:371/1480 train_time:12283ms step_avg:33.11ms
+step:372/1480 train_time:12319ms step_avg:33.12ms
+step:373/1480 train_time:12349ms step_avg:33.11ms
+step:374/1480 train_time:12385ms step_avg:33.12ms
+step:375/1480 train_time:12415ms step_avg:33.11ms
+step:376/1480 train_time:12451ms step_avg:33.11ms
+step:377/1480 train_time:12482ms step_avg:33.11ms
+step:378/1480 train_time:12518ms step_avg:33.12ms
+step:379/1480 train_time:12549ms step_avg:33.11ms
+step:380/1480 train_time:12587ms step_avg:33.12ms
+step:381/1480 train_time:12617ms step_avg:33.12ms
+step:382/1480 train_time:12654ms step_avg:33.13ms
+step:383/1480 train_time:12687ms step_avg:33.12ms
+step:384/1480 train_time:12725ms step_avg:33.14ms
+step:385/1480 train_time:12758ms step_avg:33.14ms
+step:386/1480 train_time:12795ms step_avg:33.15ms
+step:387/1480 train_time:12827ms step_avg:33.14ms
+step:388/1480 train_time:12864ms step_avg:33.15ms
+step:389/1480 train_time:12896ms step_avg:33.15ms
+step:390/1480 train_time:12935ms step_avg:33.17ms
+step:391/1480 train_time:12966ms step_avg:33.16ms
+step:392/1480 train_time:13005ms step_avg:33.18ms
+step:393/1480 train_time:13036ms step_avg:33.17ms
+step:394/1480 train_time:13072ms step_avg:33.18ms
+step:395/1480 train_time:13101ms step_avg:33.17ms
+step:396/1480 train_time:13135ms step_avg:33.17ms
+step:397/1480 train_time:13164ms step_avg:33.16ms
+step:398/1480 train_time:13198ms step_avg:33.16ms
+step:399/1480 train_time:13229ms step_avg:33.15ms
+step:400/1480 train_time:13266ms step_avg:33.17ms
+step:401/1480 train_time:13295ms step_avg:33.15ms
+step:402/1480 train_time:13331ms step_avg:33.16ms
+step:403/1480 train_time:13360ms step_avg:33.15ms
+step:404/1480 train_time:13397ms step_avg:33.16ms
+step:405/1480 train_time:13426ms step_avg:33.15ms
+step:406/1480 train_time:13462ms step_avg:33.16ms
+step:407/1480 train_time:13492ms step_avg:33.15ms
+step:408/1480 train_time:13529ms step_avg:33.16ms
+step:409/1480 train_time:13559ms step_avg:33.15ms
+step:410/1480 train_time:13595ms step_avg:33.16ms
+step:411/1480 train_time:13625ms step_avg:33.15ms
+step:412/1480 train_time:13661ms step_avg:33.16ms
+step:413/1480 train_time:13690ms step_avg:33.15ms
+step:414/1480 train_time:13727ms step_avg:33.16ms
+step:415/1480 train_time:13757ms step_avg:33.15ms
+step:416/1480 train_time:13793ms step_avg:33.16ms
+step:417/1480 train_time:13823ms step_avg:33.15ms
+step:418/1480 train_time:13860ms step_avg:33.16ms
+step:419/1480 train_time:13890ms step_avg:33.15ms
+step:420/1480 train_time:13926ms step_avg:33.16ms
+step:421/1480 train_time:13956ms step_avg:33.15ms
+step:422/1480 train_time:13993ms step_avg:33.16ms
+step:423/1480 train_time:14023ms step_avg:33.15ms
+step:424/1480 train_time:14060ms step_avg:33.16ms
+step:425/1480 train_time:14089ms step_avg:33.15ms
+step:426/1480 train_time:14126ms step_avg:33.16ms
+step:427/1480 train_time:14155ms step_avg:33.15ms
+step:428/1480 train_time:14192ms step_avg:33.16ms
+step:429/1480 train_time:14222ms step_avg:33.15ms
+step:430/1480 train_time:14257ms step_avg:33.16ms
+step:431/1480 train_time:14287ms step_avg:33.15ms
+step:432/1480 train_time:14324ms step_avg:33.16ms
+step:433/1480 train_time:14354ms step_avg:33.15ms
+step:434/1480 train_time:14390ms step_avg:33.16ms
+step:435/1480 train_time:14421ms step_avg:33.15ms
+step:436/1480 train_time:14456ms step_avg:33.16ms
+step:437/1480 train_time:14487ms step_avg:33.15ms
+step:438/1480 train_time:14523ms step_avg:33.16ms
+step:439/1480 train_time:14553ms step_avg:33.15ms
+step:440/1480 train_time:14589ms step_avg:33.16ms
+step:441/1480 train_time:14619ms step_avg:33.15ms
+step:442/1480 train_time:14655ms step_avg:33.16ms
+step:443/1480 train_time:14685ms step_avg:33.15ms
+step:444/1480 train_time:14724ms step_avg:33.16ms
+step:445/1480 train_time:14756ms step_avg:33.16ms
+step:446/1480 train_time:14795ms step_avg:33.17ms
+step:447/1480 train_time:14827ms step_avg:33.17ms
+step:448/1480 train_time:14866ms step_avg:33.18ms
+step:449/1480 train_time:14897ms step_avg:33.18ms
+step:450/1480 train_time:14935ms step_avg:33.19ms
+step:451/1480 train_time:14966ms step_avg:33.18ms
+step:452/1480 train_time:15005ms step_avg:33.20ms
+step:453/1480 train_time:15036ms step_avg:33.19ms
+step:454/1480 train_time:15075ms step_avg:33.20ms
+step:455/1480 train_time:15107ms step_avg:33.20ms
+step:456/1480 train_time:15142ms step_avg:33.21ms
+step:457/1480 train_time:15170ms step_avg:33.19ms
+step:458/1480 train_time:15205ms step_avg:33.20ms
+step:459/1480 train_time:15234ms step_avg:33.19ms
+step:460/1480 train_time:15269ms step_avg:33.19ms
+step:461/1480 train_time:15299ms step_avg:33.19ms
+step:462/1480 train_time:15337ms step_avg:33.20ms
+step:463/1480 train_time:15366ms step_avg:33.19ms
+step:464/1480 train_time:15402ms step_avg:33.19ms
+step:465/1480 train_time:15432ms step_avg:33.19ms
+step:466/1480 train_time:15469ms step_avg:33.20ms
+step:467/1480 train_time:15498ms step_avg:33.19ms
+step:468/1480 train_time:15535ms step_avg:33.19ms
+step:469/1480 train_time:15565ms step_avg:33.19ms
+step:470/1480 train_time:15603ms step_avg:33.20ms
+step:471/1480 train_time:15633ms step_avg:33.19ms
+step:472/1480 train_time:15671ms step_avg:33.20ms
+step:473/1480 train_time:15703ms step_avg:33.20ms
+step:474/1480 train_time:15740ms step_avg:33.21ms
+step:475/1480 train_time:15770ms step_avg:33.20ms
+step:476/1480 train_time:15807ms step_avg:33.21ms
+step:477/1480 train_time:15838ms step_avg:33.20ms
+step:478/1480 train_time:15875ms step_avg:33.21ms
+step:479/1480 train_time:15905ms step_avg:33.21ms
+step:480/1480 train_time:15943ms step_avg:33.22ms
+step:481/1480 train_time:15976ms step_avg:33.21ms
+step:482/1480 train_time:16036ms step_avg:33.27ms
+step:483/1480 train_time:16096ms step_avg:33.33ms
+step:484/1480 train_time:16162ms step_avg:33.39ms
+step:485/1480 train_time:16219ms step_avg:33.44ms
+step:486/1480 train_time:16284ms step_avg:33.51ms
+step:487/1480 train_time:16342ms step_avg:33.56ms
+step:488/1480 train_time:16407ms step_avg:33.62ms
+step:489/1480 train_time:16466ms step_avg:33.67ms
+step:490/1480 train_time:16530ms step_avg:33.74ms
+step:491/1480 train_time:16591ms step_avg:33.79ms
+step:492/1480 train_time:16656ms step_avg:33.85ms
+step:493/1480 train_time:16716ms step_avg:33.91ms
+step:494/1480 train_time:16781ms step_avg:33.97ms
+step:495/1480 train_time:16839ms step_avg:34.02ms
+step:496/1480 train_time:16904ms step_avg:34.08ms
+step:497/1480 train_time:16962ms step_avg:34.13ms
+step:498/1480 train_time:17027ms step_avg:34.19ms
+step:499/1480 train_time:17085ms step_avg:34.24ms
+step:500/1480 train_time:17151ms step_avg:34.30ms
+step:500/1480 val_loss:4.2158 train_time:17232ms step_avg:34.46ms
+step:501/1480 train_time:17249ms step_avg:34.43ms
+step:502/1480 train_time:17274ms step_avg:34.41ms
+step:503/1480 train_time:17334ms step_avg:34.46ms
+step:504/1480 train_time:17400ms step_avg:34.52ms
+step:505/1480 train_time:17461ms step_avg:34.58ms
+step:506/1480 train_time:17525ms step_avg:34.63ms
+step:507/1480 train_time:17583ms step_avg:34.68ms
+step:508/1480 train_time:17646ms step_avg:34.74ms
+step:509/1480 train_time:17703ms step_avg:34.78ms
+step:510/1480 train_time:17766ms step_avg:34.84ms
+step:511/1480 train_time:17825ms step_avg:34.88ms
+step:512/1480 train_time:17889ms step_avg:34.94ms
+step:513/1480 train_time:17947ms step_avg:34.98ms
+step:514/1480 train_time:18012ms step_avg:35.04ms
+step:515/1480 train_time:18072ms step_avg:35.09ms
+step:516/1480 train_time:18136ms step_avg:35.15ms
+step:517/1480 train_time:18196ms step_avg:35.20ms
+step:518/1480 train_time:18264ms step_avg:35.26ms
+step:519/1480 train_time:18323ms step_avg:35.30ms
+step:520/1480 train_time:18389ms step_avg:35.36ms
+step:521/1480 train_time:18447ms step_avg:35.41ms
+step:522/1480 train_time:18512ms step_avg:35.46ms
+step:523/1480 train_time:18571ms step_avg:35.51ms
+step:524/1480 train_time:18635ms step_avg:35.56ms
+step:525/1480 train_time:18694ms step_avg:35.61ms
+step:526/1480 train_time:18759ms step_avg:35.66ms
+step:527/1480 train_time:18818ms step_avg:35.71ms
+step:528/1480 train_time:18883ms step_avg:35.76ms
+step:529/1480 train_time:18941ms step_avg:35.81ms
+step:530/1480 train_time:19006ms step_avg:35.86ms
+step:531/1480 train_time:19065ms step_avg:35.90ms
+step:532/1480 train_time:19131ms step_avg:35.96ms
+step:533/1480 train_time:19189ms step_avg:36.00ms
+step:534/1480 train_time:19253ms step_avg:36.05ms
+step:535/1480 train_time:19311ms step_avg:36.10ms
+step:536/1480 train_time:19375ms step_avg:36.15ms
+step:537/1480 train_time:19433ms step_avg:36.19ms
+step:538/1480 train_time:19497ms step_avg:36.24ms
+step:539/1480 train_time:19556ms step_avg:36.28ms
+step:540/1480 train_time:19620ms step_avg:36.33ms
+step:541/1480 train_time:19679ms step_avg:36.38ms
+step:542/1480 train_time:19743ms step_avg:36.43ms
+step:543/1480 train_time:19802ms step_avg:36.47ms
+step:544/1480 train_time:19867ms step_avg:36.52ms
+step:545/1480 train_time:19925ms step_avg:36.56ms
+step:546/1480 train_time:19990ms step_avg:36.61ms
+step:547/1480 train_time:20047ms step_avg:36.65ms
+step:548/1480 train_time:20111ms step_avg:36.70ms
+step:549/1480 train_time:20169ms step_avg:36.74ms
+step:550/1480 train_time:20233ms step_avg:36.79ms
+step:551/1480 train_time:20291ms step_avg:36.83ms
+step:552/1480 train_time:20355ms step_avg:36.88ms
+step:553/1480 train_time:20414ms step_avg:36.91ms
+step:554/1480 train_time:20478ms step_avg:36.96ms
+step:555/1480 train_time:20536ms step_avg:37.00ms
+step:556/1480 train_time:20599ms step_avg:37.05ms
+step:557/1480 train_time:20658ms step_avg:37.09ms
+step:558/1480 train_time:20723ms step_avg:37.14ms
+step:559/1480 train_time:20782ms step_avg:37.18ms
+step:560/1480 train_time:20849ms step_avg:37.23ms
+step:561/1480 train_time:20907ms step_avg:37.27ms
+step:562/1480 train_time:20971ms step_avg:37.31ms
+step:563/1480 train_time:21031ms step_avg:37.35ms
+step:564/1480 train_time:21095ms step_avg:37.40ms
+step:565/1480 train_time:21152ms step_avg:37.44ms
+step:566/1480 train_time:21216ms step_avg:37.48ms
+step:567/1480 train_time:21274ms step_avg:37.52ms
+step:568/1480 train_time:21338ms step_avg:37.57ms
+step:569/1480 train_time:21397ms step_avg:37.60ms
+step:570/1480 train_time:21464ms step_avg:37.66ms
+step:571/1480 train_time:21522ms step_avg:37.69ms
+step:572/1480 train_time:21584ms step_avg:37.74ms
+step:573/1480 train_time:21643ms step_avg:37.77ms
+step:574/1480 train_time:21706ms step_avg:37.82ms
+step:575/1480 train_time:21764ms step_avg:37.85ms
+step:576/1480 train_time:21831ms step_avg:37.90ms
+step:577/1480 train_time:21889ms step_avg:37.94ms
+step:578/1480 train_time:21954ms step_avg:37.98ms
+step:579/1480 train_time:22013ms step_avg:38.02ms
+step:580/1480 train_time:22078ms step_avg:38.06ms
+step:581/1480 train_time:22137ms step_avg:38.10ms
+step:582/1480 train_time:22203ms step_avg:38.15ms
+step:583/1480 train_time:22263ms step_avg:38.19ms
+step:584/1480 train_time:22326ms step_avg:38.23ms
+step:585/1480 train_time:22384ms step_avg:38.26ms
+step:586/1480 train_time:22447ms step_avg:38.30ms
+step:587/1480 train_time:22504ms step_avg:38.34ms
+step:588/1480 train_time:22568ms step_avg:38.38ms
+step:589/1480 train_time:22625ms step_avg:38.41ms
+step:590/1480 train_time:22688ms step_avg:38.46ms
+step:591/1480 train_time:22746ms step_avg:38.49ms
+step:592/1480 train_time:22808ms step_avg:38.53ms
+step:593/1480 train_time:22867ms step_avg:38.56ms
+step:594/1480 train_time:22931ms step_avg:38.60ms
+step:595/1480 train_time:22989ms step_avg:38.64ms
+step:596/1480 train_time:23055ms step_avg:38.68ms
+step:597/1480 train_time:23114ms step_avg:38.72ms
+step:598/1480 train_time:23180ms step_avg:38.76ms
+step:599/1480 train_time:23240ms step_avg:38.80ms
+step:600/1480 train_time:23306ms step_avg:38.84ms
+step:601/1480 train_time:23366ms step_avg:38.88ms
+step:602/1480 train_time:23434ms step_avg:38.93ms
+step:603/1480 train_time:23493ms step_avg:38.96ms
+step:604/1480 train_time:23559ms step_avg:39.00ms
+step:605/1480 train_time:23620ms step_avg:39.04ms
+step:606/1480 train_time:23685ms step_avg:39.08ms
+step:607/1480 train_time:23744ms step_avg:39.12ms
+step:608/1480 train_time:23809ms step_avg:39.16ms
+step:609/1480 train_time:23868ms step_avg:39.19ms
+step:610/1480 train_time:23933ms step_avg:39.23ms
+step:611/1480 train_time:23991ms step_avg:39.27ms
+step:612/1480 train_time:24055ms step_avg:39.31ms
+step:613/1480 train_time:24114ms step_avg:39.34ms
+step:614/1480 train_time:24179ms step_avg:39.38ms
+step:615/1480 train_time:24238ms step_avg:39.41ms
+step:616/1480 train_time:24303ms step_avg:39.45ms
+step:617/1480 train_time:24363ms step_avg:39.49ms
+step:618/1480 train_time:24428ms step_avg:39.53ms
+step:619/1480 train_time:24486ms step_avg:39.56ms
+step:620/1480 train_time:24550ms step_avg:39.60ms
+step:621/1480 train_time:24608ms step_avg:39.63ms
+step:622/1480 train_time:24672ms step_avg:39.67ms
+step:623/1480 train_time:24729ms step_avg:39.69ms
+step:624/1480 train_time:24793ms step_avg:39.73ms
+step:625/1480 train_time:24851ms step_avg:39.76ms
+step:626/1480 train_time:24915ms step_avg:39.80ms
+step:627/1480 train_time:24973ms step_avg:39.83ms
+step:628/1480 train_time:25037ms step_avg:39.87ms
+step:629/1480 train_time:25096ms step_avg:39.90ms
+step:630/1480 train_time:25160ms step_avg:39.94ms
+step:631/1480 train_time:25218ms step_avg:39.97ms
+step:632/1480 train_time:25283ms step_avg:40.00ms
+step:633/1480 train_time:25341ms step_avg:40.03ms
+step:634/1480 train_time:25407ms step_avg:40.07ms
+step:635/1480 train_time:25466ms step_avg:40.10ms
+step:636/1480 train_time:25530ms step_avg:40.14ms
+step:637/1480 train_time:25588ms step_avg:40.17ms
+step:638/1480 train_time:25651ms step_avg:40.21ms
+step:639/1480 train_time:25708ms step_avg:40.23ms
+step:640/1480 train_time:25773ms step_avg:40.27ms
+step:641/1480 train_time:25831ms step_avg:40.30ms
+step:642/1480 train_time:25896ms step_avg:40.34ms
+step:643/1480 train_time:25954ms step_avg:40.36ms
+step:644/1480 train_time:26017ms step_avg:40.40ms
+step:645/1480 train_time:26075ms step_avg:40.43ms
+step:646/1480 train_time:26142ms step_avg:40.47ms
+step:647/1480 train_time:26200ms step_avg:40.49ms
+step:648/1480 train_time:26264ms step_avg:40.53ms
+step:649/1480 train_time:26322ms step_avg:40.56ms
+step:650/1480 train_time:26385ms step_avg:40.59ms
+step:651/1480 train_time:26443ms step_avg:40.62ms
+step:652/1480 train_time:26506ms step_avg:40.65ms
+step:653/1480 train_time:26564ms step_avg:40.68ms
+step:654/1480 train_time:26627ms step_avg:40.71ms
+step:655/1480 train_time:26684ms step_avg:40.74ms
+step:656/1480 train_time:26747ms step_avg:40.77ms
+step:657/1480 train_time:26805ms step_avg:40.80ms
+step:658/1480 train_time:26869ms step_avg:40.83ms
+step:659/1480 train_time:26927ms step_avg:40.86ms
+step:660/1480 train_time:26990ms step_avg:40.89ms
+step:661/1480 train_time:27047ms step_avg:40.92ms
+step:662/1480 train_time:27110ms step_avg:40.95ms
+step:663/1480 train_time:27167ms step_avg:40.98ms
+step:664/1480 train_time:27232ms step_avg:41.01ms
+step:665/1480 train_time:27291ms step_avg:41.04ms
+step:666/1480 train_time:27358ms step_avg:41.08ms
+step:667/1480 train_time:27420ms step_avg:41.11ms
+step:668/1480 train_time:27486ms step_avg:41.15ms
+step:669/1480 train_time:27545ms step_avg:41.17ms
+step:670/1480 train_time:27611ms step_avg:41.21ms
+step:671/1480 train_time:27671ms step_avg:41.24ms
+step:672/1480 train_time:27737ms step_avg:41.28ms
+step:673/1480 train_time:27798ms step_avg:41.30ms
+step:674/1480 train_time:27862ms step_avg:41.34ms
+step:675/1480 train_time:27917ms step_avg:41.36ms
+step:676/1480 train_time:27978ms step_avg:41.39ms
+step:677/1480 train_time:28036ms step_avg:41.41ms
+step:678/1480 train_time:28101ms step_avg:41.45ms
+step:679/1480 train_time:28160ms step_avg:41.47ms
+step:680/1480 train_time:28224ms step_avg:41.51ms
+step:681/1480 train_time:28281ms step_avg:41.53ms
+step:682/1480 train_time:28346ms step_avg:41.56ms
+step:683/1480 train_time:28404ms step_avg:41.59ms
+step:684/1480 train_time:28470ms step_avg:41.62ms
+step:685/1480 train_time:28529ms step_avg:41.65ms
+step:686/1480 train_time:28595ms step_avg:41.68ms
+step:687/1480 train_time:28653ms step_avg:41.71ms
+step:688/1480 train_time:28718ms step_avg:41.74ms
+step:689/1480 train_time:28777ms step_avg:41.77ms
+step:690/1480 train_time:28844ms step_avg:41.80ms
+step:691/1480 train_time:28903ms step_avg:41.83ms
+step:692/1480 train_time:28968ms step_avg:41.86ms
+step:693/1480 train_time:29026ms step_avg:41.89ms
+step:694/1480 train_time:29090ms step_avg:41.92ms
+step:695/1480 train_time:29148ms step_avg:41.94ms
+step:696/1480 train_time:29211ms step_avg:41.97ms
+step:697/1480 train_time:29269ms step_avg:41.99ms
+step:698/1480 train_time:29333ms step_avg:42.02ms
+step:699/1480 train_time:29391ms step_avg:42.05ms
+step:700/1480 train_time:29454ms step_avg:42.08ms
+step:701/1480 train_time:29512ms step_avg:42.10ms
+step:702/1480 train_time:29575ms step_avg:42.13ms
+step:703/1480 train_time:29632ms step_avg:42.15ms
+step:704/1480 train_time:29696ms step_avg:42.18ms
+step:705/1480 train_time:29754ms step_avg:42.20ms
+step:706/1480 train_time:29819ms step_avg:42.24ms
+step:707/1480 train_time:29879ms step_avg:42.26ms
+step:708/1480 train_time:29946ms step_avg:42.30ms
+step:709/1480 train_time:30007ms step_avg:42.32ms
+step:710/1480 train_time:30074ms step_avg:42.36ms
+step:711/1480 train_time:30135ms step_avg:42.38ms
+step:712/1480 train_time:30203ms step_avg:42.42ms
+step:713/1480 train_time:30265ms step_avg:42.45ms
+step:714/1480 train_time:30332ms step_avg:42.48ms
+step:715/1480 train_time:30392ms step_avg:42.51ms
+step:716/1480 train_time:30460ms step_avg:42.54ms
+step:717/1480 train_time:30517ms step_avg:42.56ms
+step:718/1480 train_time:30576ms step_avg:42.59ms
+step:719/1480 train_time:30630ms step_avg:42.60ms
+step:720/1480 train_time:30692ms step_avg:42.63ms
+step:721/1480 train_time:30749ms step_avg:42.65ms
+step:722/1480 train_time:30813ms step_avg:42.68ms
+step:723/1480 train_time:30872ms step_avg:42.70ms
+step:724/1480 train_time:30936ms step_avg:42.73ms
+step:725/1480 train_time:30994ms step_avg:42.75ms
+step:726/1480 train_time:31059ms step_avg:42.78ms
+step:727/1480 train_time:31119ms step_avg:42.80ms
+step:728/1480 train_time:31183ms step_avg:42.83ms
+step:729/1480 train_time:31240ms step_avg:42.85ms
+step:730/1480 train_time:31304ms step_avg:42.88ms
+step:731/1480 train_time:31361ms step_avg:42.90ms
+step:732/1480 train_time:31427ms step_avg:42.93ms
+step:733/1480 train_time:31484ms step_avg:42.95ms
+step:734/1480 train_time:31548ms step_avg:42.98ms
+step:735/1480 train_time:31606ms step_avg:43.00ms
+step:736/1480 train_time:31671ms step_avg:43.03ms
+step:737/1480 train_time:31731ms step_avg:43.05ms
+step:738/1480 train_time:31803ms step_avg:43.09ms
+step:739/1480 train_time:31868ms step_avg:43.12ms
+step:740/1480 train_time:31937ms step_avg:43.16ms
+step:741/1480 train_time:32001ms step_avg:43.19ms
+step:742/1480 train_time:32071ms step_avg:43.22ms
+step:743/1480 train_time:32133ms step_avg:43.25ms
+step:744/1480 train_time:32192ms step_avg:43.27ms
+step:745/1480 train_time:32246ms step_avg:43.28ms
+step:746/1480 train_time:32306ms step_avg:43.31ms
+step:747/1480 train_time:32363ms step_avg:43.32ms
+step:748/1480 train_time:32428ms step_avg:43.35ms
+step:749/1480 train_time:32491ms step_avg:43.38ms
+step:750/1480 train_time:32561ms step_avg:43.41ms
+step:750/1480 val_loss:3.8054 train_time:32649ms step_avg:43.53ms
+step:751/1480 train_time:32666ms step_avg:43.50ms
+step:752/1480 train_time:32691ms step_avg:43.47ms
+step:753/1480 train_time:32749ms step_avg:43.49ms
+step:754/1480 train_time:32815ms step_avg:43.52ms
+step:755/1480 train_time:32874ms step_avg:43.54ms
+step:756/1480 train_time:32940ms step_avg:43.57ms
+step:757/1480 train_time:33000ms step_avg:43.59ms
+step:758/1480 train_time:33065ms step_avg:43.62ms
+step:759/1480 train_time:33124ms step_avg:43.64ms
+step:760/1480 train_time:33190ms step_avg:43.67ms
+step:761/1480 train_time:33250ms step_avg:43.69ms
+step:762/1480 train_time:33316ms step_avg:43.72ms
+step:763/1480 train_time:33375ms step_avg:43.74ms
+step:764/1480 train_time:33442ms step_avg:43.77ms
+step:765/1480 train_time:33501ms step_avg:43.79ms
+step:766/1480 train_time:33566ms step_avg:43.82ms
+step:767/1480 train_time:33625ms step_avg:43.84ms
+step:768/1480 train_time:33689ms step_avg:43.87ms
+step:769/1480 train_time:33746ms step_avg:43.88ms
+step:770/1480 train_time:33806ms step_avg:43.90ms
+step:771/1480 train_time:33864ms step_avg:43.92ms
+step:772/1480 train_time:33928ms step_avg:43.95ms
+step:773/1480 train_time:33986ms step_avg:43.97ms
+step:774/1480 train_time:34049ms step_avg:43.99ms
+step:775/1480 train_time:34107ms step_avg:44.01ms
+step:776/1480 train_time:34171ms step_avg:44.03ms
+step:777/1480 train_time:34231ms step_avg:44.05ms
+step:778/1480 train_time:34295ms step_avg:44.08ms
+step:779/1480 train_time:34354ms step_avg:44.10ms
+step:780/1480 train_time:34418ms step_avg:44.13ms
+step:781/1480 train_time:34475ms step_avg:44.14ms
+step:782/1480 train_time:34540ms step_avg:44.17ms
+step:783/1480 train_time:34598ms step_avg:44.19ms
+step:784/1480 train_time:34663ms step_avg:44.21ms
+step:785/1480 train_time:34720ms step_avg:44.23ms
+step:786/1480 train_time:34784ms step_avg:44.25ms
+step:787/1480 train_time:34842ms step_avg:44.27ms
+step:788/1480 train_time:34906ms step_avg:44.30ms
+step:789/1480 train_time:34964ms step_avg:44.31ms
+step:790/1480 train_time:35029ms step_avg:44.34ms
+step:791/1480 train_time:35089ms step_avg:44.36ms
+step:792/1480 train_time:35153ms step_avg:44.38ms
+step:793/1480 train_time:35209ms step_avg:44.40ms
+step:794/1480 train_time:35273ms step_avg:44.42ms
+step:795/1480 train_time:35332ms step_avg:44.44ms
+step:796/1480 train_time:35398ms step_avg:44.47ms
+step:797/1480 train_time:35456ms step_avg:44.49ms
+step:798/1480 train_time:35518ms step_avg:44.51ms
+step:799/1480 train_time:35577ms step_avg:44.53ms
+step:800/1480 train_time:35647ms step_avg:44.56ms
+step:801/1480 train_time:35712ms step_avg:44.58ms
+step:802/1480 train_time:35784ms step_avg:44.62ms
+step:803/1480 train_time:35848ms step_avg:44.64ms
+step:804/1480 train_time:35918ms step_avg:44.67ms
+step:805/1480 train_time:35979ms step_avg:44.69ms
+step:806/1480 train_time:36038ms step_avg:44.71ms
+step:807/1480 train_time:36092ms step_avg:44.72ms
+step:808/1480 train_time:36153ms step_avg:44.74ms
+step:809/1480 train_time:36210ms step_avg:44.76ms
+step:810/1480 train_time:36275ms step_avg:44.78ms
+step:811/1480 train_time:36338ms step_avg:44.81ms
+step:812/1480 train_time:36403ms step_avg:44.83ms
+step:813/1480 train_time:36462ms step_avg:44.85ms
+step:814/1480 train_time:36527ms step_avg:44.87ms
+step:815/1480 train_time:36586ms step_avg:44.89ms
+step:816/1480 train_time:36653ms step_avg:44.92ms
+step:817/1480 train_time:36713ms step_avg:44.94ms
+step:818/1480 train_time:36779ms step_avg:44.96ms
+step:819/1480 train_time:36837ms step_avg:44.98ms
+step:820/1480 train_time:36903ms step_avg:45.00ms
+step:821/1480 train_time:36962ms step_avg:45.02ms
+step:822/1480 train_time:37027ms step_avg:45.05ms
+step:823/1480 train_time:37087ms step_avg:45.06ms
+step:824/1480 train_time:37154ms step_avg:45.09ms
+step:825/1480 train_time:37213ms step_avg:45.11ms
+step:826/1480 train_time:37278ms step_avg:45.13ms
+step:827/1480 train_time:37337ms step_avg:45.15ms
+step:828/1480 train_time:37402ms step_avg:45.17ms
+step:829/1480 train_time:37460ms step_avg:45.19ms
+step:830/1480 train_time:37525ms step_avg:45.21ms
+step:831/1480 train_time:37584ms step_avg:45.23ms
+step:832/1480 train_time:37650ms step_avg:45.25ms
+step:833/1480 train_time:37709ms step_avg:45.27ms
+step:834/1480 train_time:37775ms step_avg:45.29ms
+step:835/1480 train_time:37834ms step_avg:45.31ms
+step:836/1480 train_time:37899ms step_avg:45.33ms
+step:837/1480 train_time:37957ms step_avg:45.35ms
+step:838/1480 train_time:38021ms step_avg:45.37ms
+step:839/1480 train_time:38079ms step_avg:45.39ms
+step:840/1480 train_time:38146ms step_avg:45.41ms
+step:841/1480 train_time:38205ms step_avg:45.43ms
+step:842/1480 train_time:38270ms step_avg:45.45ms
+step:843/1480 train_time:38329ms step_avg:45.47ms
+step:844/1480 train_time:38396ms step_avg:45.49ms
+step:845/1480 train_time:38454ms step_avg:45.51ms
+step:846/1480 train_time:38519ms step_avg:45.53ms
+step:847/1480 train_time:38577ms step_avg:45.55ms
+step:848/1480 train_time:38641ms step_avg:45.57ms
+step:849/1480 train_time:38700ms step_avg:45.58ms
+step:850/1480 train_time:38764ms step_avg:45.60ms
+step:851/1480 train_time:38822ms step_avg:45.62ms
+step:852/1480 train_time:38886ms step_avg:45.64ms
+step:853/1480 train_time:38944ms step_avg:45.66ms
+step:854/1480 train_time:39009ms step_avg:45.68ms
+step:855/1480 train_time:39067ms step_avg:45.69ms
+step:856/1480 train_time:39132ms step_avg:45.71ms
+step:857/1480 train_time:39190ms step_avg:45.73ms
+step:858/1480 train_time:39257ms step_avg:45.75ms
+step:859/1480 train_time:39315ms step_avg:45.77ms
+step:860/1480 train_time:39380ms step_avg:45.79ms
+step:861/1480 train_time:39439ms step_avg:45.81ms
+step:862/1480 train_time:39505ms step_avg:45.83ms
+step:863/1480 train_time:39564ms step_avg:45.84ms
+step:864/1480 train_time:39630ms step_avg:45.87ms
+step:865/1480 train_time:39688ms step_avg:45.88ms
+step:866/1480 train_time:39749ms step_avg:45.90ms
+step:867/1480 train_time:39807ms step_avg:45.91ms
+step:868/1480 train_time:39873ms step_avg:45.94ms
+step:869/1480 train_time:39932ms step_avg:45.95ms
+step:870/1480 train_time:39997ms step_avg:45.97ms
+step:871/1480 train_time:40062ms step_avg:46.00ms
+step:872/1480 train_time:40128ms step_avg:46.02ms
+step:873/1480 train_time:40189ms step_avg:46.04ms
+step:874/1480 train_time:40253ms step_avg:46.06ms
+step:875/1480 train_time:40311ms step_avg:46.07ms
+step:876/1480 train_time:40375ms step_avg:46.09ms
+step:877/1480 train_time:40435ms step_avg:46.11ms
+step:878/1480 train_time:40501ms step_avg:46.13ms
+step:879/1480 train_time:40558ms step_avg:46.14ms
+step:880/1480 train_time:40622ms step_avg:46.16ms
+step:881/1480 train_time:40679ms step_avg:46.17ms
+step:882/1480 train_time:40743ms step_avg:46.19ms
+step:883/1480 train_time:40801ms step_avg:46.21ms
+step:884/1480 train_time:40864ms step_avg:46.23ms
+step:885/1480 train_time:40922ms step_avg:46.24ms
+step:886/1480 train_time:40985ms step_avg:46.26ms
+step:887/1480 train_time:41044ms step_avg:46.27ms
+step:888/1480 train_time:41108ms step_avg:46.29ms
+step:889/1480 train_time:41166ms step_avg:46.31ms
+step:890/1480 train_time:41230ms step_avg:46.33ms
+step:891/1480 train_time:41290ms step_avg:46.34ms
+step:892/1480 train_time:41357ms step_avg:46.36ms
+step:893/1480 train_time:41415ms step_avg:46.38ms
+step:894/1480 train_time:41480ms step_avg:46.40ms
+step:895/1480 train_time:41538ms step_avg:46.41ms
+step:896/1480 train_time:41602ms step_avg:46.43ms
+step:897/1480 train_time:41660ms step_avg:46.44ms
+step:898/1480 train_time:41724ms step_avg:46.46ms
+step:899/1480 train_time:41784ms step_avg:46.48ms
+step:900/1480 train_time:41850ms step_avg:46.50ms
+step:901/1480 train_time:41910ms step_avg:46.51ms
+step:902/1480 train_time:41976ms step_avg:46.54ms
+step:903/1480 train_time:42036ms step_avg:46.55ms
+step:904/1480 train_time:42102ms step_avg:46.57ms
+step:905/1480 train_time:42160ms step_avg:46.59ms
+step:906/1480 train_time:42225ms step_avg:46.61ms
+step:907/1480 train_time:42285ms step_avg:46.62ms
+step:908/1480 train_time:42351ms step_avg:46.64ms
+step:909/1480 train_time:42411ms step_avg:46.66ms
+step:910/1480 train_time:42477ms step_avg:46.68ms
+step:911/1480 train_time:42536ms step_avg:46.69ms
+step:912/1480 train_time:42602ms step_avg:46.71ms
+step:913/1480 train_time:42659ms step_avg:46.72ms
+step:914/1480 train_time:42724ms step_avg:46.74ms
+step:915/1480 train_time:42783ms step_avg:46.76ms
+step:916/1480 train_time:42849ms step_avg:46.78ms
+step:917/1480 train_time:42910ms step_avg:46.79ms
+step:918/1480 train_time:42975ms step_avg:46.81ms
+step:919/1480 train_time:43034ms step_avg:46.83ms
+step:920/1480 train_time:43100ms step_avg:46.85ms
+step:921/1480 train_time:43158ms step_avg:46.86ms
+step:922/1480 train_time:43222ms step_avg:46.88ms
+step:923/1480 train_time:43280ms step_avg:46.89ms
+step:924/1480 train_time:43344ms step_avg:46.91ms
+step:925/1480 train_time:43403ms step_avg:46.92ms
+step:926/1480 train_time:43467ms step_avg:46.94ms
+step:927/1480 train_time:43526ms step_avg:46.95ms
+step:928/1480 train_time:43591ms step_avg:46.97ms
+step:929/1480 train_time:43650ms step_avg:46.99ms
+step:930/1480 train_time:43715ms step_avg:47.00ms
+step:931/1480 train_time:43773ms step_avg:47.02ms
+step:932/1480 train_time:43837ms step_avg:47.04ms
+step:933/1480 train_time:43896ms step_avg:47.05ms
+step:934/1480 train_time:43961ms step_avg:47.07ms
+step:935/1480 train_time:44017ms step_avg:47.08ms
+step:936/1480 train_time:44082ms step_avg:47.10ms
+step:937/1480 train_time:44140ms step_avg:47.11ms
+step:938/1480 train_time:44204ms step_avg:47.13ms
+step:939/1480 train_time:44262ms step_avg:47.14ms
+step:940/1480 train_time:44326ms step_avg:47.16ms
+step:941/1480 train_time:44384ms step_avg:47.17ms
+step:942/1480 train_time:44448ms step_avg:47.19ms
+step:943/1480 train_time:44508ms step_avg:47.20ms
+step:944/1480 train_time:44572ms step_avg:47.22ms
+step:945/1480 train_time:44631ms step_avg:47.23ms
+step:946/1480 train_time:44697ms step_avg:47.25ms
+step:947/1480 train_time:44755ms step_avg:47.26ms
+step:948/1480 train_time:44820ms step_avg:47.28ms
+step:949/1480 train_time:44878ms step_avg:47.29ms
+step:950/1480 train_time:44942ms step_avg:47.31ms
+step:951/1480 train_time:45001ms step_avg:47.32ms
+step:952/1480 train_time:45065ms step_avg:47.34ms
+step:953/1480 train_time:45124ms step_avg:47.35ms
+step:954/1480 train_time:45188ms step_avg:47.37ms
+step:955/1480 train_time:45246ms step_avg:47.38ms
+step:956/1480 train_time:45310ms step_avg:47.40ms
+step:957/1480 train_time:45368ms step_avg:47.41ms
+step:958/1480 train_time:45432ms step_avg:47.42ms
+step:959/1480 train_time:45491ms step_avg:47.44ms
+step:960/1480 train_time:45555ms step_avg:47.45ms
+step:961/1480 train_time:45616ms step_avg:47.47ms
+step:962/1480 train_time:45704ms step_avg:47.51ms
+step:963/1480 train_time:45792ms step_avg:47.55ms
+step:964/1480 train_time:45884ms step_avg:47.60ms
+step:965/1480 train_time:45968ms step_avg:47.64ms
+step:966/1480 train_time:46062ms step_avg:47.68ms
+step:967/1480 train_time:46151ms step_avg:47.73ms
+step:968/1480 train_time:46246ms step_avg:47.77ms
+step:969/1480 train_time:46334ms step_avg:47.82ms
+step:970/1480 train_time:46428ms step_avg:47.86ms
+step:971/1480 train_time:46517ms step_avg:47.91ms
+step:972/1480 train_time:46611ms step_avg:47.95ms
+step:973/1480 train_time:46698ms step_avg:47.99ms
+step:974/1480 train_time:46792ms step_avg:48.04ms
+step:975/1480 train_time:46880ms step_avg:48.08ms
+step:976/1480 train_time:46974ms step_avg:48.13ms
+step:977/1480 train_time:47062ms step_avg:48.17ms
+step:978/1480 train_time:47156ms step_avg:48.22ms
+step:979/1480 train_time:47243ms step_avg:48.26ms
+step:980/1480 train_time:47336ms step_avg:48.30ms
+step:981/1480 train_time:47423ms step_avg:48.34ms
+step:982/1480 train_time:47516ms step_avg:48.39ms
+step:983/1480 train_time:47602ms step_avg:48.43ms
+step:984/1480 train_time:47695ms step_avg:48.47ms
+step:985/1480 train_time:47782ms step_avg:48.51ms
+step:986/1480 train_time:47875ms step_avg:48.55ms
+step:987/1480 train_time:47961ms step_avg:48.59ms
+step:988/1480 train_time:48056ms step_avg:48.64ms
+step:989/1480 train_time:48142ms step_avg:48.68ms
+step:990/1480 train_time:48235ms step_avg:48.72ms
+step:991/1480 train_time:48320ms step_avg:48.76ms
+step:992/1480 train_time:48413ms step_avg:48.80ms
+step:993/1480 train_time:48499ms step_avg:48.84ms
+step:994/1480 train_time:48591ms step_avg:48.88ms
+step:995/1480 train_time:48679ms step_avg:48.92ms
+step:996/1480 train_time:48771ms step_avg:48.97ms
+step:997/1480 train_time:48858ms step_avg:49.00ms
+step:998/1480 train_time:48951ms step_avg:49.05ms
+step:999/1480 train_time:49037ms step_avg:49.09ms
+step:1000/1480 train_time:49129ms step_avg:49.13ms
+step:1000/1480 val_loss:3.5121 train_time:49246ms step_avg:49.25ms
+step:1001/1480 train_time:49263ms step_avg:49.21ms
+step:1002/1480 train_time:49308ms step_avg:49.21ms
+step:1003/1480 train_time:49396ms step_avg:49.25ms
+step:1004/1480 train_time:49497ms step_avg:49.30ms
+step:1005/1480 train_time:49587ms step_avg:49.34ms
+step:1006/1480 train_time:49683ms step_avg:49.39ms
+step:1007/1480 train_time:49774ms step_avg:49.43ms
+step:1008/1480 train_time:49867ms step_avg:49.47ms
+step:1009/1480 train_time:49957ms step_avg:49.51ms
+step:1010/1480 train_time:50053ms step_avg:49.56ms
+step:1011/1480 train_time:50142ms step_avg:49.60ms
+step:1012/1480 train_time:50237ms step_avg:49.64ms
+step:1013/1480 train_time:50325ms step_avg:49.68ms
+step:1014/1480 train_time:50420ms step_avg:49.72ms
+step:1015/1480 train_time:50507ms step_avg:49.76ms
+step:1016/1480 train_time:50602ms step_avg:49.81ms
+step:1017/1480 train_time:50688ms step_avg:49.84ms
+step:1018/1480 train_time:50782ms step_avg:49.88ms
+step:1019/1480 train_time:50869ms step_avg:49.92ms
+step:1020/1480 train_time:50963ms step_avg:49.96ms
+step:1021/1480 train_time:51049ms step_avg:50.00ms
+step:1022/1480 train_time:51143ms step_avg:50.04ms
+step:1023/1480 train_time:51230ms step_avg:50.08ms
+step:1024/1480 train_time:51323ms step_avg:50.12ms
+step:1025/1480 train_time:51410ms step_avg:50.16ms
+step:1026/1480 train_time:51503ms step_avg:50.20ms
+step:1027/1480 train_time:51589ms step_avg:50.23ms
+step:1028/1480 train_time:51681ms step_avg:50.27ms
+step:1029/1480 train_time:51768ms step_avg:50.31ms
+step:1030/1480 train_time:51862ms step_avg:50.35ms
+step:1031/1480 train_time:51947ms step_avg:50.39ms
+step:1032/1480 train_time:52041ms step_avg:50.43ms
+step:1033/1480 train_time:52128ms step_avg:50.46ms
+step:1034/1480 train_time:52222ms step_avg:50.50ms
+step:1035/1480 train_time:52307ms step_avg:50.54ms
+step:1036/1480 train_time:52400ms step_avg:50.58ms
+step:1037/1480 train_time:52488ms step_avg:50.62ms
+step:1038/1480 train_time:52579ms step_avg:50.65ms
+step:1039/1480 train_time:52666ms step_avg:50.69ms
+step:1040/1480 train_time:52759ms step_avg:50.73ms
+step:1041/1480 train_time:52843ms step_avg:50.76ms
+step:1042/1480 train_time:52936ms step_avg:50.80ms
+step:1043/1480 train_time:53021ms step_avg:50.84ms
+step:1044/1480 train_time:53113ms step_avg:50.87ms
+step:1045/1480 train_time:53199ms step_avg:50.91ms
+step:1046/1480 train_time:53291ms step_avg:50.95ms
+step:1047/1480 train_time:53375ms step_avg:50.98ms
+step:1048/1480 train_time:53468ms step_avg:51.02ms
+step:1049/1480 train_time:53555ms step_avg:51.05ms
+step:1050/1480 train_time:53648ms step_avg:51.09ms
+step:1051/1480 train_time:53734ms step_avg:51.13ms
+step:1052/1480 train_time:53828ms step_avg:51.17ms
+step:1053/1480 train_time:53914ms step_avg:51.20ms
+step:1054/1480 train_time:54007ms step_avg:51.24ms
+step:1055/1480 train_time:54094ms step_avg:51.27ms
+step:1056/1480 train_time:54187ms step_avg:51.31ms
+step:1057/1480 train_time:54274ms step_avg:51.35ms
+step:1058/1480 train_time:54366ms step_avg:51.39ms
+step:1059/1480 train_time:54452ms step_avg:51.42ms
+step:1060/1480 train_time:54542ms step_avg:51.45ms
+step:1061/1480 train_time:54628ms step_avg:51.49ms
+step:1062/1480 train_time:54720ms step_avg:51.53ms
+step:1063/1480 train_time:54806ms step_avg:51.56ms
+step:1064/1480 train_time:54899ms step_avg:51.60ms
+step:1065/1480 train_time:54984ms step_avg:51.63ms
+step:1066/1480 train_time:55077ms step_avg:51.67ms
+step:1067/1480 train_time:55162ms step_avg:51.70ms
+step:1068/1480 train_time:55254ms step_avg:51.74ms
+step:1069/1480 train_time:55338ms step_avg:51.77ms
+step:1070/1480 train_time:55428ms step_avg:51.80ms
+step:1071/1480 train_time:55513ms step_avg:51.83ms
+step:1072/1480 train_time:55607ms step_avg:51.87ms
+step:1073/1480 train_time:55694ms step_avg:51.91ms
+step:1074/1480 train_time:55791ms step_avg:51.95ms
+step:1075/1480 train_time:55878ms step_avg:51.98ms
+step:1076/1480 train_time:55972ms step_avg:52.02ms
+step:1077/1480 train_time:56061ms step_avg:52.05ms
+step:1078/1480 train_time:56154ms step_avg:52.09ms
+step:1079/1480 train_time:56239ms step_avg:52.12ms
+step:1080/1480 train_time:56332ms step_avg:52.16ms
+step:1081/1480 train_time:56419ms step_avg:52.19ms
+step:1082/1480 train_time:56512ms step_avg:52.23ms
+step:1083/1480 train_time:56600ms step_avg:52.26ms
+step:1084/1480 train_time:56693ms step_avg:52.30ms
+step:1085/1480 train_time:56779ms step_avg:52.33ms
+step:1086/1480 train_time:56871ms step_avg:52.37ms
+step:1087/1480 train_time:56958ms step_avg:52.40ms
+step:1088/1480 train_time:57050ms step_avg:52.44ms
+step:1089/1480 train_time:57137ms step_avg:52.47ms
+step:1090/1480 train_time:57230ms step_avg:52.50ms
+step:1091/1480 train_time:57317ms step_avg:52.54ms
+step:1092/1480 train_time:57408ms step_avg:52.57ms
+step:1093/1480 train_time:57495ms step_avg:52.60ms
+step:1094/1480 train_time:57585ms step_avg:52.64ms
+step:1095/1480 train_time:57670ms step_avg:52.67ms
+step:1096/1480 train_time:57763ms step_avg:52.70ms
+step:1097/1480 train_time:57848ms step_avg:52.73ms
+step:1098/1480 train_time:57938ms step_avg:52.77ms
+step:1099/1480 train_time:58025ms step_avg:52.80ms
+step:1100/1480 train_time:58117ms step_avg:52.83ms
+step:1101/1480 train_time:58202ms step_avg:52.86ms
+step:1102/1480 train_time:58294ms step_avg:52.90ms
+step:1103/1480 train_time:58379ms step_avg:52.93ms
+step:1104/1480 train_time:58471ms step_avg:52.96ms
+step:1105/1480 train_time:58558ms step_avg:52.99ms
+step:1106/1480 train_time:58656ms step_avg:53.03ms
+step:1107/1480 train_time:58745ms step_avg:53.07ms
+step:1108/1480 train_time:58841ms step_avg:53.11ms
+step:1109/1480 train_time:58930ms step_avg:53.14ms
+step:1110/1480 train_time:59026ms step_avg:53.18ms
+step:1111/1480 train_time:59115ms step_avg:53.21ms
+step:1112/1480 train_time:59209ms step_avg:53.25ms
+step:1113/1480 train_time:59298ms step_avg:53.28ms
+step:1114/1480 train_time:59394ms step_avg:53.32ms
+step:1115/1480 train_time:59483ms step_avg:53.35ms
+step:1116/1480 train_time:59578ms step_avg:53.38ms
+step:1117/1480 train_time:59666ms step_avg:53.42ms
+step:1118/1480 train_time:59760ms step_avg:53.45ms
+step:1119/1480 train_time:59847ms step_avg:53.48ms
+step:1120/1480 train_time:59941ms step_avg:53.52ms
+step:1121/1480 train_time:60028ms step_avg:53.55ms
+step:1122/1480 train_time:60121ms step_avg:53.58ms
+step:1123/1480 train_time:60208ms step_avg:53.61ms
+step:1124/1480 train_time:60301ms step_avg:53.65ms
+step:1125/1480 train_time:60388ms step_avg:53.68ms
+step:1126/1480 train_time:60481ms step_avg:53.71ms
+step:1127/1480 train_time:60568ms step_avg:53.74ms
+step:1128/1480 train_time:60662ms step_avg:53.78ms
+step:1129/1480 train_time:60749ms step_avg:53.81ms
+step:1130/1480 train_time:60842ms step_avg:53.84ms
+step:1131/1480 train_time:60930ms step_avg:53.87ms
+step:1132/1480 train_time:61022ms step_avg:53.91ms
+step:1133/1480 train_time:61107ms step_avg:53.93ms
+step:1134/1480 train_time:61202ms step_avg:53.97ms
+step:1135/1480 train_time:61287ms step_avg:54.00ms
+step:1136/1480 train_time:61382ms step_avg:54.03ms
+step:1137/1480 train_time:61468ms step_avg:54.06ms
+step:1138/1480 train_time:61563ms step_avg:54.10ms
+step:1139/1480 train_time:61648ms step_avg:54.12ms
+step:1140/1480 train_time:61741ms step_avg:54.16ms
+step:1141/1480 train_time:61827ms step_avg:54.19ms
+step:1142/1480 train_time:61920ms step_avg:54.22ms
+step:1143/1480 train_time:62003ms step_avg:54.25ms
+step:1144/1480 train_time:62093ms step_avg:54.28ms
+step:1145/1480 train_time:62175ms step_avg:54.30ms
+step:1146/1480 train_time:62267ms step_avg:54.33ms
+step:1147/1480 train_time:62354ms step_avg:54.36ms
+step:1148/1480 train_time:62445ms step_avg:54.39ms
+step:1149/1480 train_time:62531ms step_avg:54.42ms
+step:1150/1480 train_time:62625ms step_avg:54.46ms
+step:1151/1480 train_time:62711ms step_avg:54.48ms
+step:1152/1480 train_time:62804ms step_avg:54.52ms
+step:1153/1480 train_time:62890ms step_avg:54.54ms
+step:1154/1480 train_time:62984ms step_avg:54.58ms
+step:1155/1480 train_time:63071ms step_avg:54.61ms
+step:1156/1480 train_time:63164ms step_avg:54.64ms
+step:1157/1480 train_time:63249ms step_avg:54.67ms
+step:1158/1480 train_time:63340ms step_avg:54.70ms
+step:1159/1480 train_time:63424ms step_avg:54.72ms
+step:1160/1480 train_time:63515ms step_avg:54.75ms
+step:1161/1480 train_time:63599ms step_avg:54.78ms
+step:1162/1480 train_time:63693ms step_avg:54.81ms
+step:1163/1480 train_time:63783ms step_avg:54.84ms
+step:1164/1480 train_time:63879ms step_avg:54.88ms
+step:1165/1480 train_time:63969ms step_avg:54.91ms
+step:1166/1480 train_time:64064ms step_avg:54.94ms
+step:1167/1480 train_time:64154ms step_avg:54.97ms
+step:1168/1480 train_time:64248ms step_avg:55.01ms
+step:1169/1480 train_time:64338ms step_avg:55.04ms
+step:1170/1480 train_time:64433ms step_avg:55.07ms
+step:1171/1480 train_time:64516ms step_avg:55.09ms
+step:1172/1480 train_time:64607ms step_avg:55.13ms
+step:1173/1480 train_time:64696ms step_avg:55.15ms
+step:1174/1480 train_time:64788ms step_avg:55.19ms
+step:1175/1480 train_time:64876ms step_avg:55.21ms
+step:1176/1480 train_time:64967ms step_avg:55.24ms
+step:1177/1480 train_time:65056ms step_avg:55.27ms
+step:1178/1480 train_time:65148ms step_avg:55.30ms
+step:1179/1480 train_time:65235ms step_avg:55.33ms
+step:1180/1480 train_time:65329ms step_avg:55.36ms
+step:1181/1480 train_time:65418ms step_avg:55.39ms
+step:1182/1480 train_time:65514ms step_avg:55.43ms
+step:1183/1480 train_time:65604ms step_avg:55.46ms
+step:1184/1480 train_time:65700ms step_avg:55.49ms
+step:1185/1480 train_time:65790ms step_avg:55.52ms
+step:1186/1480 train_time:65887ms step_avg:55.55ms
+step:1187/1480 train_time:65976ms step_avg:55.58ms
+step:1188/1480 train_time:66071ms step_avg:55.62ms
+step:1189/1480 train_time:66154ms step_avg:55.64ms
+step:1190/1480 train_time:66244ms step_avg:55.67ms
+step:1191/1480 train_time:66330ms step_avg:55.69ms
+step:1192/1480 train_time:66425ms step_avg:55.73ms
+step:1193/1480 train_time:66516ms step_avg:55.75ms
+step:1194/1480 train_time:66608ms step_avg:55.79ms
+step:1195/1480 train_time:66702ms step_avg:55.82ms
+step:1196/1480 train_time:66797ms step_avg:55.85ms
+step:1197/1480 train_time:66887ms step_avg:55.88ms
+step:1198/1480 train_time:66983ms step_avg:55.91ms
+step:1199/1480 train_time:67073ms step_avg:55.94ms
+step:1200/1480 train_time:67169ms step_avg:55.97ms
+step:1201/1480 train_time:67260ms step_avg:56.00ms
+step:1202/1480 train_time:67357ms step_avg:56.04ms
+step:1203/1480 train_time:67448ms step_avg:56.07ms
+step:1204/1480 train_time:67544ms step_avg:56.10ms
+step:1205/1480 train_time:67634ms step_avg:56.13ms
+step:1206/1480 train_time:67731ms step_avg:56.16ms
+step:1207/1480 train_time:67822ms step_avg:56.19ms
+step:1208/1480 train_time:67918ms step_avg:56.22ms
+step:1209/1480 train_time:67999ms step_avg:56.24ms
+step:1210/1480 train_time:68086ms step_avg:56.27ms
+step:1211/1480 train_time:68173ms step_avg:56.29ms
+step:1212/1480 train_time:68264ms step_avg:56.32ms
+step:1213/1480 train_time:68350ms step_avg:56.35ms
+step:1214/1480 train_time:68440ms step_avg:56.38ms
+step:1215/1480 train_time:68524ms step_avg:56.40ms
+step:1216/1480 train_time:68619ms step_avg:56.43ms
+step:1217/1480 train_time:68707ms step_avg:56.46ms
+step:1218/1480 train_time:68803ms step_avg:56.49ms
+step:1219/1480 train_time:68890ms step_avg:56.51ms
+step:1220/1480 train_time:68986ms step_avg:56.55ms
+step:1221/1480 train_time:69076ms step_avg:56.57ms
+step:1222/1480 train_time:69171ms step_avg:56.61ms
+step:1223/1480 train_time:69262ms step_avg:56.63ms
+step:1224/1480 train_time:69358ms step_avg:56.67ms
+step:1225/1480 train_time:69438ms step_avg:56.68ms
+step:1226/1480 train_time:69528ms step_avg:56.71ms
+step:1227/1480 train_time:69615ms step_avg:56.74ms
+step:1228/1480 train_time:69706ms step_avg:56.76ms
+step:1229/1480 train_time:69792ms step_avg:56.79ms
+step:1230/1480 train_time:69884ms step_avg:56.82ms
+step:1231/1480 train_time:69974ms step_avg:56.84ms
+step:1232/1480 train_time:70067ms step_avg:56.87ms
+step:1233/1480 train_time:70154ms step_avg:56.90ms
+step:1234/1480 train_time:70250ms step_avg:56.93ms
+step:1235/1480 train_time:70338ms step_avg:56.95ms
+step:1236/1480 train_time:70432ms step_avg:56.98ms
+step:1237/1480 train_time:70520ms step_avg:57.01ms
+step:1238/1480 train_time:70613ms step_avg:57.04ms
+step:1239/1480 train_time:70699ms step_avg:57.06ms
+step:1240/1480 train_time:70792ms step_avg:57.09ms
+step:1241/1480 train_time:70877ms step_avg:57.11ms
+step:1242/1480 train_time:70969ms step_avg:57.14ms
+step:1243/1480 train_time:71055ms step_avg:57.16ms
+step:1244/1480 train_time:71147ms step_avg:57.19ms
+step:1245/1480 train_time:71233ms step_avg:57.21ms
+step:1246/1480 train_time:71324ms step_avg:57.24ms
+step:1247/1480 train_time:71409ms step_avg:57.26ms
+step:1248/1480 train_time:71501ms step_avg:57.29ms
+step:1249/1480 train_time:71584ms step_avg:57.31ms
+step:1250/1480 train_time:71679ms step_avg:57.34ms
+step:1250/1480 val_loss:3.3698 train_time:71797ms step_avg:57.44ms
+step:1251/1480 train_time:71815ms step_avg:57.41ms
+step:1252/1480 train_time:71860ms step_avg:57.40ms
+step:1253/1480 train_time:71945ms step_avg:57.42ms
+step:1254/1480 train_time:72040ms step_avg:57.45ms
+step:1255/1480 train_time:72126ms step_avg:57.47ms
+step:1256/1480 train_time:72215ms step_avg:57.50ms
+step:1257/1480 train_time:72302ms step_avg:57.52ms
+step:1258/1480 train_time:72396ms step_avg:57.55ms
+step:1259/1480 train_time:72484ms step_avg:57.57ms
+step:1260/1480 train_time:72578ms step_avg:57.60ms
+step:1261/1480 train_time:72667ms step_avg:57.63ms
+step:1262/1480 train_time:72763ms step_avg:57.66ms
+step:1263/1480 train_time:72851ms step_avg:57.68ms
+step:1264/1480 train_time:72945ms step_avg:57.71ms
+step:1265/1480 train_time:73033ms step_avg:57.73ms
+step:1266/1480 train_time:73128ms step_avg:57.76ms
+step:1267/1480 train_time:73215ms step_avg:57.79ms
+step:1268/1480 train_time:73309ms step_avg:57.81ms
+step:1269/1480 train_time:73395ms step_avg:57.84ms
+step:1270/1480 train_time:73489ms step_avg:57.87ms
+step:1271/1480 train_time:73577ms step_avg:57.89ms
+step:1272/1480 train_time:73669ms step_avg:57.92ms
+step:1273/1480 train_time:73757ms step_avg:57.94ms
+step:1274/1480 train_time:73850ms step_avg:57.97ms
+step:1275/1480 train_time:73937ms step_avg:57.99ms
+step:1276/1480 train_time:74032ms step_avg:58.02ms
+step:1277/1480 train_time:74119ms step_avg:58.04ms
+step:1278/1480 train_time:74212ms step_avg:58.07ms
+step:1279/1480 train_time:74300ms step_avg:58.09ms
+step:1280/1480 train_time:74392ms step_avg:58.12ms
+step:1281/1480 train_time:74480ms step_avg:58.14ms
+step:1282/1480 train_time:74573ms step_avg:58.17ms
+step:1283/1480 train_time:74660ms step_avg:58.19ms
+step:1284/1480 train_time:74753ms step_avg:58.22ms
+step:1285/1480 train_time:74842ms step_avg:58.24ms
+step:1286/1480 train_time:74934ms step_avg:58.27ms
+step:1287/1480 train_time:75021ms step_avg:58.29ms
+step:1288/1480 train_time:75115ms step_avg:58.32ms
+step:1289/1480 train_time:75201ms step_avg:58.34ms
+step:1290/1480 train_time:75295ms step_avg:58.37ms
+step:1291/1480 train_time:75382ms step_avg:58.39ms
+step:1292/1480 train_time:75475ms step_avg:58.42ms
+step:1293/1480 train_time:75561ms step_avg:58.44ms
+step:1294/1480 train_time:75653ms step_avg:58.46ms
+step:1295/1480 train_time:75742ms step_avg:58.49ms
+step:1296/1480 train_time:75834ms step_avg:58.51ms
+step:1297/1480 train_time:75923ms step_avg:58.54ms
+step:1298/1480 train_time:76017ms step_avg:58.56ms
+step:1299/1480 train_time:76105ms step_avg:58.59ms
+step:1300/1480 train_time:76198ms step_avg:58.61ms
+step:1301/1480 train_time:76286ms step_avg:58.64ms
+step:1302/1480 train_time:76380ms step_avg:58.66ms
+step:1303/1480 train_time:76468ms step_avg:58.69ms
+step:1304/1480 train_time:76562ms step_avg:58.71ms
+step:1305/1480 train_time:76649ms step_avg:58.73ms
+step:1306/1480 train_time:76743ms step_avg:58.76ms
+step:1307/1480 train_time:76830ms step_avg:58.78ms
+step:1308/1480 train_time:76923ms step_avg:58.81ms
+step:1309/1480 train_time:77010ms step_avg:58.83ms
+step:1310/1480 train_time:77103ms step_avg:58.86ms
+step:1311/1480 train_time:77189ms step_avg:58.88ms
+step:1312/1480 train_time:77282ms step_avg:58.90ms
+step:1313/1480 train_time:77368ms step_avg:58.92ms
+step:1314/1480 train_time:77461ms step_avg:58.95ms
+step:1315/1480 train_time:77549ms step_avg:58.97ms
+step:1316/1480 train_time:77642ms step_avg:59.00ms
+step:1317/1480 train_time:77729ms step_avg:59.02ms
+step:1318/1480 train_time:77821ms step_avg:59.05ms
+step:1319/1480 train_time:77908ms step_avg:59.07ms
+step:1320/1480 train_time:78000ms step_avg:59.09ms
+step:1321/1480 train_time:78087ms step_avg:59.11ms
+step:1322/1480 train_time:78179ms step_avg:59.14ms
+step:1323/1480 train_time:78264ms step_avg:59.16ms
+step:1324/1480 train_time:78356ms step_avg:59.18ms
+step:1325/1480 train_time:78443ms step_avg:59.20ms
+step:1326/1480 train_time:78535ms step_avg:59.23ms
+step:1327/1480 train_time:78622ms step_avg:59.25ms
+step:1328/1480 train_time:78717ms step_avg:59.28ms
+step:1329/1480 train_time:78805ms step_avg:59.30ms
+step:1330/1480 train_time:78901ms step_avg:59.32ms
+step:1331/1480 train_time:78989ms step_avg:59.35ms
+step:1332/1480 train_time:79083ms step_avg:59.37ms
+step:1333/1480 train_time:79171ms step_avg:59.39ms
+step:1334/1480 train_time:79265ms step_avg:59.42ms
+step:1335/1480 train_time:79351ms step_avg:59.44ms
+step:1336/1480 train_time:79446ms step_avg:59.47ms
+step:1337/1480 train_time:79533ms step_avg:59.49ms
+step:1338/1480 train_time:79627ms step_avg:59.51ms
+step:1339/1480 train_time:79714ms step_avg:59.53ms
+step:1340/1480 train_time:79807ms step_avg:59.56ms
+step:1341/1480 train_time:79893ms step_avg:59.58ms
+step:1342/1480 train_time:79987ms step_avg:59.60ms
+step:1343/1480 train_time:80073ms step_avg:59.62ms
+step:1344/1480 train_time:80166ms step_avg:59.65ms
+step:1345/1480 train_time:80253ms step_avg:59.67ms
+step:1346/1480 train_time:80347ms step_avg:59.69ms
+step:1347/1480 train_time:80434ms step_avg:59.71ms
+step:1348/1480 train_time:80527ms step_avg:59.74ms
+step:1349/1480 train_time:80613ms step_avg:59.76ms
+step:1350/1480 train_time:80707ms step_avg:59.78ms
+step:1351/1480 train_time:80792ms step_avg:59.80ms
+step:1352/1480 train_time:80886ms step_avg:59.83ms
+step:1353/1480 train_time:80971ms step_avg:59.85ms
+step:1354/1480 train_time:81066ms step_avg:59.87ms
+step:1355/1480 train_time:81153ms step_avg:59.89ms
+step:1356/1480 train_time:81246ms step_avg:59.92ms
+step:1357/1480 train_time:81331ms step_avg:59.93ms
+step:1358/1480 train_time:81424ms step_avg:59.96ms
+step:1359/1480 train_time:81509ms step_avg:59.98ms
+step:1360/1480 train_time:81601ms step_avg:60.00ms
+step:1361/1480 train_time:81687ms step_avg:60.02ms
+step:1362/1480 train_time:81779ms step_avg:60.04ms
+step:1363/1480 train_time:81863ms step_avg:60.06ms
+step:1364/1480 train_time:81955ms step_avg:60.08ms
+step:1365/1480 train_time:82040ms step_avg:60.10ms
+step:1366/1480 train_time:82131ms step_avg:60.13ms
+step:1367/1480 train_time:82220ms step_avg:60.15ms
+step:1368/1480 train_time:82314ms step_avg:60.17ms
+step:1369/1480 train_time:82403ms step_avg:60.19ms
+step:1370/1480 train_time:82499ms step_avg:60.22ms
+step:1371/1480 train_time:82589ms step_avg:60.24ms
+step:1372/1480 train_time:82684ms step_avg:60.27ms
+step:1373/1480 train_time:82773ms step_avg:60.29ms
+step:1374/1480 train_time:82868ms step_avg:60.31ms
+step:1375/1480 train_time:82955ms step_avg:60.33ms
+step:1376/1480 train_time:83050ms step_avg:60.36ms
+step:1377/1480 train_time:83139ms step_avg:60.38ms
+step:1378/1480 train_time:83232ms step_avg:60.40ms
+step:1379/1480 train_time:83321ms step_avg:60.42ms
+step:1380/1480 train_time:83415ms step_avg:60.45ms
+step:1381/1480 train_time:83504ms step_avg:60.47ms
+step:1382/1480 train_time:83597ms step_avg:60.49ms
+step:1383/1480 train_time:83685ms step_avg:60.51ms
+step:1384/1480 train_time:83779ms step_avg:60.53ms
+step:1385/1480 train_time:83867ms step_avg:60.55ms
+step:1386/1480 train_time:83961ms step_avg:60.58ms
+step:1387/1480 train_time:84049ms step_avg:60.60ms
+step:1388/1480 train_time:84141ms step_avg:60.62ms
+step:1389/1480 train_time:84228ms step_avg:60.64ms
+step:1390/1480 train_time:84322ms step_avg:60.66ms
+step:1391/1480 train_time:84408ms step_avg:60.68ms
+step:1392/1480 train_time:84502ms step_avg:60.71ms
+step:1393/1480 train_time:84589ms step_avg:60.72ms
+step:1394/1480 train_time:84682ms step_avg:60.75ms
+step:1395/1480 train_time:84769ms step_avg:60.77ms
+step:1396/1480 train_time:84861ms step_avg:60.79ms
+step:1397/1480 train_time:84949ms step_avg:60.81ms
+step:1398/1480 train_time:85042ms step_avg:60.83ms
+step:1399/1480 train_time:85129ms step_avg:60.85ms
+step:1400/1480 train_time:85221ms step_avg:60.87ms
+step:1401/1480 train_time:85307ms step_avg:60.89ms
+step:1402/1480 train_time:85400ms step_avg:60.91ms
+step:1403/1480 train_time:85485ms step_avg:60.93ms
+step:1404/1480 train_time:85578ms step_avg:60.95ms
+step:1405/1480 train_time:85664ms step_avg:60.97ms
+step:1406/1480 train_time:85756ms step_avg:60.99ms
+step:1407/1480 train_time:85843ms step_avg:61.01ms
+step:1408/1480 train_time:85935ms step_avg:61.03ms
+step:1409/1480 train_time:86022ms step_avg:61.05ms
+step:1410/1480 train_time:86114ms step_avg:61.07ms
+step:1411/1480 train_time:86201ms step_avg:61.09ms
+step:1412/1480 train_time:86291ms step_avg:61.11ms
+step:1413/1480 train_time:86376ms step_avg:61.13ms
+step:1414/1480 train_time:86465ms step_avg:61.15ms
+step:1415/1480 train_time:86551ms step_avg:61.17ms
+step:1416/1480 train_time:86646ms step_avg:61.19ms
+step:1417/1480 train_time:86733ms step_avg:61.21ms
+step:1418/1480 train_time:86827ms step_avg:61.23ms
+step:1419/1480 train_time:86915ms step_avg:61.25ms
+step:1420/1480 train_time:87009ms step_avg:61.27ms
+step:1421/1480 train_time:87096ms step_avg:61.29ms
+step:1422/1480 train_time:87191ms step_avg:61.32ms
+step:1423/1480 train_time:87278ms step_avg:61.33ms
+step:1424/1480 train_time:87371ms step_avg:61.36ms
+step:1425/1480 train_time:87459ms step_avg:61.37ms
+step:1426/1480 train_time:87552ms step_avg:61.40ms
+step:1427/1480 train_time:87639ms step_avg:61.41ms
+step:1428/1480 train_time:87733ms step_avg:61.44ms
+step:1429/1480 train_time:87819ms step_avg:61.45ms
+step:1430/1480 train_time:87910ms step_avg:61.48ms
+step:1431/1480 train_time:87996ms step_avg:61.49ms
+step:1432/1480 train_time:88087ms step_avg:61.51ms
+step:1433/1480 train_time:88173ms step_avg:61.53ms
+step:1434/1480 train_time:88266ms step_avg:61.55ms
+step:1435/1480 train_time:88353ms step_avg:61.57ms
+step:1436/1480 train_time:88448ms step_avg:61.59ms
+step:1437/1480 train_time:88534ms step_avg:61.61ms
+step:1438/1480 train_time:88629ms step_avg:61.63ms
+step:1439/1480 train_time:88717ms step_avg:61.65ms
+step:1440/1480 train_time:88810ms step_avg:61.67ms
+step:1441/1480 train_time:88901ms step_avg:61.69ms
+step:1442/1480 train_time:88996ms step_avg:61.72ms
+step:1443/1480 train_time:89084ms step_avg:61.74ms
+step:1444/1480 train_time:89178ms step_avg:61.76ms
+step:1445/1480 train_time:89265ms step_avg:61.78ms
+step:1446/1480 train_time:89356ms step_avg:61.80ms
+step:1447/1480 train_time:89443ms step_avg:61.81ms
+step:1448/1480 train_time:89536ms step_avg:61.83ms
+step:1449/1480 train_time:89623ms step_avg:61.85ms
+step:1450/1480 train_time:89716ms step_avg:61.87ms
+step:1451/1480 train_time:89805ms step_avg:61.89ms
+step:1452/1480 train_time:89897ms step_avg:61.91ms
+step:1453/1480 train_time:89985ms step_avg:61.93ms
+step:1454/1480 train_time:90080ms step_avg:61.95ms
+step:1455/1480 train_time:90167ms step_avg:61.97ms
+step:1456/1480 train_time:90262ms step_avg:61.99ms
+step:1457/1480 train_time:90350ms step_avg:62.01ms
+step:1458/1480 train_time:90443ms step_avg:62.03ms
+step:1459/1480 train_time:90530ms step_avg:62.05ms
+step:1460/1480 train_time:90624ms step_avg:62.07ms
+step:1461/1480 train_time:90710ms step_avg:62.09ms
+step:1462/1480 train_time:90805ms step_avg:62.11ms
+step:1463/1480 train_time:90891ms step_avg:62.13ms
+step:1464/1480 train_time:90987ms step_avg:62.15ms
+step:1465/1480 train_time:91075ms step_avg:62.17ms
+step:1466/1480 train_time:91167ms step_avg:62.19ms
+step:1467/1480 train_time:91253ms step_avg:62.20ms
+step:1468/1480 train_time:91348ms step_avg:62.23ms
+step:1469/1480 train_time:91434ms step_avg:62.24ms
+step:1470/1480 train_time:91529ms step_avg:62.26ms
+step:1471/1480 train_time:91618ms step_avg:62.28ms
+step:1472/1480 train_time:91713ms step_avg:62.31ms
+step:1473/1480 train_time:91802ms step_avg:62.32ms
+step:1474/1480 train_time:91897ms step_avg:62.35ms
+step:1475/1480 train_time:91987ms step_avg:62.36ms
+step:1476/1480 train_time:92083ms step_avg:62.39ms
+step:1477/1480 train_time:92171ms step_avg:62.40ms
+step:1478/1480 train_time:92266ms step_avg:62.43ms
+step:1479/1480 train_time:92354ms step_avg:62.44ms
+step:1480/1480 train_time:92450ms step_avg:62.47ms
+step:1480/1480 val_loss:3.2804 train_time:92568ms step_avg:62.55ms
+peak memory allocated: 31315 MiB reserved: 47222 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline5-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline5-1480.txt
@@ -1,0 +1,4447 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:30:25 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   39C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   39C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   66C    P0            152W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          372630      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          372631      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          372632      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          372633      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          372634      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          372635      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          372636      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          372637      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8277 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:74ms step_avg:73.74ms
+step:2/1480 train_time:94ms step_avg:47.00ms
+step:3/1480 train_time:110ms step_avg:36.78ms
+step:4/1480 train_time:140ms step_avg:34.98ms
+step:5/1480 train_time:168ms step_avg:33.57ms
+step:6/1480 train_time:203ms step_avg:33.78ms
+step:7/1480 train_time:231ms step_avg:32.98ms
+step:8/1480 train_time:266ms step_avg:33.23ms
+step:9/1480 train_time:294ms step_avg:32.63ms
+step:10/1480 train_time:329ms step_avg:32.87ms
+step:11/1480 train_time:357ms step_avg:32.42ms
+step:12/1480 train_time:391ms step_avg:32.60ms
+step:13/1480 train_time:419ms step_avg:32.25ms
+step:14/1480 train_time:454ms step_avg:32.42ms
+step:15/1480 train_time:483ms step_avg:32.18ms
+step:16/1480 train_time:518ms step_avg:32.39ms
+step:17/1480 train_time:547ms step_avg:32.15ms
+step:18/1480 train_time:581ms step_avg:32.29ms
+step:19/1480 train_time:610ms step_avg:32.13ms
+step:20/1480 train_time:645ms step_avg:32.25ms
+step:21/1480 train_time:674ms step_avg:32.09ms
+step:22/1480 train_time:709ms step_avg:32.23ms
+step:23/1480 train_time:738ms step_avg:32.07ms
+step:24/1480 train_time:773ms step_avg:32.20ms
+step:25/1480 train_time:801ms step_avg:32.05ms
+step:26/1480 train_time:836ms step_avg:32.17ms
+step:27/1480 train_time:865ms step_avg:32.03ms
+step:28/1480 train_time:901ms step_avg:32.18ms
+step:29/1480 train_time:930ms step_avg:32.07ms
+step:30/1480 train_time:966ms step_avg:32.19ms
+step:31/1480 train_time:995ms step_avg:32.10ms
+step:32/1480 train_time:1031ms step_avg:32.23ms
+step:33/1480 train_time:1060ms step_avg:32.12ms
+step:34/1480 train_time:1097ms step_avg:32.26ms
+step:35/1480 train_time:1125ms step_avg:32.15ms
+step:36/1480 train_time:1161ms step_avg:32.26ms
+step:37/1480 train_time:1190ms step_avg:32.15ms
+step:38/1480 train_time:1226ms step_avg:32.25ms
+step:39/1480 train_time:1254ms step_avg:32.16ms
+step:40/1480 train_time:1290ms step_avg:32.24ms
+step:41/1480 train_time:1318ms step_avg:32.15ms
+step:42/1480 train_time:1355ms step_avg:32.26ms
+step:43/1480 train_time:1383ms step_avg:32.16ms
+step:44/1480 train_time:1419ms step_avg:32.24ms
+step:45/1480 train_time:1448ms step_avg:32.18ms
+step:46/1480 train_time:1484ms step_avg:32.26ms
+step:47/1480 train_time:1515ms step_avg:32.24ms
+step:48/1480 train_time:1553ms step_avg:32.36ms
+step:49/1480 train_time:1585ms step_avg:32.34ms
+step:50/1480 train_time:1623ms step_avg:32.47ms
+step:51/1480 train_time:1654ms step_avg:32.43ms
+step:52/1480 train_time:1691ms step_avg:32.53ms
+step:53/1480 train_time:1722ms step_avg:32.49ms
+step:54/1480 train_time:1760ms step_avg:32.59ms
+step:55/1480 train_time:1791ms step_avg:32.57ms
+step:56/1480 train_time:1829ms step_avg:32.66ms
+step:57/1480 train_time:1859ms step_avg:32.61ms
+step:58/1480 train_time:1897ms step_avg:32.71ms
+step:59/1480 train_time:1927ms step_avg:32.67ms
+step:60/1480 train_time:1964ms step_avg:32.74ms
+step:61/1480 train_time:1995ms step_avg:32.71ms
+step:62/1480 train_time:2033ms step_avg:32.80ms
+step:63/1480 train_time:2064ms step_avg:32.76ms
+step:64/1480 train_time:2101ms step_avg:32.83ms
+step:65/1480 train_time:2132ms step_avg:32.80ms
+step:66/1480 train_time:2169ms step_avg:32.87ms
+step:67/1480 train_time:2200ms step_avg:32.83ms
+step:68/1480 train_time:2237ms step_avg:32.90ms
+step:69/1480 train_time:2268ms step_avg:32.87ms
+step:70/1480 train_time:2304ms step_avg:32.92ms
+step:71/1480 train_time:2332ms step_avg:32.85ms
+step:72/1480 train_time:2367ms step_avg:32.87ms
+step:73/1480 train_time:2395ms step_avg:32.81ms
+step:74/1480 train_time:2430ms step_avg:32.83ms
+step:75/1480 train_time:2458ms step_avg:32.77ms
+step:76/1480 train_time:2493ms step_avg:32.81ms
+step:77/1480 train_time:2522ms step_avg:32.75ms
+step:78/1480 train_time:2557ms step_avg:32.78ms
+step:79/1480 train_time:2586ms step_avg:32.73ms
+step:80/1480 train_time:2621ms step_avg:32.77ms
+step:81/1480 train_time:2650ms step_avg:32.72ms
+step:82/1480 train_time:2685ms step_avg:32.75ms
+step:83/1480 train_time:2714ms step_avg:32.70ms
+step:84/1480 train_time:2750ms step_avg:32.74ms
+step:85/1480 train_time:2780ms step_avg:32.70ms
+step:86/1480 train_time:2816ms step_avg:32.74ms
+step:87/1480 train_time:2845ms step_avg:32.70ms
+step:88/1480 train_time:2881ms step_avg:32.73ms
+step:89/1480 train_time:2910ms step_avg:32.70ms
+step:90/1480 train_time:2946ms step_avg:32.73ms
+step:91/1480 train_time:2975ms step_avg:32.69ms
+step:92/1480 train_time:3011ms step_avg:32.73ms
+step:93/1480 train_time:3040ms step_avg:32.69ms
+step:94/1480 train_time:3075ms step_avg:32.72ms
+step:95/1480 train_time:3105ms step_avg:32.68ms
+step:96/1480 train_time:3141ms step_avg:32.72ms
+step:97/1480 train_time:3171ms step_avg:32.69ms
+step:98/1480 train_time:3206ms step_avg:32.71ms
+step:99/1480 train_time:3235ms step_avg:32.68ms
+step:100/1480 train_time:3271ms step_avg:32.71ms
+step:101/1480 train_time:3300ms step_avg:32.67ms
+step:102/1480 train_time:3336ms step_avg:32.70ms
+step:103/1480 train_time:3365ms step_avg:32.67ms
+step:104/1480 train_time:3402ms step_avg:32.71ms
+step:105/1480 train_time:3432ms step_avg:32.68ms
+step:106/1480 train_time:3468ms step_avg:32.72ms
+step:107/1480 train_time:3497ms step_avg:32.68ms
+step:108/1480 train_time:3534ms step_avg:32.72ms
+step:109/1480 train_time:3563ms step_avg:32.69ms
+step:110/1480 train_time:3599ms step_avg:32.72ms
+step:111/1480 train_time:3629ms step_avg:32.70ms
+step:112/1480 train_time:3665ms step_avg:32.72ms
+step:113/1480 train_time:3695ms step_avg:32.70ms
+step:114/1480 train_time:3731ms step_avg:32.73ms
+step:115/1480 train_time:3761ms step_avg:32.70ms
+step:116/1480 train_time:3797ms step_avg:32.73ms
+step:117/1480 train_time:3827ms step_avg:32.71ms
+step:118/1480 train_time:3863ms step_avg:32.74ms
+step:119/1480 train_time:3893ms step_avg:32.71ms
+step:120/1480 train_time:3930ms step_avg:32.75ms
+step:121/1480 train_time:3958ms step_avg:32.71ms
+step:122/1480 train_time:3994ms step_avg:32.74ms
+step:123/1480 train_time:4023ms step_avg:32.71ms
+step:124/1480 train_time:4059ms step_avg:32.74ms
+step:125/1480 train_time:4089ms step_avg:32.72ms
+step:126/1480 train_time:4125ms step_avg:32.74ms
+step:127/1480 train_time:4156ms step_avg:32.72ms
+step:128/1480 train_time:4193ms step_avg:32.76ms
+step:129/1480 train_time:4224ms step_avg:32.74ms
+step:130/1480 train_time:4261ms step_avg:32.78ms
+step:131/1480 train_time:4292ms step_avg:32.76ms
+step:132/1480 train_time:4330ms step_avg:32.80ms
+step:133/1480 train_time:4360ms step_avg:32.79ms
+step:134/1480 train_time:4398ms step_avg:32.82ms
+step:135/1480 train_time:4429ms step_avg:32.81ms
+step:136/1480 train_time:4466ms step_avg:32.84ms
+step:137/1480 train_time:4497ms step_avg:32.82ms
+step:138/1480 train_time:4535ms step_avg:32.86ms
+step:139/1480 train_time:4565ms step_avg:32.84ms
+step:140/1480 train_time:4602ms step_avg:32.87ms
+step:141/1480 train_time:4633ms step_avg:32.86ms
+step:142/1480 train_time:4671ms step_avg:32.90ms
+step:143/1480 train_time:4702ms step_avg:32.88ms
+step:144/1480 train_time:4740ms step_avg:32.92ms
+step:145/1480 train_time:4770ms step_avg:32.90ms
+step:146/1480 train_time:4807ms step_avg:32.93ms
+step:147/1480 train_time:4837ms step_avg:32.90ms
+step:148/1480 train_time:4875ms step_avg:32.94ms
+step:149/1480 train_time:4905ms step_avg:32.92ms
+step:150/1480 train_time:4942ms step_avg:32.95ms
+step:151/1480 train_time:4973ms step_avg:32.93ms
+step:152/1480 train_time:5010ms step_avg:32.96ms
+step:153/1480 train_time:5040ms step_avg:32.94ms
+step:154/1480 train_time:5077ms step_avg:32.97ms
+step:155/1480 train_time:5108ms step_avg:32.95ms
+step:156/1480 train_time:5144ms step_avg:32.98ms
+step:157/1480 train_time:5175ms step_avg:32.96ms
+step:158/1480 train_time:5212ms step_avg:32.99ms
+step:159/1480 train_time:5243ms step_avg:32.97ms
+step:160/1480 train_time:5280ms step_avg:33.00ms
+step:161/1480 train_time:5311ms step_avg:32.99ms
+step:162/1480 train_time:5347ms step_avg:33.01ms
+step:163/1480 train_time:5378ms step_avg:32.99ms
+step:164/1480 train_time:5414ms step_avg:33.01ms
+step:165/1480 train_time:5444ms step_avg:33.00ms
+step:166/1480 train_time:5480ms step_avg:33.01ms
+step:167/1480 train_time:5511ms step_avg:33.00ms
+step:168/1480 train_time:5548ms step_avg:33.02ms
+step:169/1480 train_time:5579ms step_avg:33.01ms
+step:170/1480 train_time:5615ms step_avg:33.03ms
+step:171/1480 train_time:5645ms step_avg:33.01ms
+step:172/1480 train_time:5682ms step_avg:33.03ms
+step:173/1480 train_time:5712ms step_avg:33.02ms
+step:174/1480 train_time:5748ms step_avg:33.04ms
+step:175/1480 train_time:5779ms step_avg:33.02ms
+step:176/1480 train_time:5815ms step_avg:33.04ms
+step:177/1480 train_time:5845ms step_avg:33.02ms
+step:178/1480 train_time:5881ms step_avg:33.04ms
+step:179/1480 train_time:5912ms step_avg:33.03ms
+step:180/1480 train_time:5949ms step_avg:33.05ms
+step:181/1480 train_time:5978ms step_avg:33.03ms
+step:182/1480 train_time:6016ms step_avg:33.05ms
+step:183/1480 train_time:6045ms step_avg:33.03ms
+step:184/1480 train_time:6082ms step_avg:33.05ms
+step:185/1480 train_time:6111ms step_avg:33.03ms
+step:186/1480 train_time:6148ms step_avg:33.05ms
+step:187/1480 train_time:6177ms step_avg:33.03ms
+step:188/1480 train_time:6214ms step_avg:33.05ms
+step:189/1480 train_time:6244ms step_avg:33.04ms
+step:190/1480 train_time:6280ms step_avg:33.05ms
+step:191/1480 train_time:6310ms step_avg:33.04ms
+step:192/1480 train_time:6346ms step_avg:33.05ms
+step:193/1480 train_time:6376ms step_avg:33.03ms
+step:194/1480 train_time:6412ms step_avg:33.05ms
+step:195/1480 train_time:6442ms step_avg:33.03ms
+step:196/1480 train_time:6478ms step_avg:33.05ms
+step:197/1480 train_time:6508ms step_avg:33.03ms
+step:198/1480 train_time:6543ms step_avg:33.05ms
+step:199/1480 train_time:6574ms step_avg:33.03ms
+step:200/1480 train_time:6610ms step_avg:33.05ms
+step:201/1480 train_time:6639ms step_avg:33.03ms
+step:202/1480 train_time:6675ms step_avg:33.04ms
+step:203/1480 train_time:6704ms step_avg:33.03ms
+step:204/1480 train_time:6740ms step_avg:33.04ms
+step:205/1480 train_time:6770ms step_avg:33.03ms
+step:206/1480 train_time:6806ms step_avg:33.04ms
+step:207/1480 train_time:6835ms step_avg:33.02ms
+step:208/1480 train_time:6871ms step_avg:33.04ms
+step:209/1480 train_time:6901ms step_avg:33.02ms
+step:210/1480 train_time:6937ms step_avg:33.03ms
+step:211/1480 train_time:6967ms step_avg:33.02ms
+step:212/1480 train_time:7002ms step_avg:33.03ms
+step:213/1480 train_time:7032ms step_avg:33.01ms
+step:214/1480 train_time:7068ms step_avg:33.03ms
+step:215/1480 train_time:7097ms step_avg:33.01ms
+step:216/1480 train_time:7134ms step_avg:33.03ms
+step:217/1480 train_time:7163ms step_avg:33.01ms
+step:218/1480 train_time:7199ms step_avg:33.02ms
+step:219/1480 train_time:7230ms step_avg:33.01ms
+step:220/1480 train_time:7266ms step_avg:33.03ms
+step:221/1480 train_time:7296ms step_avg:33.02ms
+step:222/1480 train_time:7334ms step_avg:33.04ms
+step:223/1480 train_time:7364ms step_avg:33.02ms
+step:224/1480 train_time:7401ms step_avg:33.04ms
+step:225/1480 train_time:7431ms step_avg:33.03ms
+step:226/1480 train_time:7468ms step_avg:33.04ms
+step:227/1480 train_time:7498ms step_avg:33.03ms
+step:228/1480 train_time:7535ms step_avg:33.05ms
+step:229/1480 train_time:7565ms step_avg:33.03ms
+step:230/1480 train_time:7601ms step_avg:33.05ms
+step:231/1480 train_time:7632ms step_avg:33.04ms
+step:232/1480 train_time:7669ms step_avg:33.06ms
+step:233/1480 train_time:7699ms step_avg:33.04ms
+step:234/1480 train_time:7736ms step_avg:33.06ms
+step:235/1480 train_time:7767ms step_avg:33.05ms
+step:236/1480 train_time:7804ms step_avg:33.07ms
+step:237/1480 train_time:7834ms step_avg:33.05ms
+step:238/1480 train_time:7872ms step_avg:33.07ms
+step:239/1480 train_time:7901ms step_avg:33.06ms
+step:240/1480 train_time:7939ms step_avg:33.08ms
+step:241/1480 train_time:7969ms step_avg:33.07ms
+step:242/1480 train_time:8006ms step_avg:33.08ms
+step:243/1480 train_time:8036ms step_avg:33.07ms
+step:244/1480 train_time:8073ms step_avg:33.09ms
+step:245/1480 train_time:8103ms step_avg:33.07ms
+step:246/1480 train_time:8140ms step_avg:33.09ms
+step:247/1480 train_time:8171ms step_avg:33.08ms
+step:248/1480 train_time:8208ms step_avg:33.10ms
+step:249/1480 train_time:8238ms step_avg:33.08ms
+step:250/1480 train_time:8274ms step_avg:33.10ms
+step:250/1480 val_loss:4.5101 train_time:8321ms step_avg:33.28ms
+step:251/1480 train_time:8338ms step_avg:33.22ms
+step:252/1480 train_time:8356ms step_avg:33.16ms
+step:253/1480 train_time:8372ms step_avg:33.09ms
+step:254/1480 train_time:8410ms step_avg:33.11ms
+step:255/1480 train_time:8441ms step_avg:33.10ms
+step:256/1480 train_time:8478ms step_avg:33.12ms
+step:257/1480 train_time:8508ms step_avg:33.10ms
+step:258/1480 train_time:8545ms step_avg:33.12ms
+step:259/1480 train_time:8575ms step_avg:33.11ms
+step:260/1480 train_time:8611ms step_avg:33.12ms
+step:261/1480 train_time:8641ms step_avg:33.11ms
+step:262/1480 train_time:8678ms step_avg:33.12ms
+step:263/1480 train_time:8708ms step_avg:33.11ms
+step:264/1480 train_time:8745ms step_avg:33.12ms
+step:265/1480 train_time:8775ms step_avg:33.11ms
+step:266/1480 train_time:8811ms step_avg:33.13ms
+step:267/1480 train_time:8842ms step_avg:33.11ms
+step:268/1480 train_time:8878ms step_avg:33.13ms
+step:269/1480 train_time:8908ms step_avg:33.12ms
+step:270/1480 train_time:8945ms step_avg:33.13ms
+step:271/1480 train_time:8975ms step_avg:33.12ms
+step:272/1480 train_time:9012ms step_avg:33.13ms
+step:273/1480 train_time:9042ms step_avg:33.12ms
+step:274/1480 train_time:9078ms step_avg:33.13ms
+step:275/1480 train_time:9108ms step_avg:33.12ms
+step:276/1480 train_time:9145ms step_avg:33.13ms
+step:277/1480 train_time:9175ms step_avg:33.12ms
+step:278/1480 train_time:9212ms step_avg:33.14ms
+step:279/1480 train_time:9242ms step_avg:33.13ms
+step:280/1480 train_time:9278ms step_avg:33.14ms
+step:281/1480 train_time:9308ms step_avg:33.12ms
+step:282/1480 train_time:9344ms step_avg:33.14ms
+step:283/1480 train_time:9374ms step_avg:33.12ms
+step:284/1480 train_time:9411ms step_avg:33.14ms
+step:285/1480 train_time:9441ms step_avg:33.13ms
+step:286/1480 train_time:9478ms step_avg:33.14ms
+step:287/1480 train_time:9507ms step_avg:33.13ms
+step:288/1480 train_time:9543ms step_avg:33.14ms
+step:289/1480 train_time:9573ms step_avg:33.13ms
+step:290/1480 train_time:9609ms step_avg:33.14ms
+step:291/1480 train_time:9639ms step_avg:33.12ms
+step:292/1480 train_time:9675ms step_avg:33.13ms
+step:293/1480 train_time:9705ms step_avg:33.12ms
+step:294/1480 train_time:9742ms step_avg:33.14ms
+step:295/1480 train_time:9771ms step_avg:33.12ms
+step:296/1480 train_time:9808ms step_avg:33.13ms
+step:297/1480 train_time:9837ms step_avg:33.12ms
+step:298/1480 train_time:9874ms step_avg:33.13ms
+step:299/1480 train_time:9904ms step_avg:33.12ms
+step:300/1480 train_time:9940ms step_avg:33.13ms
+step:301/1480 train_time:9970ms step_avg:33.12ms
+step:302/1480 train_time:10007ms step_avg:33.13ms
+step:303/1480 train_time:10036ms step_avg:33.12ms
+step:304/1480 train_time:10073ms step_avg:33.13ms
+step:305/1480 train_time:10103ms step_avg:33.12ms
+step:306/1480 train_time:10139ms step_avg:33.13ms
+step:307/1480 train_time:10169ms step_avg:33.12ms
+step:308/1480 train_time:10205ms step_avg:33.13ms
+step:309/1480 train_time:10235ms step_avg:33.12ms
+step:310/1480 train_time:10271ms step_avg:33.13ms
+step:311/1480 train_time:10301ms step_avg:33.12ms
+step:312/1480 train_time:10337ms step_avg:33.13ms
+step:313/1480 train_time:10367ms step_avg:33.12ms
+step:314/1480 train_time:10403ms step_avg:33.13ms
+step:315/1480 train_time:10433ms step_avg:33.12ms
+step:316/1480 train_time:10469ms step_avg:33.13ms
+step:317/1480 train_time:10499ms step_avg:33.12ms
+step:318/1480 train_time:10536ms step_avg:33.13ms
+step:319/1480 train_time:10565ms step_avg:33.12ms
+step:320/1480 train_time:10601ms step_avg:33.13ms
+step:321/1480 train_time:10630ms step_avg:33.12ms
+step:322/1480 train_time:10666ms step_avg:33.13ms
+step:323/1480 train_time:10696ms step_avg:33.11ms
+step:324/1480 train_time:10732ms step_avg:33.12ms
+step:325/1480 train_time:10762ms step_avg:33.11ms
+step:326/1480 train_time:10798ms step_avg:33.12ms
+step:327/1480 train_time:10827ms step_avg:33.11ms
+step:328/1480 train_time:10863ms step_avg:33.12ms
+step:329/1480 train_time:10892ms step_avg:33.11ms
+step:330/1480 train_time:10929ms step_avg:33.12ms
+step:331/1480 train_time:10959ms step_avg:33.11ms
+step:332/1480 train_time:10995ms step_avg:33.12ms
+step:333/1480 train_time:11025ms step_avg:33.11ms
+step:334/1480 train_time:11062ms step_avg:33.12ms
+step:335/1480 train_time:11091ms step_avg:33.11ms
+step:336/1480 train_time:11127ms step_avg:33.12ms
+step:337/1480 train_time:11157ms step_avg:33.11ms
+step:338/1480 train_time:11193ms step_avg:33.12ms
+step:339/1480 train_time:11223ms step_avg:33.11ms
+step:340/1480 train_time:11259ms step_avg:33.12ms
+step:341/1480 train_time:11289ms step_avg:33.10ms
+step:342/1480 train_time:11325ms step_avg:33.11ms
+step:343/1480 train_time:11354ms step_avg:33.10ms
+step:344/1480 train_time:11390ms step_avg:33.11ms
+step:345/1480 train_time:11420ms step_avg:33.10ms
+step:346/1480 train_time:11457ms step_avg:33.11ms
+step:347/1480 train_time:11487ms step_avg:33.10ms
+step:348/1480 train_time:11525ms step_avg:33.12ms
+step:349/1480 train_time:11552ms step_avg:33.10ms
+step:350/1480 train_time:11589ms step_avg:33.11ms
+step:351/1480 train_time:11618ms step_avg:33.10ms
+step:352/1480 train_time:11655ms step_avg:33.11ms
+step:353/1480 train_time:11685ms step_avg:33.10ms
+step:354/1480 train_time:11721ms step_avg:33.11ms
+step:355/1480 train_time:11750ms step_avg:33.10ms
+step:356/1480 train_time:11786ms step_avg:33.11ms
+step:357/1480 train_time:11816ms step_avg:33.10ms
+step:358/1480 train_time:11852ms step_avg:33.11ms
+step:359/1480 train_time:11882ms step_avg:33.10ms
+step:360/1480 train_time:11917ms step_avg:33.10ms
+step:361/1480 train_time:11947ms step_avg:33.10ms
+step:362/1480 train_time:11983ms step_avg:33.10ms
+step:363/1480 train_time:12013ms step_avg:33.09ms
+step:364/1480 train_time:12050ms step_avg:33.10ms
+step:365/1480 train_time:12079ms step_avg:33.09ms
+step:366/1480 train_time:12115ms step_avg:33.10ms
+step:367/1480 train_time:12145ms step_avg:33.09ms
+step:368/1480 train_time:12180ms step_avg:33.10ms
+step:369/1480 train_time:12210ms step_avg:33.09ms
+step:370/1480 train_time:12246ms step_avg:33.10ms
+step:371/1480 train_time:12275ms step_avg:33.09ms
+step:372/1480 train_time:12311ms step_avg:33.10ms
+step:373/1480 train_time:12341ms step_avg:33.09ms
+step:374/1480 train_time:12377ms step_avg:33.09ms
+step:375/1480 train_time:12407ms step_avg:33.08ms
+step:376/1480 train_time:12442ms step_avg:33.09ms
+step:377/1480 train_time:12472ms step_avg:33.08ms
+step:378/1480 train_time:12508ms step_avg:33.09ms
+step:379/1480 train_time:12538ms step_avg:33.08ms
+step:380/1480 train_time:12574ms step_avg:33.09ms
+step:381/1480 train_time:12605ms step_avg:33.08ms
+step:382/1480 train_time:12642ms step_avg:33.09ms
+step:383/1480 train_time:12672ms step_avg:33.09ms
+step:384/1480 train_time:12710ms step_avg:33.10ms
+step:385/1480 train_time:12740ms step_avg:33.09ms
+step:386/1480 train_time:12776ms step_avg:33.10ms
+step:387/1480 train_time:12807ms step_avg:33.09ms
+step:388/1480 train_time:12844ms step_avg:33.10ms
+step:389/1480 train_time:12875ms step_avg:33.10ms
+step:390/1480 train_time:12912ms step_avg:33.11ms
+step:391/1480 train_time:12943ms step_avg:33.10ms
+step:392/1480 train_time:12979ms step_avg:33.11ms
+step:393/1480 train_time:13009ms step_avg:33.10ms
+step:394/1480 train_time:13046ms step_avg:33.11ms
+step:395/1480 train_time:13076ms step_avg:33.10ms
+step:396/1480 train_time:13112ms step_avg:33.11ms
+step:397/1480 train_time:13143ms step_avg:33.11ms
+step:398/1480 train_time:13179ms step_avg:33.11ms
+step:399/1480 train_time:13209ms step_avg:33.11ms
+step:400/1480 train_time:13246ms step_avg:33.11ms
+step:401/1480 train_time:13276ms step_avg:33.11ms
+step:402/1480 train_time:13312ms step_avg:33.12ms
+step:403/1480 train_time:13343ms step_avg:33.11ms
+step:404/1480 train_time:13380ms step_avg:33.12ms
+step:405/1480 train_time:13410ms step_avg:33.11ms
+step:406/1480 train_time:13447ms step_avg:33.12ms
+step:407/1480 train_time:13477ms step_avg:33.11ms
+step:408/1480 train_time:13514ms step_avg:33.12ms
+step:409/1480 train_time:13545ms step_avg:33.12ms
+step:410/1480 train_time:13581ms step_avg:33.13ms
+step:411/1480 train_time:13611ms step_avg:33.12ms
+step:412/1480 train_time:13648ms step_avg:33.13ms
+step:413/1480 train_time:13677ms step_avg:33.12ms
+step:414/1480 train_time:13714ms step_avg:33.13ms
+step:415/1480 train_time:13744ms step_avg:33.12ms
+step:416/1480 train_time:13781ms step_avg:33.13ms
+step:417/1480 train_time:13810ms step_avg:33.12ms
+step:418/1480 train_time:13847ms step_avg:33.13ms
+step:419/1480 train_time:13876ms step_avg:33.12ms
+step:420/1480 train_time:13913ms step_avg:33.13ms
+step:421/1480 train_time:13943ms step_avg:33.12ms
+step:422/1480 train_time:13979ms step_avg:33.13ms
+step:423/1480 train_time:14008ms step_avg:33.12ms
+step:424/1480 train_time:14045ms step_avg:33.12ms
+step:425/1480 train_time:14075ms step_avg:33.12ms
+step:426/1480 train_time:14111ms step_avg:33.12ms
+step:427/1480 train_time:14141ms step_avg:33.12ms
+step:428/1480 train_time:14177ms step_avg:33.12ms
+step:429/1480 train_time:14207ms step_avg:33.12ms
+step:430/1480 train_time:14244ms step_avg:33.13ms
+step:431/1480 train_time:14274ms step_avg:33.12ms
+step:432/1480 train_time:14311ms step_avg:33.13ms
+step:433/1480 train_time:14341ms step_avg:33.12ms
+step:434/1480 train_time:14377ms step_avg:33.13ms
+step:435/1480 train_time:14407ms step_avg:33.12ms
+step:436/1480 train_time:14444ms step_avg:33.13ms
+step:437/1480 train_time:14474ms step_avg:33.12ms
+step:438/1480 train_time:14511ms step_avg:33.13ms
+step:439/1480 train_time:14540ms step_avg:33.12ms
+step:440/1480 train_time:14576ms step_avg:33.13ms
+step:441/1480 train_time:14606ms step_avg:33.12ms
+step:442/1480 train_time:14643ms step_avg:33.13ms
+step:443/1480 train_time:14672ms step_avg:33.12ms
+step:444/1480 train_time:14709ms step_avg:33.13ms
+step:445/1480 train_time:14739ms step_avg:33.12ms
+step:446/1480 train_time:14775ms step_avg:33.13ms
+step:447/1480 train_time:14805ms step_avg:33.12ms
+step:448/1480 train_time:14842ms step_avg:33.13ms
+step:449/1480 train_time:14871ms step_avg:33.12ms
+step:450/1480 train_time:14908ms step_avg:33.13ms
+step:451/1480 train_time:14938ms step_avg:33.12ms
+step:452/1480 train_time:14974ms step_avg:33.13ms
+step:453/1480 train_time:15003ms step_avg:33.12ms
+step:454/1480 train_time:15040ms step_avg:33.13ms
+step:455/1480 train_time:15069ms step_avg:33.12ms
+step:456/1480 train_time:15106ms step_avg:33.13ms
+step:457/1480 train_time:15135ms step_avg:33.12ms
+step:458/1480 train_time:15172ms step_avg:33.13ms
+step:459/1480 train_time:15201ms step_avg:33.12ms
+step:460/1480 train_time:15237ms step_avg:33.12ms
+step:461/1480 train_time:15267ms step_avg:33.12ms
+step:462/1480 train_time:15304ms step_avg:33.13ms
+step:463/1480 train_time:15333ms step_avg:33.12ms
+step:464/1480 train_time:15370ms step_avg:33.12ms
+step:465/1480 train_time:15399ms step_avg:33.12ms
+step:466/1480 train_time:15435ms step_avg:33.12ms
+step:467/1480 train_time:15467ms step_avg:33.12ms
+step:468/1480 train_time:15505ms step_avg:33.13ms
+step:469/1480 train_time:15535ms step_avg:33.12ms
+step:470/1480 train_time:15573ms step_avg:33.13ms
+step:471/1480 train_time:15604ms step_avg:33.13ms
+step:472/1480 train_time:15641ms step_avg:33.14ms
+step:473/1480 train_time:15672ms step_avg:33.13ms
+step:474/1480 train_time:15710ms step_avg:33.14ms
+step:475/1480 train_time:15740ms step_avg:33.14ms
+step:476/1480 train_time:15777ms step_avg:33.15ms
+step:477/1480 train_time:15808ms step_avg:33.14ms
+step:478/1480 train_time:15846ms step_avg:33.15ms
+step:479/1480 train_time:15876ms step_avg:33.14ms
+step:480/1480 train_time:15913ms step_avg:33.15ms
+step:481/1480 train_time:15948ms step_avg:33.16ms
+step:482/1480 train_time:16007ms step_avg:33.21ms
+step:483/1480 train_time:16065ms step_avg:33.26ms
+step:484/1480 train_time:16130ms step_avg:33.33ms
+step:485/1480 train_time:16190ms step_avg:33.38ms
+step:486/1480 train_time:16255ms step_avg:33.45ms
+step:487/1480 train_time:16315ms step_avg:33.50ms
+step:488/1480 train_time:16380ms step_avg:33.57ms
+step:489/1480 train_time:16438ms step_avg:33.62ms
+step:490/1480 train_time:16502ms step_avg:33.68ms
+step:491/1480 train_time:16559ms step_avg:33.73ms
+step:492/1480 train_time:16625ms step_avg:33.79ms
+step:493/1480 train_time:16682ms step_avg:33.84ms
+step:494/1480 train_time:16745ms step_avg:33.90ms
+step:495/1480 train_time:16804ms step_avg:33.95ms
+step:496/1480 train_time:16869ms step_avg:34.01ms
+step:497/1480 train_time:16928ms step_avg:34.06ms
+step:498/1480 train_time:16993ms step_avg:34.12ms
+step:499/1480 train_time:17052ms step_avg:34.17ms
+step:500/1480 train_time:17117ms step_avg:34.23ms
+step:500/1480 val_loss:4.2105 train_time:17199ms step_avg:34.40ms
+step:501/1480 train_time:17216ms step_avg:34.36ms
+step:502/1480 train_time:17241ms step_avg:34.34ms
+step:503/1480 train_time:17305ms step_avg:34.40ms
+step:504/1480 train_time:17372ms step_avg:34.47ms
+step:505/1480 train_time:17430ms step_avg:34.51ms
+step:506/1480 train_time:17492ms step_avg:34.57ms
+step:507/1480 train_time:17550ms step_avg:34.62ms
+step:508/1480 train_time:17614ms step_avg:34.67ms
+step:509/1480 train_time:17675ms step_avg:34.73ms
+step:510/1480 train_time:17740ms step_avg:34.78ms
+step:511/1480 train_time:17799ms step_avg:34.83ms
+step:512/1480 train_time:17865ms step_avg:34.89ms
+step:513/1480 train_time:17925ms step_avg:34.94ms
+step:514/1480 train_time:17990ms step_avg:35.00ms
+step:515/1480 train_time:18048ms step_avg:35.04ms
+step:516/1480 train_time:18112ms step_avg:35.10ms
+step:517/1480 train_time:18170ms step_avg:35.15ms
+step:518/1480 train_time:18234ms step_avg:35.20ms
+step:519/1480 train_time:18294ms step_avg:35.25ms
+step:520/1480 train_time:18364ms step_avg:35.32ms
+step:521/1480 train_time:18433ms step_avg:35.38ms
+step:522/1480 train_time:18500ms step_avg:35.44ms
+step:523/1480 train_time:18554ms step_avg:35.48ms
+step:524/1480 train_time:18613ms step_avg:35.52ms
+step:525/1480 train_time:18669ms step_avg:35.56ms
+step:526/1480 train_time:18730ms step_avg:35.61ms
+step:527/1480 train_time:18787ms step_avg:35.65ms
+step:528/1480 train_time:18850ms step_avg:35.70ms
+step:529/1480 train_time:18910ms step_avg:35.75ms
+step:530/1480 train_time:18978ms step_avg:35.81ms
+step:531/1480 train_time:19040ms step_avg:35.86ms
+step:532/1480 train_time:19108ms step_avg:35.92ms
+step:533/1480 train_time:19169ms step_avg:35.96ms
+step:534/1480 train_time:19235ms step_avg:36.02ms
+step:535/1480 train_time:19295ms step_avg:36.07ms
+step:536/1480 train_time:19362ms step_avg:36.12ms
+step:537/1480 train_time:19423ms step_avg:36.17ms
+step:538/1480 train_time:19489ms step_avg:36.23ms
+step:539/1480 train_time:19549ms step_avg:36.27ms
+step:540/1480 train_time:19615ms step_avg:36.32ms
+step:541/1480 train_time:19675ms step_avg:36.37ms
+step:542/1480 train_time:19740ms step_avg:36.42ms
+step:543/1480 train_time:19800ms step_avg:36.46ms
+step:544/1480 train_time:19866ms step_avg:36.52ms
+step:545/1480 train_time:19927ms step_avg:36.56ms
+step:546/1480 train_time:19992ms step_avg:36.61ms
+step:547/1480 train_time:20050ms step_avg:36.65ms
+step:548/1480 train_time:20115ms step_avg:36.71ms
+step:549/1480 train_time:20174ms step_avg:36.75ms
+step:550/1480 train_time:20239ms step_avg:36.80ms
+step:551/1480 train_time:20298ms step_avg:36.84ms
+step:552/1480 train_time:20361ms step_avg:36.89ms
+step:553/1480 train_time:20415ms step_avg:36.92ms
+step:554/1480 train_time:20474ms step_avg:36.96ms
+step:555/1480 train_time:20535ms step_avg:37.00ms
+step:556/1480 train_time:20597ms step_avg:37.04ms
+step:557/1480 train_time:20654ms step_avg:37.08ms
+step:558/1480 train_time:20718ms step_avg:37.13ms
+step:559/1480 train_time:20776ms step_avg:37.17ms
+step:560/1480 train_time:20840ms step_avg:37.21ms
+step:561/1480 train_time:20898ms step_avg:37.25ms
+step:562/1480 train_time:20963ms step_avg:37.30ms
+step:563/1480 train_time:21024ms step_avg:37.34ms
+step:564/1480 train_time:21087ms step_avg:37.39ms
+step:565/1480 train_time:21147ms step_avg:37.43ms
+step:566/1480 train_time:21212ms step_avg:37.48ms
+step:567/1480 train_time:21271ms step_avg:37.52ms
+step:568/1480 train_time:21336ms step_avg:37.56ms
+step:569/1480 train_time:21394ms step_avg:37.60ms
+step:570/1480 train_time:21458ms step_avg:37.65ms
+step:571/1480 train_time:21517ms step_avg:37.68ms
+step:572/1480 train_time:21583ms step_avg:37.73ms
+step:573/1480 train_time:21643ms step_avg:37.77ms
+step:574/1480 train_time:21708ms step_avg:37.82ms
+step:575/1480 train_time:21768ms step_avg:37.86ms
+step:576/1480 train_time:21833ms step_avg:37.91ms
+step:577/1480 train_time:21891ms step_avg:37.94ms
+step:578/1480 train_time:21956ms step_avg:37.99ms
+step:579/1480 train_time:22014ms step_avg:38.02ms
+step:580/1480 train_time:22079ms step_avg:38.07ms
+step:581/1480 train_time:22138ms step_avg:38.10ms
+step:582/1480 train_time:22203ms step_avg:38.15ms
+step:583/1480 train_time:22262ms step_avg:38.19ms
+step:584/1480 train_time:22328ms step_avg:38.23ms
+step:585/1480 train_time:22386ms step_avg:38.27ms
+step:586/1480 train_time:22449ms step_avg:38.31ms
+step:587/1480 train_time:22507ms step_avg:38.34ms
+step:588/1480 train_time:22570ms step_avg:38.39ms
+step:589/1480 train_time:22628ms step_avg:38.42ms
+step:590/1480 train_time:22691ms step_avg:38.46ms
+step:591/1480 train_time:22749ms step_avg:38.49ms
+step:592/1480 train_time:22813ms step_avg:38.54ms
+step:593/1480 train_time:22871ms step_avg:38.57ms
+step:594/1480 train_time:22935ms step_avg:38.61ms
+step:595/1480 train_time:22991ms step_avg:38.64ms
+step:596/1480 train_time:23057ms step_avg:38.69ms
+step:597/1480 train_time:23116ms step_avg:38.72ms
+step:598/1480 train_time:23183ms step_avg:38.77ms
+step:599/1480 train_time:23242ms step_avg:38.80ms
+step:600/1480 train_time:23308ms step_avg:38.85ms
+step:601/1480 train_time:23368ms step_avg:38.88ms
+step:602/1480 train_time:23432ms step_avg:38.92ms
+step:603/1480 train_time:23489ms step_avg:38.95ms
+step:604/1480 train_time:23552ms step_avg:38.99ms
+step:605/1480 train_time:23609ms step_avg:39.02ms
+step:606/1480 train_time:23673ms step_avg:39.06ms
+step:607/1480 train_time:23731ms step_avg:39.09ms
+step:608/1480 train_time:23794ms step_avg:39.13ms
+step:609/1480 train_time:23850ms step_avg:39.16ms
+step:610/1480 train_time:23913ms step_avg:39.20ms
+step:611/1480 train_time:23971ms step_avg:39.23ms
+step:612/1480 train_time:24035ms step_avg:39.27ms
+step:613/1480 train_time:24093ms step_avg:39.30ms
+step:614/1480 train_time:24159ms step_avg:39.35ms
+step:615/1480 train_time:24218ms step_avg:39.38ms
+step:616/1480 train_time:24285ms step_avg:39.42ms
+step:617/1480 train_time:24344ms step_avg:39.46ms
+step:618/1480 train_time:24410ms step_avg:39.50ms
+step:619/1480 train_time:24470ms step_avg:39.53ms
+step:620/1480 train_time:24535ms step_avg:39.57ms
+step:621/1480 train_time:24593ms step_avg:39.60ms
+step:622/1480 train_time:24658ms step_avg:39.64ms
+step:623/1480 train_time:24717ms step_avg:39.67ms
+step:624/1480 train_time:24783ms step_avg:39.72ms
+step:625/1480 train_time:24842ms step_avg:39.75ms
+step:626/1480 train_time:24907ms step_avg:39.79ms
+step:627/1480 train_time:24967ms step_avg:39.82ms
+step:628/1480 train_time:25033ms step_avg:39.86ms
+step:629/1480 train_time:25091ms step_avg:39.89ms
+step:630/1480 train_time:25155ms step_avg:39.93ms
+step:631/1480 train_time:25212ms step_avg:39.96ms
+step:632/1480 train_time:25277ms step_avg:40.00ms
+step:633/1480 train_time:25335ms step_avg:40.02ms
+step:634/1480 train_time:25398ms step_avg:40.06ms
+step:635/1480 train_time:25456ms step_avg:40.09ms
+step:636/1480 train_time:25521ms step_avg:40.13ms
+step:637/1480 train_time:25580ms step_avg:40.16ms
+step:638/1480 train_time:25647ms step_avg:40.20ms
+step:639/1480 train_time:25705ms step_avg:40.23ms
+step:640/1480 train_time:25769ms step_avg:40.26ms
+step:641/1480 train_time:25828ms step_avg:40.29ms
+step:642/1480 train_time:25892ms step_avg:40.33ms
+step:643/1480 train_time:25950ms step_avg:40.36ms
+step:644/1480 train_time:26014ms step_avg:40.39ms
+step:645/1480 train_time:26072ms step_avg:40.42ms
+step:646/1480 train_time:26136ms step_avg:40.46ms
+step:647/1480 train_time:26193ms step_avg:40.48ms
+step:648/1480 train_time:26257ms step_avg:40.52ms
+step:649/1480 train_time:26313ms step_avg:40.54ms
+step:650/1480 train_time:26376ms step_avg:40.58ms
+step:651/1480 train_time:26435ms step_avg:40.61ms
+step:652/1480 train_time:26500ms step_avg:40.64ms
+step:653/1480 train_time:26558ms step_avg:40.67ms
+step:654/1480 train_time:26624ms step_avg:40.71ms
+step:655/1480 train_time:26682ms step_avg:40.74ms
+step:656/1480 train_time:26747ms step_avg:40.77ms
+step:657/1480 train_time:26806ms step_avg:40.80ms
+step:658/1480 train_time:26872ms step_avg:40.84ms
+step:659/1480 train_time:26930ms step_avg:40.87ms
+step:660/1480 train_time:26994ms step_avg:40.90ms
+step:661/1480 train_time:27051ms step_avg:40.92ms
+step:662/1480 train_time:27116ms step_avg:40.96ms
+step:663/1480 train_time:27174ms step_avg:40.99ms
+step:664/1480 train_time:27237ms step_avg:41.02ms
+step:665/1480 train_time:27295ms step_avg:41.04ms
+step:666/1480 train_time:27359ms step_avg:41.08ms
+step:667/1480 train_time:27418ms step_avg:41.11ms
+step:668/1480 train_time:27483ms step_avg:41.14ms
+step:669/1480 train_time:27543ms step_avg:41.17ms
+step:670/1480 train_time:27607ms step_avg:41.21ms
+step:671/1480 train_time:27665ms step_avg:41.23ms
+step:672/1480 train_time:27729ms step_avg:41.26ms
+step:673/1480 train_time:27786ms step_avg:41.29ms
+step:674/1480 train_time:27850ms step_avg:41.32ms
+step:675/1480 train_time:27907ms step_avg:41.34ms
+step:676/1480 train_time:27971ms step_avg:41.38ms
+step:677/1480 train_time:28028ms step_avg:41.40ms
+step:678/1480 train_time:28091ms step_avg:41.43ms
+step:679/1480 train_time:28148ms step_avg:41.45ms
+step:680/1480 train_time:28211ms step_avg:41.49ms
+step:681/1480 train_time:28268ms step_avg:41.51ms
+step:682/1480 train_time:28333ms step_avg:41.54ms
+step:683/1480 train_time:28393ms step_avg:41.57ms
+step:684/1480 train_time:28460ms step_avg:41.61ms
+step:685/1480 train_time:28519ms step_avg:41.63ms
+step:686/1480 train_time:28585ms step_avg:41.67ms
+step:687/1480 train_time:28645ms step_avg:41.70ms
+step:688/1480 train_time:28710ms step_avg:41.73ms
+step:689/1480 train_time:28770ms step_avg:41.76ms
+step:690/1480 train_time:28835ms step_avg:41.79ms
+step:691/1480 train_time:28893ms step_avg:41.81ms
+step:692/1480 train_time:28958ms step_avg:41.85ms
+step:693/1480 train_time:29017ms step_avg:41.87ms
+step:694/1480 train_time:29083ms step_avg:41.91ms
+step:695/1480 train_time:29143ms step_avg:41.93ms
+step:696/1480 train_time:29208ms step_avg:41.97ms
+step:697/1480 train_time:29267ms step_avg:41.99ms
+step:698/1480 train_time:29333ms step_avg:42.02ms
+step:699/1480 train_time:29391ms step_avg:42.05ms
+step:700/1480 train_time:29455ms step_avg:42.08ms
+step:701/1480 train_time:29514ms step_avg:42.10ms
+step:702/1480 train_time:29579ms step_avg:42.13ms
+step:703/1480 train_time:29637ms step_avg:42.16ms
+step:704/1480 train_time:29702ms step_avg:42.19ms
+step:705/1480 train_time:29762ms step_avg:42.22ms
+step:706/1480 train_time:29826ms step_avg:42.25ms
+step:707/1480 train_time:29885ms step_avg:42.27ms
+step:708/1480 train_time:29952ms step_avg:42.31ms
+step:709/1480 train_time:30009ms step_avg:42.33ms
+step:710/1480 train_time:30074ms step_avg:42.36ms
+step:711/1480 train_time:30131ms step_avg:42.38ms
+step:712/1480 train_time:30196ms step_avg:42.41ms
+step:713/1480 train_time:30253ms step_avg:42.43ms
+step:714/1480 train_time:30316ms step_avg:42.46ms
+step:715/1480 train_time:30374ms step_avg:42.48ms
+step:716/1480 train_time:30438ms step_avg:42.51ms
+step:717/1480 train_time:30496ms step_avg:42.53ms
+step:718/1480 train_time:30559ms step_avg:42.56ms
+step:719/1480 train_time:30616ms step_avg:42.58ms
+step:720/1480 train_time:30679ms step_avg:42.61ms
+step:721/1480 train_time:30737ms step_avg:42.63ms
+step:722/1480 train_time:30800ms step_avg:42.66ms
+step:723/1480 train_time:30858ms step_avg:42.68ms
+step:724/1480 train_time:30923ms step_avg:42.71ms
+step:725/1480 train_time:30982ms step_avg:42.73ms
+step:726/1480 train_time:31051ms step_avg:42.77ms
+step:727/1480 train_time:31113ms step_avg:42.80ms
+step:728/1480 train_time:31180ms step_avg:42.83ms
+step:729/1480 train_time:31242ms step_avg:42.86ms
+step:730/1480 train_time:31310ms step_avg:42.89ms
+step:731/1480 train_time:31371ms step_avg:42.92ms
+step:732/1480 train_time:31438ms step_avg:42.95ms
+step:733/1480 train_time:31497ms step_avg:42.97ms
+step:734/1480 train_time:31565ms step_avg:43.00ms
+step:735/1480 train_time:31621ms step_avg:43.02ms
+step:736/1480 train_time:31681ms step_avg:43.04ms
+step:737/1480 train_time:31735ms step_avg:43.06ms
+step:738/1480 train_time:31796ms step_avg:43.08ms
+step:739/1480 train_time:31853ms step_avg:43.10ms
+step:740/1480 train_time:31914ms step_avg:43.13ms
+step:741/1480 train_time:31974ms step_avg:43.15ms
+step:742/1480 train_time:32040ms step_avg:43.18ms
+step:743/1480 train_time:32102ms step_avg:43.21ms
+step:744/1480 train_time:32170ms step_avg:43.24ms
+step:745/1480 train_time:32228ms step_avg:43.26ms
+step:746/1480 train_time:32294ms step_avg:43.29ms
+step:747/1480 train_time:32353ms step_avg:43.31ms
+step:748/1480 train_time:32420ms step_avg:43.34ms
+step:749/1480 train_time:32481ms step_avg:43.37ms
+step:750/1480 train_time:32547ms step_avg:43.40ms
+step:750/1480 val_loss:3.8017 train_time:32633ms step_avg:43.51ms
+step:751/1480 train_time:32650ms step_avg:43.47ms
+step:752/1480 train_time:32674ms step_avg:43.45ms
+step:753/1480 train_time:32733ms step_avg:43.47ms
+step:754/1480 train_time:32797ms step_avg:43.50ms
+step:755/1480 train_time:32854ms step_avg:43.52ms
+step:756/1480 train_time:32921ms step_avg:43.55ms
+step:757/1480 train_time:32982ms step_avg:43.57ms
+step:758/1480 train_time:33045ms step_avg:43.60ms
+step:759/1480 train_time:33103ms step_avg:43.61ms
+step:760/1480 train_time:33168ms step_avg:43.64ms
+step:761/1480 train_time:33227ms step_avg:43.66ms
+step:762/1480 train_time:33290ms step_avg:43.69ms
+step:763/1480 train_time:33348ms step_avg:43.71ms
+step:764/1480 train_time:33413ms step_avg:43.73ms
+step:765/1480 train_time:33471ms step_avg:43.75ms
+step:766/1480 train_time:33535ms step_avg:43.78ms
+step:767/1480 train_time:33591ms step_avg:43.80ms
+step:768/1480 train_time:33654ms step_avg:43.82ms
+step:769/1480 train_time:33711ms step_avg:43.84ms
+step:770/1480 train_time:33774ms step_avg:43.86ms
+step:771/1480 train_time:33831ms step_avg:43.88ms
+step:772/1480 train_time:33895ms step_avg:43.90ms
+step:773/1480 train_time:33952ms step_avg:43.92ms
+step:774/1480 train_time:34016ms step_avg:43.95ms
+step:775/1480 train_time:34074ms step_avg:43.97ms
+step:776/1480 train_time:34137ms step_avg:43.99ms
+step:777/1480 train_time:34197ms step_avg:44.01ms
+step:778/1480 train_time:34264ms step_avg:44.04ms
+step:779/1480 train_time:34323ms step_avg:44.06ms
+step:780/1480 train_time:34388ms step_avg:44.09ms
+step:781/1480 train_time:34447ms step_avg:44.11ms
+step:782/1480 train_time:34512ms step_avg:44.13ms
+step:783/1480 train_time:34570ms step_avg:44.15ms
+step:784/1480 train_time:34634ms step_avg:44.18ms
+step:785/1480 train_time:34691ms step_avg:44.19ms
+step:786/1480 train_time:34755ms step_avg:44.22ms
+step:787/1480 train_time:34812ms step_avg:44.23ms
+step:788/1480 train_time:34876ms step_avg:44.26ms
+step:789/1480 train_time:34934ms step_avg:44.28ms
+step:790/1480 train_time:34996ms step_avg:44.30ms
+step:791/1480 train_time:35054ms step_avg:44.32ms
+step:792/1480 train_time:35118ms step_avg:44.34ms
+step:793/1480 train_time:35178ms step_avg:44.36ms
+step:794/1480 train_time:35246ms step_avg:44.39ms
+step:795/1480 train_time:35306ms step_avg:44.41ms
+step:796/1480 train_time:35373ms step_avg:44.44ms
+step:797/1480 train_time:35432ms step_avg:44.46ms
+step:798/1480 train_time:35498ms step_avg:44.48ms
+step:799/1480 train_time:35557ms step_avg:44.50ms
+step:800/1480 train_time:35624ms step_avg:44.53ms
+step:801/1480 train_time:35685ms step_avg:44.55ms
+step:802/1480 train_time:35752ms step_avg:44.58ms
+step:803/1480 train_time:35811ms step_avg:44.60ms
+step:804/1480 train_time:35877ms step_avg:44.62ms
+step:805/1480 train_time:35936ms step_avg:44.64ms
+step:806/1480 train_time:36003ms step_avg:44.67ms
+step:807/1480 train_time:36065ms step_avg:44.69ms
+step:808/1480 train_time:36130ms step_avg:44.72ms
+step:809/1480 train_time:36189ms step_avg:44.73ms
+step:810/1480 train_time:36255ms step_avg:44.76ms
+step:811/1480 train_time:36313ms step_avg:44.78ms
+step:812/1480 train_time:36379ms step_avg:44.80ms
+step:813/1480 train_time:36438ms step_avg:44.82ms
+step:814/1480 train_time:36504ms step_avg:44.85ms
+step:815/1480 train_time:36561ms step_avg:44.86ms
+step:816/1480 train_time:36622ms step_avg:44.88ms
+step:817/1480 train_time:36677ms step_avg:44.89ms
+step:818/1480 train_time:36737ms step_avg:44.91ms
+step:819/1480 train_time:36793ms step_avg:44.92ms
+step:820/1480 train_time:36854ms step_avg:44.94ms
+step:821/1480 train_time:36912ms step_avg:44.96ms
+step:822/1480 train_time:36976ms step_avg:44.98ms
+step:823/1480 train_time:37036ms step_avg:45.00ms
+step:824/1480 train_time:37102ms step_avg:45.03ms
+step:825/1480 train_time:37163ms step_avg:45.05ms
+step:826/1480 train_time:37231ms step_avg:45.07ms
+step:827/1480 train_time:37290ms step_avg:45.09ms
+step:828/1480 train_time:37357ms step_avg:45.12ms
+step:829/1480 train_time:37419ms step_avg:45.14ms
+step:830/1480 train_time:37487ms step_avg:45.17ms
+step:831/1480 train_time:37547ms step_avg:45.18ms
+step:832/1480 train_time:37614ms step_avg:45.21ms
+step:833/1480 train_time:37674ms step_avg:45.23ms
+step:834/1480 train_time:37740ms step_avg:45.25ms
+step:835/1480 train_time:37800ms step_avg:45.27ms
+step:836/1480 train_time:37867ms step_avg:45.30ms
+step:837/1480 train_time:37928ms step_avg:45.31ms
+step:838/1480 train_time:37993ms step_avg:45.34ms
+step:839/1480 train_time:38051ms step_avg:45.35ms
+step:840/1480 train_time:38117ms step_avg:45.38ms
+step:841/1480 train_time:38176ms step_avg:45.39ms
+step:842/1480 train_time:38243ms step_avg:45.42ms
+step:843/1480 train_time:38303ms step_avg:45.44ms
+step:844/1480 train_time:38368ms step_avg:45.46ms
+step:845/1480 train_time:38428ms step_avg:45.48ms
+step:846/1480 train_time:38492ms step_avg:45.50ms
+step:847/1480 train_time:38550ms step_avg:45.51ms
+step:848/1480 train_time:38615ms step_avg:45.54ms
+step:849/1480 train_time:38674ms step_avg:45.55ms
+step:850/1480 train_time:38738ms step_avg:45.57ms
+step:851/1480 train_time:38797ms step_avg:45.59ms
+step:852/1480 train_time:38862ms step_avg:45.61ms
+step:853/1480 train_time:38922ms step_avg:45.63ms
+step:854/1480 train_time:38986ms step_avg:45.65ms
+step:855/1480 train_time:39044ms step_avg:45.67ms
+step:856/1480 train_time:39109ms step_avg:45.69ms
+step:857/1480 train_time:39168ms step_avg:45.70ms
+step:858/1480 train_time:39232ms step_avg:45.72ms
+step:859/1480 train_time:39290ms step_avg:45.74ms
+step:860/1480 train_time:39354ms step_avg:45.76ms
+step:861/1480 train_time:39412ms step_avg:45.77ms
+step:862/1480 train_time:39476ms step_avg:45.80ms
+step:863/1480 train_time:39534ms step_avg:45.81ms
+step:864/1480 train_time:39597ms step_avg:45.83ms
+step:865/1480 train_time:39655ms step_avg:45.84ms
+step:866/1480 train_time:39719ms step_avg:45.86ms
+step:867/1480 train_time:39777ms step_avg:45.88ms
+step:868/1480 train_time:39841ms step_avg:45.90ms
+step:869/1480 train_time:39899ms step_avg:45.91ms
+step:870/1480 train_time:39964ms step_avg:45.94ms
+step:871/1480 train_time:40023ms step_avg:45.95ms
+step:872/1480 train_time:40087ms step_avg:45.97ms
+step:873/1480 train_time:40145ms step_avg:45.98ms
+step:874/1480 train_time:40209ms step_avg:46.01ms
+step:875/1480 train_time:40267ms step_avg:46.02ms
+step:876/1480 train_time:40331ms step_avg:46.04ms
+step:877/1480 train_time:40388ms step_avg:46.05ms
+step:878/1480 train_time:40452ms step_avg:46.07ms
+step:879/1480 train_time:40509ms step_avg:46.09ms
+step:880/1480 train_time:40574ms step_avg:46.11ms
+step:881/1480 train_time:40631ms step_avg:46.12ms
+step:882/1480 train_time:40694ms step_avg:46.14ms
+step:883/1480 train_time:40752ms step_avg:46.15ms
+step:884/1480 train_time:40816ms step_avg:46.17ms
+step:885/1480 train_time:40873ms step_avg:46.18ms
+step:886/1480 train_time:40937ms step_avg:46.20ms
+step:887/1480 train_time:40995ms step_avg:46.22ms
+step:888/1480 train_time:41060ms step_avg:46.24ms
+step:889/1480 train_time:41119ms step_avg:46.25ms
+step:890/1480 train_time:41184ms step_avg:46.27ms
+step:891/1480 train_time:41243ms step_avg:46.29ms
+step:892/1480 train_time:41308ms step_avg:46.31ms
+step:893/1480 train_time:41367ms step_avg:46.32ms
+step:894/1480 train_time:41432ms step_avg:46.34ms
+step:895/1480 train_time:41490ms step_avg:46.36ms
+step:896/1480 train_time:41554ms step_avg:46.38ms
+step:897/1480 train_time:41611ms step_avg:46.39ms
+step:898/1480 train_time:41676ms step_avg:46.41ms
+step:899/1480 train_time:41734ms step_avg:46.42ms
+step:900/1480 train_time:41799ms step_avg:46.44ms
+step:901/1480 train_time:41859ms step_avg:46.46ms
+step:902/1480 train_time:41926ms step_avg:46.48ms
+step:903/1480 train_time:41987ms step_avg:46.50ms
+step:904/1480 train_time:42053ms step_avg:46.52ms
+step:905/1480 train_time:42112ms step_avg:46.53ms
+step:906/1480 train_time:42178ms step_avg:46.55ms
+step:907/1480 train_time:42237ms step_avg:46.57ms
+step:908/1480 train_time:42302ms step_avg:46.59ms
+step:909/1480 train_time:42363ms step_avg:46.60ms
+step:910/1480 train_time:42429ms step_avg:46.63ms
+step:911/1480 train_time:42488ms step_avg:46.64ms
+step:912/1480 train_time:42553ms step_avg:46.66ms
+step:913/1480 train_time:42612ms step_avg:46.67ms
+step:914/1480 train_time:42678ms step_avg:46.69ms
+step:915/1480 train_time:42738ms step_avg:46.71ms
+step:916/1480 train_time:42804ms step_avg:46.73ms
+step:917/1480 train_time:42865ms step_avg:46.74ms
+step:918/1480 train_time:42930ms step_avg:46.76ms
+step:919/1480 train_time:42988ms step_avg:46.78ms
+step:920/1480 train_time:43052ms step_avg:46.80ms
+step:921/1480 train_time:43110ms step_avg:46.81ms
+step:922/1480 train_time:43175ms step_avg:46.83ms
+step:923/1480 train_time:43235ms step_avg:46.84ms
+step:924/1480 train_time:43300ms step_avg:46.86ms
+step:925/1480 train_time:43358ms step_avg:46.87ms
+step:926/1480 train_time:43423ms step_avg:46.89ms
+step:927/1480 train_time:43482ms step_avg:46.91ms
+step:928/1480 train_time:43546ms step_avg:46.92ms
+step:929/1480 train_time:43604ms step_avg:46.94ms
+step:930/1480 train_time:43669ms step_avg:46.96ms
+step:931/1480 train_time:43727ms step_avg:46.97ms
+step:932/1480 train_time:43791ms step_avg:46.99ms
+step:933/1480 train_time:43849ms step_avg:47.00ms
+step:934/1480 train_time:43913ms step_avg:47.02ms
+step:935/1480 train_time:43971ms step_avg:47.03ms
+step:936/1480 train_time:44035ms step_avg:47.05ms
+step:937/1480 train_time:44092ms step_avg:47.06ms
+step:938/1480 train_time:44154ms step_avg:47.07ms
+step:939/1480 train_time:44210ms step_avg:47.08ms
+step:940/1480 train_time:44274ms step_avg:47.10ms
+step:941/1480 train_time:44330ms step_avg:47.11ms
+step:942/1480 train_time:44394ms step_avg:47.13ms
+step:943/1480 train_time:44450ms step_avg:47.14ms
+step:944/1480 train_time:44514ms step_avg:47.15ms
+step:945/1480 train_time:44572ms step_avg:47.17ms
+step:946/1480 train_time:44637ms step_avg:47.19ms
+step:947/1480 train_time:44696ms step_avg:47.20ms
+step:948/1480 train_time:44762ms step_avg:47.22ms
+step:949/1480 train_time:44821ms step_avg:47.23ms
+step:950/1480 train_time:44886ms step_avg:47.25ms
+step:951/1480 train_time:44943ms step_avg:47.26ms
+step:952/1480 train_time:45006ms step_avg:47.28ms
+step:953/1480 train_time:45064ms step_avg:47.29ms
+step:954/1480 train_time:45131ms step_avg:47.31ms
+step:955/1480 train_time:45188ms step_avg:47.32ms
+step:956/1480 train_time:45252ms step_avg:47.33ms
+step:957/1480 train_time:45310ms step_avg:47.35ms
+step:958/1480 train_time:45372ms step_avg:47.36ms
+step:959/1480 train_time:45430ms step_avg:47.37ms
+step:960/1480 train_time:45493ms step_avg:47.39ms
+step:961/1480 train_time:45556ms step_avg:47.40ms
+step:962/1480 train_time:45644ms step_avg:47.45ms
+step:963/1480 train_time:45731ms step_avg:47.49ms
+step:964/1480 train_time:45827ms step_avg:47.54ms
+step:965/1480 train_time:45917ms step_avg:47.58ms
+step:966/1480 train_time:46013ms step_avg:47.63ms
+step:967/1480 train_time:46102ms step_avg:47.68ms
+step:968/1480 train_time:46199ms step_avg:47.73ms
+step:969/1480 train_time:46288ms step_avg:47.77ms
+step:970/1480 train_time:46384ms step_avg:47.82ms
+step:971/1480 train_time:46474ms step_avg:47.86ms
+step:972/1480 train_time:46571ms step_avg:47.91ms
+step:973/1480 train_time:46660ms step_avg:47.95ms
+step:974/1480 train_time:46756ms step_avg:48.00ms
+step:975/1480 train_time:46838ms step_avg:48.04ms
+step:976/1480 train_time:46925ms step_avg:48.08ms
+step:977/1480 train_time:47010ms step_avg:48.12ms
+step:978/1480 train_time:47101ms step_avg:48.16ms
+step:979/1480 train_time:47184ms step_avg:48.20ms
+step:980/1480 train_time:47275ms step_avg:48.24ms
+step:981/1480 train_time:47361ms step_avg:48.28ms
+step:982/1480 train_time:47455ms step_avg:48.33ms
+step:983/1480 train_time:47540ms step_avg:48.36ms
+step:984/1480 train_time:47633ms step_avg:48.41ms
+step:985/1480 train_time:47720ms step_avg:48.45ms
+step:986/1480 train_time:47813ms step_avg:48.49ms
+step:987/1480 train_time:47898ms step_avg:48.53ms
+step:988/1480 train_time:47990ms step_avg:48.57ms
+step:989/1480 train_time:48076ms step_avg:48.61ms
+step:990/1480 train_time:48171ms step_avg:48.66ms
+step:991/1480 train_time:48256ms step_avg:48.69ms
+step:992/1480 train_time:48349ms step_avg:48.74ms
+step:993/1480 train_time:48435ms step_avg:48.78ms
+step:994/1480 train_time:48524ms step_avg:48.82ms
+step:995/1480 train_time:48610ms step_avg:48.85ms
+step:996/1480 train_time:48700ms step_avg:48.90ms
+step:997/1480 train_time:48786ms step_avg:48.93ms
+step:998/1480 train_time:48882ms step_avg:48.98ms
+step:999/1480 train_time:48972ms step_avg:49.02ms
+step:1000/1480 train_time:49069ms step_avg:49.07ms
+step:1000/1480 val_loss:3.5137 train_time:49194ms step_avg:49.19ms
+step:1001/1480 train_time:49211ms step_avg:49.16ms
+step:1002/1480 train_time:49256ms step_avg:49.16ms
+step:1003/1480 train_time:49345ms step_avg:49.20ms
+step:1004/1480 train_time:49441ms step_avg:49.24ms
+step:1005/1480 train_time:49529ms step_avg:49.28ms
+step:1006/1480 train_time:49624ms step_avg:49.33ms
+step:1007/1480 train_time:49705ms step_avg:49.36ms
+step:1008/1480 train_time:49790ms step_avg:49.39ms
+step:1009/1480 train_time:49875ms step_avg:49.43ms
+step:1010/1480 train_time:49966ms step_avg:49.47ms
+step:1011/1480 train_time:50056ms step_avg:49.51ms
+step:1012/1480 train_time:50148ms step_avg:49.55ms
+step:1013/1480 train_time:50236ms step_avg:49.59ms
+step:1014/1480 train_time:50329ms step_avg:49.63ms
+step:1015/1480 train_time:50414ms step_avg:49.67ms
+step:1016/1480 train_time:50505ms step_avg:49.71ms
+step:1017/1480 train_time:50592ms step_avg:49.75ms
+step:1018/1480 train_time:50682ms step_avg:49.79ms
+step:1019/1480 train_time:50768ms step_avg:49.82ms
+step:1020/1480 train_time:50862ms step_avg:49.86ms
+step:1021/1480 train_time:50950ms step_avg:49.90ms
+step:1022/1480 train_time:51045ms step_avg:49.95ms
+step:1023/1480 train_time:51134ms step_avg:49.98ms
+step:1024/1480 train_time:51229ms step_avg:50.03ms
+step:1025/1480 train_time:51318ms step_avg:50.07ms
+step:1026/1480 train_time:51414ms step_avg:50.11ms
+step:1027/1480 train_time:51503ms step_avg:50.15ms
+step:1028/1480 train_time:51598ms step_avg:50.19ms
+step:1029/1480 train_time:51686ms step_avg:50.23ms
+step:1030/1480 train_time:51781ms step_avg:50.27ms
+step:1031/1480 train_time:51868ms step_avg:50.31ms
+step:1032/1480 train_time:51963ms step_avg:50.35ms
+step:1033/1480 train_time:52050ms step_avg:50.39ms
+step:1034/1480 train_time:52144ms step_avg:50.43ms
+step:1035/1480 train_time:52229ms step_avg:50.46ms
+step:1036/1480 train_time:52323ms step_avg:50.50ms
+step:1037/1480 train_time:52409ms step_avg:50.54ms
+step:1038/1480 train_time:52502ms step_avg:50.58ms
+step:1039/1480 train_time:52589ms step_avg:50.61ms
+step:1040/1480 train_time:52682ms step_avg:50.66ms
+step:1041/1480 train_time:52767ms step_avg:50.69ms
+step:1042/1480 train_time:52861ms step_avg:50.73ms
+step:1043/1480 train_time:52946ms step_avg:50.76ms
+step:1044/1480 train_time:53040ms step_avg:50.80ms
+step:1045/1480 train_time:53126ms step_avg:50.84ms
+step:1046/1480 train_time:53220ms step_avg:50.88ms
+step:1047/1480 train_time:53305ms step_avg:50.91ms
+step:1048/1480 train_time:53398ms step_avg:50.95ms
+step:1049/1480 train_time:53484ms step_avg:50.99ms
+step:1050/1480 train_time:53578ms step_avg:51.03ms
+step:1051/1480 train_time:53663ms step_avg:51.06ms
+step:1052/1480 train_time:53755ms step_avg:51.10ms
+step:1053/1480 train_time:53838ms step_avg:51.13ms
+step:1054/1480 train_time:53931ms step_avg:51.17ms
+step:1055/1480 train_time:54017ms step_avg:51.20ms
+step:1056/1480 train_time:54106ms step_avg:51.24ms
+step:1057/1480 train_time:54192ms step_avg:51.27ms
+step:1058/1480 train_time:54283ms step_avg:51.31ms
+step:1059/1480 train_time:54368ms step_avg:51.34ms
+step:1060/1480 train_time:54458ms step_avg:51.38ms
+step:1061/1480 train_time:54545ms step_avg:51.41ms
+step:1062/1480 train_time:54639ms step_avg:51.45ms
+step:1063/1480 train_time:54726ms step_avg:51.48ms
+step:1064/1480 train_time:54819ms step_avg:51.52ms
+step:1065/1480 train_time:54908ms step_avg:51.56ms
+step:1066/1480 train_time:55004ms step_avg:51.60ms
+step:1067/1480 train_time:55092ms step_avg:51.63ms
+step:1068/1480 train_time:55187ms step_avg:51.67ms
+step:1069/1480 train_time:55278ms step_avg:51.71ms
+step:1070/1480 train_time:55372ms step_avg:51.75ms
+step:1071/1480 train_time:55462ms step_avg:51.78ms
+step:1072/1480 train_time:55557ms step_avg:51.83ms
+step:1073/1480 train_time:55644ms step_avg:51.86ms
+step:1074/1480 train_time:55740ms step_avg:51.90ms
+step:1075/1480 train_time:55829ms step_avg:51.93ms
+step:1076/1480 train_time:55923ms step_avg:51.97ms
+step:1077/1480 train_time:56010ms step_avg:52.01ms
+step:1078/1480 train_time:56104ms step_avg:52.04ms
+step:1079/1480 train_time:56191ms step_avg:52.08ms
+step:1080/1480 train_time:56285ms step_avg:52.12ms
+step:1081/1480 train_time:56372ms step_avg:52.15ms
+step:1082/1480 train_time:56466ms step_avg:52.19ms
+step:1083/1480 train_time:56552ms step_avg:52.22ms
+step:1084/1480 train_time:56645ms step_avg:52.26ms
+step:1085/1480 train_time:56731ms step_avg:52.29ms
+step:1086/1480 train_time:56825ms step_avg:52.32ms
+step:1087/1480 train_time:56912ms step_avg:52.36ms
+step:1088/1480 train_time:57004ms step_avg:52.39ms
+step:1089/1480 train_time:57091ms step_avg:52.42ms
+step:1090/1480 train_time:57183ms step_avg:52.46ms
+step:1091/1480 train_time:57268ms step_avg:52.49ms
+step:1092/1480 train_time:57362ms step_avg:52.53ms
+step:1093/1480 train_time:57446ms step_avg:52.56ms
+step:1094/1480 train_time:57539ms step_avg:52.60ms
+step:1095/1480 train_time:57625ms step_avg:52.63ms
+step:1096/1480 train_time:57718ms step_avg:52.66ms
+step:1097/1480 train_time:57805ms step_avg:52.69ms
+step:1098/1480 train_time:57897ms step_avg:52.73ms
+step:1099/1480 train_time:57984ms step_avg:52.76ms
+step:1100/1480 train_time:58076ms step_avg:52.80ms
+step:1101/1480 train_time:58162ms step_avg:52.83ms
+step:1102/1480 train_time:58254ms step_avg:52.86ms
+step:1103/1480 train_time:58339ms step_avg:52.89ms
+step:1104/1480 train_time:58431ms step_avg:52.93ms
+step:1105/1480 train_time:58517ms step_avg:52.96ms
+step:1106/1480 train_time:58609ms step_avg:52.99ms
+step:1107/1480 train_time:58695ms step_avg:53.02ms
+step:1108/1480 train_time:58787ms step_avg:53.06ms
+step:1109/1480 train_time:58872ms step_avg:53.09ms
+step:1110/1480 train_time:58963ms step_avg:53.12ms
+step:1111/1480 train_time:59049ms step_avg:53.15ms
+step:1112/1480 train_time:59142ms step_avg:53.19ms
+step:1113/1480 train_time:59229ms step_avg:53.22ms
+step:1114/1480 train_time:59323ms step_avg:53.25ms
+step:1115/1480 train_time:59409ms step_avg:53.28ms
+step:1116/1480 train_time:59503ms step_avg:53.32ms
+step:1117/1480 train_time:59592ms step_avg:53.35ms
+step:1118/1480 train_time:59688ms step_avg:53.39ms
+step:1119/1480 train_time:59777ms step_avg:53.42ms
+step:1120/1480 train_time:59872ms step_avg:53.46ms
+step:1121/1480 train_time:59960ms step_avg:53.49ms
+step:1122/1480 train_time:60055ms step_avg:53.52ms
+step:1123/1480 train_time:60145ms step_avg:53.56ms
+step:1124/1480 train_time:60240ms step_avg:53.59ms
+step:1125/1480 train_time:60328ms step_avg:53.63ms
+step:1126/1480 train_time:60424ms step_avg:53.66ms
+step:1127/1480 train_time:60513ms step_avg:53.69ms
+step:1128/1480 train_time:60607ms step_avg:53.73ms
+step:1129/1480 train_time:60696ms step_avg:53.76ms
+step:1130/1480 train_time:60789ms step_avg:53.80ms
+step:1131/1480 train_time:60879ms step_avg:53.83ms
+step:1132/1480 train_time:60971ms step_avg:53.86ms
+step:1133/1480 train_time:61059ms step_avg:53.89ms
+step:1134/1480 train_time:61153ms step_avg:53.93ms
+step:1135/1480 train_time:61240ms step_avg:53.96ms
+step:1136/1480 train_time:61334ms step_avg:53.99ms
+step:1137/1480 train_time:61421ms step_avg:54.02ms
+step:1138/1480 train_time:61515ms step_avg:54.06ms
+step:1139/1480 train_time:61601ms step_avg:54.08ms
+step:1140/1480 train_time:61695ms step_avg:54.12ms
+step:1141/1480 train_time:61782ms step_avg:54.15ms
+step:1142/1480 train_time:61874ms step_avg:54.18ms
+step:1143/1480 train_time:61960ms step_avg:54.21ms
+step:1144/1480 train_time:62051ms step_avg:54.24ms
+step:1145/1480 train_time:62136ms step_avg:54.27ms
+step:1146/1480 train_time:62229ms step_avg:54.30ms
+step:1147/1480 train_time:62316ms step_avg:54.33ms
+step:1148/1480 train_time:62407ms step_avg:54.36ms
+step:1149/1480 train_time:62493ms step_avg:54.39ms
+step:1150/1480 train_time:62584ms step_avg:54.42ms
+step:1151/1480 train_time:62669ms step_avg:54.45ms
+step:1152/1480 train_time:62761ms step_avg:54.48ms
+step:1153/1480 train_time:62845ms step_avg:54.51ms
+step:1154/1480 train_time:62937ms step_avg:54.54ms
+step:1155/1480 train_time:63022ms step_avg:54.56ms
+step:1156/1480 train_time:63113ms step_avg:54.60ms
+step:1157/1480 train_time:63201ms step_avg:54.62ms
+step:1158/1480 train_time:63299ms step_avg:54.66ms
+step:1159/1480 train_time:63390ms step_avg:54.69ms
+step:1160/1480 train_time:63488ms step_avg:54.73ms
+step:1161/1480 train_time:63577ms step_avg:54.76ms
+step:1162/1480 train_time:63672ms step_avg:54.80ms
+step:1163/1480 train_time:63763ms step_avg:54.83ms
+step:1164/1480 train_time:63859ms step_avg:54.86ms
+step:1165/1480 train_time:63948ms step_avg:54.89ms
+step:1166/1480 train_time:64036ms step_avg:54.92ms
+step:1167/1480 train_time:64117ms step_avg:54.94ms
+step:1168/1480 train_time:64206ms step_avg:54.97ms
+step:1169/1480 train_time:64291ms step_avg:55.00ms
+step:1170/1480 train_time:64381ms step_avg:55.03ms
+step:1171/1480 train_time:64469ms step_avg:55.05ms
+step:1172/1480 train_time:64562ms step_avg:55.09ms
+step:1173/1480 train_time:64657ms step_avg:55.12ms
+step:1174/1480 train_time:64759ms step_avg:55.16ms
+step:1175/1480 train_time:64856ms step_avg:55.20ms
+step:1176/1480 train_time:64958ms step_avg:55.24ms
+step:1177/1480 train_time:65048ms step_avg:55.27ms
+step:1178/1480 train_time:65133ms step_avg:55.29ms
+step:1179/1480 train_time:65215ms step_avg:55.31ms
+step:1180/1480 train_time:65303ms step_avg:55.34ms
+step:1181/1480 train_time:65391ms step_avg:55.37ms
+step:1182/1480 train_time:65488ms step_avg:55.40ms
+step:1183/1480 train_time:65585ms step_avg:55.44ms
+step:1184/1480 train_time:65685ms step_avg:55.48ms
+step:1185/1480 train_time:65775ms step_avg:55.51ms
+step:1186/1480 train_time:65869ms step_avg:55.54ms
+step:1187/1480 train_time:65957ms step_avg:55.57ms
+step:1188/1480 train_time:66052ms step_avg:55.60ms
+step:1189/1480 train_time:66140ms step_avg:55.63ms
+step:1190/1480 train_time:66234ms step_avg:55.66ms
+step:1191/1480 train_time:66322ms step_avg:55.69ms
+step:1192/1480 train_time:66417ms step_avg:55.72ms
+step:1193/1480 train_time:66505ms step_avg:55.75ms
+step:1194/1480 train_time:66599ms step_avg:55.78ms
+step:1195/1480 train_time:66687ms step_avg:55.81ms
+step:1196/1480 train_time:66780ms step_avg:55.84ms
+step:1197/1480 train_time:66868ms step_avg:55.86ms
+step:1198/1480 train_time:66962ms step_avg:55.90ms
+step:1199/1480 train_time:67049ms step_avg:55.92ms
+step:1200/1480 train_time:67143ms step_avg:55.95ms
+step:1201/1480 train_time:67229ms step_avg:55.98ms
+step:1202/1480 train_time:67323ms step_avg:56.01ms
+step:1203/1480 train_time:67409ms step_avg:56.03ms
+step:1204/1480 train_time:67502ms step_avg:56.06ms
+step:1205/1480 train_time:67588ms step_avg:56.09ms
+step:1206/1480 train_time:67681ms step_avg:56.12ms
+step:1207/1480 train_time:67766ms step_avg:56.14ms
+step:1208/1480 train_time:67860ms step_avg:56.18ms
+step:1209/1480 train_time:67944ms step_avg:56.20ms
+step:1210/1480 train_time:68038ms step_avg:56.23ms
+step:1211/1480 train_time:68124ms step_avg:56.25ms
+step:1212/1480 train_time:68217ms step_avg:56.28ms
+step:1213/1480 train_time:68303ms step_avg:56.31ms
+step:1214/1480 train_time:68393ms step_avg:56.34ms
+step:1215/1480 train_time:68478ms step_avg:56.36ms
+step:1216/1480 train_time:68569ms step_avg:56.39ms
+step:1217/1480 train_time:68653ms step_avg:56.41ms
+step:1218/1480 train_time:68742ms step_avg:56.44ms
+step:1219/1480 train_time:68827ms step_avg:56.46ms
+step:1220/1480 train_time:68924ms step_avg:56.50ms
+step:1221/1480 train_time:69016ms step_avg:56.52ms
+step:1222/1480 train_time:69113ms step_avg:56.56ms
+step:1223/1480 train_time:69205ms step_avg:56.59ms
+step:1224/1480 train_time:69299ms step_avg:56.62ms
+step:1225/1480 train_time:69388ms step_avg:56.64ms
+step:1226/1480 train_time:69485ms step_avg:56.68ms
+step:1227/1480 train_time:69568ms step_avg:56.70ms
+step:1228/1480 train_time:69659ms step_avg:56.73ms
+step:1229/1480 train_time:69748ms step_avg:56.75ms
+step:1230/1480 train_time:69848ms step_avg:56.79ms
+step:1231/1480 train_time:69948ms step_avg:56.82ms
+step:1232/1480 train_time:70043ms step_avg:56.85ms
+step:1233/1480 train_time:70132ms step_avg:56.88ms
+step:1234/1480 train_time:70227ms step_avg:56.91ms
+step:1235/1480 train_time:70313ms step_avg:56.93ms
+step:1236/1480 train_time:70406ms step_avg:56.96ms
+step:1237/1480 train_time:70493ms step_avg:56.99ms
+step:1238/1480 train_time:70587ms step_avg:57.02ms
+step:1239/1480 train_time:70674ms step_avg:57.04ms
+step:1240/1480 train_time:70768ms step_avg:57.07ms
+step:1241/1480 train_time:70855ms step_avg:57.09ms
+step:1242/1480 train_time:70949ms step_avg:57.12ms
+step:1243/1480 train_time:71036ms step_avg:57.15ms
+step:1244/1480 train_time:71129ms step_avg:57.18ms
+step:1245/1480 train_time:71217ms step_avg:57.20ms
+step:1246/1480 train_time:71310ms step_avg:57.23ms
+step:1247/1480 train_time:71397ms step_avg:57.25ms
+step:1248/1480 train_time:71490ms step_avg:57.28ms
+step:1249/1480 train_time:71579ms step_avg:57.31ms
+step:1250/1480 train_time:71670ms step_avg:57.34ms
+step:1250/1480 val_loss:3.3713 train_time:71790ms step_avg:57.43ms
+step:1251/1480 train_time:71808ms step_avg:57.40ms
+step:1252/1480 train_time:71852ms step_avg:57.39ms
+step:1253/1480 train_time:71939ms step_avg:57.41ms
+step:1254/1480 train_time:72030ms step_avg:57.44ms
+step:1255/1480 train_time:72117ms step_avg:57.46ms
+step:1256/1480 train_time:72210ms step_avg:57.49ms
+step:1257/1480 train_time:72295ms step_avg:57.51ms
+step:1258/1480 train_time:72387ms step_avg:57.54ms
+step:1259/1480 train_time:72473ms step_avg:57.56ms
+step:1260/1480 train_time:72565ms step_avg:57.59ms
+step:1261/1480 train_time:72650ms step_avg:57.61ms
+step:1262/1480 train_time:72743ms step_avg:57.64ms
+step:1263/1480 train_time:72828ms step_avg:57.66ms
+step:1264/1480 train_time:72918ms step_avg:57.69ms
+step:1265/1480 train_time:73005ms step_avg:57.71ms
+step:1266/1480 train_time:73101ms step_avg:57.74ms
+step:1267/1480 train_time:73189ms step_avg:57.77ms
+step:1268/1480 train_time:73284ms step_avg:57.79ms
+step:1269/1480 train_time:73373ms step_avg:57.82ms
+step:1270/1480 train_time:73468ms step_avg:57.85ms
+step:1271/1480 train_time:73557ms step_avg:57.87ms
+step:1272/1480 train_time:73652ms step_avg:57.90ms
+step:1273/1480 train_time:73740ms step_avg:57.93ms
+step:1274/1480 train_time:73834ms step_avg:57.95ms
+step:1275/1480 train_time:73921ms step_avg:57.98ms
+step:1276/1480 train_time:74016ms step_avg:58.01ms
+step:1277/1480 train_time:74104ms step_avg:58.03ms
+step:1278/1480 train_time:74197ms step_avg:58.06ms
+step:1279/1480 train_time:74284ms step_avg:58.08ms
+step:1280/1480 train_time:74378ms step_avg:58.11ms
+step:1281/1480 train_time:74459ms step_avg:58.13ms
+step:1282/1480 train_time:74553ms step_avg:58.15ms
+step:1283/1480 train_time:74643ms step_avg:58.18ms
+step:1284/1480 train_time:74738ms step_avg:58.21ms
+step:1285/1480 train_time:74833ms step_avg:58.24ms
+step:1286/1480 train_time:74927ms step_avg:58.26ms
+step:1287/1480 train_time:75013ms step_avg:58.28ms
+step:1288/1480 train_time:75109ms step_avg:58.31ms
+step:1289/1480 train_time:75193ms step_avg:58.33ms
+step:1290/1480 train_time:75285ms step_avg:58.36ms
+step:1291/1480 train_time:75372ms step_avg:58.38ms
+step:1292/1480 train_time:75466ms step_avg:58.41ms
+step:1293/1480 train_time:75552ms step_avg:58.43ms
+step:1294/1480 train_time:75646ms step_avg:58.46ms
+step:1295/1480 train_time:75733ms step_avg:58.48ms
+step:1296/1480 train_time:75826ms step_avg:58.51ms
+step:1297/1480 train_time:75911ms step_avg:58.53ms
+step:1298/1480 train_time:76003ms step_avg:58.55ms
+step:1299/1480 train_time:76089ms step_avg:58.57ms
+step:1300/1480 train_time:76180ms step_avg:58.60ms
+step:1301/1480 train_time:76266ms step_avg:58.62ms
+step:1302/1480 train_time:76360ms step_avg:58.65ms
+step:1303/1480 train_time:76449ms step_avg:58.67ms
+step:1304/1480 train_time:76540ms step_avg:58.70ms
+step:1305/1480 train_time:76624ms step_avg:58.72ms
+step:1306/1480 train_time:76715ms step_avg:58.74ms
+step:1307/1480 train_time:76801ms step_avg:58.76ms
+step:1308/1480 train_time:76891ms step_avg:58.79ms
+step:1309/1480 train_time:76978ms step_avg:58.81ms
+step:1310/1480 train_time:77070ms step_avg:58.83ms
+step:1311/1480 train_time:77155ms step_avg:58.85ms
+step:1312/1480 train_time:77250ms step_avg:58.88ms
+step:1313/1480 train_time:77333ms step_avg:58.90ms
+step:1314/1480 train_time:77427ms step_avg:58.92ms
+step:1315/1480 train_time:77518ms step_avg:58.95ms
+step:1316/1480 train_time:77620ms step_avg:58.98ms
+step:1317/1480 train_time:77716ms step_avg:59.01ms
+step:1318/1480 train_time:77818ms step_avg:59.04ms
+step:1319/1480 train_time:77909ms step_avg:59.07ms
+step:1320/1480 train_time:77993ms step_avg:59.09ms
+step:1321/1480 train_time:78077ms step_avg:59.10ms
+step:1322/1480 train_time:78168ms step_avg:59.13ms
+step:1323/1480 train_time:78255ms step_avg:59.15ms
+step:1324/1480 train_time:78349ms step_avg:59.18ms
+step:1325/1480 train_time:78434ms step_avg:59.20ms
+step:1326/1480 train_time:78530ms step_avg:59.22ms
+step:1327/1480 train_time:78618ms step_avg:59.25ms
+step:1328/1480 train_time:78713ms step_avg:59.27ms
+step:1329/1480 train_time:78800ms step_avg:59.29ms
+step:1330/1480 train_time:78891ms step_avg:59.32ms
+step:1331/1480 train_time:78977ms step_avg:59.34ms
+step:1332/1480 train_time:79071ms step_avg:59.36ms
+step:1333/1480 train_time:79158ms step_avg:59.38ms
+step:1334/1480 train_time:79248ms step_avg:59.41ms
+step:1335/1480 train_time:79334ms step_avg:59.43ms
+step:1336/1480 train_time:79425ms step_avg:59.45ms
+step:1337/1480 train_time:79508ms step_avg:59.47ms
+step:1338/1480 train_time:79599ms step_avg:59.49ms
+step:1339/1480 train_time:79683ms step_avg:59.51ms
+step:1340/1480 train_time:79775ms step_avg:59.53ms
+step:1341/1480 train_time:79862ms step_avg:59.55ms
+step:1342/1480 train_time:79956ms step_avg:59.58ms
+step:1343/1480 train_time:80046ms step_avg:59.60ms
+step:1344/1480 train_time:80141ms step_avg:59.63ms
+step:1345/1480 train_time:80232ms step_avg:59.65ms
+step:1346/1480 train_time:80327ms step_avg:59.68ms
+step:1347/1480 train_time:80415ms step_avg:59.70ms
+step:1348/1480 train_time:80511ms step_avg:59.73ms
+step:1349/1480 train_time:80598ms step_avg:59.75ms
+step:1350/1480 train_time:80694ms step_avg:59.77ms
+step:1351/1480 train_time:80782ms step_avg:59.79ms
+step:1352/1480 train_time:80876ms step_avg:59.82ms
+step:1353/1480 train_time:80965ms step_avg:59.84ms
+step:1354/1480 train_time:81058ms step_avg:59.87ms
+step:1355/1480 train_time:81145ms step_avg:59.89ms
+step:1356/1480 train_time:81240ms step_avg:59.91ms
+step:1357/1480 train_time:81329ms step_avg:59.93ms
+step:1358/1480 train_time:81423ms step_avg:59.96ms
+step:1359/1480 train_time:81510ms step_avg:59.98ms
+step:1360/1480 train_time:81605ms step_avg:60.00ms
+step:1361/1480 train_time:81691ms step_avg:60.02ms
+step:1362/1480 train_time:81786ms step_avg:60.05ms
+step:1363/1480 train_time:81873ms step_avg:60.07ms
+step:1364/1480 train_time:81966ms step_avg:60.09ms
+step:1365/1480 train_time:82052ms step_avg:60.11ms
+step:1366/1480 train_time:82145ms step_avg:60.14ms
+step:1367/1480 train_time:82232ms step_avg:60.15ms
+step:1368/1480 train_time:82324ms step_avg:60.18ms
+step:1369/1480 train_time:82410ms step_avg:60.20ms
+step:1370/1480 train_time:82502ms step_avg:60.22ms
+step:1371/1480 train_time:82586ms step_avg:60.24ms
+step:1372/1480 train_time:82677ms step_avg:60.26ms
+step:1373/1480 train_time:82760ms step_avg:60.28ms
+step:1374/1480 train_time:82851ms step_avg:60.30ms
+step:1375/1480 train_time:82938ms step_avg:60.32ms
+step:1376/1480 train_time:83030ms step_avg:60.34ms
+step:1377/1480 train_time:83116ms step_avg:60.36ms
+step:1378/1480 train_time:83209ms step_avg:60.38ms
+step:1379/1480 train_time:83294ms step_avg:60.40ms
+step:1380/1480 train_time:83391ms step_avg:60.43ms
+step:1381/1480 train_time:83478ms step_avg:60.45ms
+step:1382/1480 train_time:83570ms step_avg:60.47ms
+step:1383/1480 train_time:83655ms step_avg:60.49ms
+step:1384/1480 train_time:83747ms step_avg:60.51ms
+step:1385/1480 train_time:83833ms step_avg:60.53ms
+step:1386/1480 train_time:83925ms step_avg:60.55ms
+step:1387/1480 train_time:84011ms step_avg:60.57ms
+step:1388/1480 train_time:84101ms step_avg:60.59ms
+step:1389/1480 train_time:84187ms step_avg:60.61ms
+step:1390/1480 train_time:84282ms step_avg:60.63ms
+step:1391/1480 train_time:84372ms step_avg:60.66ms
+step:1392/1480 train_time:84467ms step_avg:60.68ms
+step:1393/1480 train_time:84556ms step_avg:60.70ms
+step:1394/1480 train_time:84652ms step_avg:60.73ms
+step:1395/1480 train_time:84741ms step_avg:60.75ms
+step:1396/1480 train_time:84836ms step_avg:60.77ms
+step:1397/1480 train_time:84927ms step_avg:60.79ms
+step:1398/1480 train_time:85021ms step_avg:60.82ms
+step:1399/1480 train_time:85104ms step_avg:60.83ms
+step:1400/1480 train_time:85193ms step_avg:60.85ms
+step:1401/1480 train_time:85281ms step_avg:60.87ms
+step:1402/1480 train_time:85373ms step_avg:60.89ms
+step:1403/1480 train_time:85458ms step_avg:60.91ms
+step:1404/1480 train_time:85550ms step_avg:60.93ms
+step:1405/1480 train_time:85637ms step_avg:60.95ms
+step:1406/1480 train_time:85730ms step_avg:60.97ms
+step:1407/1480 train_time:85818ms step_avg:60.99ms
+step:1408/1480 train_time:85910ms step_avg:61.02ms
+step:1409/1480 train_time:86001ms step_avg:61.04ms
+step:1410/1480 train_time:86096ms step_avg:61.06ms
+step:1411/1480 train_time:86185ms step_avg:61.08ms
+step:1412/1480 train_time:86281ms step_avg:61.11ms
+step:1413/1480 train_time:86372ms step_avg:61.13ms
+step:1414/1480 train_time:86467ms step_avg:61.15ms
+step:1415/1480 train_time:86556ms step_avg:61.17ms
+step:1416/1480 train_time:86652ms step_avg:61.20ms
+step:1417/1480 train_time:86733ms step_avg:61.21ms
+step:1418/1480 train_time:86824ms step_avg:61.23ms
+step:1419/1480 train_time:86911ms step_avg:61.25ms
+step:1420/1480 train_time:87004ms step_avg:61.27ms
+step:1421/1480 train_time:87092ms step_avg:61.29ms
+step:1422/1480 train_time:87187ms step_avg:61.31ms
+step:1423/1480 train_time:87273ms step_avg:61.33ms
+step:1424/1480 train_time:87367ms step_avg:61.35ms
+step:1425/1480 train_time:87453ms step_avg:61.37ms
+step:1426/1480 train_time:87547ms step_avg:61.39ms
+step:1427/1480 train_time:87634ms step_avg:61.41ms
+step:1428/1480 train_time:87729ms step_avg:61.43ms
+step:1429/1480 train_time:87815ms step_avg:61.45ms
+step:1430/1480 train_time:87911ms step_avg:61.48ms
+step:1431/1480 train_time:87997ms step_avg:61.49ms
+step:1432/1480 train_time:88091ms step_avg:61.52ms
+step:1433/1480 train_time:88178ms step_avg:61.53ms
+step:1434/1480 train_time:88272ms step_avg:61.56ms
+step:1435/1480 train_time:88359ms step_avg:61.57ms
+step:1436/1480 train_time:88452ms step_avg:61.60ms
+step:1437/1480 train_time:88540ms step_avg:61.61ms
+step:1438/1480 train_time:88633ms step_avg:61.64ms
+step:1439/1480 train_time:88720ms step_avg:61.65ms
+step:1440/1480 train_time:88814ms step_avg:61.68ms
+step:1441/1480 train_time:88905ms step_avg:61.70ms
+step:1442/1480 train_time:89000ms step_avg:61.72ms
+step:1443/1480 train_time:89086ms step_avg:61.74ms
+step:1444/1480 train_time:89179ms step_avg:61.76ms
+step:1445/1480 train_time:89267ms step_avg:61.78ms
+step:1446/1480 train_time:89360ms step_avg:61.80ms
+step:1447/1480 train_time:89447ms step_avg:61.82ms
+step:1448/1480 train_time:89542ms step_avg:61.84ms
+step:1449/1480 train_time:89629ms step_avg:61.86ms
+step:1450/1480 train_time:89722ms step_avg:61.88ms
+step:1451/1480 train_time:89810ms step_avg:61.90ms
+step:1452/1480 train_time:89903ms step_avg:61.92ms
+step:1453/1480 train_time:89989ms step_avg:61.93ms
+step:1454/1480 train_time:90083ms step_avg:61.96ms
+step:1455/1480 train_time:90171ms step_avg:61.97ms
+step:1456/1480 train_time:90264ms step_avg:61.99ms
+step:1457/1480 train_time:90351ms step_avg:62.01ms
+step:1458/1480 train_time:90445ms step_avg:62.03ms
+step:1459/1480 train_time:90530ms step_avg:62.05ms
+step:1460/1480 train_time:90624ms step_avg:62.07ms
+step:1461/1480 train_time:90711ms step_avg:62.09ms
+step:1462/1480 train_time:90802ms step_avg:62.11ms
+step:1463/1480 train_time:90887ms step_avg:62.12ms
+step:1464/1480 train_time:90978ms step_avg:62.14ms
+step:1465/1480 train_time:91063ms step_avg:62.16ms
+step:1466/1480 train_time:91153ms step_avg:62.18ms
+step:1467/1480 train_time:91240ms step_avg:62.20ms
+step:1468/1480 train_time:91333ms step_avg:62.22ms
+step:1469/1480 train_time:91418ms step_avg:62.23ms
+step:1470/1480 train_time:91508ms step_avg:62.25ms
+step:1471/1480 train_time:91598ms step_avg:62.27ms
+step:1472/1480 train_time:91694ms step_avg:62.29ms
+step:1473/1480 train_time:91780ms step_avg:62.31ms
+step:1474/1480 train_time:91877ms step_avg:62.33ms
+step:1475/1480 train_time:91964ms step_avg:62.35ms
+step:1476/1480 train_time:92059ms step_avg:62.37ms
+step:1477/1480 train_time:92150ms step_avg:62.39ms
+step:1478/1480 train_time:92246ms step_avg:62.41ms
+step:1479/1480 train_time:92336ms step_avg:62.43ms
+step:1480/1480 train_time:92433ms step_avg:62.45ms
+step:1480/1480 val_loss:3.2820 train_time:92555ms step_avg:62.54ms
+peak memory allocated: 31277 MiB reserved: 47082 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline6-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline6-1480.txt
@@ -1,0 +1,4447 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:33:41 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   40C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   35C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   39C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   40C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   67C    P0            153W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          389732      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          389733      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          389734      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          389735      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          389736      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          389737      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          389738      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          389739      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8295 train_time:0ms step_avg:0.04ms
+step:1/1480 train_time:82ms step_avg:81.75ms
+step:2/1480 train_time:107ms step_avg:53.45ms
+step:3/1480 train_time:125ms step_avg:41.50ms
+step:4/1480 train_time:146ms step_avg:36.55ms
+step:5/1480 train_time:173ms step_avg:34.68ms
+step:6/1480 train_time:209ms step_avg:34.77ms
+step:7/1480 train_time:236ms step_avg:33.78ms
+step:8/1480 train_time:272ms step_avg:34.02ms
+step:9/1480 train_time:300ms step_avg:33.32ms
+step:10/1480 train_time:335ms step_avg:33.51ms
+step:11/1480 train_time:363ms step_avg:32.99ms
+step:12/1480 train_time:398ms step_avg:33.14ms
+step:13/1480 train_time:426ms step_avg:32.76ms
+step:14/1480 train_time:461ms step_avg:32.91ms
+step:15/1480 train_time:490ms step_avg:32.68ms
+step:16/1480 train_time:526ms step_avg:32.90ms
+step:17/1480 train_time:555ms step_avg:32.67ms
+step:18/1480 train_time:592ms step_avg:32.88ms
+step:19/1480 train_time:621ms step_avg:32.69ms
+step:20/1480 train_time:657ms step_avg:32.84ms
+step:21/1480 train_time:687ms step_avg:32.70ms
+step:22/1480 train_time:722ms step_avg:32.83ms
+step:23/1480 train_time:752ms step_avg:32.68ms
+step:24/1480 train_time:787ms step_avg:32.81ms
+step:25/1480 train_time:816ms step_avg:32.65ms
+step:26/1480 train_time:853ms step_avg:32.79ms
+step:27/1480 train_time:881ms step_avg:32.64ms
+step:28/1480 train_time:916ms step_avg:32.73ms
+step:29/1480 train_time:945ms step_avg:32.58ms
+step:30/1480 train_time:980ms step_avg:32.65ms
+step:31/1480 train_time:1008ms step_avg:32.51ms
+step:32/1480 train_time:1043ms step_avg:32.59ms
+step:33/1480 train_time:1071ms step_avg:32.45ms
+step:34/1480 train_time:1109ms step_avg:32.60ms
+step:35/1480 train_time:1140ms step_avg:32.58ms
+step:36/1480 train_time:1179ms step_avg:32.74ms
+step:37/1480 train_time:1210ms step_avg:32.70ms
+step:38/1480 train_time:1247ms step_avg:32.83ms
+step:39/1480 train_time:1278ms step_avg:32.77ms
+step:40/1480 train_time:1316ms step_avg:32.90ms
+step:41/1480 train_time:1347ms step_avg:32.85ms
+step:42/1480 train_time:1385ms step_avg:32.97ms
+step:43/1480 train_time:1415ms step_avg:32.91ms
+step:44/1480 train_time:1453ms step_avg:33.02ms
+step:45/1480 train_time:1484ms step_avg:32.97ms
+step:46/1480 train_time:1519ms step_avg:33.03ms
+step:47/1480 train_time:1548ms step_avg:32.93ms
+step:48/1480 train_time:1582ms step_avg:32.96ms
+step:49/1480 train_time:1611ms step_avg:32.87ms
+step:50/1480 train_time:1645ms step_avg:32.90ms
+step:51/1480 train_time:1673ms step_avg:32.80ms
+step:52/1480 train_time:1708ms step_avg:32.84ms
+step:53/1480 train_time:1736ms step_avg:32.75ms
+step:54/1480 train_time:1771ms step_avg:32.80ms
+step:55/1480 train_time:1799ms step_avg:32.71ms
+step:56/1480 train_time:1834ms step_avg:32.75ms
+step:57/1480 train_time:1862ms step_avg:32.67ms
+step:58/1480 train_time:1898ms step_avg:32.72ms
+step:59/1480 train_time:1929ms step_avg:32.69ms
+step:60/1480 train_time:1966ms step_avg:32.76ms
+step:61/1480 train_time:1995ms step_avg:32.71ms
+step:62/1480 train_time:2032ms step_avg:32.77ms
+step:63/1480 train_time:2062ms step_avg:32.73ms
+step:64/1480 train_time:2098ms step_avg:32.78ms
+step:65/1480 train_time:2129ms step_avg:32.75ms
+step:66/1480 train_time:2166ms step_avg:32.81ms
+step:67/1480 train_time:2195ms step_avg:32.77ms
+step:68/1480 train_time:2232ms step_avg:32.83ms
+step:69/1480 train_time:2262ms step_avg:32.78ms
+step:70/1480 train_time:2298ms step_avg:32.83ms
+step:71/1480 train_time:2329ms step_avg:32.80ms
+step:72/1480 train_time:2365ms step_avg:32.85ms
+step:73/1480 train_time:2395ms step_avg:32.80ms
+step:74/1480 train_time:2431ms step_avg:32.85ms
+step:75/1480 train_time:2461ms step_avg:32.82ms
+step:76/1480 train_time:2497ms step_avg:32.86ms
+step:77/1480 train_time:2528ms step_avg:32.83ms
+step:78/1480 train_time:2565ms step_avg:32.88ms
+step:79/1480 train_time:2594ms step_avg:32.84ms
+step:80/1480 train_time:2631ms step_avg:32.88ms
+step:81/1480 train_time:2660ms step_avg:32.84ms
+step:82/1480 train_time:2699ms step_avg:32.91ms
+step:83/1480 train_time:2727ms step_avg:32.86ms
+step:84/1480 train_time:2766ms step_avg:32.93ms
+step:85/1480 train_time:2793ms step_avg:32.86ms
+step:86/1480 train_time:2829ms step_avg:32.90ms
+step:87/1480 train_time:2858ms step_avg:32.85ms
+step:88/1480 train_time:2895ms step_avg:32.90ms
+step:89/1480 train_time:2924ms step_avg:32.85ms
+step:90/1480 train_time:2960ms step_avg:32.89ms
+step:91/1480 train_time:2990ms step_avg:32.85ms
+step:92/1480 train_time:3026ms step_avg:32.89ms
+step:93/1480 train_time:3055ms step_avg:32.85ms
+step:94/1480 train_time:3091ms step_avg:32.88ms
+step:95/1480 train_time:3121ms step_avg:32.85ms
+step:96/1480 train_time:3157ms step_avg:32.88ms
+step:97/1480 train_time:3186ms step_avg:32.85ms
+step:98/1480 train_time:3222ms step_avg:32.88ms
+step:99/1480 train_time:3252ms step_avg:32.84ms
+step:100/1480 train_time:3288ms step_avg:32.88ms
+step:101/1480 train_time:3317ms step_avg:32.84ms
+step:102/1480 train_time:3353ms step_avg:32.87ms
+step:103/1480 train_time:3383ms step_avg:32.84ms
+step:104/1480 train_time:3419ms step_avg:32.87ms
+step:105/1480 train_time:3448ms step_avg:32.84ms
+step:106/1480 train_time:3484ms step_avg:32.87ms
+step:107/1480 train_time:3513ms step_avg:32.83ms
+step:108/1480 train_time:3549ms step_avg:32.86ms
+step:109/1480 train_time:3578ms step_avg:32.83ms
+step:110/1480 train_time:3614ms step_avg:32.86ms
+step:111/1480 train_time:3643ms step_avg:32.82ms
+step:112/1480 train_time:3679ms step_avg:32.85ms
+step:113/1480 train_time:3709ms step_avg:32.82ms
+step:114/1480 train_time:3745ms step_avg:32.85ms
+step:115/1480 train_time:3774ms step_avg:32.82ms
+step:116/1480 train_time:3810ms step_avg:32.84ms
+step:117/1480 train_time:3839ms step_avg:32.81ms
+step:118/1480 train_time:3875ms step_avg:32.84ms
+step:119/1480 train_time:3905ms step_avg:32.81ms
+step:120/1480 train_time:3941ms step_avg:32.84ms
+step:121/1480 train_time:3972ms step_avg:32.83ms
+step:122/1480 train_time:4010ms step_avg:32.87ms
+step:123/1480 train_time:4042ms step_avg:32.86ms
+step:124/1480 train_time:4079ms step_avg:32.89ms
+step:125/1480 train_time:4109ms step_avg:32.88ms
+step:126/1480 train_time:4146ms step_avg:32.91ms
+step:127/1480 train_time:4176ms step_avg:32.89ms
+step:128/1480 train_time:4214ms step_avg:32.92ms
+step:129/1480 train_time:4244ms step_avg:32.90ms
+step:130/1480 train_time:4281ms step_avg:32.93ms
+step:131/1480 train_time:4311ms step_avg:32.91ms
+step:132/1480 train_time:4348ms step_avg:32.94ms
+step:133/1480 train_time:4378ms step_avg:32.92ms
+step:134/1480 train_time:4416ms step_avg:32.95ms
+step:135/1480 train_time:4445ms step_avg:32.93ms
+step:136/1480 train_time:4482ms step_avg:32.95ms
+step:137/1480 train_time:4512ms step_avg:32.93ms
+step:138/1480 train_time:4549ms step_avg:32.96ms
+step:139/1480 train_time:4579ms step_avg:32.94ms
+step:140/1480 train_time:4616ms step_avg:32.97ms
+step:141/1480 train_time:4645ms step_avg:32.95ms
+step:142/1480 train_time:4682ms step_avg:32.97ms
+step:143/1480 train_time:4712ms step_avg:32.95ms
+step:144/1480 train_time:4748ms step_avg:32.98ms
+step:145/1480 train_time:4778ms step_avg:32.95ms
+step:146/1480 train_time:4815ms step_avg:32.98ms
+step:147/1480 train_time:4845ms step_avg:32.96ms
+step:148/1480 train_time:4881ms step_avg:32.98ms
+step:149/1480 train_time:4911ms step_avg:32.96ms
+step:150/1480 train_time:4947ms step_avg:32.98ms
+step:151/1480 train_time:4977ms step_avg:32.96ms
+step:152/1480 train_time:5012ms step_avg:32.97ms
+step:153/1480 train_time:5040ms step_avg:32.94ms
+step:154/1480 train_time:5074ms step_avg:32.95ms
+step:155/1480 train_time:5102ms step_avg:32.92ms
+step:156/1480 train_time:5140ms step_avg:32.95ms
+step:157/1480 train_time:5168ms step_avg:32.92ms
+step:158/1480 train_time:5205ms step_avg:32.94ms
+step:159/1480 train_time:5236ms step_avg:32.93ms
+step:160/1480 train_time:5273ms step_avg:32.96ms
+step:161/1480 train_time:5304ms step_avg:32.94ms
+step:162/1480 train_time:5341ms step_avg:32.97ms
+step:163/1480 train_time:5372ms step_avg:32.96ms
+step:164/1480 train_time:5410ms step_avg:32.99ms
+step:165/1480 train_time:5441ms step_avg:32.97ms
+step:166/1480 train_time:5478ms step_avg:33.00ms
+step:167/1480 train_time:5509ms step_avg:32.99ms
+step:168/1480 train_time:5546ms step_avg:33.01ms
+step:169/1480 train_time:5577ms step_avg:33.00ms
+step:170/1480 train_time:5614ms step_avg:33.03ms
+step:171/1480 train_time:5645ms step_avg:33.01ms
+step:172/1480 train_time:5682ms step_avg:33.03ms
+step:173/1480 train_time:5712ms step_avg:33.02ms
+step:174/1480 train_time:5749ms step_avg:33.04ms
+step:175/1480 train_time:5779ms step_avg:33.02ms
+step:176/1480 train_time:5816ms step_avg:33.05ms
+step:177/1480 train_time:5847ms step_avg:33.03ms
+step:178/1480 train_time:5883ms step_avg:33.05ms
+step:179/1480 train_time:5914ms step_avg:33.04ms
+step:180/1480 train_time:5950ms step_avg:33.06ms
+step:181/1480 train_time:5980ms step_avg:33.04ms
+step:182/1480 train_time:6018ms step_avg:33.06ms
+step:183/1480 train_time:6048ms step_avg:33.05ms
+step:184/1480 train_time:6085ms step_avg:33.07ms
+step:185/1480 train_time:6115ms step_avg:33.05ms
+step:186/1480 train_time:6152ms step_avg:33.07ms
+step:187/1480 train_time:6181ms step_avg:33.05ms
+step:188/1480 train_time:6218ms step_avg:33.08ms
+step:189/1480 train_time:6248ms step_avg:33.06ms
+step:190/1480 train_time:6285ms step_avg:33.08ms
+step:191/1480 train_time:6314ms step_avg:33.06ms
+step:192/1480 train_time:6351ms step_avg:33.08ms
+step:193/1480 train_time:6380ms step_avg:33.06ms
+step:194/1480 train_time:6417ms step_avg:33.08ms
+step:195/1480 train_time:6447ms step_avg:33.06ms
+step:196/1480 train_time:6483ms step_avg:33.08ms
+step:197/1480 train_time:6513ms step_avg:33.06ms
+step:198/1480 train_time:6550ms step_avg:33.08ms
+step:199/1480 train_time:6579ms step_avg:33.06ms
+step:200/1480 train_time:6616ms step_avg:33.08ms
+step:201/1480 train_time:6646ms step_avg:33.07ms
+step:202/1480 train_time:6683ms step_avg:33.08ms
+step:203/1480 train_time:6712ms step_avg:33.07ms
+step:204/1480 train_time:6749ms step_avg:33.08ms
+step:205/1480 train_time:6778ms step_avg:33.06ms
+step:206/1480 train_time:6815ms step_avg:33.08ms
+step:207/1480 train_time:6845ms step_avg:33.07ms
+step:208/1480 train_time:6881ms step_avg:33.08ms
+step:209/1480 train_time:6911ms step_avg:33.07ms
+step:210/1480 train_time:6947ms step_avg:33.08ms
+step:211/1480 train_time:6977ms step_avg:33.07ms
+step:212/1480 train_time:7014ms step_avg:33.08ms
+step:213/1480 train_time:7043ms step_avg:33.07ms
+step:214/1480 train_time:7079ms step_avg:33.08ms
+step:215/1480 train_time:7109ms step_avg:33.07ms
+step:216/1480 train_time:7145ms step_avg:33.08ms
+step:217/1480 train_time:7175ms step_avg:33.06ms
+step:218/1480 train_time:7211ms step_avg:33.08ms
+step:219/1480 train_time:7241ms step_avg:33.06ms
+step:220/1480 train_time:7277ms step_avg:33.08ms
+step:221/1480 train_time:7307ms step_avg:33.07ms
+step:222/1480 train_time:7343ms step_avg:33.08ms
+step:223/1480 train_time:7373ms step_avg:33.06ms
+step:224/1480 train_time:7409ms step_avg:33.08ms
+step:225/1480 train_time:7439ms step_avg:33.06ms
+step:226/1480 train_time:7475ms step_avg:33.08ms
+step:227/1480 train_time:7505ms step_avg:33.06ms
+step:228/1480 train_time:7541ms step_avg:33.07ms
+step:229/1480 train_time:7571ms step_avg:33.06ms
+step:230/1480 train_time:7607ms step_avg:33.07ms
+step:231/1480 train_time:7637ms step_avg:33.06ms
+step:232/1480 train_time:7673ms step_avg:33.07ms
+step:233/1480 train_time:7702ms step_avg:33.06ms
+step:234/1480 train_time:7738ms step_avg:33.07ms
+step:235/1480 train_time:7768ms step_avg:33.05ms
+step:236/1480 train_time:7803ms step_avg:33.06ms
+step:237/1480 train_time:7833ms step_avg:33.05ms
+step:238/1480 train_time:7869ms step_avg:33.06ms
+step:239/1480 train_time:7898ms step_avg:33.05ms
+step:240/1480 train_time:7934ms step_avg:33.06ms
+step:241/1480 train_time:7964ms step_avg:33.04ms
+step:242/1480 train_time:8000ms step_avg:33.06ms
+step:243/1480 train_time:8029ms step_avg:33.04ms
+step:244/1480 train_time:8066ms step_avg:33.06ms
+step:245/1480 train_time:8095ms step_avg:33.04ms
+step:246/1480 train_time:8131ms step_avg:33.05ms
+step:247/1480 train_time:8160ms step_avg:33.04ms
+step:248/1480 train_time:8196ms step_avg:33.05ms
+step:249/1480 train_time:8226ms step_avg:33.04ms
+step:250/1480 train_time:8262ms step_avg:33.05ms
+step:250/1480 val_loss:4.5129 train_time:8307ms step_avg:33.23ms
+step:251/1480 train_time:8330ms step_avg:33.19ms
+step:252/1480 train_time:8355ms step_avg:33.15ms
+step:253/1480 train_time:8375ms step_avg:33.10ms
+step:254/1480 train_time:8400ms step_avg:33.07ms
+step:255/1480 train_time:8428ms step_avg:33.05ms
+step:256/1480 train_time:8465ms step_avg:33.07ms
+step:257/1480 train_time:8496ms step_avg:33.06ms
+step:258/1480 train_time:8534ms step_avg:33.08ms
+step:259/1480 train_time:8566ms step_avg:33.07ms
+step:260/1480 train_time:8603ms step_avg:33.09ms
+step:261/1480 train_time:8634ms step_avg:33.08ms
+step:262/1480 train_time:8672ms step_avg:33.10ms
+step:263/1480 train_time:8703ms step_avg:33.09ms
+step:264/1480 train_time:8741ms step_avg:33.11ms
+step:265/1480 train_time:8772ms step_avg:33.10ms
+step:266/1480 train_time:8810ms step_avg:33.12ms
+step:267/1480 train_time:8841ms step_avg:33.11ms
+step:268/1480 train_time:8879ms step_avg:33.13ms
+step:269/1480 train_time:8910ms step_avg:33.12ms
+step:270/1480 train_time:8947ms step_avg:33.14ms
+step:271/1480 train_time:8978ms step_avg:33.13ms
+step:272/1480 train_time:9015ms step_avg:33.14ms
+step:273/1480 train_time:9046ms step_avg:33.13ms
+step:274/1480 train_time:9083ms step_avg:33.15ms
+step:275/1480 train_time:9114ms step_avg:33.14ms
+step:276/1480 train_time:9151ms step_avg:33.15ms
+step:277/1480 train_time:9181ms step_avg:33.14ms
+step:278/1480 train_time:9218ms step_avg:33.16ms
+step:279/1480 train_time:9249ms step_avg:33.15ms
+step:280/1480 train_time:9287ms step_avg:33.17ms
+step:281/1480 train_time:9317ms step_avg:33.16ms
+step:282/1480 train_time:9354ms step_avg:33.17ms
+step:283/1480 train_time:9384ms step_avg:33.16ms
+step:284/1480 train_time:9421ms step_avg:33.17ms
+step:285/1480 train_time:9452ms step_avg:33.16ms
+step:286/1480 train_time:9489ms step_avg:33.18ms
+step:287/1480 train_time:9519ms step_avg:33.17ms
+step:288/1480 train_time:9556ms step_avg:33.18ms
+step:289/1480 train_time:9587ms step_avg:33.17ms
+step:290/1480 train_time:9624ms step_avg:33.18ms
+step:291/1480 train_time:9653ms step_avg:33.17ms
+step:292/1480 train_time:9690ms step_avg:33.19ms
+step:293/1480 train_time:9720ms step_avg:33.18ms
+step:294/1480 train_time:9757ms step_avg:33.19ms
+step:295/1480 train_time:9787ms step_avg:33.18ms
+step:296/1480 train_time:9824ms step_avg:33.19ms
+step:297/1480 train_time:9854ms step_avg:33.18ms
+step:298/1480 train_time:9891ms step_avg:33.19ms
+step:299/1480 train_time:9921ms step_avg:33.18ms
+step:300/1480 train_time:9956ms step_avg:33.19ms
+step:301/1480 train_time:9984ms step_avg:33.17ms
+step:302/1480 train_time:10019ms step_avg:33.18ms
+step:303/1480 train_time:10047ms step_avg:33.16ms
+step:304/1480 train_time:10084ms step_avg:33.17ms
+step:305/1480 train_time:10114ms step_avg:33.16ms
+step:306/1480 train_time:10151ms step_avg:33.17ms
+step:307/1480 train_time:10183ms step_avg:33.17ms
+step:308/1480 train_time:10221ms step_avg:33.19ms
+step:309/1480 train_time:10251ms step_avg:33.18ms
+step:310/1480 train_time:10289ms step_avg:33.19ms
+step:311/1480 train_time:10320ms step_avg:33.18ms
+step:312/1480 train_time:10358ms step_avg:33.20ms
+step:313/1480 train_time:10389ms step_avg:33.19ms
+step:314/1480 train_time:10427ms step_avg:33.21ms
+step:315/1480 train_time:10457ms step_avg:33.20ms
+step:316/1480 train_time:10495ms step_avg:33.21ms
+step:317/1480 train_time:10526ms step_avg:33.21ms
+step:318/1480 train_time:10563ms step_avg:33.22ms
+step:319/1480 train_time:10593ms step_avg:33.21ms
+step:320/1480 train_time:10631ms step_avg:33.22ms
+step:321/1480 train_time:10661ms step_avg:33.21ms
+step:322/1480 train_time:10699ms step_avg:33.23ms
+step:323/1480 train_time:10730ms step_avg:33.22ms
+step:324/1480 train_time:10768ms step_avg:33.24ms
+step:325/1480 train_time:10798ms step_avg:33.23ms
+step:326/1480 train_time:10836ms step_avg:33.24ms
+step:327/1480 train_time:10867ms step_avg:33.23ms
+step:328/1480 train_time:10904ms step_avg:33.24ms
+step:329/1480 train_time:10935ms step_avg:33.24ms
+step:330/1480 train_time:10972ms step_avg:33.25ms
+step:331/1480 train_time:11002ms step_avg:33.24ms
+step:332/1480 train_time:11040ms step_avg:33.25ms
+step:333/1480 train_time:11070ms step_avg:33.24ms
+step:334/1480 train_time:11107ms step_avg:33.25ms
+step:335/1480 train_time:11137ms step_avg:33.25ms
+step:336/1480 train_time:11173ms step_avg:33.25ms
+step:337/1480 train_time:11200ms step_avg:33.24ms
+step:338/1480 train_time:11235ms step_avg:33.24ms
+step:339/1480 train_time:11263ms step_avg:33.22ms
+step:340/1480 train_time:11300ms step_avg:33.23ms
+step:341/1480 train_time:11328ms step_avg:33.22ms
+step:342/1480 train_time:11365ms step_avg:33.23ms
+step:343/1480 train_time:11395ms step_avg:33.22ms
+step:344/1480 train_time:11432ms step_avg:33.23ms
+step:345/1480 train_time:11462ms step_avg:33.22ms
+step:346/1480 train_time:11499ms step_avg:33.23ms
+step:347/1480 train_time:11530ms step_avg:33.23ms
+step:348/1480 train_time:11568ms step_avg:33.24ms
+step:349/1480 train_time:11598ms step_avg:33.23ms
+step:350/1480 train_time:11636ms step_avg:33.24ms
+step:351/1480 train_time:11665ms step_avg:33.23ms
+step:352/1480 train_time:11702ms step_avg:33.24ms
+step:353/1480 train_time:11733ms step_avg:33.24ms
+step:354/1480 train_time:11770ms step_avg:33.25ms
+step:355/1480 train_time:11800ms step_avg:33.24ms
+step:356/1480 train_time:11837ms step_avg:33.25ms
+step:357/1480 train_time:11867ms step_avg:33.24ms
+step:358/1480 train_time:11904ms step_avg:33.25ms
+step:359/1480 train_time:11934ms step_avg:33.24ms
+step:360/1480 train_time:11971ms step_avg:33.25ms
+step:361/1480 train_time:12001ms step_avg:33.24ms
+step:362/1480 train_time:12038ms step_avg:33.26ms
+step:363/1480 train_time:12069ms step_avg:33.25ms
+step:364/1480 train_time:12105ms step_avg:33.26ms
+step:365/1480 train_time:12136ms step_avg:33.25ms
+step:366/1480 train_time:12173ms step_avg:33.26ms
+step:367/1480 train_time:12203ms step_avg:33.25ms
+step:368/1480 train_time:12239ms step_avg:33.26ms
+step:369/1480 train_time:12270ms step_avg:33.25ms
+step:370/1480 train_time:12307ms step_avg:33.26ms
+step:371/1480 train_time:12337ms step_avg:33.25ms
+step:372/1480 train_time:12375ms step_avg:33.26ms
+step:373/1480 train_time:12405ms step_avg:33.26ms
+step:374/1480 train_time:12441ms step_avg:33.27ms
+step:375/1480 train_time:12471ms step_avg:33.26ms
+step:376/1480 train_time:12508ms step_avg:33.27ms
+step:377/1480 train_time:12538ms step_avg:33.26ms
+step:378/1480 train_time:12575ms step_avg:33.27ms
+step:379/1480 train_time:12605ms step_avg:33.26ms
+step:380/1480 train_time:12642ms step_avg:33.27ms
+step:381/1480 train_time:12672ms step_avg:33.26ms
+step:382/1480 train_time:12709ms step_avg:33.27ms
+step:383/1480 train_time:12739ms step_avg:33.26ms
+step:384/1480 train_time:12776ms step_avg:33.27ms
+step:385/1480 train_time:12806ms step_avg:33.26ms
+step:386/1480 train_time:12843ms step_avg:33.27ms
+step:387/1480 train_time:12873ms step_avg:33.26ms
+step:388/1480 train_time:12909ms step_avg:33.27ms
+step:389/1480 train_time:12939ms step_avg:33.26ms
+step:390/1480 train_time:12976ms step_avg:33.27ms
+step:391/1480 train_time:13006ms step_avg:33.26ms
+step:392/1480 train_time:13042ms step_avg:33.27ms
+step:393/1480 train_time:13072ms step_avg:33.26ms
+step:394/1480 train_time:13109ms step_avg:33.27ms
+step:395/1480 train_time:13139ms step_avg:33.26ms
+step:396/1480 train_time:13176ms step_avg:33.27ms
+step:397/1480 train_time:13206ms step_avg:33.26ms
+step:398/1480 train_time:13242ms step_avg:33.27ms
+step:399/1480 train_time:13273ms step_avg:33.26ms
+step:400/1480 train_time:13309ms step_avg:33.27ms
+step:401/1480 train_time:13339ms step_avg:33.26ms
+step:402/1480 train_time:13376ms step_avg:33.27ms
+step:403/1480 train_time:13406ms step_avg:33.26ms
+step:404/1480 train_time:13442ms step_avg:33.27ms
+step:405/1480 train_time:13472ms step_avg:33.26ms
+step:406/1480 train_time:13509ms step_avg:33.27ms
+step:407/1480 train_time:13539ms step_avg:33.26ms
+step:408/1480 train_time:13575ms step_avg:33.27ms
+step:409/1480 train_time:13605ms step_avg:33.26ms
+step:410/1480 train_time:13641ms step_avg:33.27ms
+step:411/1480 train_time:13671ms step_avg:33.26ms
+step:412/1480 train_time:13707ms step_avg:33.27ms
+step:413/1480 train_time:13737ms step_avg:33.26ms
+step:414/1480 train_time:13774ms step_avg:33.27ms
+step:415/1480 train_time:13803ms step_avg:33.26ms
+step:416/1480 train_time:13840ms step_avg:33.27ms
+step:417/1480 train_time:13869ms step_avg:33.26ms
+step:418/1480 train_time:13905ms step_avg:33.27ms
+step:419/1480 train_time:13935ms step_avg:33.26ms
+step:420/1480 train_time:13971ms step_avg:33.26ms
+step:421/1480 train_time:14001ms step_avg:33.26ms
+step:422/1480 train_time:14037ms step_avg:33.26ms
+step:423/1480 train_time:14067ms step_avg:33.25ms
+step:424/1480 train_time:14103ms step_avg:33.26ms
+step:425/1480 train_time:14132ms step_avg:33.25ms
+step:426/1480 train_time:14169ms step_avg:33.26ms
+step:427/1480 train_time:14198ms step_avg:33.25ms
+step:428/1480 train_time:14235ms step_avg:33.26ms
+step:429/1480 train_time:14265ms step_avg:33.25ms
+step:430/1480 train_time:14301ms step_avg:33.26ms
+step:431/1480 train_time:14331ms step_avg:33.25ms
+step:432/1480 train_time:14368ms step_avg:33.26ms
+step:433/1480 train_time:14398ms step_avg:33.25ms
+step:434/1480 train_time:14435ms step_avg:33.26ms
+step:435/1480 train_time:14465ms step_avg:33.25ms
+step:436/1480 train_time:14502ms step_avg:33.26ms
+step:437/1480 train_time:14532ms step_avg:33.25ms
+step:438/1480 train_time:14569ms step_avg:33.26ms
+step:439/1480 train_time:14599ms step_avg:33.25ms
+step:440/1480 train_time:14636ms step_avg:33.26ms
+step:441/1480 train_time:14666ms step_avg:33.26ms
+step:442/1480 train_time:14702ms step_avg:33.26ms
+step:443/1480 train_time:14732ms step_avg:33.26ms
+step:444/1480 train_time:14769ms step_avg:33.26ms
+step:445/1480 train_time:14799ms step_avg:33.26ms
+step:446/1480 train_time:14836ms step_avg:33.26ms
+step:447/1480 train_time:14866ms step_avg:33.26ms
+step:448/1480 train_time:14902ms step_avg:33.26ms
+step:449/1480 train_time:14932ms step_avg:33.26ms
+step:450/1480 train_time:14969ms step_avg:33.27ms
+step:451/1480 train_time:14999ms step_avg:33.26ms
+step:452/1480 train_time:15036ms step_avg:33.27ms
+step:453/1480 train_time:15066ms step_avg:33.26ms
+step:454/1480 train_time:15102ms step_avg:33.27ms
+step:455/1480 train_time:15132ms step_avg:33.26ms
+step:456/1480 train_time:15170ms step_avg:33.27ms
+step:457/1480 train_time:15199ms step_avg:33.26ms
+step:458/1480 train_time:15236ms step_avg:33.27ms
+step:459/1480 train_time:15266ms step_avg:33.26ms
+step:460/1480 train_time:15302ms step_avg:33.27ms
+step:461/1480 train_time:15332ms step_avg:33.26ms
+step:462/1480 train_time:15369ms step_avg:33.27ms
+step:463/1480 train_time:15399ms step_avg:33.26ms
+step:464/1480 train_time:15436ms step_avg:33.27ms
+step:465/1480 train_time:15466ms step_avg:33.26ms
+step:466/1480 train_time:15502ms step_avg:33.27ms
+step:467/1480 train_time:15532ms step_avg:33.26ms
+step:468/1480 train_time:15569ms step_avg:33.27ms
+step:469/1480 train_time:15599ms step_avg:33.26ms
+step:470/1480 train_time:15636ms step_avg:33.27ms
+step:471/1480 train_time:15665ms step_avg:33.26ms
+step:472/1480 train_time:15702ms step_avg:33.27ms
+step:473/1480 train_time:15732ms step_avg:33.26ms
+step:474/1480 train_time:15769ms step_avg:33.27ms
+step:475/1480 train_time:15799ms step_avg:33.26ms
+step:476/1480 train_time:15836ms step_avg:33.27ms
+step:477/1480 train_time:15866ms step_avg:33.26ms
+step:478/1480 train_time:15902ms step_avg:33.27ms
+step:479/1480 train_time:15932ms step_avg:33.26ms
+step:480/1480 train_time:15969ms step_avg:33.27ms
+step:481/1480 train_time:16002ms step_avg:33.27ms
+step:482/1480 train_time:16061ms step_avg:33.32ms
+step:483/1480 train_time:16119ms step_avg:33.37ms
+step:484/1480 train_time:16184ms step_avg:33.44ms
+step:485/1480 train_time:16241ms step_avg:33.49ms
+step:486/1480 train_time:16306ms step_avg:33.55ms
+step:487/1480 train_time:16363ms step_avg:33.60ms
+step:488/1480 train_time:16426ms step_avg:33.66ms
+step:489/1480 train_time:16484ms step_avg:33.71ms
+step:490/1480 train_time:16550ms step_avg:33.78ms
+step:491/1480 train_time:16609ms step_avg:33.83ms
+step:492/1480 train_time:16673ms step_avg:33.89ms
+step:493/1480 train_time:16733ms step_avg:33.94ms
+step:494/1480 train_time:16796ms step_avg:34.00ms
+step:495/1480 train_time:16856ms step_avg:34.05ms
+step:496/1480 train_time:16920ms step_avg:34.11ms
+step:497/1480 train_time:16980ms step_avg:34.16ms
+step:498/1480 train_time:17045ms step_avg:34.23ms
+step:499/1480 train_time:17102ms step_avg:34.27ms
+step:500/1480 train_time:17167ms step_avg:34.33ms
+step:500/1480 val_loss:4.2034 train_time:17247ms step_avg:34.49ms
+step:501/1480 train_time:17265ms step_avg:34.46ms
+step:502/1480 train_time:17289ms step_avg:34.44ms
+step:503/1480 train_time:17347ms step_avg:34.49ms
+step:504/1480 train_time:17411ms step_avg:34.54ms
+step:505/1480 train_time:17468ms step_avg:34.59ms
+step:506/1480 train_time:17531ms step_avg:34.65ms
+step:507/1480 train_time:17589ms step_avg:34.69ms
+step:508/1480 train_time:17653ms step_avg:34.75ms
+step:509/1480 train_time:17710ms step_avg:34.79ms
+step:510/1480 train_time:17773ms step_avg:34.85ms
+step:511/1480 train_time:17830ms step_avg:34.89ms
+step:512/1480 train_time:17893ms step_avg:34.95ms
+step:513/1480 train_time:17950ms step_avg:34.99ms
+step:514/1480 train_time:18013ms step_avg:35.04ms
+step:515/1480 train_time:18070ms step_avg:35.09ms
+step:516/1480 train_time:18134ms step_avg:35.14ms
+step:517/1480 train_time:18191ms step_avg:35.19ms
+step:518/1480 train_time:18254ms step_avg:35.24ms
+step:519/1480 train_time:18311ms step_avg:35.28ms
+step:520/1480 train_time:18374ms step_avg:35.33ms
+step:521/1480 train_time:18431ms step_avg:35.38ms
+step:522/1480 train_time:18494ms step_avg:35.43ms
+step:523/1480 train_time:18551ms step_avg:35.47ms
+step:524/1480 train_time:18614ms step_avg:35.52ms
+step:525/1480 train_time:18672ms step_avg:35.56ms
+step:526/1480 train_time:18735ms step_avg:35.62ms
+step:527/1480 train_time:18793ms step_avg:35.66ms
+step:528/1480 train_time:18857ms step_avg:35.71ms
+step:529/1480 train_time:18914ms step_avg:35.75ms
+step:530/1480 train_time:18978ms step_avg:35.81ms
+step:531/1480 train_time:19037ms step_avg:35.85ms
+step:532/1480 train_time:19103ms step_avg:35.91ms
+step:533/1480 train_time:19161ms step_avg:35.95ms
+step:534/1480 train_time:19226ms step_avg:36.00ms
+step:535/1480 train_time:19285ms step_avg:36.05ms
+step:536/1480 train_time:19350ms step_avg:36.10ms
+step:537/1480 train_time:19408ms step_avg:36.14ms
+step:538/1480 train_time:19471ms step_avg:36.19ms
+step:539/1480 train_time:19529ms step_avg:36.23ms
+step:540/1480 train_time:19594ms step_avg:36.29ms
+step:541/1480 train_time:19651ms step_avg:36.32ms
+step:542/1480 train_time:19714ms step_avg:36.37ms
+step:543/1480 train_time:19771ms step_avg:36.41ms
+step:544/1480 train_time:19833ms step_avg:36.46ms
+step:545/1480 train_time:19890ms step_avg:36.50ms
+step:546/1480 train_time:19953ms step_avg:36.54ms
+step:547/1480 train_time:20011ms step_avg:36.58ms
+step:548/1480 train_time:20074ms step_avg:36.63ms
+step:549/1480 train_time:20131ms step_avg:36.67ms
+step:550/1480 train_time:20195ms step_avg:36.72ms
+step:551/1480 train_time:20252ms step_avg:36.75ms
+step:552/1480 train_time:20316ms step_avg:36.80ms
+step:553/1480 train_time:20373ms step_avg:36.84ms
+step:554/1480 train_time:20440ms step_avg:36.89ms
+step:555/1480 train_time:20501ms step_avg:36.94ms
+step:556/1480 train_time:20567ms step_avg:36.99ms
+step:557/1480 train_time:20627ms step_avg:37.03ms
+step:558/1480 train_time:20693ms step_avg:37.09ms
+step:559/1480 train_time:20752ms step_avg:37.12ms
+step:560/1480 train_time:20818ms step_avg:37.17ms
+step:561/1480 train_time:20877ms step_avg:37.21ms
+step:562/1480 train_time:20943ms step_avg:37.27ms
+step:563/1480 train_time:21004ms step_avg:37.31ms
+step:564/1480 train_time:21070ms step_avg:37.36ms
+step:565/1480 train_time:21129ms step_avg:37.40ms
+step:566/1480 train_time:21195ms step_avg:37.45ms
+step:567/1480 train_time:21253ms step_avg:37.48ms
+step:568/1480 train_time:21318ms step_avg:37.53ms
+step:569/1480 train_time:21377ms step_avg:37.57ms
+step:570/1480 train_time:21443ms step_avg:37.62ms
+step:571/1480 train_time:21503ms step_avg:37.66ms
+step:572/1480 train_time:21568ms step_avg:37.71ms
+step:573/1480 train_time:21628ms step_avg:37.74ms
+step:574/1480 train_time:21693ms step_avg:37.79ms
+step:575/1480 train_time:21752ms step_avg:37.83ms
+step:576/1480 train_time:21816ms step_avg:37.87ms
+step:577/1480 train_time:21872ms step_avg:37.91ms
+step:578/1480 train_time:21932ms step_avg:37.94ms
+step:579/1480 train_time:21986ms step_avg:37.97ms
+step:580/1480 train_time:22051ms step_avg:38.02ms
+step:581/1480 train_time:22107ms step_avg:38.05ms
+step:582/1480 train_time:22169ms step_avg:38.09ms
+step:583/1480 train_time:22225ms step_avg:38.12ms
+step:584/1480 train_time:22289ms step_avg:38.17ms
+step:585/1480 train_time:22347ms step_avg:38.20ms
+step:586/1480 train_time:22409ms step_avg:38.24ms
+step:587/1480 train_time:22468ms step_avg:38.28ms
+step:588/1480 train_time:22537ms step_avg:38.33ms
+step:589/1480 train_time:22600ms step_avg:38.37ms
+step:590/1480 train_time:22669ms step_avg:38.42ms
+step:591/1480 train_time:22730ms step_avg:38.46ms
+step:592/1480 train_time:22798ms step_avg:38.51ms
+step:593/1480 train_time:22859ms step_avg:38.55ms
+step:594/1480 train_time:22927ms step_avg:38.60ms
+step:595/1480 train_time:22989ms step_avg:38.64ms
+step:596/1480 train_time:23056ms step_avg:38.68ms
+step:597/1480 train_time:23117ms step_avg:38.72ms
+step:598/1480 train_time:23184ms step_avg:38.77ms
+step:599/1480 train_time:23246ms step_avg:38.81ms
+step:600/1480 train_time:23307ms step_avg:38.85ms
+step:601/1480 train_time:23360ms step_avg:38.87ms
+step:602/1480 train_time:23420ms step_avg:38.90ms
+step:603/1480 train_time:23476ms step_avg:38.93ms
+step:604/1480 train_time:23540ms step_avg:38.97ms
+step:605/1480 train_time:23597ms step_avg:39.00ms
+step:606/1480 train_time:23661ms step_avg:39.04ms
+step:607/1480 train_time:23722ms step_avg:39.08ms
+step:608/1480 train_time:23787ms step_avg:39.12ms
+step:609/1480 train_time:23848ms step_avg:39.16ms
+step:610/1480 train_time:23915ms step_avg:39.20ms
+step:611/1480 train_time:23973ms step_avg:39.24ms
+step:612/1480 train_time:24038ms step_avg:39.28ms
+step:613/1480 train_time:24097ms step_avg:39.31ms
+step:614/1480 train_time:24162ms step_avg:39.35ms
+step:615/1480 train_time:24224ms step_avg:39.39ms
+step:616/1480 train_time:24291ms step_avg:39.43ms
+step:617/1480 train_time:24350ms step_avg:39.47ms
+step:618/1480 train_time:24414ms step_avg:39.51ms
+step:619/1480 train_time:24473ms step_avg:39.54ms
+step:620/1480 train_time:24539ms step_avg:39.58ms
+step:621/1480 train_time:24598ms step_avg:39.61ms
+step:622/1480 train_time:24664ms step_avg:39.65ms
+step:623/1480 train_time:24725ms step_avg:39.69ms
+step:624/1480 train_time:24790ms step_avg:39.73ms
+step:625/1480 train_time:24849ms step_avg:39.76ms
+step:626/1480 train_time:24914ms step_avg:39.80ms
+step:627/1480 train_time:24972ms step_avg:39.83ms
+step:628/1480 train_time:25037ms step_avg:39.87ms
+step:629/1480 train_time:25096ms step_avg:39.90ms
+step:630/1480 train_time:25160ms step_avg:39.94ms
+step:631/1480 train_time:25219ms step_avg:39.97ms
+step:632/1480 train_time:25285ms step_avg:40.01ms
+step:633/1480 train_time:25345ms step_avg:40.04ms
+step:634/1480 train_time:25409ms step_avg:40.08ms
+step:635/1480 train_time:25468ms step_avg:40.11ms
+step:636/1480 train_time:25532ms step_avg:40.14ms
+step:637/1480 train_time:25591ms step_avg:40.17ms
+step:638/1480 train_time:25655ms step_avg:40.21ms
+step:639/1480 train_time:25713ms step_avg:40.24ms
+step:640/1480 train_time:25777ms step_avg:40.28ms
+step:641/1480 train_time:25835ms step_avg:40.30ms
+step:642/1480 train_time:25899ms step_avg:40.34ms
+step:643/1480 train_time:25957ms step_avg:40.37ms
+step:644/1480 train_time:26021ms step_avg:40.41ms
+step:645/1480 train_time:26080ms step_avg:40.43ms
+step:646/1480 train_time:26145ms step_avg:40.47ms
+step:647/1480 train_time:26203ms step_avg:40.50ms
+step:648/1480 train_time:26268ms step_avg:40.54ms
+step:649/1480 train_time:26326ms step_avg:40.56ms
+step:650/1480 train_time:26391ms step_avg:40.60ms
+step:651/1480 train_time:26450ms step_avg:40.63ms
+step:652/1480 train_time:26513ms step_avg:40.66ms
+step:653/1480 train_time:26570ms step_avg:40.69ms
+step:654/1480 train_time:26634ms step_avg:40.73ms
+step:655/1480 train_time:26692ms step_avg:40.75ms
+step:656/1480 train_time:26755ms step_avg:40.79ms
+step:657/1480 train_time:26812ms step_avg:40.81ms
+step:658/1480 train_time:26876ms step_avg:40.84ms
+step:659/1480 train_time:26933ms step_avg:40.87ms
+step:660/1480 train_time:26997ms step_avg:40.90ms
+step:661/1480 train_time:27054ms step_avg:40.93ms
+step:662/1480 train_time:27117ms step_avg:40.96ms
+step:663/1480 train_time:27174ms step_avg:40.99ms
+step:664/1480 train_time:27237ms step_avg:41.02ms
+step:665/1480 train_time:27295ms step_avg:41.04ms
+step:666/1480 train_time:27357ms step_avg:41.08ms
+step:667/1480 train_time:27414ms step_avg:41.10ms
+step:668/1480 train_time:27477ms step_avg:41.13ms
+step:669/1480 train_time:27534ms step_avg:41.16ms
+step:670/1480 train_time:27598ms step_avg:41.19ms
+step:671/1480 train_time:27659ms step_avg:41.22ms
+step:672/1480 train_time:27725ms step_avg:41.26ms
+step:673/1480 train_time:27786ms step_avg:41.29ms
+step:674/1480 train_time:27851ms step_avg:41.32ms
+step:675/1480 train_time:27910ms step_avg:41.35ms
+step:676/1480 train_time:27976ms step_avg:41.39ms
+step:677/1480 train_time:28035ms step_avg:41.41ms
+step:678/1480 train_time:28100ms step_avg:41.45ms
+step:679/1480 train_time:28159ms step_avg:41.47ms
+step:680/1480 train_time:28223ms step_avg:41.51ms
+step:681/1480 train_time:28283ms step_avg:41.53ms
+step:682/1480 train_time:28349ms step_avg:41.57ms
+step:683/1480 train_time:28407ms step_avg:41.59ms
+step:684/1480 train_time:28472ms step_avg:41.63ms
+step:685/1480 train_time:28530ms step_avg:41.65ms
+step:686/1480 train_time:28594ms step_avg:41.68ms
+step:687/1480 train_time:28652ms step_avg:41.71ms
+step:688/1480 train_time:28715ms step_avg:41.74ms
+step:689/1480 train_time:28773ms step_avg:41.76ms
+step:690/1480 train_time:28837ms step_avg:41.79ms
+step:691/1480 train_time:28895ms step_avg:41.82ms
+step:692/1480 train_time:28959ms step_avg:41.85ms
+step:693/1480 train_time:29017ms step_avg:41.87ms
+step:694/1480 train_time:29081ms step_avg:41.90ms
+step:695/1480 train_time:29140ms step_avg:41.93ms
+step:696/1480 train_time:29204ms step_avg:41.96ms
+step:697/1480 train_time:29262ms step_avg:41.98ms
+step:698/1480 train_time:29326ms step_avg:42.01ms
+step:699/1480 train_time:29386ms step_avg:42.04ms
+step:700/1480 train_time:29450ms step_avg:42.07ms
+step:701/1480 train_time:29509ms step_avg:42.10ms
+step:702/1480 train_time:29575ms step_avg:42.13ms
+step:703/1480 train_time:29632ms step_avg:42.15ms
+step:704/1480 train_time:29696ms step_avg:42.18ms
+step:705/1480 train_time:29753ms step_avg:42.20ms
+step:706/1480 train_time:29817ms step_avg:42.23ms
+step:707/1480 train_time:29874ms step_avg:42.25ms
+step:708/1480 train_time:29936ms step_avg:42.28ms
+step:709/1480 train_time:29994ms step_avg:42.30ms
+step:710/1480 train_time:30058ms step_avg:42.34ms
+step:711/1480 train_time:30119ms step_avg:42.36ms
+step:712/1480 train_time:30187ms step_avg:42.40ms
+step:713/1480 train_time:30247ms step_avg:42.42ms
+step:714/1480 train_time:30313ms step_avg:42.46ms
+step:715/1480 train_time:30372ms step_avg:42.48ms
+step:716/1480 train_time:30437ms step_avg:42.51ms
+step:717/1480 train_time:30497ms step_avg:42.53ms
+step:718/1480 train_time:30563ms step_avg:42.57ms
+step:719/1480 train_time:30624ms step_avg:42.59ms
+step:720/1480 train_time:30690ms step_avg:42.63ms
+step:721/1480 train_time:30749ms step_avg:42.65ms
+step:722/1480 train_time:30814ms step_avg:42.68ms
+step:723/1480 train_time:30872ms step_avg:42.70ms
+step:724/1480 train_time:30939ms step_avg:42.73ms
+step:725/1480 train_time:30999ms step_avg:42.76ms
+step:726/1480 train_time:31065ms step_avg:42.79ms
+step:727/1480 train_time:31125ms step_avg:42.81ms
+step:728/1480 train_time:31191ms step_avg:42.84ms
+step:729/1480 train_time:31250ms step_avg:42.87ms
+step:730/1480 train_time:31314ms step_avg:42.90ms
+step:731/1480 train_time:31371ms step_avg:42.92ms
+step:732/1480 train_time:31436ms step_avg:42.95ms
+step:733/1480 train_time:31494ms step_avg:42.97ms
+step:734/1480 train_time:31558ms step_avg:43.00ms
+step:735/1480 train_time:31616ms step_avg:43.02ms
+step:736/1480 train_time:31681ms step_avg:43.04ms
+step:737/1480 train_time:31740ms step_avg:43.07ms
+step:738/1480 train_time:31804ms step_avg:43.10ms
+step:739/1480 train_time:31863ms step_avg:43.12ms
+step:740/1480 train_time:31928ms step_avg:43.15ms
+step:741/1480 train_time:31987ms step_avg:43.17ms
+step:742/1480 train_time:32052ms step_avg:43.20ms
+step:743/1480 train_time:32110ms step_avg:43.22ms
+step:744/1480 train_time:32174ms step_avg:43.25ms
+step:745/1480 train_time:32232ms step_avg:43.26ms
+step:746/1480 train_time:32296ms step_avg:43.29ms
+step:747/1480 train_time:32354ms step_avg:43.31ms
+step:748/1480 train_time:32417ms step_avg:43.34ms
+step:749/1480 train_time:32475ms step_avg:43.36ms
+step:750/1480 train_time:32539ms step_avg:43.39ms
+step:750/1480 val_loss:3.8010 train_time:32621ms step_avg:43.49ms
+step:751/1480 train_time:32641ms step_avg:43.46ms
+step:752/1480 train_time:32663ms step_avg:43.43ms
+step:753/1480 train_time:32721ms step_avg:43.45ms
+step:754/1480 train_time:32789ms step_avg:43.49ms
+step:755/1480 train_time:32849ms step_avg:43.51ms
+step:756/1480 train_time:32914ms step_avg:43.54ms
+step:757/1480 train_time:32974ms step_avg:43.56ms
+step:758/1480 train_time:33040ms step_avg:43.59ms
+step:759/1480 train_time:33098ms step_avg:43.61ms
+step:760/1480 train_time:33162ms step_avg:43.63ms
+step:761/1480 train_time:33221ms step_avg:43.65ms
+step:762/1480 train_time:33285ms step_avg:43.68ms
+step:763/1480 train_time:33344ms step_avg:43.70ms
+step:764/1480 train_time:33411ms step_avg:43.73ms
+step:765/1480 train_time:33471ms step_avg:43.75ms
+step:766/1480 train_time:33537ms step_avg:43.78ms
+step:767/1480 train_time:33596ms step_avg:43.80ms
+step:768/1480 train_time:33660ms step_avg:43.83ms
+step:769/1480 train_time:33718ms step_avg:43.85ms
+step:770/1480 train_time:33782ms step_avg:43.87ms
+step:771/1480 train_time:33841ms step_avg:43.89ms
+step:772/1480 train_time:33905ms step_avg:43.92ms
+step:773/1480 train_time:33963ms step_avg:43.94ms
+step:774/1480 train_time:34027ms step_avg:43.96ms
+step:775/1480 train_time:34086ms step_avg:43.98ms
+step:776/1480 train_time:34151ms step_avg:44.01ms
+step:777/1480 train_time:34209ms step_avg:44.03ms
+step:778/1480 train_time:34274ms step_avg:44.05ms
+step:779/1480 train_time:34333ms step_avg:44.07ms
+step:780/1480 train_time:34398ms step_avg:44.10ms
+step:781/1480 train_time:34456ms step_avg:44.12ms
+step:782/1480 train_time:34519ms step_avg:44.14ms
+step:783/1480 train_time:34577ms step_avg:44.16ms
+step:784/1480 train_time:34641ms step_avg:44.19ms
+step:785/1480 train_time:34699ms step_avg:44.20ms
+step:786/1480 train_time:34763ms step_avg:44.23ms
+step:787/1480 train_time:34820ms step_avg:44.24ms
+step:788/1480 train_time:34884ms step_avg:44.27ms
+step:789/1480 train_time:34943ms step_avg:44.29ms
+step:790/1480 train_time:35006ms step_avg:44.31ms
+step:791/1480 train_time:35063ms step_avg:44.33ms
+step:792/1480 train_time:35127ms step_avg:44.35ms
+step:793/1480 train_time:35186ms step_avg:44.37ms
+step:794/1480 train_time:35250ms step_avg:44.40ms
+step:795/1480 train_time:35308ms step_avg:44.41ms
+step:796/1480 train_time:35374ms step_avg:44.44ms
+step:797/1480 train_time:35434ms step_avg:44.46ms
+step:798/1480 train_time:35498ms step_avg:44.48ms
+step:799/1480 train_time:35556ms step_avg:44.50ms
+step:800/1480 train_time:35620ms step_avg:44.52ms
+step:801/1480 train_time:35678ms step_avg:44.54ms
+step:802/1480 train_time:35744ms step_avg:44.57ms
+step:803/1480 train_time:35800ms step_avg:44.58ms
+step:804/1480 train_time:35863ms step_avg:44.61ms
+step:805/1480 train_time:35920ms step_avg:44.62ms
+step:806/1480 train_time:35986ms step_avg:44.65ms
+step:807/1480 train_time:36045ms step_avg:44.67ms
+step:808/1480 train_time:36108ms step_avg:44.69ms
+step:809/1480 train_time:36167ms step_avg:44.71ms
+step:810/1480 train_time:36235ms step_avg:44.73ms
+step:811/1480 train_time:36296ms step_avg:44.75ms
+step:812/1480 train_time:36362ms step_avg:44.78ms
+step:813/1480 train_time:36422ms step_avg:44.80ms
+step:814/1480 train_time:36489ms step_avg:44.83ms
+step:815/1480 train_time:36551ms step_avg:44.85ms
+step:816/1480 train_time:36617ms step_avg:44.87ms
+step:817/1480 train_time:36676ms step_avg:44.89ms
+step:818/1480 train_time:36742ms step_avg:44.92ms
+step:819/1480 train_time:36796ms step_avg:44.93ms
+step:820/1480 train_time:36858ms step_avg:44.95ms
+step:821/1480 train_time:36916ms step_avg:44.96ms
+step:822/1480 train_time:36981ms step_avg:44.99ms
+step:823/1480 train_time:37039ms step_avg:45.00ms
+step:824/1480 train_time:37104ms step_avg:45.03ms
+step:825/1480 train_time:37162ms step_avg:45.04ms
+step:826/1480 train_time:37224ms step_avg:45.07ms
+step:827/1480 train_time:37282ms step_avg:45.08ms
+step:828/1480 train_time:37345ms step_avg:45.10ms
+step:829/1480 train_time:37403ms step_avg:45.12ms
+step:830/1480 train_time:37467ms step_avg:45.14ms
+step:831/1480 train_time:37525ms step_avg:45.16ms
+step:832/1480 train_time:37591ms step_avg:45.18ms
+step:833/1480 train_time:37651ms step_avg:45.20ms
+step:834/1480 train_time:37715ms step_avg:45.22ms
+step:835/1480 train_time:37773ms step_avg:45.24ms
+step:836/1480 train_time:37838ms step_avg:45.26ms
+step:837/1480 train_time:37896ms step_avg:45.28ms
+step:838/1480 train_time:37959ms step_avg:45.30ms
+step:839/1480 train_time:38017ms step_avg:45.31ms
+step:840/1480 train_time:38081ms step_avg:45.33ms
+step:841/1480 train_time:38138ms step_avg:45.35ms
+step:842/1480 train_time:38202ms step_avg:45.37ms
+step:843/1480 train_time:38259ms step_avg:45.38ms
+step:844/1480 train_time:38323ms step_avg:45.41ms
+step:845/1480 train_time:38380ms step_avg:45.42ms
+step:846/1480 train_time:38443ms step_avg:45.44ms
+step:847/1480 train_time:38499ms step_avg:45.45ms
+step:848/1480 train_time:38564ms step_avg:45.48ms
+step:849/1480 train_time:38621ms step_avg:45.49ms
+step:850/1480 train_time:38686ms step_avg:45.51ms
+step:851/1480 train_time:38744ms step_avg:45.53ms
+step:852/1480 train_time:38809ms step_avg:45.55ms
+step:853/1480 train_time:38870ms step_avg:45.57ms
+step:854/1480 train_time:38936ms step_avg:45.59ms
+step:855/1480 train_time:38994ms step_avg:45.61ms
+step:856/1480 train_time:39058ms step_avg:45.63ms
+step:857/1480 train_time:39117ms step_avg:45.64ms
+step:858/1480 train_time:39182ms step_avg:45.67ms
+step:859/1480 train_time:39242ms step_avg:45.68ms
+step:860/1480 train_time:39305ms step_avg:45.70ms
+step:861/1480 train_time:39363ms step_avg:45.72ms
+step:862/1480 train_time:39426ms step_avg:45.74ms
+step:863/1480 train_time:39484ms step_avg:45.75ms
+step:864/1480 train_time:39546ms step_avg:45.77ms
+step:865/1480 train_time:39604ms step_avg:45.79ms
+step:866/1480 train_time:39666ms step_avg:45.80ms
+step:867/1480 train_time:39724ms step_avg:45.82ms
+step:868/1480 train_time:39787ms step_avg:45.84ms
+step:869/1480 train_time:39846ms step_avg:45.85ms
+step:870/1480 train_time:39912ms step_avg:45.88ms
+step:871/1480 train_time:39973ms step_avg:45.89ms
+step:872/1480 train_time:40039ms step_avg:45.92ms
+step:873/1480 train_time:40098ms step_avg:45.93ms
+step:874/1480 train_time:40163ms step_avg:45.95ms
+step:875/1480 train_time:40222ms step_avg:45.97ms
+step:876/1480 train_time:40288ms step_avg:45.99ms
+step:877/1480 train_time:40348ms step_avg:46.01ms
+step:878/1480 train_time:40414ms step_avg:46.03ms
+step:879/1480 train_time:40474ms step_avg:46.05ms
+step:880/1480 train_time:40540ms step_avg:46.07ms
+step:881/1480 train_time:40598ms step_avg:46.08ms
+step:882/1480 train_time:40663ms step_avg:46.10ms
+step:883/1480 train_time:40721ms step_avg:46.12ms
+step:884/1480 train_time:40787ms step_avg:46.14ms
+step:885/1480 train_time:40847ms step_avg:46.15ms
+step:886/1480 train_time:40913ms step_avg:46.18ms
+step:887/1480 train_time:40972ms step_avg:46.19ms
+step:888/1480 train_time:41038ms step_avg:46.21ms
+step:889/1480 train_time:41097ms step_avg:46.23ms
+step:890/1480 train_time:41161ms step_avg:46.25ms
+step:891/1480 train_time:41219ms step_avg:46.26ms
+step:892/1480 train_time:41283ms step_avg:46.28ms
+step:893/1480 train_time:41342ms step_avg:46.30ms
+step:894/1480 train_time:41409ms step_avg:46.32ms
+step:895/1480 train_time:41469ms step_avg:46.33ms
+step:896/1480 train_time:41533ms step_avg:46.35ms
+step:897/1480 train_time:41593ms step_avg:46.37ms
+step:898/1480 train_time:41658ms step_avg:46.39ms
+step:899/1480 train_time:41716ms step_avg:46.40ms
+step:900/1480 train_time:41780ms step_avg:46.42ms
+step:901/1480 train_time:41838ms step_avg:46.43ms
+step:902/1480 train_time:41902ms step_avg:46.45ms
+step:903/1480 train_time:41959ms step_avg:46.47ms
+step:904/1480 train_time:42022ms step_avg:46.49ms
+step:905/1480 train_time:42080ms step_avg:46.50ms
+step:906/1480 train_time:42144ms step_avg:46.52ms
+step:907/1480 train_time:42202ms step_avg:46.53ms
+step:908/1480 train_time:42266ms step_avg:46.55ms
+step:909/1480 train_time:42324ms step_avg:46.56ms
+step:910/1480 train_time:42387ms step_avg:46.58ms
+step:911/1480 train_time:42446ms step_avg:46.59ms
+step:912/1480 train_time:42510ms step_avg:46.61ms
+step:913/1480 train_time:42571ms step_avg:46.63ms
+step:914/1480 train_time:42637ms step_avg:46.65ms
+step:915/1480 train_time:42695ms step_avg:46.66ms
+step:916/1480 train_time:42760ms step_avg:46.68ms
+step:917/1480 train_time:42818ms step_avg:46.69ms
+step:918/1480 train_time:42882ms step_avg:46.71ms
+step:919/1480 train_time:42941ms step_avg:46.73ms
+step:920/1480 train_time:43005ms step_avg:46.74ms
+step:921/1480 train_time:43062ms step_avg:46.76ms
+step:922/1480 train_time:43127ms step_avg:46.78ms
+step:923/1480 train_time:43186ms step_avg:46.79ms
+step:924/1480 train_time:43251ms step_avg:46.81ms
+step:925/1480 train_time:43310ms step_avg:46.82ms
+step:926/1480 train_time:43374ms step_avg:46.84ms
+step:927/1480 train_time:43433ms step_avg:46.85ms
+step:928/1480 train_time:43500ms step_avg:46.87ms
+step:929/1480 train_time:43556ms step_avg:46.88ms
+step:930/1480 train_time:43621ms step_avg:46.90ms
+step:931/1480 train_time:43682ms step_avg:46.92ms
+step:932/1480 train_time:43752ms step_avg:46.94ms
+step:933/1480 train_time:43809ms step_avg:46.96ms
+step:934/1480 train_time:43873ms step_avg:46.97ms
+step:935/1480 train_time:43931ms step_avg:46.99ms
+step:936/1480 train_time:43997ms step_avg:47.01ms
+step:937/1480 train_time:44054ms step_avg:47.02ms
+step:938/1480 train_time:44117ms step_avg:47.03ms
+step:939/1480 train_time:44174ms step_avg:47.04ms
+step:940/1480 train_time:44238ms step_avg:47.06ms
+step:941/1480 train_time:44295ms step_avg:47.07ms
+step:942/1480 train_time:44359ms step_avg:47.09ms
+step:943/1480 train_time:44417ms step_avg:47.10ms
+step:944/1480 train_time:44480ms step_avg:47.12ms
+step:945/1480 train_time:44539ms step_avg:47.13ms
+step:946/1480 train_time:44604ms step_avg:47.15ms
+step:947/1480 train_time:44662ms step_avg:47.16ms
+step:948/1480 train_time:44727ms step_avg:47.18ms
+step:949/1480 train_time:44785ms step_avg:47.19ms
+step:950/1480 train_time:44850ms step_avg:47.21ms
+step:951/1480 train_time:44909ms step_avg:47.22ms
+step:952/1480 train_time:44973ms step_avg:47.24ms
+step:953/1480 train_time:45033ms step_avg:47.25ms
+step:954/1480 train_time:45096ms step_avg:47.27ms
+step:955/1480 train_time:45153ms step_avg:47.28ms
+step:956/1480 train_time:45215ms step_avg:47.30ms
+step:957/1480 train_time:45272ms step_avg:47.31ms
+step:958/1480 train_time:45336ms step_avg:47.32ms
+step:959/1480 train_time:45395ms step_avg:47.34ms
+step:960/1480 train_time:45459ms step_avg:47.35ms
+step:961/1480 train_time:45520ms step_avg:47.37ms
+step:962/1480 train_time:45607ms step_avg:47.41ms
+step:963/1480 train_time:45695ms step_avg:47.45ms
+step:964/1480 train_time:45788ms step_avg:47.50ms
+step:965/1480 train_time:45875ms step_avg:47.54ms
+step:966/1480 train_time:45969ms step_avg:47.59ms
+step:967/1480 train_time:46057ms step_avg:47.63ms
+step:968/1480 train_time:46151ms step_avg:47.68ms
+step:969/1480 train_time:46238ms step_avg:47.72ms
+step:970/1480 train_time:46331ms step_avg:47.76ms
+step:971/1480 train_time:46419ms step_avg:47.81ms
+step:972/1480 train_time:46509ms step_avg:47.85ms
+step:973/1480 train_time:46593ms step_avg:47.89ms
+step:974/1480 train_time:46683ms step_avg:47.93ms
+step:975/1480 train_time:46768ms step_avg:47.97ms
+step:976/1480 train_time:46861ms step_avg:48.01ms
+step:977/1480 train_time:46950ms step_avg:48.06ms
+step:978/1480 train_time:47045ms step_avg:48.10ms
+step:979/1480 train_time:47135ms step_avg:48.15ms
+step:980/1480 train_time:47232ms step_avg:48.20ms
+step:981/1480 train_time:47322ms step_avg:48.24ms
+step:982/1480 train_time:47419ms step_avg:48.29ms
+step:983/1480 train_time:47507ms step_avg:48.33ms
+step:984/1480 train_time:47603ms step_avg:48.38ms
+step:985/1480 train_time:47692ms step_avg:48.42ms
+step:986/1480 train_time:47787ms step_avg:48.47ms
+step:987/1480 train_time:47874ms step_avg:48.50ms
+step:988/1480 train_time:47962ms step_avg:48.54ms
+step:989/1480 train_time:48048ms step_avg:48.58ms
+step:990/1480 train_time:48139ms step_avg:48.63ms
+step:991/1480 train_time:48223ms step_avg:48.66ms
+step:992/1480 train_time:48319ms step_avg:48.71ms
+step:993/1480 train_time:48408ms step_avg:48.75ms
+step:994/1480 train_time:48504ms step_avg:48.80ms
+step:995/1480 train_time:48596ms step_avg:48.84ms
+step:996/1480 train_time:48694ms step_avg:48.89ms
+step:997/1480 train_time:48787ms step_avg:48.93ms
+step:998/1480 train_time:48884ms step_avg:48.98ms
+step:999/1480 train_time:48975ms step_avg:49.02ms
+step:1000/1480 train_time:49073ms step_avg:49.07ms
+step:1000/1480 val_loss:3.5091 train_time:49174ms step_avg:49.17ms
+step:1001/1480 train_time:49192ms step_avg:49.14ms
+step:1002/1480 train_time:49237ms step_avg:49.14ms
+step:1003/1480 train_time:49319ms step_avg:49.17ms
+step:1004/1480 train_time:49412ms step_avg:49.22ms
+step:1005/1480 train_time:49499ms step_avg:49.25ms
+step:1006/1480 train_time:49593ms step_avg:49.30ms
+step:1007/1480 train_time:49678ms step_avg:49.33ms
+step:1008/1480 train_time:49770ms step_avg:49.37ms
+step:1009/1480 train_time:49856ms step_avg:49.41ms
+step:1010/1480 train_time:49946ms step_avg:49.45ms
+step:1011/1480 train_time:50030ms step_avg:49.49ms
+step:1012/1480 train_time:50123ms step_avg:49.53ms
+step:1013/1480 train_time:50208ms step_avg:49.56ms
+step:1014/1480 train_time:50304ms step_avg:49.61ms
+step:1015/1480 train_time:50390ms step_avg:49.65ms
+step:1016/1480 train_time:50485ms step_avg:49.69ms
+step:1017/1480 train_time:50571ms step_avg:49.73ms
+step:1018/1480 train_time:50665ms step_avg:49.77ms
+step:1019/1480 train_time:50751ms step_avg:49.80ms
+step:1020/1480 train_time:50845ms step_avg:49.85ms
+step:1021/1480 train_time:50932ms step_avg:49.88ms
+step:1022/1480 train_time:51026ms step_avg:49.93ms
+step:1023/1480 train_time:51111ms step_avg:49.96ms
+step:1024/1480 train_time:51203ms step_avg:50.00ms
+step:1025/1480 train_time:51287ms step_avg:50.04ms
+step:1026/1480 train_time:51380ms step_avg:50.08ms
+step:1027/1480 train_time:51465ms step_avg:50.11ms
+step:1028/1480 train_time:51562ms step_avg:50.16ms
+step:1029/1480 train_time:51651ms step_avg:50.20ms
+step:1030/1480 train_time:51748ms step_avg:50.24ms
+step:1031/1480 train_time:51838ms step_avg:50.28ms
+step:1032/1480 train_time:51935ms step_avg:50.32ms
+step:1033/1480 train_time:52025ms step_avg:50.36ms
+step:1034/1480 train_time:52121ms step_avg:50.41ms
+step:1035/1480 train_time:52211ms step_avg:50.44ms
+step:1036/1480 train_time:52306ms step_avg:50.49ms
+step:1037/1480 train_time:52395ms step_avg:50.53ms
+step:1038/1480 train_time:52488ms step_avg:50.57ms
+step:1039/1480 train_time:52569ms step_avg:50.60ms
+step:1040/1480 train_time:52659ms step_avg:50.63ms
+step:1041/1480 train_time:52747ms step_avg:50.67ms
+step:1042/1480 train_time:52836ms step_avg:50.71ms
+step:1043/1480 train_time:52921ms step_avg:50.74ms
+step:1044/1480 train_time:53014ms step_avg:50.78ms
+step:1045/1480 train_time:53102ms step_avg:50.82ms
+step:1046/1480 train_time:53195ms step_avg:50.86ms
+step:1047/1480 train_time:53285ms step_avg:50.89ms
+step:1048/1480 train_time:53380ms step_avg:50.94ms
+step:1049/1480 train_time:53470ms step_avg:50.97ms
+step:1050/1480 train_time:53566ms step_avg:51.02ms
+step:1051/1480 train_time:53655ms step_avg:51.05ms
+step:1052/1480 train_time:53750ms step_avg:51.09ms
+step:1053/1480 train_time:53838ms step_avg:51.13ms
+step:1054/1480 train_time:53933ms step_avg:51.17ms
+step:1055/1480 train_time:54020ms step_avg:51.20ms
+step:1056/1480 train_time:54107ms step_avg:51.24ms
+step:1057/1480 train_time:54200ms step_avg:51.28ms
+step:1058/1480 train_time:54292ms step_avg:51.32ms
+step:1059/1480 train_time:54384ms step_avg:51.35ms
+step:1060/1480 train_time:54479ms step_avg:51.40ms
+step:1061/1480 train_time:54567ms step_avg:51.43ms
+step:1062/1480 train_time:54662ms step_avg:51.47ms
+step:1063/1480 train_time:54749ms step_avg:51.50ms
+step:1064/1480 train_time:54844ms step_avg:51.54ms
+step:1065/1480 train_time:54930ms step_avg:51.58ms
+step:1066/1480 train_time:55025ms step_avg:51.62ms
+step:1067/1480 train_time:55111ms step_avg:51.65ms
+step:1068/1480 train_time:55207ms step_avg:51.69ms
+step:1069/1480 train_time:55293ms step_avg:51.72ms
+step:1070/1480 train_time:55388ms step_avg:51.76ms
+step:1071/1480 train_time:55478ms step_avg:51.80ms
+step:1072/1480 train_time:55573ms step_avg:51.84ms
+step:1073/1480 train_time:55662ms step_avg:51.88ms
+step:1074/1480 train_time:55756ms step_avg:51.91ms
+step:1075/1480 train_time:55846ms step_avg:51.95ms
+step:1076/1480 train_time:55940ms step_avg:51.99ms
+step:1077/1480 train_time:56030ms step_avg:52.02ms
+step:1078/1480 train_time:56122ms step_avg:52.06ms
+step:1079/1480 train_time:56208ms step_avg:52.09ms
+step:1080/1480 train_time:56303ms step_avg:52.13ms
+step:1081/1480 train_time:56389ms step_avg:52.16ms
+step:1082/1480 train_time:56484ms step_avg:52.20ms
+step:1083/1480 train_time:56570ms step_avg:52.23ms
+step:1084/1480 train_time:56664ms step_avg:52.27ms
+step:1085/1480 train_time:56750ms step_avg:52.30ms
+step:1086/1480 train_time:56843ms step_avg:52.34ms
+step:1087/1480 train_time:56930ms step_avg:52.37ms
+step:1088/1480 train_time:57024ms step_avg:52.41ms
+step:1089/1480 train_time:57109ms step_avg:52.44ms
+step:1090/1480 train_time:57203ms step_avg:52.48ms
+step:1091/1480 train_time:57287ms step_avg:52.51ms
+step:1092/1480 train_time:57381ms step_avg:52.55ms
+step:1093/1480 train_time:57467ms step_avg:52.58ms
+step:1094/1480 train_time:57562ms step_avg:52.62ms
+step:1095/1480 train_time:57649ms step_avg:52.65ms
+step:1096/1480 train_time:57743ms step_avg:52.69ms
+step:1097/1480 train_time:57829ms step_avg:52.72ms
+step:1098/1480 train_time:57924ms step_avg:52.75ms
+step:1099/1480 train_time:58009ms step_avg:52.78ms
+step:1100/1480 train_time:58104ms step_avg:52.82ms
+step:1101/1480 train_time:58188ms step_avg:52.85ms
+step:1102/1480 train_time:58282ms step_avg:52.89ms
+step:1103/1480 train_time:58366ms step_avg:52.92ms
+step:1104/1480 train_time:58460ms step_avg:52.95ms
+step:1105/1480 train_time:58546ms step_avg:52.98ms
+step:1106/1480 train_time:58639ms step_avg:53.02ms
+step:1107/1480 train_time:58726ms step_avg:53.05ms
+step:1108/1480 train_time:58817ms step_avg:53.08ms
+step:1109/1480 train_time:58904ms step_avg:53.11ms
+step:1110/1480 train_time:58995ms step_avg:53.15ms
+step:1111/1480 train_time:59081ms step_avg:53.18ms
+step:1112/1480 train_time:59170ms step_avg:53.21ms
+step:1113/1480 train_time:59254ms step_avg:53.24ms
+step:1114/1480 train_time:59344ms step_avg:53.27ms
+step:1115/1480 train_time:59428ms step_avg:53.30ms
+step:1116/1480 train_time:59520ms step_avg:53.33ms
+step:1117/1480 train_time:59605ms step_avg:53.36ms
+step:1118/1480 train_time:59696ms step_avg:53.40ms
+step:1119/1480 train_time:59782ms step_avg:53.42ms
+step:1120/1480 train_time:59873ms step_avg:53.46ms
+step:1121/1480 train_time:59959ms step_avg:53.49ms
+step:1122/1480 train_time:60049ms step_avg:53.52ms
+step:1123/1480 train_time:60135ms step_avg:53.55ms
+step:1124/1480 train_time:60229ms step_avg:53.58ms
+step:1125/1480 train_time:60316ms step_avg:53.61ms
+step:1126/1480 train_time:60407ms step_avg:53.65ms
+step:1127/1480 train_time:60493ms step_avg:53.68ms
+step:1128/1480 train_time:60586ms step_avg:53.71ms
+step:1129/1480 train_time:60672ms step_avg:53.74ms
+step:1130/1480 train_time:60765ms step_avg:53.77ms
+step:1131/1480 train_time:60853ms step_avg:53.80ms
+step:1132/1480 train_time:60947ms step_avg:53.84ms
+step:1133/1480 train_time:61038ms step_avg:53.87ms
+step:1134/1480 train_time:61136ms step_avg:53.91ms
+step:1135/1480 train_time:61228ms step_avg:53.95ms
+step:1136/1480 train_time:61325ms step_avg:53.98ms
+step:1137/1480 train_time:61415ms step_avg:54.02ms
+step:1138/1480 train_time:61513ms step_avg:54.05ms
+step:1139/1480 train_time:61595ms step_avg:54.08ms
+step:1140/1480 train_time:61682ms step_avg:54.11ms
+step:1141/1480 train_time:61767ms step_avg:54.13ms
+step:1142/1480 train_time:61865ms step_avg:54.17ms
+step:1143/1480 train_time:61960ms step_avg:54.21ms
+step:1144/1480 train_time:62054ms step_avg:54.24ms
+step:1145/1480 train_time:62140ms step_avg:54.27ms
+step:1146/1480 train_time:62234ms step_avg:54.31ms
+step:1147/1480 train_time:62319ms step_avg:54.33ms
+step:1148/1480 train_time:62410ms step_avg:54.36ms
+step:1149/1480 train_time:62499ms step_avg:54.39ms
+step:1150/1480 train_time:62592ms step_avg:54.43ms
+step:1151/1480 train_time:62678ms step_avg:54.46ms
+step:1152/1480 train_time:62771ms step_avg:54.49ms
+step:1153/1480 train_time:62859ms step_avg:54.52ms
+step:1154/1480 train_time:62952ms step_avg:54.55ms
+step:1155/1480 train_time:63041ms step_avg:54.58ms
+step:1156/1480 train_time:63135ms step_avg:54.62ms
+step:1157/1480 train_time:63223ms step_avg:54.64ms
+step:1158/1480 train_time:63318ms step_avg:54.68ms
+step:1159/1480 train_time:63406ms step_avg:54.71ms
+step:1160/1480 train_time:63500ms step_avg:54.74ms
+step:1161/1480 train_time:63587ms step_avg:54.77ms
+step:1162/1480 train_time:63681ms step_avg:54.80ms
+step:1163/1480 train_time:63768ms step_avg:54.83ms
+step:1164/1480 train_time:63862ms step_avg:54.86ms
+step:1165/1480 train_time:63950ms step_avg:54.89ms
+step:1166/1480 train_time:64044ms step_avg:54.93ms
+step:1167/1480 train_time:64131ms step_avg:54.95ms
+step:1168/1480 train_time:64225ms step_avg:54.99ms
+step:1169/1480 train_time:64310ms step_avg:55.01ms
+step:1170/1480 train_time:64405ms step_avg:55.05ms
+step:1171/1480 train_time:64490ms step_avg:55.07ms
+step:1172/1480 train_time:64584ms step_avg:55.11ms
+step:1173/1480 train_time:64670ms step_avg:55.13ms
+step:1174/1480 train_time:64765ms step_avg:55.17ms
+step:1175/1480 train_time:64849ms step_avg:55.19ms
+step:1176/1480 train_time:64941ms step_avg:55.22ms
+step:1177/1480 train_time:65025ms step_avg:55.25ms
+step:1178/1480 train_time:65115ms step_avg:55.28ms
+step:1179/1480 train_time:65200ms step_avg:55.30ms
+step:1180/1480 train_time:65290ms step_avg:55.33ms
+step:1181/1480 train_time:65376ms step_avg:55.36ms
+step:1182/1480 train_time:65469ms step_avg:55.39ms
+step:1183/1480 train_time:65557ms step_avg:55.42ms
+step:1184/1480 train_time:65651ms step_avg:55.45ms
+step:1185/1480 train_time:65740ms step_avg:55.48ms
+step:1186/1480 train_time:65835ms step_avg:55.51ms
+step:1187/1480 train_time:65923ms step_avg:55.54ms
+step:1188/1480 train_time:66018ms step_avg:55.57ms
+step:1189/1480 train_time:66106ms step_avg:55.60ms
+step:1190/1480 train_time:66200ms step_avg:55.63ms
+step:1191/1480 train_time:66288ms step_avg:55.66ms
+step:1192/1480 train_time:66382ms step_avg:55.69ms
+step:1193/1480 train_time:66469ms step_avg:55.72ms
+step:1194/1480 train_time:66565ms step_avg:55.75ms
+step:1195/1480 train_time:66651ms step_avg:55.77ms
+step:1196/1480 train_time:66745ms step_avg:55.81ms
+step:1197/1480 train_time:66832ms step_avg:55.83ms
+step:1198/1480 train_time:66926ms step_avg:55.86ms
+step:1199/1480 train_time:67013ms step_avg:55.89ms
+step:1200/1480 train_time:67107ms step_avg:55.92ms
+step:1201/1480 train_time:67193ms step_avg:55.95ms
+step:1202/1480 train_time:67286ms step_avg:55.98ms
+step:1203/1480 train_time:67372ms step_avg:56.00ms
+step:1204/1480 train_time:67466ms step_avg:56.03ms
+step:1205/1480 train_time:67552ms step_avg:56.06ms
+step:1206/1480 train_time:67645ms step_avg:56.09ms
+step:1207/1480 train_time:67731ms step_avg:56.12ms
+step:1208/1480 train_time:67825ms step_avg:56.15ms
+step:1209/1480 train_time:67910ms step_avg:56.17ms
+step:1210/1480 train_time:68005ms step_avg:56.20ms
+step:1211/1480 train_time:68090ms step_avg:56.23ms
+step:1212/1480 train_time:68181ms step_avg:56.25ms
+step:1213/1480 train_time:68264ms step_avg:56.28ms
+step:1214/1480 train_time:68354ms step_avg:56.30ms
+step:1215/1480 train_time:68437ms step_avg:56.33ms
+step:1216/1480 train_time:68531ms step_avg:56.36ms
+step:1217/1480 train_time:68619ms step_avg:56.38ms
+step:1218/1480 train_time:68710ms step_avg:56.41ms
+step:1219/1480 train_time:68797ms step_avg:56.44ms
+step:1220/1480 train_time:68891ms step_avg:56.47ms
+step:1221/1480 train_time:68981ms step_avg:56.50ms
+step:1222/1480 train_time:69075ms step_avg:56.53ms
+step:1223/1480 train_time:69165ms step_avg:56.55ms
+step:1224/1480 train_time:69260ms step_avg:56.59ms
+step:1225/1480 train_time:69348ms step_avg:56.61ms
+step:1226/1480 train_time:69444ms step_avg:56.64ms
+step:1227/1480 train_time:69531ms step_avg:56.67ms
+step:1228/1480 train_time:69626ms step_avg:56.70ms
+step:1229/1480 train_time:69713ms step_avg:56.72ms
+step:1230/1480 train_time:69808ms step_avg:56.75ms
+step:1231/1480 train_time:69896ms step_avg:56.78ms
+step:1232/1480 train_time:69989ms step_avg:56.81ms
+step:1233/1480 train_time:70076ms step_avg:56.83ms
+step:1234/1480 train_time:70171ms step_avg:56.86ms
+step:1235/1480 train_time:70257ms step_avg:56.89ms
+step:1236/1480 train_time:70350ms step_avg:56.92ms
+step:1237/1480 train_time:70437ms step_avg:56.94ms
+step:1238/1480 train_time:70530ms step_avg:56.97ms
+step:1239/1480 train_time:70617ms step_avg:57.00ms
+step:1240/1480 train_time:70711ms step_avg:57.03ms
+step:1241/1480 train_time:70798ms step_avg:57.05ms
+step:1242/1480 train_time:70891ms step_avg:57.08ms
+step:1243/1480 train_time:70978ms step_avg:57.10ms
+step:1244/1480 train_time:71072ms step_avg:57.13ms
+step:1245/1480 train_time:71160ms step_avg:57.16ms
+step:1246/1480 train_time:71252ms step_avg:57.18ms
+step:1247/1480 train_time:71338ms step_avg:57.21ms
+step:1248/1480 train_time:71432ms step_avg:57.24ms
+step:1249/1480 train_time:71518ms step_avg:57.26ms
+step:1250/1480 train_time:71613ms step_avg:57.29ms
+step:1250/1480 val_loss:3.3664 train_time:71731ms step_avg:57.38ms
+step:1251/1480 train_time:71749ms step_avg:57.35ms
+step:1252/1480 train_time:71793ms step_avg:57.34ms
+step:1253/1480 train_time:71879ms step_avg:57.37ms
+step:1254/1480 train_time:71978ms step_avg:57.40ms
+step:1255/1480 train_time:72064ms step_avg:57.42ms
+step:1256/1480 train_time:72159ms step_avg:57.45ms
+step:1257/1480 train_time:72247ms step_avg:57.48ms
+step:1258/1480 train_time:72339ms step_avg:57.50ms
+step:1259/1480 train_time:72427ms step_avg:57.53ms
+step:1260/1480 train_time:72521ms step_avg:57.56ms
+step:1261/1480 train_time:72609ms step_avg:57.58ms
+step:1262/1480 train_time:72704ms step_avg:57.61ms
+step:1263/1480 train_time:72792ms step_avg:57.63ms
+step:1264/1480 train_time:72884ms step_avg:57.66ms
+step:1265/1480 train_time:72971ms step_avg:57.68ms
+step:1266/1480 train_time:73064ms step_avg:57.71ms
+step:1267/1480 train_time:73151ms step_avg:57.74ms
+step:1268/1480 train_time:73244ms step_avg:57.76ms
+step:1269/1480 train_time:73331ms step_avg:57.79ms
+step:1270/1480 train_time:73423ms step_avg:57.81ms
+step:1271/1480 train_time:73511ms step_avg:57.84ms
+step:1272/1480 train_time:73603ms step_avg:57.86ms
+step:1273/1480 train_time:73690ms step_avg:57.89ms
+step:1274/1480 train_time:73782ms step_avg:57.91ms
+step:1275/1480 train_time:73868ms step_avg:57.94ms
+step:1276/1480 train_time:73961ms step_avg:57.96ms
+step:1277/1480 train_time:74048ms step_avg:57.99ms
+step:1278/1480 train_time:74138ms step_avg:58.01ms
+step:1279/1480 train_time:74222ms step_avg:58.03ms
+step:1280/1480 train_time:74312ms step_avg:58.06ms
+step:1281/1480 train_time:74395ms step_avg:58.08ms
+step:1282/1480 train_time:74487ms step_avg:58.10ms
+step:1283/1480 train_time:74573ms step_avg:58.12ms
+step:1284/1480 train_time:74664ms step_avg:58.15ms
+step:1285/1480 train_time:74750ms step_avg:58.17ms
+step:1286/1480 train_time:74841ms step_avg:58.20ms
+step:1287/1480 train_time:74928ms step_avg:58.22ms
+step:1288/1480 train_time:75019ms step_avg:58.24ms
+step:1289/1480 train_time:75109ms step_avg:58.27ms
+step:1290/1480 train_time:75205ms step_avg:58.30ms
+step:1291/1480 train_time:75292ms step_avg:58.32ms
+step:1292/1480 train_time:75385ms step_avg:58.35ms
+step:1293/1480 train_time:75472ms step_avg:58.37ms
+step:1294/1480 train_time:75562ms step_avg:58.39ms
+step:1295/1480 train_time:75648ms step_avg:58.42ms
+step:1296/1480 train_time:75738ms step_avg:58.44ms
+step:1297/1480 train_time:75822ms step_avg:58.46ms
+step:1298/1480 train_time:75914ms step_avg:58.49ms
+step:1299/1480 train_time:76002ms step_avg:58.51ms
+step:1300/1480 train_time:76097ms step_avg:58.54ms
+step:1301/1480 train_time:76184ms step_avg:58.56ms
+step:1302/1480 train_time:76277ms step_avg:58.58ms
+step:1303/1480 train_time:76364ms step_avg:58.61ms
+step:1304/1480 train_time:76459ms step_avg:58.63ms
+step:1305/1480 train_time:76545ms step_avg:58.66ms
+step:1306/1480 train_time:76639ms step_avg:58.68ms
+step:1307/1480 train_time:76727ms step_avg:58.70ms
+step:1308/1480 train_time:76820ms step_avg:58.73ms
+step:1309/1480 train_time:76907ms step_avg:58.75ms
+step:1310/1480 train_time:76998ms step_avg:58.78ms
+step:1311/1480 train_time:77082ms step_avg:58.80ms
+step:1312/1480 train_time:77173ms step_avg:58.82ms
+step:1313/1480 train_time:77257ms step_avg:58.84ms
+step:1314/1480 train_time:77349ms step_avg:58.87ms
+step:1315/1480 train_time:77436ms step_avg:58.89ms
+step:1316/1480 train_time:77529ms step_avg:58.91ms
+step:1317/1480 train_time:77615ms step_avg:58.93ms
+step:1318/1480 train_time:77707ms step_avg:58.96ms
+step:1319/1480 train_time:77793ms step_avg:58.98ms
+step:1320/1480 train_time:77884ms step_avg:59.00ms
+step:1321/1480 train_time:77973ms step_avg:59.03ms
+step:1322/1480 train_time:78070ms step_avg:59.05ms
+step:1323/1480 train_time:78162ms step_avg:59.08ms
+step:1324/1480 train_time:78259ms step_avg:59.11ms
+step:1325/1480 train_time:78350ms step_avg:59.13ms
+step:1326/1480 train_time:78447ms step_avg:59.16ms
+step:1327/1480 train_time:78538ms step_avg:59.18ms
+step:1328/1480 train_time:78636ms step_avg:59.21ms
+step:1329/1480 train_time:78726ms step_avg:59.24ms
+step:1330/1480 train_time:78823ms step_avg:59.27ms
+step:1331/1480 train_time:78914ms step_avg:59.29ms
+step:1332/1480 train_time:79003ms step_avg:59.31ms
+step:1333/1480 train_time:79086ms step_avg:59.33ms
+step:1334/1480 train_time:79174ms step_avg:59.35ms
+step:1335/1480 train_time:79259ms step_avg:59.37ms
+step:1336/1480 train_time:79356ms step_avg:59.40ms
+step:1337/1480 train_time:79446ms step_avg:59.42ms
+step:1338/1480 train_time:79545ms step_avg:59.45ms
+step:1339/1480 train_time:79634ms step_avg:59.47ms
+step:1340/1480 train_time:79725ms step_avg:59.50ms
+step:1341/1480 train_time:79812ms step_avg:59.52ms
+step:1342/1480 train_time:79907ms step_avg:59.54ms
+step:1343/1480 train_time:79997ms step_avg:59.57ms
+step:1344/1480 train_time:80094ms step_avg:59.59ms
+step:1345/1480 train_time:80182ms step_avg:59.61ms
+step:1346/1480 train_time:80276ms step_avg:59.64ms
+step:1347/1480 train_time:80364ms step_avg:59.66ms
+step:1348/1480 train_time:80458ms step_avg:59.69ms
+step:1349/1480 train_time:80546ms step_avg:59.71ms
+step:1350/1480 train_time:80640ms step_avg:59.73ms
+step:1351/1480 train_time:80728ms step_avg:59.75ms
+step:1352/1480 train_time:80822ms step_avg:59.78ms
+step:1353/1480 train_time:80909ms step_avg:59.80ms
+step:1354/1480 train_time:81001ms step_avg:59.82ms
+step:1355/1480 train_time:81091ms step_avg:59.85ms
+step:1356/1480 train_time:81185ms step_avg:59.87ms
+step:1357/1480 train_time:81266ms step_avg:59.89ms
+step:1358/1480 train_time:81363ms step_avg:59.91ms
+step:1359/1480 train_time:81453ms step_avg:59.94ms
+step:1360/1480 train_time:81544ms step_avg:59.96ms
+step:1361/1480 train_time:81633ms step_avg:59.98ms
+step:1362/1480 train_time:81727ms step_avg:60.01ms
+step:1363/1480 train_time:81815ms step_avg:60.03ms
+step:1364/1480 train_time:81908ms step_avg:60.05ms
+step:1365/1480 train_time:81994ms step_avg:60.07ms
+step:1366/1480 train_time:82088ms step_avg:60.09ms
+step:1367/1480 train_time:82174ms step_avg:60.11ms
+step:1368/1480 train_time:82268ms step_avg:60.14ms
+step:1369/1480 train_time:82356ms step_avg:60.16ms
+step:1370/1480 train_time:82449ms step_avg:60.18ms
+step:1371/1480 train_time:82535ms step_avg:60.20ms
+step:1372/1480 train_time:82629ms step_avg:60.23ms
+step:1373/1480 train_time:82715ms step_avg:60.24ms
+step:1374/1480 train_time:82809ms step_avg:60.27ms
+step:1375/1480 train_time:82895ms step_avg:60.29ms
+step:1376/1480 train_time:82988ms step_avg:60.31ms
+step:1377/1480 train_time:83074ms step_avg:60.33ms
+step:1378/1480 train_time:83166ms step_avg:60.35ms
+step:1379/1480 train_time:83253ms step_avg:60.37ms
+step:1380/1480 train_time:83344ms step_avg:60.39ms
+step:1381/1480 train_time:83431ms step_avg:60.41ms
+step:1382/1480 train_time:83523ms step_avg:60.44ms
+step:1383/1480 train_time:83609ms step_avg:60.45ms
+step:1384/1480 train_time:83701ms step_avg:60.48ms
+step:1385/1480 train_time:83789ms step_avg:60.50ms
+step:1386/1480 train_time:83881ms step_avg:60.52ms
+step:1387/1480 train_time:83967ms step_avg:60.54ms
+step:1388/1480 train_time:84058ms step_avg:60.56ms
+step:1389/1480 train_time:84144ms step_avg:60.58ms
+step:1390/1480 train_time:84237ms step_avg:60.60ms
+step:1391/1480 train_time:84323ms step_avg:60.62ms
+step:1392/1480 train_time:84417ms step_avg:60.64ms
+step:1393/1480 train_time:84502ms step_avg:60.66ms
+step:1394/1480 train_time:84593ms step_avg:60.68ms
+step:1395/1480 train_time:84677ms step_avg:60.70ms
+step:1396/1480 train_time:84768ms step_avg:60.72ms
+step:1397/1480 train_time:84854ms step_avg:60.74ms
+step:1398/1480 train_time:84950ms step_avg:60.77ms
+step:1399/1480 train_time:85039ms step_avg:60.79ms
+step:1400/1480 train_time:85134ms step_avg:60.81ms
+step:1401/1480 train_time:85223ms step_avg:60.83ms
+step:1402/1480 train_time:85320ms step_avg:60.86ms
+step:1403/1480 train_time:85409ms step_avg:60.88ms
+step:1404/1480 train_time:85505ms step_avg:60.90ms
+step:1405/1480 train_time:85595ms step_avg:60.92ms
+step:1406/1480 train_time:85691ms step_avg:60.95ms
+step:1407/1480 train_time:85771ms step_avg:60.96ms
+step:1408/1480 train_time:85860ms step_avg:60.98ms
+step:1409/1480 train_time:85953ms step_avg:61.00ms
+step:1410/1480 train_time:86051ms step_avg:61.03ms
+step:1411/1480 train_time:86150ms step_avg:61.06ms
+step:1412/1480 train_time:86245ms step_avg:61.08ms
+step:1413/1480 train_time:86332ms step_avg:61.10ms
+step:1414/1480 train_time:86425ms step_avg:61.12ms
+step:1415/1480 train_time:86511ms step_avg:61.14ms
+step:1416/1480 train_time:86603ms step_avg:61.16ms
+step:1417/1480 train_time:86689ms step_avg:61.18ms
+step:1418/1480 train_time:86783ms step_avg:61.20ms
+step:1419/1480 train_time:86874ms step_avg:61.22ms
+step:1420/1480 train_time:86970ms step_avg:61.25ms
+step:1421/1480 train_time:87061ms step_avg:61.27ms
+step:1422/1480 train_time:87158ms step_avg:61.29ms
+step:1423/1480 train_time:87249ms step_avg:61.31ms
+step:1424/1480 train_time:87344ms step_avg:61.34ms
+step:1425/1480 train_time:87434ms step_avg:61.36ms
+step:1426/1480 train_time:87530ms step_avg:61.38ms
+step:1427/1480 train_time:87611ms step_avg:61.40ms
+step:1428/1480 train_time:87701ms step_avg:61.42ms
+step:1429/1480 train_time:87789ms step_avg:61.43ms
+step:1430/1480 train_time:87881ms step_avg:61.46ms
+step:1431/1480 train_time:87967ms step_avg:61.47ms
+step:1432/1480 train_time:88058ms step_avg:61.49ms
+step:1433/1480 train_time:88145ms step_avg:61.51ms
+step:1434/1480 train_time:88236ms step_avg:61.53ms
+step:1435/1480 train_time:88323ms step_avg:61.55ms
+step:1436/1480 train_time:88420ms step_avg:61.57ms
+step:1437/1480 train_time:88508ms step_avg:61.59ms
+step:1438/1480 train_time:88599ms step_avg:61.61ms
+step:1439/1480 train_time:88689ms step_avg:61.63ms
+step:1440/1480 train_time:88781ms step_avg:61.65ms
+step:1441/1480 train_time:88872ms step_avg:61.67ms
+step:1442/1480 train_time:88969ms step_avg:61.70ms
+step:1443/1480 train_time:89058ms step_avg:61.72ms
+step:1444/1480 train_time:89153ms step_avg:61.74ms
+step:1445/1480 train_time:89240ms step_avg:61.76ms
+step:1446/1480 train_time:89336ms step_avg:61.78ms
+step:1447/1480 train_time:89423ms step_avg:61.80ms
+step:1448/1480 train_time:89518ms step_avg:61.82ms
+step:1449/1480 train_time:89606ms step_avg:61.84ms
+step:1450/1480 train_time:89700ms step_avg:61.86ms
+step:1451/1480 train_time:89788ms step_avg:61.88ms
+step:1452/1480 train_time:89882ms step_avg:61.90ms
+step:1453/1480 train_time:89971ms step_avg:61.92ms
+step:1454/1480 train_time:90065ms step_avg:61.94ms
+step:1455/1480 train_time:90154ms step_avg:61.96ms
+step:1456/1480 train_time:90249ms step_avg:61.98ms
+step:1457/1480 train_time:90337ms step_avg:62.00ms
+step:1458/1480 train_time:90432ms step_avg:62.02ms
+step:1459/1480 train_time:90518ms step_avg:62.04ms
+step:1460/1480 train_time:90613ms step_avg:62.06ms
+step:1461/1480 train_time:90699ms step_avg:62.08ms
+step:1462/1480 train_time:90794ms step_avg:62.10ms
+step:1463/1480 train_time:90880ms step_avg:62.12ms
+step:1464/1480 train_time:90974ms step_avg:62.14ms
+step:1465/1480 train_time:91060ms step_avg:62.16ms
+step:1466/1480 train_time:91152ms step_avg:62.18ms
+step:1467/1480 train_time:91235ms step_avg:62.19ms
+step:1468/1480 train_time:91327ms step_avg:62.21ms
+step:1469/1480 train_time:91412ms step_avg:62.23ms
+step:1470/1480 train_time:91508ms step_avg:62.25ms
+step:1471/1480 train_time:91598ms step_avg:62.27ms
+step:1472/1480 train_time:91695ms step_avg:62.29ms
+step:1473/1480 train_time:91786ms step_avg:62.31ms
+step:1474/1480 train_time:91883ms step_avg:62.34ms
+step:1475/1480 train_time:91974ms step_avg:62.36ms
+step:1476/1480 train_time:92071ms step_avg:62.38ms
+step:1477/1480 train_time:92161ms step_avg:62.40ms
+step:1478/1480 train_time:92259ms step_avg:62.42ms
+step:1479/1480 train_time:92348ms step_avg:62.44ms
+step:1480/1480 train_time:92444ms step_avg:62.46ms
+step:1480/1480 val_loss:3.2775 train_time:92550ms step_avg:62.53ms
+peak memory allocated: 31315 MiB reserved: 47222 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline7-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/baseline7-1480.txt
@@ -1,0 +1,4447 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:36:47 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   36C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   41C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   36C    P0            126W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   41C    P0            125W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   36C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   37C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   67C    P0            151W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          406878      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          406879      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          406880      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          406881      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          406882      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          406883      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          406884      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          406885      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8311 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:87ms step_avg:87.49ms
+step:2/1480 train_time:116ms step_avg:57.82ms
+step:3/1480 train_time:135ms step_avg:45.03ms
+step:4/1480 train_time:159ms step_avg:39.75ms
+step:5/1480 train_time:182ms step_avg:36.40ms
+step:6/1480 train_time:217ms step_avg:36.11ms
+step:7/1480 train_time:244ms step_avg:34.83ms
+step:8/1480 train_time:280ms step_avg:34.94ms
+step:9/1480 train_time:306ms step_avg:34.02ms
+step:10/1480 train_time:342ms step_avg:34.16ms
+step:11/1480 train_time:369ms step_avg:33.53ms
+step:12/1480 train_time:404ms step_avg:33.67ms
+step:13/1480 train_time:432ms step_avg:33.22ms
+step:14/1480 train_time:467ms step_avg:33.35ms
+step:15/1480 train_time:495ms step_avg:33.00ms
+step:16/1480 train_time:530ms step_avg:33.12ms
+step:17/1480 train_time:558ms step_avg:32.83ms
+step:18/1480 train_time:593ms step_avg:32.94ms
+step:19/1480 train_time:621ms step_avg:32.68ms
+step:20/1480 train_time:656ms step_avg:32.79ms
+step:21/1480 train_time:684ms step_avg:32.56ms
+step:22/1480 train_time:719ms step_avg:32.68ms
+step:23/1480 train_time:746ms step_avg:32.45ms
+step:24/1480 train_time:783ms step_avg:32.61ms
+step:25/1480 train_time:811ms step_avg:32.44ms
+step:26/1480 train_time:847ms step_avg:32.56ms
+step:27/1480 train_time:877ms step_avg:32.47ms
+step:28/1480 train_time:913ms step_avg:32.61ms
+step:29/1480 train_time:942ms step_avg:32.49ms
+step:30/1480 train_time:979ms step_avg:32.63ms
+step:31/1480 train_time:1008ms step_avg:32.53ms
+step:32/1480 train_time:1045ms step_avg:32.66ms
+step:33/1480 train_time:1074ms step_avg:32.54ms
+step:34/1480 train_time:1110ms step_avg:32.64ms
+step:35/1480 train_time:1139ms step_avg:32.55ms
+step:36/1480 train_time:1176ms step_avg:32.65ms
+step:37/1480 train_time:1204ms step_avg:32.54ms
+step:38/1480 train_time:1240ms step_avg:32.64ms
+step:39/1480 train_time:1269ms step_avg:32.54ms
+step:40/1480 train_time:1305ms step_avg:32.63ms
+step:41/1480 train_time:1334ms step_avg:32.55ms
+step:42/1480 train_time:1371ms step_avg:32.63ms
+step:43/1480 train_time:1400ms step_avg:32.56ms
+step:44/1480 train_time:1436ms step_avg:32.64ms
+step:45/1480 train_time:1465ms step_avg:32.55ms
+step:46/1480 train_time:1501ms step_avg:32.63ms
+step:47/1480 train_time:1530ms step_avg:32.55ms
+step:48/1480 train_time:1566ms step_avg:32.63ms
+step:49/1480 train_time:1596ms step_avg:32.57ms
+step:50/1480 train_time:1632ms step_avg:32.63ms
+step:51/1480 train_time:1661ms step_avg:32.56ms
+step:52/1480 train_time:1697ms step_avg:32.64ms
+step:53/1480 train_time:1726ms step_avg:32.57ms
+step:54/1480 train_time:1762ms step_avg:32.64ms
+step:55/1480 train_time:1791ms step_avg:32.57ms
+step:56/1480 train_time:1828ms step_avg:32.64ms
+step:57/1480 train_time:1857ms step_avg:32.58ms
+step:58/1480 train_time:1892ms step_avg:32.63ms
+step:59/1480 train_time:1922ms step_avg:32.58ms
+step:60/1480 train_time:1958ms step_avg:32.63ms
+step:61/1480 train_time:1987ms step_avg:32.57ms
+step:62/1480 train_time:2023ms step_avg:32.63ms
+step:63/1480 train_time:2052ms step_avg:32.57ms
+step:64/1480 train_time:2088ms step_avg:32.62ms
+step:65/1480 train_time:2117ms step_avg:32.57ms
+step:66/1480 train_time:2152ms step_avg:32.61ms
+step:67/1480 train_time:2181ms step_avg:32.56ms
+step:68/1480 train_time:2217ms step_avg:32.60ms
+step:69/1480 train_time:2246ms step_avg:32.55ms
+step:70/1480 train_time:2282ms step_avg:32.60ms
+step:71/1480 train_time:2311ms step_avg:32.54ms
+step:72/1480 train_time:2347ms step_avg:32.60ms
+step:73/1480 train_time:2376ms step_avg:32.55ms
+step:74/1480 train_time:2412ms step_avg:32.60ms
+step:75/1480 train_time:2441ms step_avg:32.55ms
+step:76/1480 train_time:2477ms step_avg:32.60ms
+step:77/1480 train_time:2506ms step_avg:32.55ms
+step:78/1480 train_time:2543ms step_avg:32.60ms
+step:79/1480 train_time:2571ms step_avg:32.55ms
+step:80/1480 train_time:2607ms step_avg:32.59ms
+step:81/1480 train_time:2637ms step_avg:32.55ms
+step:82/1480 train_time:2672ms step_avg:32.59ms
+step:83/1480 train_time:2701ms step_avg:32.55ms
+step:84/1480 train_time:2738ms step_avg:32.59ms
+step:85/1480 train_time:2766ms step_avg:32.54ms
+step:86/1480 train_time:2802ms step_avg:32.58ms
+step:87/1480 train_time:2831ms step_avg:32.54ms
+step:88/1480 train_time:2867ms step_avg:32.58ms
+step:89/1480 train_time:2897ms step_avg:32.55ms
+step:90/1480 train_time:2933ms step_avg:32.59ms
+step:91/1480 train_time:2962ms step_avg:32.55ms
+step:92/1480 train_time:2998ms step_avg:32.59ms
+step:93/1480 train_time:3027ms step_avg:32.55ms
+step:94/1480 train_time:3063ms step_avg:32.59ms
+step:95/1480 train_time:3092ms step_avg:32.55ms
+step:96/1480 train_time:3128ms step_avg:32.58ms
+step:97/1480 train_time:3157ms step_avg:32.55ms
+step:98/1480 train_time:3193ms step_avg:32.58ms
+step:99/1480 train_time:3222ms step_avg:32.55ms
+step:100/1480 train_time:3258ms step_avg:32.58ms
+step:101/1480 train_time:3287ms step_avg:32.54ms
+step:102/1480 train_time:3323ms step_avg:32.58ms
+step:103/1480 train_time:3352ms step_avg:32.54ms
+step:104/1480 train_time:3388ms step_avg:32.58ms
+step:105/1480 train_time:3417ms step_avg:32.55ms
+step:106/1480 train_time:3453ms step_avg:32.58ms
+step:107/1480 train_time:3482ms step_avg:32.54ms
+step:108/1480 train_time:3522ms step_avg:32.61ms
+step:109/1480 train_time:3554ms step_avg:32.61ms
+step:110/1480 train_time:3593ms step_avg:32.66ms
+step:111/1480 train_time:3626ms step_avg:32.66ms
+step:112/1480 train_time:3665ms step_avg:32.72ms
+step:113/1480 train_time:3697ms step_avg:32.72ms
+step:114/1480 train_time:3735ms step_avg:32.76ms
+step:115/1480 train_time:3762ms step_avg:32.71ms
+step:116/1480 train_time:3797ms step_avg:32.73ms
+step:117/1480 train_time:3824ms step_avg:32.69ms
+step:118/1480 train_time:3859ms step_avg:32.71ms
+step:119/1480 train_time:3887ms step_avg:32.66ms
+step:120/1480 train_time:3924ms step_avg:32.70ms
+step:121/1480 train_time:3954ms step_avg:32.68ms
+step:122/1480 train_time:3991ms step_avg:32.71ms
+step:123/1480 train_time:4019ms step_avg:32.68ms
+step:124/1480 train_time:4055ms step_avg:32.70ms
+step:125/1480 train_time:4084ms step_avg:32.67ms
+step:126/1480 train_time:4120ms step_avg:32.70ms
+step:127/1480 train_time:4149ms step_avg:32.67ms
+step:128/1480 train_time:4185ms step_avg:32.70ms
+step:129/1480 train_time:4214ms step_avg:32.67ms
+step:130/1480 train_time:4250ms step_avg:32.69ms
+step:131/1480 train_time:4280ms step_avg:32.67ms
+step:132/1480 train_time:4316ms step_avg:32.70ms
+step:133/1480 train_time:4344ms step_avg:32.67ms
+step:134/1480 train_time:4381ms step_avg:32.69ms
+step:135/1480 train_time:4409ms step_avg:32.66ms
+step:136/1480 train_time:4445ms step_avg:32.69ms
+step:137/1480 train_time:4474ms step_avg:32.66ms
+step:138/1480 train_time:4511ms step_avg:32.69ms
+step:139/1480 train_time:4540ms step_avg:32.66ms
+step:140/1480 train_time:4576ms step_avg:32.69ms
+step:141/1480 train_time:4605ms step_avg:32.66ms
+step:142/1480 train_time:4641ms step_avg:32.68ms
+step:143/1480 train_time:4670ms step_avg:32.65ms
+step:144/1480 train_time:4706ms step_avg:32.68ms
+step:145/1480 train_time:4735ms step_avg:32.65ms
+step:146/1480 train_time:4771ms step_avg:32.67ms
+step:147/1480 train_time:4800ms step_avg:32.65ms
+step:148/1480 train_time:4836ms step_avg:32.68ms
+step:149/1480 train_time:4865ms step_avg:32.65ms
+step:150/1480 train_time:4901ms step_avg:32.67ms
+step:151/1480 train_time:4930ms step_avg:32.65ms
+step:152/1480 train_time:4966ms step_avg:32.67ms
+step:153/1480 train_time:4995ms step_avg:32.65ms
+step:154/1480 train_time:5031ms step_avg:32.67ms
+step:155/1480 train_time:5061ms step_avg:32.65ms
+step:156/1480 train_time:5097ms step_avg:32.67ms
+step:157/1480 train_time:5126ms step_avg:32.65ms
+step:158/1480 train_time:5162ms step_avg:32.67ms
+step:159/1480 train_time:5191ms step_avg:32.65ms
+step:160/1480 train_time:5227ms step_avg:32.67ms
+step:161/1480 train_time:5257ms step_avg:32.65ms
+step:162/1480 train_time:5292ms step_avg:32.67ms
+step:163/1480 train_time:5322ms step_avg:32.65ms
+step:164/1480 train_time:5358ms step_avg:32.67ms
+step:165/1480 train_time:5387ms step_avg:32.65ms
+step:166/1480 train_time:5424ms step_avg:32.68ms
+step:167/1480 train_time:5454ms step_avg:32.66ms
+step:168/1480 train_time:5490ms step_avg:32.68ms
+step:169/1480 train_time:5520ms step_avg:32.66ms
+step:170/1480 train_time:5558ms step_avg:32.69ms
+step:171/1480 train_time:5587ms step_avg:32.67ms
+step:172/1480 train_time:5624ms step_avg:32.70ms
+step:173/1480 train_time:5653ms step_avg:32.68ms
+step:174/1480 train_time:5689ms step_avg:32.70ms
+step:175/1480 train_time:5720ms step_avg:32.68ms
+step:176/1480 train_time:5757ms step_avg:32.71ms
+step:177/1480 train_time:5785ms step_avg:32.69ms
+step:178/1480 train_time:5822ms step_avg:32.71ms
+step:179/1480 train_time:5852ms step_avg:32.69ms
+step:180/1480 train_time:5893ms step_avg:32.74ms
+step:181/1480 train_time:5918ms step_avg:32.70ms
+step:182/1480 train_time:5955ms step_avg:32.72ms
+step:183/1480 train_time:5983ms step_avg:32.70ms
+step:184/1480 train_time:6020ms step_avg:32.72ms
+step:185/1480 train_time:6049ms step_avg:32.70ms
+step:186/1480 train_time:6086ms step_avg:32.72ms
+step:187/1480 train_time:6115ms step_avg:32.70ms
+step:188/1480 train_time:6152ms step_avg:32.72ms
+step:189/1480 train_time:6181ms step_avg:32.70ms
+step:190/1480 train_time:6217ms step_avg:32.72ms
+step:191/1480 train_time:6247ms step_avg:32.71ms
+step:192/1480 train_time:6283ms step_avg:32.73ms
+step:193/1480 train_time:6312ms step_avg:32.71ms
+step:194/1480 train_time:6348ms step_avg:32.72ms
+step:195/1480 train_time:6378ms step_avg:32.71ms
+step:196/1480 train_time:6414ms step_avg:32.72ms
+step:197/1480 train_time:6443ms step_avg:32.70ms
+step:198/1480 train_time:6479ms step_avg:32.72ms
+step:199/1480 train_time:6508ms step_avg:32.70ms
+step:200/1480 train_time:6545ms step_avg:32.72ms
+step:201/1480 train_time:6573ms step_avg:32.70ms
+step:202/1480 train_time:6609ms step_avg:32.72ms
+step:203/1480 train_time:6639ms step_avg:32.70ms
+step:204/1480 train_time:6675ms step_avg:32.72ms
+step:205/1480 train_time:6704ms step_avg:32.70ms
+step:206/1480 train_time:6740ms step_avg:32.72ms
+step:207/1480 train_time:6769ms step_avg:32.70ms
+step:208/1480 train_time:6808ms step_avg:32.73ms
+step:209/1480 train_time:6839ms step_avg:32.72ms
+step:210/1480 train_time:6878ms step_avg:32.75ms
+step:211/1480 train_time:6909ms step_avg:32.74ms
+step:212/1480 train_time:6948ms step_avg:32.77ms
+step:213/1480 train_time:6978ms step_avg:32.76ms
+step:214/1480 train_time:7015ms step_avg:32.78ms
+step:215/1480 train_time:7045ms step_avg:32.77ms
+step:216/1480 train_time:7082ms step_avg:32.79ms
+step:217/1480 train_time:7113ms step_avg:32.78ms
+step:218/1480 train_time:7150ms step_avg:32.80ms
+step:219/1480 train_time:7182ms step_avg:32.80ms
+step:220/1480 train_time:7218ms step_avg:32.81ms
+step:221/1480 train_time:7245ms step_avg:32.78ms
+step:222/1480 train_time:7280ms step_avg:32.79ms
+step:223/1480 train_time:7308ms step_avg:32.77ms
+step:224/1480 train_time:7345ms step_avg:32.79ms
+step:225/1480 train_time:7375ms step_avg:32.78ms
+step:226/1480 train_time:7412ms step_avg:32.80ms
+step:227/1480 train_time:7441ms step_avg:32.78ms
+step:228/1480 train_time:7478ms step_avg:32.80ms
+step:229/1480 train_time:7507ms step_avg:32.78ms
+step:230/1480 train_time:7544ms step_avg:32.80ms
+step:231/1480 train_time:7573ms step_avg:32.78ms
+step:232/1480 train_time:7610ms step_avg:32.80ms
+step:233/1480 train_time:7640ms step_avg:32.79ms
+step:234/1480 train_time:7679ms step_avg:32.81ms
+step:235/1480 train_time:7709ms step_avg:32.80ms
+step:236/1480 train_time:7748ms step_avg:32.83ms
+step:237/1480 train_time:7779ms step_avg:32.82ms
+step:238/1480 train_time:7818ms step_avg:32.85ms
+step:239/1480 train_time:7848ms step_avg:32.84ms
+step:240/1480 train_time:7886ms step_avg:32.86ms
+step:241/1480 train_time:7917ms step_avg:32.85ms
+step:242/1480 train_time:7955ms step_avg:32.87ms
+step:243/1480 train_time:7985ms step_avg:32.86ms
+step:244/1480 train_time:8023ms step_avg:32.88ms
+step:245/1480 train_time:8054ms step_avg:32.87ms
+step:246/1480 train_time:8091ms step_avg:32.89ms
+step:247/1480 train_time:8122ms step_avg:32.88ms
+step:248/1480 train_time:8161ms step_avg:32.91ms
+step:249/1480 train_time:8192ms step_avg:32.90ms
+step:250/1480 train_time:8230ms step_avg:32.92ms
+step:250/1480 val_loss:4.4958 train_time:8279ms step_avg:33.11ms
+step:251/1480 train_time:8296ms step_avg:33.05ms
+step:252/1480 train_time:8316ms step_avg:33.00ms
+step:253/1480 train_time:8332ms step_avg:32.93ms
+step:254/1480 train_time:8367ms step_avg:32.94ms
+step:255/1480 train_time:8396ms step_avg:32.92ms
+step:256/1480 train_time:8432ms step_avg:32.94ms
+step:257/1480 train_time:8463ms step_avg:32.93ms
+step:258/1480 train_time:8500ms step_avg:32.94ms
+step:259/1480 train_time:8530ms step_avg:32.93ms
+step:260/1480 train_time:8568ms step_avg:32.95ms
+step:261/1480 train_time:8599ms step_avg:32.95ms
+step:262/1480 train_time:8637ms step_avg:32.96ms
+step:263/1480 train_time:8667ms step_avg:32.96ms
+step:264/1480 train_time:8704ms step_avg:32.97ms
+step:265/1480 train_time:8735ms step_avg:32.96ms
+step:266/1480 train_time:8772ms step_avg:32.98ms
+step:267/1480 train_time:8803ms step_avg:32.97ms
+step:268/1480 train_time:8840ms step_avg:32.98ms
+step:269/1480 train_time:8870ms step_avg:32.97ms
+step:270/1480 train_time:8907ms step_avg:32.99ms
+step:271/1480 train_time:8937ms step_avg:32.98ms
+step:272/1480 train_time:8975ms step_avg:33.00ms
+step:273/1480 train_time:9006ms step_avg:32.99ms
+step:274/1480 train_time:9043ms step_avg:33.01ms
+step:275/1480 train_time:9074ms step_avg:33.00ms
+step:276/1480 train_time:9112ms step_avg:33.01ms
+step:277/1480 train_time:9142ms step_avg:33.00ms
+step:278/1480 train_time:9180ms step_avg:33.02ms
+step:279/1480 train_time:9210ms step_avg:33.01ms
+step:280/1480 train_time:9248ms step_avg:33.03ms
+step:281/1480 train_time:9278ms step_avg:33.02ms
+step:282/1480 train_time:9315ms step_avg:33.03ms
+step:283/1480 train_time:9345ms step_avg:33.02ms
+step:284/1480 train_time:9383ms step_avg:33.04ms
+step:285/1480 train_time:9413ms step_avg:33.03ms
+step:286/1480 train_time:9450ms step_avg:33.04ms
+step:287/1480 train_time:9481ms step_avg:33.04ms
+step:288/1480 train_time:9518ms step_avg:33.05ms
+step:289/1480 train_time:9548ms step_avg:33.04ms
+step:290/1480 train_time:9586ms step_avg:33.05ms
+step:291/1480 train_time:9619ms step_avg:33.05ms
+step:292/1480 train_time:9653ms step_avg:33.06ms
+step:293/1480 train_time:9683ms step_avg:33.05ms
+step:294/1480 train_time:9720ms step_avg:33.06ms
+step:295/1480 train_time:9749ms step_avg:33.05ms
+step:296/1480 train_time:9786ms step_avg:33.06ms
+step:297/1480 train_time:9816ms step_avg:33.05ms
+step:298/1480 train_time:9853ms step_avg:33.06ms
+step:299/1480 train_time:9882ms step_avg:33.05ms
+step:300/1480 train_time:9917ms step_avg:33.06ms
+step:301/1480 train_time:9945ms step_avg:33.04ms
+step:302/1480 train_time:9980ms step_avg:33.05ms
+step:303/1480 train_time:10009ms step_avg:33.03ms
+step:304/1480 train_time:10046ms step_avg:33.04ms
+step:305/1480 train_time:10074ms step_avg:33.03ms
+step:306/1480 train_time:10111ms step_avg:33.04ms
+step:307/1480 train_time:10141ms step_avg:33.03ms
+step:308/1480 train_time:10178ms step_avg:33.05ms
+step:309/1480 train_time:10208ms step_avg:33.04ms
+step:310/1480 train_time:10245ms step_avg:33.05ms
+step:311/1480 train_time:10275ms step_avg:33.04ms
+step:312/1480 train_time:10312ms step_avg:33.05ms
+step:313/1480 train_time:10342ms step_avg:33.04ms
+step:314/1480 train_time:10379ms step_avg:33.05ms
+step:315/1480 train_time:10409ms step_avg:33.04ms
+step:316/1480 train_time:10445ms step_avg:33.06ms
+step:317/1480 train_time:10475ms step_avg:33.04ms
+step:318/1480 train_time:10513ms step_avg:33.06ms
+step:319/1480 train_time:10543ms step_avg:33.05ms
+step:320/1480 train_time:10580ms step_avg:33.06ms
+step:321/1480 train_time:10609ms step_avg:33.05ms
+step:322/1480 train_time:10646ms step_avg:33.06ms
+step:323/1480 train_time:10676ms step_avg:33.05ms
+step:324/1480 train_time:10713ms step_avg:33.07ms
+step:325/1480 train_time:10743ms step_avg:33.06ms
+step:326/1480 train_time:10781ms step_avg:33.07ms
+step:327/1480 train_time:10810ms step_avg:33.06ms
+step:328/1480 train_time:10848ms step_avg:33.07ms
+step:329/1480 train_time:10877ms step_avg:33.06ms
+step:330/1480 train_time:10914ms step_avg:33.07ms
+step:331/1480 train_time:10945ms step_avg:33.07ms
+step:332/1480 train_time:10982ms step_avg:33.08ms
+step:333/1480 train_time:11012ms step_avg:33.07ms
+step:334/1480 train_time:11049ms step_avg:33.08ms
+step:335/1480 train_time:11079ms step_avg:33.07ms
+step:336/1480 train_time:11115ms step_avg:33.08ms
+step:337/1480 train_time:11146ms step_avg:33.07ms
+step:338/1480 train_time:11183ms step_avg:33.09ms
+step:339/1480 train_time:11212ms step_avg:33.07ms
+step:340/1480 train_time:11250ms step_avg:33.09ms
+step:341/1480 train_time:11279ms step_avg:33.08ms
+step:342/1480 train_time:11316ms step_avg:33.09ms
+step:343/1480 train_time:11346ms step_avg:33.08ms
+step:344/1480 train_time:11383ms step_avg:33.09ms
+step:345/1480 train_time:11412ms step_avg:33.08ms
+step:346/1480 train_time:11449ms step_avg:33.09ms
+step:347/1480 train_time:11479ms step_avg:33.08ms
+step:348/1480 train_time:11515ms step_avg:33.09ms
+step:349/1480 train_time:11545ms step_avg:33.08ms
+step:350/1480 train_time:11582ms step_avg:33.09ms
+step:351/1480 train_time:11611ms step_avg:33.08ms
+step:352/1480 train_time:11648ms step_avg:33.09ms
+step:353/1480 train_time:11678ms step_avg:33.08ms
+step:354/1480 train_time:11715ms step_avg:33.09ms
+step:355/1480 train_time:11744ms step_avg:33.08ms
+step:356/1480 train_time:11782ms step_avg:33.09ms
+step:357/1480 train_time:11812ms step_avg:33.09ms
+step:358/1480 train_time:11849ms step_avg:33.10ms
+step:359/1480 train_time:11879ms step_avg:33.09ms
+step:360/1480 train_time:11915ms step_avg:33.10ms
+step:361/1480 train_time:11945ms step_avg:33.09ms
+step:362/1480 train_time:11982ms step_avg:33.10ms
+step:363/1480 train_time:12012ms step_avg:33.09ms
+step:364/1480 train_time:12049ms step_avg:33.10ms
+step:365/1480 train_time:12079ms step_avg:33.09ms
+step:366/1480 train_time:12115ms step_avg:33.10ms
+step:367/1480 train_time:12145ms step_avg:33.09ms
+step:368/1480 train_time:12182ms step_avg:33.10ms
+step:369/1480 train_time:12211ms step_avg:33.09ms
+step:370/1480 train_time:12248ms step_avg:33.10ms
+step:371/1480 train_time:12278ms step_avg:33.09ms
+step:372/1480 train_time:12315ms step_avg:33.10ms
+step:373/1480 train_time:12345ms step_avg:33.10ms
+step:374/1480 train_time:12382ms step_avg:33.11ms
+step:375/1480 train_time:12411ms step_avg:33.10ms
+step:376/1480 train_time:12448ms step_avg:33.11ms
+step:377/1480 train_time:12478ms step_avg:33.10ms
+step:378/1480 train_time:12515ms step_avg:33.11ms
+step:379/1480 train_time:12544ms step_avg:33.10ms
+step:380/1480 train_time:12581ms step_avg:33.11ms
+step:381/1480 train_time:12610ms step_avg:33.10ms
+step:382/1480 train_time:12646ms step_avg:33.11ms
+step:383/1480 train_time:12676ms step_avg:33.10ms
+step:384/1480 train_time:12712ms step_avg:33.10ms
+step:385/1480 train_time:12742ms step_avg:33.10ms
+step:386/1480 train_time:12778ms step_avg:33.10ms
+step:387/1480 train_time:12808ms step_avg:33.09ms
+step:388/1480 train_time:12844ms step_avg:33.10ms
+step:389/1480 train_time:12874ms step_avg:33.09ms
+step:390/1480 train_time:12910ms step_avg:33.10ms
+step:391/1480 train_time:12940ms step_avg:33.09ms
+step:392/1480 train_time:12976ms step_avg:33.10ms
+step:393/1480 train_time:13006ms step_avg:33.09ms
+step:394/1480 train_time:13042ms step_avg:33.10ms
+step:395/1480 train_time:13072ms step_avg:33.09ms
+step:396/1480 train_time:13109ms step_avg:33.10ms
+step:397/1480 train_time:13138ms step_avg:33.09ms
+step:398/1480 train_time:13175ms step_avg:33.10ms
+step:399/1480 train_time:13204ms step_avg:33.09ms
+step:400/1480 train_time:13241ms step_avg:33.10ms
+step:401/1480 train_time:13270ms step_avg:33.09ms
+step:402/1480 train_time:13307ms step_avg:33.10ms
+step:403/1480 train_time:13336ms step_avg:33.09ms
+step:404/1480 train_time:13373ms step_avg:33.10ms
+step:405/1480 train_time:13403ms step_avg:33.09ms
+step:406/1480 train_time:13441ms step_avg:33.11ms
+step:407/1480 train_time:13471ms step_avg:33.10ms
+step:408/1480 train_time:13509ms step_avg:33.11ms
+step:409/1480 train_time:13540ms step_avg:33.10ms
+step:410/1480 train_time:13577ms step_avg:33.11ms
+step:411/1480 train_time:13607ms step_avg:33.11ms
+step:412/1480 train_time:13645ms step_avg:33.12ms
+step:413/1480 train_time:13675ms step_avg:33.11ms
+step:414/1480 train_time:13712ms step_avg:33.12ms
+step:415/1480 train_time:13743ms step_avg:33.12ms
+step:416/1480 train_time:13780ms step_avg:33.13ms
+step:417/1480 train_time:13810ms step_avg:33.12ms
+step:418/1480 train_time:13847ms step_avg:33.13ms
+step:419/1480 train_time:13877ms step_avg:33.12ms
+step:420/1480 train_time:13914ms step_avg:33.13ms
+step:421/1480 train_time:13944ms step_avg:33.12ms
+step:422/1480 train_time:13982ms step_avg:33.13ms
+step:423/1480 train_time:14011ms step_avg:33.12ms
+step:424/1480 train_time:14048ms step_avg:33.13ms
+step:425/1480 train_time:14079ms step_avg:33.13ms
+step:426/1480 train_time:14115ms step_avg:33.13ms
+step:427/1480 train_time:14146ms step_avg:33.13ms
+step:428/1480 train_time:14183ms step_avg:33.14ms
+step:429/1480 train_time:14213ms step_avg:33.13ms
+step:430/1480 train_time:14250ms step_avg:33.14ms
+step:431/1480 train_time:14280ms step_avg:33.13ms
+step:432/1480 train_time:14316ms step_avg:33.14ms
+step:433/1480 train_time:14346ms step_avg:33.13ms
+step:434/1480 train_time:14384ms step_avg:33.14ms
+step:435/1480 train_time:14413ms step_avg:33.13ms
+step:436/1480 train_time:14450ms step_avg:33.14ms
+step:437/1480 train_time:14480ms step_avg:33.14ms
+step:438/1480 train_time:14517ms step_avg:33.14ms
+step:439/1480 train_time:14547ms step_avg:33.14ms
+step:440/1480 train_time:14584ms step_avg:33.15ms
+step:441/1480 train_time:14614ms step_avg:33.14ms
+step:442/1480 train_time:14651ms step_avg:33.15ms
+step:443/1480 train_time:14681ms step_avg:33.14ms
+step:444/1480 train_time:14718ms step_avg:33.15ms
+step:445/1480 train_time:14747ms step_avg:33.14ms
+step:446/1480 train_time:14785ms step_avg:33.15ms
+step:447/1480 train_time:14814ms step_avg:33.14ms
+step:448/1480 train_time:14851ms step_avg:33.15ms
+step:449/1480 train_time:14881ms step_avg:33.14ms
+step:450/1480 train_time:14918ms step_avg:33.15ms
+step:451/1480 train_time:14948ms step_avg:33.14ms
+step:452/1480 train_time:14985ms step_avg:33.15ms
+step:453/1480 train_time:15015ms step_avg:33.14ms
+step:454/1480 train_time:15052ms step_avg:33.15ms
+step:455/1480 train_time:15082ms step_avg:33.15ms
+step:456/1480 train_time:15119ms step_avg:33.15ms
+step:457/1480 train_time:15148ms step_avg:33.15ms
+step:458/1480 train_time:15186ms step_avg:33.16ms
+step:459/1480 train_time:15215ms step_avg:33.15ms
+step:460/1480 train_time:15252ms step_avg:33.16ms
+step:461/1480 train_time:15282ms step_avg:33.15ms
+step:462/1480 train_time:15319ms step_avg:33.16ms
+step:463/1480 train_time:15348ms step_avg:33.15ms
+step:464/1480 train_time:15386ms step_avg:33.16ms
+step:465/1480 train_time:15415ms step_avg:33.15ms
+step:466/1480 train_time:15452ms step_avg:33.16ms
+step:467/1480 train_time:15482ms step_avg:33.15ms
+step:468/1480 train_time:15519ms step_avg:33.16ms
+step:469/1480 train_time:15548ms step_avg:33.15ms
+step:470/1480 train_time:15586ms step_avg:33.16ms
+step:471/1480 train_time:15614ms step_avg:33.15ms
+step:472/1480 train_time:15651ms step_avg:33.16ms
+step:473/1480 train_time:15681ms step_avg:33.15ms
+step:474/1480 train_time:15718ms step_avg:33.16ms
+step:475/1480 train_time:15747ms step_avg:33.15ms
+step:476/1480 train_time:15784ms step_avg:33.16ms
+step:477/1480 train_time:15813ms step_avg:33.15ms
+step:478/1480 train_time:15850ms step_avg:33.16ms
+step:479/1480 train_time:15880ms step_avg:33.15ms
+step:480/1480 train_time:15916ms step_avg:33.16ms
+step:481/1480 train_time:15948ms step_avg:33.16ms
+step:482/1480 train_time:16007ms step_avg:33.21ms
+step:483/1480 train_time:16064ms step_avg:33.26ms
+step:484/1480 train_time:16128ms step_avg:33.32ms
+step:485/1480 train_time:16186ms step_avg:33.37ms
+step:486/1480 train_time:16251ms step_avg:33.44ms
+step:487/1480 train_time:16313ms step_avg:33.50ms
+step:488/1480 train_time:16378ms step_avg:33.56ms
+step:489/1480 train_time:16436ms step_avg:33.61ms
+step:490/1480 train_time:16499ms step_avg:33.67ms
+step:491/1480 train_time:16556ms step_avg:33.72ms
+step:492/1480 train_time:16618ms step_avg:33.78ms
+step:493/1480 train_time:16676ms step_avg:33.83ms
+step:494/1480 train_time:16739ms step_avg:33.88ms
+step:495/1480 train_time:16795ms step_avg:33.93ms
+step:496/1480 train_time:16858ms step_avg:33.99ms
+step:497/1480 train_time:16914ms step_avg:34.03ms
+step:498/1480 train_time:16977ms step_avg:34.09ms
+step:499/1480 train_time:17035ms step_avg:34.14ms
+step:500/1480 train_time:17098ms step_avg:34.20ms
+step:500/1480 val_loss:4.2326 train_time:17180ms step_avg:34.36ms
+step:501/1480 train_time:17198ms step_avg:34.33ms
+step:502/1480 train_time:17221ms step_avg:34.30ms
+step:503/1480 train_time:17282ms step_avg:34.36ms
+step:504/1480 train_time:17346ms step_avg:34.42ms
+step:505/1480 train_time:17405ms step_avg:34.47ms
+step:506/1480 train_time:17472ms step_avg:34.53ms
+step:507/1480 train_time:17532ms step_avg:34.58ms
+step:508/1480 train_time:17596ms step_avg:34.64ms
+step:509/1480 train_time:17656ms step_avg:34.69ms
+step:510/1480 train_time:17721ms step_avg:34.75ms
+step:511/1480 train_time:17777ms step_avg:34.79ms
+step:512/1480 train_time:17840ms step_avg:34.84ms
+step:513/1480 train_time:17897ms step_avg:34.89ms
+step:514/1480 train_time:17960ms step_avg:34.94ms
+step:515/1480 train_time:18017ms step_avg:34.99ms
+step:516/1480 train_time:18081ms step_avg:35.04ms
+step:517/1480 train_time:18139ms step_avg:35.09ms
+step:518/1480 train_time:18206ms step_avg:35.15ms
+step:519/1480 train_time:18265ms step_avg:35.19ms
+step:520/1480 train_time:18331ms step_avg:35.25ms
+step:521/1480 train_time:18391ms step_avg:35.30ms
+step:522/1480 train_time:18456ms step_avg:35.36ms
+step:523/1480 train_time:18516ms step_avg:35.40ms
+step:524/1480 train_time:18581ms step_avg:35.46ms
+step:525/1480 train_time:18639ms step_avg:35.50ms
+step:526/1480 train_time:18704ms step_avg:35.56ms
+step:527/1480 train_time:18763ms step_avg:35.60ms
+step:528/1480 train_time:18829ms step_avg:35.66ms
+step:529/1480 train_time:18887ms step_avg:35.70ms
+step:530/1480 train_time:18953ms step_avg:35.76ms
+step:531/1480 train_time:19013ms step_avg:35.81ms
+step:532/1480 train_time:19079ms step_avg:35.86ms
+step:533/1480 train_time:19137ms step_avg:35.90ms
+step:534/1480 train_time:19201ms step_avg:35.96ms
+step:535/1480 train_time:19259ms step_avg:36.00ms
+step:536/1480 train_time:19324ms step_avg:36.05ms
+step:537/1480 train_time:19382ms step_avg:36.09ms
+step:538/1480 train_time:19446ms step_avg:36.14ms
+step:539/1480 train_time:19504ms step_avg:36.19ms
+step:540/1480 train_time:19569ms step_avg:36.24ms
+step:541/1480 train_time:19628ms step_avg:36.28ms
+step:542/1480 train_time:19692ms step_avg:36.33ms
+step:543/1480 train_time:19751ms step_avg:36.37ms
+step:544/1480 train_time:19816ms step_avg:36.43ms
+step:545/1480 train_time:19875ms step_avg:36.47ms
+step:546/1480 train_time:19938ms step_avg:36.52ms
+step:547/1480 train_time:19996ms step_avg:36.56ms
+step:548/1480 train_time:20060ms step_avg:36.61ms
+step:549/1480 train_time:20118ms step_avg:36.64ms
+step:550/1480 train_time:20182ms step_avg:36.69ms
+step:551/1480 train_time:20239ms step_avg:36.73ms
+step:552/1480 train_time:20302ms step_avg:36.78ms
+step:553/1480 train_time:20359ms step_avg:36.82ms
+step:554/1480 train_time:20423ms step_avg:36.86ms
+step:555/1480 train_time:20482ms step_avg:36.91ms
+step:556/1480 train_time:20546ms step_avg:36.95ms
+step:557/1480 train_time:20604ms step_avg:36.99ms
+step:558/1480 train_time:20668ms step_avg:37.04ms
+step:559/1480 train_time:20726ms step_avg:37.08ms
+step:560/1480 train_time:20790ms step_avg:37.13ms
+step:561/1480 train_time:20848ms step_avg:37.16ms
+step:562/1480 train_time:20913ms step_avg:37.21ms
+step:563/1480 train_time:20972ms step_avg:37.25ms
+step:564/1480 train_time:21036ms step_avg:37.30ms
+step:565/1480 train_time:21094ms step_avg:37.33ms
+step:566/1480 train_time:21158ms step_avg:37.38ms
+step:567/1480 train_time:21216ms step_avg:37.42ms
+step:568/1480 train_time:21280ms step_avg:37.46ms
+step:569/1480 train_time:21337ms step_avg:37.50ms
+step:570/1480 train_time:21401ms step_avg:37.54ms
+step:571/1480 train_time:21458ms step_avg:37.58ms
+step:572/1480 train_time:21521ms step_avg:37.62ms
+step:573/1480 train_time:21579ms step_avg:37.66ms
+step:574/1480 train_time:21644ms step_avg:37.71ms
+step:575/1480 train_time:21703ms step_avg:37.74ms
+step:576/1480 train_time:21768ms step_avg:37.79ms
+step:577/1480 train_time:21827ms step_avg:37.83ms
+step:578/1480 train_time:21891ms step_avg:37.87ms
+step:579/1480 train_time:21950ms step_avg:37.91ms
+step:580/1480 train_time:22018ms step_avg:37.96ms
+step:581/1480 train_time:22078ms step_avg:38.00ms
+step:582/1480 train_time:22144ms step_avg:38.05ms
+step:583/1480 train_time:22203ms step_avg:38.08ms
+step:584/1480 train_time:22271ms step_avg:38.13ms
+step:585/1480 train_time:22332ms step_avg:38.18ms
+step:586/1480 train_time:22399ms step_avg:38.22ms
+step:587/1480 train_time:22458ms step_avg:38.26ms
+step:588/1480 train_time:22525ms step_avg:38.31ms
+step:589/1480 train_time:22581ms step_avg:38.34ms
+step:590/1480 train_time:22640ms step_avg:38.37ms
+step:591/1480 train_time:22696ms step_avg:38.40ms
+step:592/1480 train_time:22762ms step_avg:38.45ms
+step:593/1480 train_time:22821ms step_avg:38.48ms
+step:594/1480 train_time:22886ms step_avg:38.53ms
+step:595/1480 train_time:22948ms step_avg:38.57ms
+step:596/1480 train_time:23013ms step_avg:38.61ms
+step:597/1480 train_time:23072ms step_avg:38.65ms
+step:598/1480 train_time:23137ms step_avg:38.69ms
+step:599/1480 train_time:23195ms step_avg:38.72ms
+step:600/1480 train_time:23260ms step_avg:38.77ms
+step:601/1480 train_time:23318ms step_avg:38.80ms
+step:602/1480 train_time:23382ms step_avg:38.84ms
+step:603/1480 train_time:23440ms step_avg:38.87ms
+step:604/1480 train_time:23505ms step_avg:38.92ms
+step:605/1480 train_time:23563ms step_avg:38.95ms
+step:606/1480 train_time:23628ms step_avg:38.99ms
+step:607/1480 train_time:23688ms step_avg:39.02ms
+step:608/1480 train_time:23753ms step_avg:39.07ms
+step:609/1480 train_time:23813ms step_avg:39.10ms
+step:610/1480 train_time:23879ms step_avg:39.15ms
+step:611/1480 train_time:23938ms step_avg:39.18ms
+step:612/1480 train_time:24003ms step_avg:39.22ms
+step:613/1480 train_time:24061ms step_avg:39.25ms
+step:614/1480 train_time:24127ms step_avg:39.29ms
+step:615/1480 train_time:24185ms step_avg:39.33ms
+step:616/1480 train_time:24251ms step_avg:39.37ms
+step:617/1480 train_time:24311ms step_avg:39.40ms
+step:618/1480 train_time:24375ms step_avg:39.44ms
+step:619/1480 train_time:24432ms step_avg:39.47ms
+step:620/1480 train_time:24496ms step_avg:39.51ms
+step:621/1480 train_time:24553ms step_avg:39.54ms
+step:622/1480 train_time:24617ms step_avg:39.58ms
+step:623/1480 train_time:24675ms step_avg:39.61ms
+step:624/1480 train_time:24737ms step_avg:39.64ms
+step:625/1480 train_time:24794ms step_avg:39.67ms
+step:626/1480 train_time:24856ms step_avg:39.71ms
+step:627/1480 train_time:24914ms step_avg:39.74ms
+step:628/1480 train_time:24978ms step_avg:39.77ms
+step:629/1480 train_time:25034ms step_avg:39.80ms
+step:630/1480 train_time:25097ms step_avg:39.84ms
+step:631/1480 train_time:25154ms step_avg:39.86ms
+step:632/1480 train_time:25217ms step_avg:39.90ms
+step:633/1480 train_time:25275ms step_avg:39.93ms
+step:634/1480 train_time:25339ms step_avg:39.97ms
+step:635/1480 train_time:25396ms step_avg:39.99ms
+step:636/1480 train_time:25460ms step_avg:40.03ms
+step:637/1480 train_time:25519ms step_avg:40.06ms
+step:638/1480 train_time:25583ms step_avg:40.10ms
+step:639/1480 train_time:25640ms step_avg:40.12ms
+step:640/1480 train_time:25704ms step_avg:40.16ms
+step:641/1480 train_time:25761ms step_avg:40.19ms
+step:642/1480 train_time:25826ms step_avg:40.23ms
+step:643/1480 train_time:25884ms step_avg:40.25ms
+step:644/1480 train_time:25949ms step_avg:40.29ms
+step:645/1480 train_time:26009ms step_avg:40.32ms
+step:646/1480 train_time:26073ms step_avg:40.36ms
+step:647/1480 train_time:26130ms step_avg:40.39ms
+step:648/1480 train_time:26193ms step_avg:40.42ms
+step:649/1480 train_time:26252ms step_avg:40.45ms
+step:650/1480 train_time:26320ms step_avg:40.49ms
+step:651/1480 train_time:26381ms step_avg:40.52ms
+step:652/1480 train_time:26447ms step_avg:40.56ms
+step:653/1480 train_time:26509ms step_avg:40.60ms
+step:654/1480 train_time:26576ms step_avg:40.64ms
+step:655/1480 train_time:26639ms step_avg:40.67ms
+step:656/1480 train_time:26708ms step_avg:40.71ms
+step:657/1480 train_time:26769ms step_avg:40.74ms
+step:658/1480 train_time:26837ms step_avg:40.79ms
+step:659/1480 train_time:26893ms step_avg:40.81ms
+step:660/1480 train_time:26952ms step_avg:40.84ms
+step:661/1480 train_time:27006ms step_avg:40.86ms
+step:662/1480 train_time:27067ms step_avg:40.89ms
+step:663/1480 train_time:27122ms step_avg:40.91ms
+step:664/1480 train_time:27186ms step_avg:40.94ms
+step:665/1480 train_time:27240ms step_avg:40.96ms
+step:666/1480 train_time:27306ms step_avg:41.00ms
+step:667/1480 train_time:27366ms step_avg:41.03ms
+step:668/1480 train_time:27431ms step_avg:41.06ms
+step:669/1480 train_time:27490ms step_avg:41.09ms
+step:670/1480 train_time:27559ms step_avg:41.13ms
+step:671/1480 train_time:27620ms step_avg:41.16ms
+step:672/1480 train_time:27687ms step_avg:41.20ms
+step:673/1480 train_time:27747ms step_avg:41.23ms
+step:674/1480 train_time:27815ms step_avg:41.27ms
+step:675/1480 train_time:27877ms step_avg:41.30ms
+step:676/1480 train_time:27943ms step_avg:41.34ms
+step:677/1480 train_time:28002ms step_avg:41.36ms
+step:678/1480 train_time:28069ms step_avg:41.40ms
+step:679/1480 train_time:28125ms step_avg:41.42ms
+step:680/1480 train_time:28184ms step_avg:41.45ms
+step:681/1480 train_time:28239ms step_avg:41.47ms
+step:682/1480 train_time:28304ms step_avg:41.50ms
+step:683/1480 train_time:28361ms step_avg:41.52ms
+step:684/1480 train_time:28425ms step_avg:41.56ms
+step:685/1480 train_time:28482ms step_avg:41.58ms
+step:686/1480 train_time:28546ms step_avg:41.61ms
+step:687/1480 train_time:28604ms step_avg:41.64ms
+step:688/1480 train_time:28669ms step_avg:41.67ms
+step:689/1480 train_time:28727ms step_avg:41.69ms
+step:690/1480 train_time:28790ms step_avg:41.72ms
+step:691/1480 train_time:28847ms step_avg:41.75ms
+step:692/1480 train_time:28910ms step_avg:41.78ms
+step:693/1480 train_time:28968ms step_avg:41.80ms
+step:694/1480 train_time:29032ms step_avg:41.83ms
+step:695/1480 train_time:29090ms step_avg:41.86ms
+step:696/1480 train_time:29155ms step_avg:41.89ms
+step:697/1480 train_time:29215ms step_avg:41.92ms
+step:698/1480 train_time:29281ms step_avg:41.95ms
+step:699/1480 train_time:29338ms step_avg:41.97ms
+step:700/1480 train_time:29403ms step_avg:42.00ms
+step:701/1480 train_time:29460ms step_avg:42.03ms
+step:702/1480 train_time:29525ms step_avg:42.06ms
+step:703/1480 train_time:29585ms step_avg:42.08ms
+step:704/1480 train_time:29650ms step_avg:42.12ms
+step:705/1480 train_time:29711ms step_avg:42.14ms
+step:706/1480 train_time:29776ms step_avg:42.18ms
+step:707/1480 train_time:29835ms step_avg:42.20ms
+step:708/1480 train_time:29899ms step_avg:42.23ms
+step:709/1480 train_time:29957ms step_avg:42.25ms
+step:710/1480 train_time:30022ms step_avg:42.28ms
+step:711/1480 train_time:30080ms step_avg:42.31ms
+step:712/1480 train_time:30143ms step_avg:42.34ms
+step:713/1480 train_time:30202ms step_avg:42.36ms
+step:714/1480 train_time:30267ms step_avg:42.39ms
+step:715/1480 train_time:30326ms step_avg:42.41ms
+step:716/1480 train_time:30392ms step_avg:42.45ms
+step:717/1480 train_time:30452ms step_avg:42.47ms
+step:718/1480 train_time:30517ms step_avg:42.50ms
+step:719/1480 train_time:30576ms step_avg:42.53ms
+step:720/1480 train_time:30640ms step_avg:42.56ms
+step:721/1480 train_time:30699ms step_avg:42.58ms
+step:722/1480 train_time:30765ms step_avg:42.61ms
+step:723/1480 train_time:30824ms step_avg:42.63ms
+step:724/1480 train_time:30889ms step_avg:42.66ms
+step:725/1480 train_time:30949ms step_avg:42.69ms
+step:726/1480 train_time:31014ms step_avg:42.72ms
+step:727/1480 train_time:31074ms step_avg:42.74ms
+step:728/1480 train_time:31139ms step_avg:42.77ms
+step:729/1480 train_time:31197ms step_avg:42.79ms
+step:730/1480 train_time:31261ms step_avg:42.82ms
+step:731/1480 train_time:31319ms step_avg:42.84ms
+step:732/1480 train_time:31383ms step_avg:42.87ms
+step:733/1480 train_time:31440ms step_avg:42.89ms
+step:734/1480 train_time:31505ms step_avg:42.92ms
+step:735/1480 train_time:31563ms step_avg:42.94ms
+step:736/1480 train_time:31627ms step_avg:42.97ms
+step:737/1480 train_time:31685ms step_avg:42.99ms
+step:738/1480 train_time:31750ms step_avg:43.02ms
+step:739/1480 train_time:31809ms step_avg:43.04ms
+step:740/1480 train_time:31874ms step_avg:43.07ms
+step:741/1480 train_time:31932ms step_avg:43.09ms
+step:742/1480 train_time:31997ms step_avg:43.12ms
+step:743/1480 train_time:32054ms step_avg:43.14ms
+step:744/1480 train_time:32118ms step_avg:43.17ms
+step:745/1480 train_time:32176ms step_avg:43.19ms
+step:746/1480 train_time:32240ms step_avg:43.22ms
+step:747/1480 train_time:32297ms step_avg:43.24ms
+step:748/1480 train_time:32361ms step_avg:43.26ms
+step:749/1480 train_time:32418ms step_avg:43.28ms
+step:750/1480 train_time:32482ms step_avg:43.31ms
+step:750/1480 val_loss:3.8097 train_time:32561ms step_avg:43.42ms
+step:751/1480 train_time:32580ms step_avg:43.38ms
+step:752/1480 train_time:32603ms step_avg:43.35ms
+step:753/1480 train_time:32667ms step_avg:43.38ms
+step:754/1480 train_time:32732ms step_avg:43.41ms
+step:755/1480 train_time:32794ms step_avg:43.44ms
+step:756/1480 train_time:32858ms step_avg:43.46ms
+step:757/1480 train_time:32916ms step_avg:43.48ms
+step:758/1480 train_time:32981ms step_avg:43.51ms
+step:759/1480 train_time:33039ms step_avg:43.53ms
+step:760/1480 train_time:33104ms step_avg:43.56ms
+step:761/1480 train_time:33163ms step_avg:43.58ms
+step:762/1480 train_time:33227ms step_avg:43.60ms
+step:763/1480 train_time:33284ms step_avg:43.62ms
+step:764/1480 train_time:33349ms step_avg:43.65ms
+step:765/1480 train_time:33408ms step_avg:43.67ms
+step:766/1480 train_time:33473ms step_avg:43.70ms
+step:767/1480 train_time:33530ms step_avg:43.72ms
+step:768/1480 train_time:33594ms step_avg:43.74ms
+step:769/1480 train_time:33650ms step_avg:43.76ms
+step:770/1480 train_time:33714ms step_avg:43.78ms
+step:771/1480 train_time:33770ms step_avg:43.80ms
+step:772/1480 train_time:33834ms step_avg:43.83ms
+step:773/1480 train_time:33891ms step_avg:43.84ms
+step:774/1480 train_time:33955ms step_avg:43.87ms
+step:775/1480 train_time:34013ms step_avg:43.89ms
+step:776/1480 train_time:34078ms step_avg:43.92ms
+step:777/1480 train_time:34139ms step_avg:43.94ms
+step:778/1480 train_time:34205ms step_avg:43.97ms
+step:779/1480 train_time:34266ms step_avg:43.99ms
+step:780/1480 train_time:34332ms step_avg:44.01ms
+step:781/1480 train_time:34391ms step_avg:44.03ms
+step:782/1480 train_time:34457ms step_avg:44.06ms
+step:783/1480 train_time:34517ms step_avg:44.08ms
+step:784/1480 train_time:34584ms step_avg:44.11ms
+step:785/1480 train_time:34644ms step_avg:44.13ms
+step:786/1480 train_time:34711ms step_avg:44.16ms
+step:787/1480 train_time:34770ms step_avg:44.18ms
+step:788/1480 train_time:34836ms step_avg:44.21ms
+step:789/1480 train_time:34893ms step_avg:44.22ms
+step:790/1480 train_time:34952ms step_avg:44.24ms
+step:791/1480 train_time:35009ms step_avg:44.26ms
+step:792/1480 train_time:35070ms step_avg:44.28ms
+step:793/1480 train_time:35131ms step_avg:44.30ms
+step:794/1480 train_time:35198ms step_avg:44.33ms
+step:795/1480 train_time:35259ms step_avg:44.35ms
+step:796/1480 train_time:35326ms step_avg:44.38ms
+step:797/1480 train_time:35386ms step_avg:44.40ms
+step:798/1480 train_time:35451ms step_avg:44.43ms
+step:799/1480 train_time:35510ms step_avg:44.44ms
+step:800/1480 train_time:35573ms step_avg:44.47ms
+step:801/1480 train_time:35629ms step_avg:44.48ms
+step:802/1480 train_time:35692ms step_avg:44.50ms
+step:803/1480 train_time:35749ms step_avg:44.52ms
+step:804/1480 train_time:35817ms step_avg:44.55ms
+step:805/1480 train_time:35874ms step_avg:44.56ms
+step:806/1480 train_time:35939ms step_avg:44.59ms
+step:807/1480 train_time:35998ms step_avg:44.61ms
+step:808/1480 train_time:36063ms step_avg:44.63ms
+step:809/1480 train_time:36122ms step_avg:44.65ms
+step:810/1480 train_time:36185ms step_avg:44.67ms
+step:811/1480 train_time:36243ms step_avg:44.69ms
+step:812/1480 train_time:36307ms step_avg:44.71ms
+step:813/1480 train_time:36367ms step_avg:44.73ms
+step:814/1480 train_time:36432ms step_avg:44.76ms
+step:815/1480 train_time:36490ms step_avg:44.77ms
+step:816/1480 train_time:36554ms step_avg:44.80ms
+step:817/1480 train_time:36611ms step_avg:44.81ms
+step:818/1480 train_time:36674ms step_avg:44.83ms
+step:819/1480 train_time:36731ms step_avg:44.85ms
+step:820/1480 train_time:36793ms step_avg:44.87ms
+step:821/1480 train_time:36849ms step_avg:44.88ms
+step:822/1480 train_time:36914ms step_avg:44.91ms
+step:823/1480 train_time:36972ms step_avg:44.92ms
+step:824/1480 train_time:37036ms step_avg:44.95ms
+step:825/1480 train_time:37095ms step_avg:44.96ms
+step:826/1480 train_time:37160ms step_avg:44.99ms
+step:827/1480 train_time:37218ms step_avg:45.00ms
+step:828/1480 train_time:37282ms step_avg:45.03ms
+step:829/1480 train_time:37342ms step_avg:45.04ms
+step:830/1480 train_time:37406ms step_avg:45.07ms
+step:831/1480 train_time:37465ms step_avg:45.08ms
+step:832/1480 train_time:37529ms step_avg:45.11ms
+step:833/1480 train_time:37587ms step_avg:45.12ms
+step:834/1480 train_time:37652ms step_avg:45.15ms
+step:835/1480 train_time:37710ms step_avg:45.16ms
+step:836/1480 train_time:37775ms step_avg:45.19ms
+step:837/1480 train_time:37832ms step_avg:45.20ms
+step:838/1480 train_time:37896ms step_avg:45.22ms
+step:839/1480 train_time:37954ms step_avg:45.24ms
+step:840/1480 train_time:38018ms step_avg:45.26ms
+step:841/1480 train_time:38076ms step_avg:45.27ms
+step:842/1480 train_time:38140ms step_avg:45.30ms
+step:843/1480 train_time:38199ms step_avg:45.31ms
+step:844/1480 train_time:38265ms step_avg:45.34ms
+step:845/1480 train_time:38325ms step_avg:45.35ms
+step:846/1480 train_time:38388ms step_avg:45.38ms
+step:847/1480 train_time:38446ms step_avg:45.39ms
+step:848/1480 train_time:38510ms step_avg:45.41ms
+step:849/1480 train_time:38567ms step_avg:45.43ms
+step:850/1480 train_time:38630ms step_avg:45.45ms
+step:851/1480 train_time:38687ms step_avg:45.46ms
+step:852/1480 train_time:38751ms step_avg:45.48ms
+step:853/1480 train_time:38809ms step_avg:45.50ms
+step:854/1480 train_time:38872ms step_avg:45.52ms
+step:855/1480 train_time:38929ms step_avg:45.53ms
+step:856/1480 train_time:38992ms step_avg:45.55ms
+step:857/1480 train_time:39050ms step_avg:45.57ms
+step:858/1480 train_time:39114ms step_avg:45.59ms
+step:859/1480 train_time:39172ms step_avg:45.60ms
+step:860/1480 train_time:39236ms step_avg:45.62ms
+step:861/1480 train_time:39295ms step_avg:45.64ms
+step:862/1480 train_time:39359ms step_avg:45.66ms
+step:863/1480 train_time:39417ms step_avg:45.67ms
+step:864/1480 train_time:39481ms step_avg:45.70ms
+step:865/1480 train_time:39541ms step_avg:45.71ms
+step:866/1480 train_time:39606ms step_avg:45.73ms
+step:867/1480 train_time:39665ms step_avg:45.75ms
+step:868/1480 train_time:39729ms step_avg:45.77ms
+step:869/1480 train_time:39786ms step_avg:45.78ms
+step:870/1480 train_time:39851ms step_avg:45.81ms
+step:871/1480 train_time:39910ms step_avg:45.82ms
+step:872/1480 train_time:39974ms step_avg:45.84ms
+step:873/1480 train_time:40030ms step_avg:45.85ms
+step:874/1480 train_time:40093ms step_avg:45.87ms
+step:875/1480 train_time:40150ms step_avg:45.89ms
+step:876/1480 train_time:40214ms step_avg:45.91ms
+step:877/1480 train_time:40272ms step_avg:45.92ms
+step:878/1480 train_time:40337ms step_avg:45.94ms
+step:879/1480 train_time:40396ms step_avg:45.96ms
+step:880/1480 train_time:40463ms step_avg:45.98ms
+step:881/1480 train_time:40522ms step_avg:45.99ms
+step:882/1480 train_time:40588ms step_avg:46.02ms
+step:883/1480 train_time:40647ms step_avg:46.03ms
+step:884/1480 train_time:40713ms step_avg:46.06ms
+step:885/1480 train_time:40771ms step_avg:46.07ms
+step:886/1480 train_time:40836ms step_avg:46.09ms
+step:887/1480 train_time:40895ms step_avg:46.10ms
+step:888/1480 train_time:40960ms step_avg:46.13ms
+step:889/1480 train_time:41020ms step_avg:46.14ms
+step:890/1480 train_time:41086ms step_avg:46.16ms
+step:891/1480 train_time:41145ms step_avg:46.18ms
+step:892/1480 train_time:41212ms step_avg:46.20ms
+step:893/1480 train_time:41270ms step_avg:46.22ms
+step:894/1480 train_time:41335ms step_avg:46.24ms
+step:895/1480 train_time:41394ms step_avg:46.25ms
+step:896/1480 train_time:41458ms step_avg:46.27ms
+step:897/1480 train_time:41517ms step_avg:46.28ms
+step:898/1480 train_time:41583ms step_avg:46.31ms
+step:899/1480 train_time:41643ms step_avg:46.32ms
+step:900/1480 train_time:41708ms step_avg:46.34ms
+step:901/1480 train_time:41767ms step_avg:46.36ms
+step:902/1480 train_time:41832ms step_avg:46.38ms
+step:903/1480 train_time:41890ms step_avg:46.39ms
+step:904/1480 train_time:41955ms step_avg:46.41ms
+step:905/1480 train_time:42013ms step_avg:46.42ms
+step:906/1480 train_time:42077ms step_avg:46.44ms
+step:907/1480 train_time:42136ms step_avg:46.46ms
+step:908/1480 train_time:42201ms step_avg:46.48ms
+step:909/1480 train_time:42260ms step_avg:46.49ms
+step:910/1480 train_time:42325ms step_avg:46.51ms
+step:911/1480 train_time:42384ms step_avg:46.52ms
+step:912/1480 train_time:42449ms step_avg:46.55ms
+step:913/1480 train_time:42508ms step_avg:46.56ms
+step:914/1480 train_time:42572ms step_avg:46.58ms
+step:915/1480 train_time:42630ms step_avg:46.59ms
+step:916/1480 train_time:42695ms step_avg:46.61ms
+step:917/1480 train_time:42753ms step_avg:46.62ms
+step:918/1480 train_time:42817ms step_avg:46.64ms
+step:919/1480 train_time:42875ms step_avg:46.65ms
+step:920/1480 train_time:42939ms step_avg:46.67ms
+step:921/1480 train_time:42997ms step_avg:46.68ms
+step:922/1480 train_time:43061ms step_avg:46.70ms
+step:923/1480 train_time:43120ms step_avg:46.72ms
+step:924/1480 train_time:43184ms step_avg:46.74ms
+step:925/1480 train_time:43244ms step_avg:46.75ms
+step:926/1480 train_time:43309ms step_avg:46.77ms
+step:927/1480 train_time:43368ms step_avg:46.78ms
+step:928/1480 train_time:43432ms step_avg:46.80ms
+step:929/1480 train_time:43489ms step_avg:46.81ms
+step:930/1480 train_time:43553ms step_avg:46.83ms
+step:931/1480 train_time:43611ms step_avg:46.84ms
+step:932/1480 train_time:43676ms step_avg:46.86ms
+step:933/1480 train_time:43733ms step_avg:46.87ms
+step:934/1480 train_time:43796ms step_avg:46.89ms
+step:935/1480 train_time:43854ms step_avg:46.90ms
+step:936/1480 train_time:43918ms step_avg:46.92ms
+step:937/1480 train_time:43975ms step_avg:46.93ms
+step:938/1480 train_time:44037ms step_avg:46.95ms
+step:939/1480 train_time:44094ms step_avg:46.96ms
+step:940/1480 train_time:44158ms step_avg:46.98ms
+step:941/1480 train_time:44215ms step_avg:46.99ms
+step:942/1480 train_time:44278ms step_avg:47.00ms
+step:943/1480 train_time:44335ms step_avg:47.02ms
+step:944/1480 train_time:44399ms step_avg:47.03ms
+step:945/1480 train_time:44456ms step_avg:47.04ms
+step:946/1480 train_time:44520ms step_avg:47.06ms
+step:947/1480 train_time:44579ms step_avg:47.07ms
+step:948/1480 train_time:44644ms step_avg:47.09ms
+step:949/1480 train_time:44704ms step_avg:47.11ms
+step:950/1480 train_time:44769ms step_avg:47.13ms
+step:951/1480 train_time:44828ms step_avg:47.14ms
+step:952/1480 train_time:44892ms step_avg:47.16ms
+step:953/1480 train_time:44950ms step_avg:47.17ms
+step:954/1480 train_time:45014ms step_avg:47.18ms
+step:955/1480 train_time:45071ms step_avg:47.20ms
+step:956/1480 train_time:45135ms step_avg:47.21ms
+step:957/1480 train_time:45192ms step_avg:47.22ms
+step:958/1480 train_time:45256ms step_avg:47.24ms
+step:959/1480 train_time:45314ms step_avg:47.25ms
+step:960/1480 train_time:45379ms step_avg:47.27ms
+step:961/1480 train_time:45440ms step_avg:47.28ms
+step:962/1480 train_time:45528ms step_avg:47.33ms
+step:963/1480 train_time:45615ms step_avg:47.37ms
+step:964/1480 train_time:45709ms step_avg:47.42ms
+step:965/1480 train_time:45797ms step_avg:47.46ms
+step:966/1480 train_time:45890ms step_avg:47.50ms
+step:967/1480 train_time:45976ms step_avg:47.55ms
+step:968/1480 train_time:46070ms step_avg:47.59ms
+step:969/1480 train_time:46157ms step_avg:47.63ms
+step:970/1480 train_time:46249ms step_avg:47.68ms
+step:971/1480 train_time:46337ms step_avg:47.72ms
+step:972/1480 train_time:46429ms step_avg:47.77ms
+step:973/1480 train_time:46516ms step_avg:47.81ms
+step:974/1480 train_time:46608ms step_avg:47.85ms
+step:975/1480 train_time:46695ms step_avg:47.89ms
+step:976/1480 train_time:46787ms step_avg:47.94ms
+step:977/1480 train_time:46871ms step_avg:47.97ms
+step:978/1480 train_time:46962ms step_avg:48.02ms
+step:979/1480 train_time:47046ms step_avg:48.06ms
+step:980/1480 train_time:47138ms step_avg:48.10ms
+step:981/1480 train_time:47221ms step_avg:48.14ms
+step:982/1480 train_time:47312ms step_avg:48.18ms
+step:983/1480 train_time:47398ms step_avg:48.22ms
+step:984/1480 train_time:47489ms step_avg:48.26ms
+step:985/1480 train_time:47574ms step_avg:48.30ms
+step:986/1480 train_time:47667ms step_avg:48.34ms
+step:987/1480 train_time:47753ms step_avg:48.38ms
+step:988/1480 train_time:47846ms step_avg:48.43ms
+step:989/1480 train_time:47938ms step_avg:48.47ms
+step:990/1480 train_time:48037ms step_avg:48.52ms
+step:991/1480 train_time:48124ms step_avg:48.56ms
+step:992/1480 train_time:48220ms step_avg:48.61ms
+step:993/1480 train_time:48311ms step_avg:48.65ms
+step:994/1480 train_time:48407ms step_avg:48.70ms
+step:995/1480 train_time:48497ms step_avg:48.74ms
+step:996/1480 train_time:48594ms step_avg:48.79ms
+step:997/1480 train_time:48682ms step_avg:48.83ms
+step:998/1480 train_time:48778ms step_avg:48.88ms
+step:999/1480 train_time:48859ms step_avg:48.91ms
+step:1000/1480 train_time:48945ms step_avg:48.94ms
+step:1000/1480 val_loss:3.5135 train_time:49063ms step_avg:49.06ms
+step:1001/1480 train_time:49083ms step_avg:49.03ms
+step:1002/1480 train_time:49126ms step_avg:49.03ms
+step:1003/1480 train_time:49215ms step_avg:49.07ms
+step:1004/1480 train_time:49313ms step_avg:49.12ms
+step:1005/1480 train_time:49397ms step_avg:49.15ms
+step:1006/1480 train_time:49487ms step_avg:49.19ms
+step:1007/1480 train_time:49574ms step_avg:49.23ms
+step:1008/1480 train_time:49665ms step_avg:49.27ms
+step:1009/1480 train_time:49754ms step_avg:49.31ms
+step:1010/1480 train_time:49851ms step_avg:49.36ms
+step:1011/1480 train_time:49943ms step_avg:49.40ms
+step:1012/1480 train_time:50041ms step_avg:49.45ms
+step:1013/1480 train_time:50132ms step_avg:49.49ms
+step:1014/1480 train_time:50230ms step_avg:49.54ms
+step:1015/1480 train_time:50322ms step_avg:49.58ms
+step:1016/1480 train_time:50420ms step_avg:49.63ms
+step:1017/1480 train_time:50500ms step_avg:49.66ms
+step:1018/1480 train_time:50586ms step_avg:49.69ms
+step:1019/1480 train_time:50677ms step_avg:49.73ms
+step:1020/1480 train_time:50779ms step_avg:49.78ms
+step:1021/1480 train_time:50870ms step_avg:49.82ms
+step:1022/1480 train_time:50968ms step_avg:49.87ms
+step:1023/1480 train_time:51059ms step_avg:49.91ms
+step:1024/1480 train_time:51156ms step_avg:49.96ms
+step:1025/1480 train_time:51248ms step_avg:50.00ms
+step:1026/1480 train_time:51333ms step_avg:50.03ms
+step:1027/1480 train_time:51413ms step_avg:50.06ms
+step:1028/1480 train_time:51502ms step_avg:50.10ms
+step:1029/1480 train_time:51584ms step_avg:50.13ms
+step:1030/1480 train_time:51674ms step_avg:50.17ms
+step:1031/1480 train_time:51760ms step_avg:50.20ms
+step:1032/1480 train_time:51851ms step_avg:50.24ms
+step:1033/1480 train_time:51939ms step_avg:50.28ms
+step:1034/1480 train_time:52032ms step_avg:50.32ms
+step:1035/1480 train_time:52121ms step_avg:50.36ms
+step:1036/1480 train_time:52212ms step_avg:50.40ms
+step:1037/1480 train_time:52303ms step_avg:50.44ms
+step:1038/1480 train_time:52395ms step_avg:50.48ms
+step:1039/1480 train_time:52479ms step_avg:50.51ms
+step:1040/1480 train_time:52570ms step_avg:50.55ms
+step:1041/1480 train_time:52659ms step_avg:50.58ms
+step:1042/1480 train_time:52751ms step_avg:50.62ms
+step:1043/1480 train_time:52838ms step_avg:50.66ms
+step:1044/1480 train_time:52931ms step_avg:50.70ms
+step:1045/1480 train_time:53020ms step_avg:50.74ms
+step:1046/1480 train_time:53115ms step_avg:50.78ms
+step:1047/1480 train_time:53204ms step_avg:50.82ms
+step:1048/1480 train_time:53300ms step_avg:50.86ms
+step:1049/1480 train_time:53389ms step_avg:50.90ms
+step:1050/1480 train_time:53485ms step_avg:50.94ms
+step:1051/1480 train_time:53573ms step_avg:50.97ms
+step:1052/1480 train_time:53668ms step_avg:51.02ms
+step:1053/1480 train_time:53754ms step_avg:51.05ms
+step:1054/1480 train_time:53848ms step_avg:51.09ms
+step:1055/1480 train_time:53935ms step_avg:51.12ms
+step:1056/1480 train_time:54030ms step_avg:51.16ms
+step:1057/1480 train_time:54117ms step_avg:51.20ms
+step:1058/1480 train_time:54211ms step_avg:51.24ms
+step:1059/1480 train_time:54299ms step_avg:51.27ms
+step:1060/1480 train_time:54392ms step_avg:51.31ms
+step:1061/1480 train_time:54481ms step_avg:51.35ms
+step:1062/1480 train_time:54574ms step_avg:51.39ms
+step:1063/1480 train_time:54661ms step_avg:51.42ms
+step:1064/1480 train_time:54755ms step_avg:51.46ms
+step:1065/1480 train_time:54843ms step_avg:51.50ms
+step:1066/1480 train_time:54935ms step_avg:51.53ms
+step:1067/1480 train_time:55023ms step_avg:51.57ms
+step:1068/1480 train_time:55116ms step_avg:51.61ms
+step:1069/1480 train_time:55203ms step_avg:51.64ms
+step:1070/1480 train_time:55295ms step_avg:51.68ms
+step:1071/1480 train_time:55383ms step_avg:51.71ms
+step:1072/1480 train_time:55475ms step_avg:51.75ms
+step:1073/1480 train_time:55562ms step_avg:51.78ms
+step:1074/1480 train_time:55655ms step_avg:51.82ms
+step:1075/1480 train_time:55742ms step_avg:51.85ms
+step:1076/1480 train_time:55833ms step_avg:51.89ms
+step:1077/1480 train_time:55918ms step_avg:51.92ms
+step:1078/1480 train_time:56008ms step_avg:51.96ms
+step:1079/1480 train_time:56092ms step_avg:51.99ms
+step:1080/1480 train_time:56185ms step_avg:52.02ms
+step:1081/1480 train_time:56271ms step_avg:52.05ms
+step:1082/1480 train_time:56364ms step_avg:52.09ms
+step:1083/1480 train_time:56449ms step_avg:52.12ms
+step:1084/1480 train_time:56541ms step_avg:52.16ms
+step:1085/1480 train_time:56627ms step_avg:52.19ms
+step:1086/1480 train_time:56719ms step_avg:52.23ms
+step:1087/1480 train_time:56805ms step_avg:52.26ms
+step:1088/1480 train_time:56897ms step_avg:52.29ms
+step:1089/1480 train_time:56984ms step_avg:52.33ms
+step:1090/1480 train_time:57075ms step_avg:52.36ms
+step:1091/1480 train_time:57159ms step_avg:52.39ms
+step:1092/1480 train_time:57249ms step_avg:52.43ms
+step:1093/1480 train_time:57333ms step_avg:52.45ms
+step:1094/1480 train_time:57424ms step_avg:52.49ms
+step:1095/1480 train_time:57510ms step_avg:52.52ms
+step:1096/1480 train_time:57602ms step_avg:52.56ms
+step:1097/1480 train_time:57688ms step_avg:52.59ms
+step:1098/1480 train_time:57780ms step_avg:52.62ms
+step:1099/1480 train_time:57865ms step_avg:52.65ms
+step:1100/1480 train_time:57955ms step_avg:52.69ms
+step:1101/1480 train_time:58043ms step_avg:52.72ms
+step:1102/1480 train_time:58138ms step_avg:52.76ms
+step:1103/1480 train_time:58228ms step_avg:52.79ms
+step:1104/1480 train_time:58323ms step_avg:52.83ms
+step:1105/1480 train_time:58414ms step_avg:52.86ms
+step:1106/1480 train_time:58510ms step_avg:52.90ms
+step:1107/1480 train_time:58597ms step_avg:52.93ms
+step:1108/1480 train_time:58693ms step_avg:52.97ms
+step:1109/1480 train_time:58781ms step_avg:53.00ms
+step:1110/1480 train_time:58876ms step_avg:53.04ms
+step:1111/1480 train_time:58966ms step_avg:53.07ms
+step:1112/1480 train_time:59060ms step_avg:53.11ms
+step:1113/1480 train_time:59149ms step_avg:53.14ms
+step:1114/1480 train_time:59245ms step_avg:53.18ms
+step:1115/1480 train_time:59332ms step_avg:53.21ms
+step:1116/1480 train_time:59427ms step_avg:53.25ms
+step:1117/1480 train_time:59515ms step_avg:53.28ms
+step:1118/1480 train_time:59609ms step_avg:53.32ms
+step:1119/1480 train_time:59690ms step_avg:53.34ms
+step:1120/1480 train_time:59783ms step_avg:53.38ms
+step:1121/1480 train_time:59871ms step_avg:53.41ms
+step:1122/1480 train_time:59965ms step_avg:53.44ms
+step:1123/1480 train_time:60054ms step_avg:53.48ms
+step:1124/1480 train_time:60146ms step_avg:53.51ms
+step:1125/1480 train_time:60235ms step_avg:53.54ms
+step:1126/1480 train_time:60329ms step_avg:53.58ms
+step:1127/1480 train_time:60414ms step_avg:53.61ms
+step:1128/1480 train_time:60509ms step_avg:53.64ms
+step:1129/1480 train_time:60597ms step_avg:53.67ms
+step:1130/1480 train_time:60693ms step_avg:53.71ms
+step:1131/1480 train_time:60785ms step_avg:53.74ms
+step:1132/1480 train_time:60880ms step_avg:53.78ms
+step:1133/1480 train_time:60970ms step_avg:53.81ms
+step:1134/1480 train_time:61068ms step_avg:53.85ms
+step:1135/1480 train_time:61160ms step_avg:53.89ms
+step:1136/1480 train_time:61256ms step_avg:53.92ms
+step:1137/1480 train_time:61339ms step_avg:53.95ms
+step:1138/1480 train_time:61429ms step_avg:53.98ms
+step:1139/1480 train_time:61516ms step_avg:54.01ms
+step:1140/1480 train_time:61606ms step_avg:54.04ms
+step:1141/1480 train_time:61695ms step_avg:54.07ms
+step:1142/1480 train_time:61790ms step_avg:54.11ms
+step:1143/1480 train_time:61879ms step_avg:54.14ms
+step:1144/1480 train_time:61973ms step_avg:54.17ms
+step:1145/1480 train_time:62060ms step_avg:54.20ms
+step:1146/1480 train_time:62155ms step_avg:54.24ms
+step:1147/1480 train_time:62246ms step_avg:54.27ms
+step:1148/1480 train_time:62342ms step_avg:54.31ms
+step:1149/1480 train_time:62434ms step_avg:54.34ms
+step:1150/1480 train_time:62531ms step_avg:54.37ms
+step:1151/1480 train_time:62622ms step_avg:54.41ms
+step:1152/1480 train_time:62719ms step_avg:54.44ms
+step:1153/1480 train_time:62812ms step_avg:54.48ms
+step:1154/1480 train_time:62908ms step_avg:54.51ms
+step:1155/1480 train_time:62996ms step_avg:54.54ms
+step:1156/1480 train_time:63093ms step_avg:54.58ms
+step:1157/1480 train_time:63174ms step_avg:54.60ms
+step:1158/1480 train_time:63262ms step_avg:54.63ms
+step:1159/1480 train_time:63347ms step_avg:54.66ms
+step:1160/1480 train_time:63442ms step_avg:54.69ms
+step:1161/1480 train_time:63532ms step_avg:54.72ms
+step:1162/1480 train_time:63623ms step_avg:54.75ms
+step:1163/1480 train_time:63710ms step_avg:54.78ms
+step:1164/1480 train_time:63805ms step_avg:54.82ms
+step:1165/1480 train_time:63893ms step_avg:54.84ms
+step:1166/1480 train_time:63987ms step_avg:54.88ms
+step:1167/1480 train_time:64074ms step_avg:54.91ms
+step:1168/1480 train_time:64169ms step_avg:54.94ms
+step:1169/1480 train_time:64258ms step_avg:54.97ms
+step:1170/1480 train_time:64353ms step_avg:55.00ms
+step:1171/1480 train_time:64443ms step_avg:55.03ms
+step:1172/1480 train_time:64537ms step_avg:55.07ms
+step:1173/1480 train_time:64626ms step_avg:55.09ms
+step:1174/1480 train_time:64722ms step_avg:55.13ms
+step:1175/1480 train_time:64810ms step_avg:55.16ms
+step:1176/1480 train_time:64905ms step_avg:55.19ms
+step:1177/1480 train_time:64992ms step_avg:55.22ms
+step:1178/1480 train_time:65087ms step_avg:55.25ms
+step:1179/1480 train_time:65173ms step_avg:55.28ms
+step:1180/1480 train_time:65267ms step_avg:55.31ms
+step:1181/1480 train_time:65354ms step_avg:55.34ms
+step:1182/1480 train_time:65448ms step_avg:55.37ms
+step:1183/1480 train_time:65535ms step_avg:55.40ms
+step:1184/1480 train_time:65629ms step_avg:55.43ms
+step:1185/1480 train_time:65716ms step_avg:55.46ms
+step:1186/1480 train_time:65810ms step_avg:55.49ms
+step:1187/1480 train_time:65896ms step_avg:55.51ms
+step:1188/1480 train_time:65990ms step_avg:55.55ms
+step:1189/1480 train_time:66076ms step_avg:55.57ms
+step:1190/1480 train_time:66170ms step_avg:55.60ms
+step:1191/1480 train_time:66256ms step_avg:55.63ms
+step:1192/1480 train_time:66349ms step_avg:55.66ms
+step:1193/1480 train_time:66434ms step_avg:55.69ms
+step:1194/1480 train_time:66526ms step_avg:55.72ms
+step:1195/1480 train_time:66610ms step_avg:55.74ms
+step:1196/1480 train_time:66701ms step_avg:55.77ms
+step:1197/1480 train_time:66784ms step_avg:55.79ms
+step:1198/1480 train_time:66873ms step_avg:55.82ms
+step:1199/1480 train_time:66959ms step_avg:55.85ms
+step:1200/1480 train_time:67054ms step_avg:55.88ms
+step:1201/1480 train_time:67143ms step_avg:55.91ms
+step:1202/1480 train_time:67235ms step_avg:55.94ms
+step:1203/1480 train_time:67321ms step_avg:55.96ms
+step:1204/1480 train_time:67413ms step_avg:55.99ms
+step:1205/1480 train_time:67497ms step_avg:56.01ms
+step:1206/1480 train_time:67589ms step_avg:56.04ms
+step:1207/1480 train_time:67682ms step_avg:56.07ms
+step:1208/1480 train_time:67788ms step_avg:56.12ms
+step:1209/1480 train_time:67881ms step_avg:56.15ms
+step:1210/1480 train_time:67966ms step_avg:56.17ms
+step:1211/1480 train_time:68054ms step_avg:56.20ms
+step:1212/1480 train_time:68143ms step_avg:56.22ms
+step:1213/1480 train_time:68229ms step_avg:56.25ms
+step:1214/1480 train_time:68322ms step_avg:56.28ms
+step:1215/1480 train_time:68408ms step_avg:56.30ms
+step:1216/1480 train_time:68504ms step_avg:56.34ms
+step:1217/1480 train_time:68596ms step_avg:56.37ms
+step:1218/1480 train_time:68694ms step_avg:56.40ms
+step:1219/1480 train_time:68784ms step_avg:56.43ms
+step:1220/1480 train_time:68881ms step_avg:56.46ms
+step:1221/1480 train_time:68971ms step_avg:56.49ms
+step:1222/1480 train_time:69066ms step_avg:56.52ms
+step:1223/1480 train_time:69155ms step_avg:56.55ms
+step:1224/1480 train_time:69250ms step_avg:56.58ms
+step:1225/1480 train_time:69338ms step_avg:56.60ms
+step:1226/1480 train_time:69433ms step_avg:56.63ms
+step:1227/1480 train_time:69522ms step_avg:56.66ms
+step:1228/1480 train_time:69617ms step_avg:56.69ms
+step:1229/1480 train_time:69702ms step_avg:56.71ms
+step:1230/1480 train_time:69790ms step_avg:56.74ms
+step:1231/1480 train_time:69875ms step_avg:56.76ms
+step:1232/1480 train_time:69965ms step_avg:56.79ms
+step:1233/1480 train_time:70050ms step_avg:56.81ms
+step:1234/1480 train_time:70146ms step_avg:56.84ms
+step:1235/1480 train_time:70233ms step_avg:56.87ms
+step:1236/1480 train_time:70326ms step_avg:56.90ms
+step:1237/1480 train_time:70412ms step_avg:56.92ms
+step:1238/1480 train_time:70505ms step_avg:56.95ms
+step:1239/1480 train_time:70590ms step_avg:56.97ms
+step:1240/1480 train_time:70686ms step_avg:57.00ms
+step:1241/1480 train_time:70770ms step_avg:57.03ms
+step:1242/1480 train_time:70865ms step_avg:57.06ms
+step:1243/1480 train_time:70950ms step_avg:57.08ms
+step:1244/1480 train_time:71045ms step_avg:57.11ms
+step:1245/1480 train_time:71130ms step_avg:57.13ms
+step:1246/1480 train_time:71221ms step_avg:57.16ms
+step:1247/1480 train_time:71306ms step_avg:57.18ms
+step:1248/1480 train_time:71399ms step_avg:57.21ms
+step:1249/1480 train_time:71486ms step_avg:57.23ms
+step:1250/1480 train_time:71578ms step_avg:57.26ms
+step:1250/1480 val_loss:3.3724 train_time:71695ms step_avg:57.36ms
+step:1251/1480 train_time:71714ms step_avg:57.33ms
+step:1252/1480 train_time:71758ms step_avg:57.31ms
+step:1253/1480 train_time:71845ms step_avg:57.34ms
+step:1254/1480 train_time:71939ms step_avg:57.37ms
+step:1255/1480 train_time:72025ms step_avg:57.39ms
+step:1256/1480 train_time:72118ms step_avg:57.42ms
+step:1257/1480 train_time:72203ms step_avg:57.44ms
+step:1258/1480 train_time:72297ms step_avg:57.47ms
+step:1259/1480 train_time:72384ms step_avg:57.49ms
+step:1260/1480 train_time:72477ms step_avg:57.52ms
+step:1261/1480 train_time:72563ms step_avg:57.54ms
+step:1262/1480 train_time:72655ms step_avg:57.57ms
+step:1263/1480 train_time:72739ms step_avg:57.59ms
+step:1264/1480 train_time:72831ms step_avg:57.62ms
+step:1265/1480 train_time:72916ms step_avg:57.64ms
+step:1266/1480 train_time:73009ms step_avg:57.67ms
+step:1267/1480 train_time:73096ms step_avg:57.69ms
+step:1268/1480 train_time:73189ms step_avg:57.72ms
+step:1269/1480 train_time:73275ms step_avg:57.74ms
+step:1270/1480 train_time:73367ms step_avg:57.77ms
+step:1271/1480 train_time:73454ms step_avg:57.79ms
+step:1272/1480 train_time:73548ms step_avg:57.82ms
+step:1273/1480 train_time:73636ms step_avg:57.84ms
+step:1274/1480 train_time:73730ms step_avg:57.87ms
+step:1275/1480 train_time:73816ms step_avg:57.90ms
+step:1276/1480 train_time:73910ms step_avg:57.92ms
+step:1277/1480 train_time:73998ms step_avg:57.95ms
+step:1278/1480 train_time:74092ms step_avg:57.97ms
+step:1279/1480 train_time:74177ms step_avg:58.00ms
+step:1280/1480 train_time:74268ms step_avg:58.02ms
+step:1281/1480 train_time:74353ms step_avg:58.04ms
+step:1282/1480 train_time:74447ms step_avg:58.07ms
+step:1283/1480 train_time:74540ms step_avg:58.10ms
+step:1284/1480 train_time:74635ms step_avg:58.13ms
+step:1285/1480 train_time:74724ms step_avg:58.15ms
+step:1286/1480 train_time:74820ms step_avg:58.18ms
+step:1287/1480 train_time:74909ms step_avg:58.20ms
+step:1288/1480 train_time:75005ms step_avg:58.23ms
+step:1289/1480 train_time:75096ms step_avg:58.26ms
+step:1290/1480 train_time:75190ms step_avg:58.29ms
+step:1291/1480 train_time:75271ms step_avg:58.30ms
+step:1292/1480 train_time:75359ms step_avg:58.33ms
+step:1293/1480 train_time:75450ms step_avg:58.35ms
+step:1294/1480 train_time:75543ms step_avg:58.38ms
+step:1295/1480 train_time:75632ms step_avg:58.40ms
+step:1296/1480 train_time:75726ms step_avg:58.43ms
+step:1297/1480 train_time:75813ms step_avg:58.45ms
+step:1298/1480 train_time:75905ms step_avg:58.48ms
+step:1299/1480 train_time:75991ms step_avg:58.50ms
+step:1300/1480 train_time:76087ms step_avg:58.53ms
+step:1301/1480 train_time:76178ms step_avg:58.55ms
+step:1302/1480 train_time:76276ms step_avg:58.58ms
+step:1303/1480 train_time:76367ms step_avg:58.61ms
+step:1304/1480 train_time:76464ms step_avg:58.64ms
+step:1305/1480 train_time:76554ms step_avg:58.66ms
+step:1306/1480 train_time:76650ms step_avg:58.69ms
+step:1307/1480 train_time:76742ms step_avg:58.72ms
+step:1308/1480 train_time:76838ms step_avg:58.74ms
+step:1309/1480 train_time:76919ms step_avg:58.76ms
+step:1310/1480 train_time:77006ms step_avg:58.78ms
+step:1311/1480 train_time:77090ms step_avg:58.80ms
+step:1312/1480 train_time:77180ms step_avg:58.83ms
+step:1313/1480 train_time:77265ms step_avg:58.85ms
+step:1314/1480 train_time:77358ms step_avg:58.87ms
+step:1315/1480 train_time:77443ms step_avg:58.89ms
+step:1316/1480 train_time:77537ms step_avg:58.92ms
+step:1317/1480 train_time:77624ms step_avg:58.94ms
+step:1318/1480 train_time:77718ms step_avg:58.97ms
+step:1319/1480 train_time:77808ms step_avg:58.99ms
+step:1320/1480 train_time:77902ms step_avg:59.02ms
+step:1321/1480 train_time:77992ms step_avg:59.04ms
+step:1322/1480 train_time:78087ms step_avg:59.07ms
+step:1323/1480 train_time:78177ms step_avg:59.09ms
+step:1324/1480 train_time:78271ms step_avg:59.12ms
+step:1325/1480 train_time:78359ms step_avg:59.14ms
+step:1326/1480 train_time:78454ms step_avg:59.17ms
+step:1327/1480 train_time:78542ms step_avg:59.19ms
+step:1328/1480 train_time:78638ms step_avg:59.22ms
+step:1329/1480 train_time:78725ms step_avg:59.24ms
+step:1330/1480 train_time:78819ms step_avg:59.26ms
+step:1331/1480 train_time:78907ms step_avg:59.28ms
+step:1332/1480 train_time:79001ms step_avg:59.31ms
+step:1333/1480 train_time:79089ms step_avg:59.33ms
+step:1334/1480 train_time:79181ms step_avg:59.36ms
+step:1335/1480 train_time:79270ms step_avg:59.38ms
+step:1336/1480 train_time:79362ms step_avg:59.40ms
+step:1337/1480 train_time:79448ms step_avg:59.42ms
+step:1338/1480 train_time:79542ms step_avg:59.45ms
+step:1339/1480 train_time:79629ms step_avg:59.47ms
+step:1340/1480 train_time:79722ms step_avg:59.49ms
+step:1341/1480 train_time:79808ms step_avg:59.51ms
+step:1342/1480 train_time:79901ms step_avg:59.54ms
+step:1343/1480 train_time:79985ms step_avg:59.56ms
+step:1344/1480 train_time:80079ms step_avg:59.58ms
+step:1345/1480 train_time:80173ms step_avg:59.61ms
+step:1346/1480 train_time:80265ms step_avg:59.63ms
+step:1347/1480 train_time:80355ms step_avg:59.65ms
+step:1348/1480 train_time:80451ms step_avg:59.68ms
+step:1349/1480 train_time:80538ms step_avg:59.70ms
+step:1350/1480 train_time:80631ms step_avg:59.73ms
+step:1351/1480 train_time:80718ms step_avg:59.75ms
+step:1352/1480 train_time:80811ms step_avg:59.77ms
+step:1353/1480 train_time:80897ms step_avg:59.79ms
+step:1354/1480 train_time:80991ms step_avg:59.82ms
+step:1355/1480 train_time:81080ms step_avg:59.84ms
+step:1356/1480 train_time:81176ms step_avg:59.86ms
+step:1357/1480 train_time:81263ms step_avg:59.88ms
+step:1358/1480 train_time:81358ms step_avg:59.91ms
+step:1359/1480 train_time:81447ms step_avg:59.93ms
+step:1360/1480 train_time:81542ms step_avg:59.96ms
+step:1361/1480 train_time:81625ms step_avg:59.97ms
+step:1362/1480 train_time:81724ms step_avg:60.00ms
+step:1363/1480 train_time:81813ms step_avg:60.02ms
+step:1364/1480 train_time:81905ms step_avg:60.05ms
+step:1365/1480 train_time:81992ms step_avg:60.07ms
+step:1366/1480 train_time:82084ms step_avg:60.09ms
+step:1367/1480 train_time:82172ms step_avg:60.11ms
+step:1368/1480 train_time:82264ms step_avg:60.13ms
+step:1369/1480 train_time:82350ms step_avg:60.15ms
+step:1370/1480 train_time:82444ms step_avg:60.18ms
+step:1371/1480 train_time:82535ms step_avg:60.20ms
+step:1372/1480 train_time:82631ms step_avg:60.23ms
+step:1373/1480 train_time:82721ms step_avg:60.25ms
+step:1374/1480 train_time:82818ms step_avg:60.27ms
+step:1375/1480 train_time:82908ms step_avg:60.30ms
+step:1376/1480 train_time:83005ms step_avg:60.32ms
+step:1377/1480 train_time:83095ms step_avg:60.34ms
+step:1378/1480 train_time:83189ms step_avg:60.37ms
+step:1379/1480 train_time:83277ms step_avg:60.39ms
+step:1380/1480 train_time:83373ms step_avg:60.42ms
+step:1381/1480 train_time:83454ms step_avg:60.43ms
+step:1382/1480 train_time:83541ms step_avg:60.45ms
+step:1383/1480 train_time:83629ms step_avg:60.47ms
+step:1384/1480 train_time:83720ms step_avg:60.49ms
+step:1385/1480 train_time:83808ms step_avg:60.51ms
+step:1386/1480 train_time:83901ms step_avg:60.53ms
+step:1387/1480 train_time:83988ms step_avg:60.55ms
+step:1388/1480 train_time:84079ms step_avg:60.58ms
+step:1389/1480 train_time:84167ms step_avg:60.60ms
+step:1390/1480 train_time:84264ms step_avg:60.62ms
+step:1391/1480 train_time:84353ms step_avg:60.64ms
+step:1392/1480 train_time:84446ms step_avg:60.66ms
+step:1393/1480 train_time:84531ms step_avg:60.68ms
+step:1394/1480 train_time:84623ms step_avg:60.70ms
+step:1395/1480 train_time:84709ms step_avg:60.72ms
+step:1396/1480 train_time:84801ms step_avg:60.75ms
+step:1397/1480 train_time:84887ms step_avg:60.76ms
+step:1398/1480 train_time:84980ms step_avg:60.79ms
+step:1399/1480 train_time:85065ms step_avg:60.80ms
+step:1400/1480 train_time:85155ms step_avg:60.83ms
+step:1401/1480 train_time:85241ms step_avg:60.84ms
+step:1402/1480 train_time:85335ms step_avg:60.87ms
+step:1403/1480 train_time:85419ms step_avg:60.88ms
+step:1404/1480 train_time:85515ms step_avg:60.91ms
+step:1405/1480 train_time:85601ms step_avg:60.93ms
+step:1406/1480 train_time:85694ms step_avg:60.95ms
+step:1407/1480 train_time:85780ms step_avg:60.97ms
+step:1408/1480 train_time:85875ms step_avg:60.99ms
+step:1409/1480 train_time:85962ms step_avg:61.01ms
+step:1410/1480 train_time:86058ms step_avg:61.03ms
+step:1411/1480 train_time:86144ms step_avg:61.05ms
+step:1412/1480 train_time:86238ms step_avg:61.07ms
+step:1413/1480 train_time:86324ms step_avg:61.09ms
+step:1414/1480 train_time:86417ms step_avg:61.12ms
+step:1415/1480 train_time:86504ms step_avg:61.13ms
+step:1416/1480 train_time:86596ms step_avg:61.16ms
+step:1417/1480 train_time:86680ms step_avg:61.17ms
+step:1418/1480 train_time:86773ms step_avg:61.19ms
+step:1419/1480 train_time:86857ms step_avg:61.21ms
+step:1420/1480 train_time:86951ms step_avg:61.23ms
+step:1421/1480 train_time:87040ms step_avg:61.25ms
+step:1422/1480 train_time:87135ms step_avg:61.28ms
+step:1423/1480 train_time:87224ms step_avg:61.30ms
+step:1424/1480 train_time:87320ms step_avg:61.32ms
+step:1425/1480 train_time:87411ms step_avg:61.34ms
+step:1426/1480 train_time:87507ms step_avg:61.37ms
+step:1427/1480 train_time:87597ms step_avg:61.39ms
+step:1428/1480 train_time:87694ms step_avg:61.41ms
+step:1429/1480 train_time:87782ms step_avg:61.43ms
+step:1430/1480 train_time:87878ms step_avg:61.45ms
+step:1431/1480 train_time:87969ms step_avg:61.47ms
+step:1432/1480 train_time:88063ms step_avg:61.50ms
+step:1433/1480 train_time:88153ms step_avg:61.52ms
+step:1434/1480 train_time:88247ms step_avg:61.54ms
+step:1435/1480 train_time:88337ms step_avg:61.56ms
+step:1436/1480 train_time:88431ms step_avg:61.58ms
+step:1437/1480 train_time:88518ms step_avg:61.60ms
+step:1438/1480 train_time:88614ms step_avg:61.62ms
+step:1439/1480 train_time:88701ms step_avg:61.64ms
+step:1440/1480 train_time:88795ms step_avg:61.66ms
+step:1441/1480 train_time:88886ms step_avg:61.68ms
+step:1442/1480 train_time:88982ms step_avg:61.71ms
+step:1443/1480 train_time:89070ms step_avg:61.73ms
+step:1444/1480 train_time:89163ms step_avg:61.75ms
+step:1445/1480 train_time:89250ms step_avg:61.76ms
+step:1446/1480 train_time:89344ms step_avg:61.79ms
+step:1447/1480 train_time:89432ms step_avg:61.81ms
+step:1448/1480 train_time:89525ms step_avg:61.83ms
+step:1449/1480 train_time:89608ms step_avg:61.84ms
+step:1450/1480 train_time:89706ms step_avg:61.87ms
+step:1451/1480 train_time:89799ms step_avg:61.89ms
+step:1452/1480 train_time:89892ms step_avg:61.91ms
+step:1453/1480 train_time:89979ms step_avg:61.93ms
+step:1454/1480 train_time:90073ms step_avg:61.95ms
+step:1455/1480 train_time:90161ms step_avg:61.97ms
+step:1456/1480 train_time:90258ms step_avg:61.99ms
+step:1457/1480 train_time:90344ms step_avg:62.01ms
+step:1458/1480 train_time:90438ms step_avg:62.03ms
+step:1459/1480 train_time:90523ms step_avg:62.04ms
+step:1460/1480 train_time:90618ms step_avg:62.07ms
+step:1461/1480 train_time:90707ms step_avg:62.09ms
+step:1462/1480 train_time:90803ms step_avg:62.11ms
+step:1463/1480 train_time:90893ms step_avg:62.13ms
+step:1464/1480 train_time:90989ms step_avg:62.15ms
+step:1465/1480 train_time:91079ms step_avg:62.17ms
+step:1466/1480 train_time:91175ms step_avg:62.19ms
+step:1467/1480 train_time:91262ms step_avg:62.21ms
+step:1468/1480 train_time:91358ms step_avg:62.23ms
+step:1469/1480 train_time:91446ms step_avg:62.25ms
+step:1470/1480 train_time:91542ms step_avg:62.27ms
+step:1471/1480 train_time:91630ms step_avg:62.29ms
+step:1472/1480 train_time:91723ms step_avg:62.31ms
+step:1473/1480 train_time:91812ms step_avg:62.33ms
+step:1474/1480 train_time:91906ms step_avg:62.35ms
+step:1475/1480 train_time:91996ms step_avg:62.37ms
+step:1476/1480 train_time:92091ms step_avg:62.39ms
+step:1477/1480 train_time:92178ms step_avg:62.41ms
+step:1478/1480 train_time:92272ms step_avg:62.43ms
+step:1479/1480 train_time:92358ms step_avg:62.45ms
+step:1480/1480 train_time:92454ms step_avg:62.47ms
+step:1480/1480 val_loss:3.2826 train_time:92572ms step_avg:62.55ms
+peak memory allocated: 31315 MiB reserved: 47222 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk0-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk0-1480.txt
@@ -1,0 +1,4463 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # QK bank: per-head-pair Muon groups for Q, K weights
+        # Each pair of adjacent heads gets its own independent polar express orthogonalization
+        self._num_attn_layers = num_attn_layers
+        num_qk_groups = num_attn_layers * 2 * (num_heads // 2)  # 10 * 2 * 3 = 60
+        self._num_qk_groups = num_qk_groups
+        num_qk_padded = next_multiple_of_n(num_qk_groups, n=world_size)  # 64
+        self.qk_bank = nn.Parameter(torch.empty(num_qk_padded, head_dim * 2, model_dim))
+        self.qk_bank.reshape = (num_qk_padded, head_dim * 2, model_dim)
+
+        # VO bank: per-layer Muon groups for V and O weights
+        num_vo_real = num_attn_layers * 2  # 20
+        num_vo_padded = next_multiple_of_n(num_vo_real, n=world_size)  # 24
+        self.vo_bank = nn.Parameter(torch.empty(num_vo_padded, hdim, hdim))
+        self.vo_bank.reshape = (num_vo_padded, hdim, hdim)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.qk_bank[:num_qk_groups].uniform_(-bound, bound)
+            self.qk_bank[num_qk_groups:].zero_()
+            self.vo_bank[:num_vo_real].uniform_(-bound, bound)
+            self.vo_bank[num_vo_real:].zero_()
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from qk_bank/vo_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        qk_all = self.qk_bank[:self._num_qk_groups].view(self._num_attn_layers, -1, self.qk_bank.shape[-1])
+        vo_flat = self.vo_bank[:self._num_attn_layers * 2].view(self._num_attn_layers, 2, *self.vo_bank.shape[1:]).flatten(1, 2)
+        attn_weights = torch.cat([qk_all, vo_flat], dim=1).unbind(0)
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            attn_idx = i - (i > 6) if i != 6 else None
+            qkvo_w = attn_weights[attn_idx] if attn_idx is not None else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "qk_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "vo_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "qk_bank", "vo_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.qk_bank.data = model.qk_bank.data.bfloat16()
+model.vo_bank.data = model.vo_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 15:24:16 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   38C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   66C    P0            149W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           90384      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A           90385      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A           90386      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A           90387      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A           90388      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A           90389      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A           90390      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A           90391      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8293 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:87ms step_avg:86.64ms
+step:2/1480 train_time:109ms step_avg:54.40ms
+step:3/1480 train_time:128ms step_avg:42.52ms
+step:4/1480 train_time:155ms step_avg:38.87ms
+step:5/1480 train_time:183ms step_avg:36.65ms
+step:6/1480 train_time:218ms step_avg:36.29ms
+step:7/1480 train_time:247ms step_avg:35.25ms
+step:8/1480 train_time:282ms step_avg:35.23ms
+step:9/1480 train_time:311ms step_avg:34.51ms
+step:10/1480 train_time:346ms step_avg:34.59ms
+step:11/1480 train_time:375ms step_avg:34.08ms
+step:12/1480 train_time:409ms step_avg:34.11ms
+step:13/1480 train_time:439ms step_avg:33.74ms
+step:14/1480 train_time:473ms step_avg:33.80ms
+step:15/1480 train_time:502ms step_avg:33.48ms
+step:16/1480 train_time:537ms step_avg:33.55ms
+step:17/1480 train_time:566ms step_avg:33.30ms
+step:18/1480 train_time:601ms step_avg:33.38ms
+step:19/1480 train_time:631ms step_avg:33.22ms
+step:20/1480 train_time:667ms step_avg:33.36ms
+step:21/1480 train_time:698ms step_avg:33.22ms
+step:22/1480 train_time:733ms step_avg:33.33ms
+step:23/1480 train_time:763ms step_avg:33.19ms
+step:24/1480 train_time:799ms step_avg:33.30ms
+step:25/1480 train_time:830ms step_avg:33.19ms
+step:26/1480 train_time:865ms step_avg:33.27ms
+step:27/1480 train_time:896ms step_avg:33.17ms
+step:28/1480 train_time:931ms step_avg:33.26ms
+step:29/1480 train_time:961ms step_avg:33.15ms
+step:30/1480 train_time:997ms step_avg:33.23ms
+step:31/1480 train_time:1027ms step_avg:33.12ms
+step:32/1480 train_time:1061ms step_avg:33.16ms
+step:33/1480 train_time:1090ms step_avg:33.03ms
+step:34/1480 train_time:1125ms step_avg:33.09ms
+step:35/1480 train_time:1154ms step_avg:32.96ms
+step:36/1480 train_time:1188ms step_avg:33.01ms
+step:37/1480 train_time:1217ms step_avg:32.90ms
+step:38/1480 train_time:1252ms step_avg:32.96ms
+step:39/1480 train_time:1281ms step_avg:32.85ms
+step:40/1480 train_time:1317ms step_avg:32.91ms
+step:41/1480 train_time:1346ms step_avg:32.82ms
+step:42/1480 train_time:1381ms step_avg:32.89ms
+step:43/1480 train_time:1411ms step_avg:32.82ms
+step:44/1480 train_time:1448ms step_avg:32.92ms
+step:45/1480 train_time:1480ms step_avg:32.89ms
+step:46/1480 train_time:1516ms step_avg:32.96ms
+step:47/1480 train_time:1547ms step_avg:32.91ms
+step:48/1480 train_time:1583ms step_avg:32.98ms
+step:49/1480 train_time:1614ms step_avg:32.94ms
+step:50/1480 train_time:1651ms step_avg:33.02ms
+step:51/1480 train_time:1682ms step_avg:32.98ms
+step:52/1480 train_time:1718ms step_avg:33.04ms
+step:53/1480 train_time:1749ms step_avg:33.00ms
+step:54/1480 train_time:1785ms step_avg:33.06ms
+step:55/1480 train_time:1816ms step_avg:33.02ms
+step:56/1480 train_time:1852ms step_avg:33.08ms
+step:57/1480 train_time:1883ms step_avg:33.04ms
+step:58/1480 train_time:1919ms step_avg:33.09ms
+step:59/1480 train_time:1950ms step_avg:33.05ms
+step:60/1480 train_time:1986ms step_avg:33.10ms
+step:61/1480 train_time:2017ms step_avg:33.06ms
+step:62/1480 train_time:2053ms step_avg:33.11ms
+step:63/1480 train_time:2083ms step_avg:33.07ms
+step:64/1480 train_time:2119ms step_avg:33.11ms
+step:65/1480 train_time:2150ms step_avg:33.07ms
+step:66/1480 train_time:2186ms step_avg:33.12ms
+step:67/1480 train_time:2216ms step_avg:33.08ms
+step:68/1480 train_time:2252ms step_avg:33.12ms
+step:69/1480 train_time:2282ms step_avg:33.08ms
+step:70/1480 train_time:2318ms step_avg:33.11ms
+step:71/1480 train_time:2348ms step_avg:33.08ms
+step:72/1480 train_time:2384ms step_avg:33.11ms
+step:73/1480 train_time:2415ms step_avg:33.08ms
+step:74/1480 train_time:2450ms step_avg:33.11ms
+step:75/1480 train_time:2481ms step_avg:33.08ms
+step:76/1480 train_time:2516ms step_avg:33.11ms
+step:77/1480 train_time:2546ms step_avg:33.07ms
+step:78/1480 train_time:2582ms step_avg:33.11ms
+step:79/1480 train_time:2612ms step_avg:33.07ms
+step:80/1480 train_time:2648ms step_avg:33.10ms
+step:81/1480 train_time:2678ms step_avg:33.07ms
+step:82/1480 train_time:2714ms step_avg:33.10ms
+step:83/1480 train_time:2744ms step_avg:33.06ms
+step:84/1480 train_time:2779ms step_avg:33.09ms
+step:85/1480 train_time:2809ms step_avg:33.05ms
+step:86/1480 train_time:2845ms step_avg:33.08ms
+step:87/1480 train_time:2876ms step_avg:33.05ms
+step:88/1480 train_time:2911ms step_avg:33.08ms
+step:89/1480 train_time:2941ms step_avg:33.04ms
+step:90/1480 train_time:2976ms step_avg:33.07ms
+step:91/1480 train_time:3006ms step_avg:33.04ms
+step:92/1480 train_time:3042ms step_avg:33.06ms
+step:93/1480 train_time:3072ms step_avg:33.03ms
+step:94/1480 train_time:3107ms step_avg:33.05ms
+step:95/1480 train_time:3137ms step_avg:33.02ms
+step:96/1480 train_time:3172ms step_avg:33.04ms
+step:97/1480 train_time:3202ms step_avg:33.01ms
+step:98/1480 train_time:3237ms step_avg:33.03ms
+step:99/1480 train_time:3267ms step_avg:33.00ms
+step:100/1480 train_time:3302ms step_avg:33.02ms
+step:101/1480 train_time:3332ms step_avg:32.99ms
+step:102/1480 train_time:3368ms step_avg:33.02ms
+step:103/1480 train_time:3398ms step_avg:32.99ms
+step:104/1480 train_time:3433ms step_avg:33.01ms
+step:105/1480 train_time:3462ms step_avg:32.97ms
+step:106/1480 train_time:3497ms step_avg:32.99ms
+step:107/1480 train_time:3528ms step_avg:32.97ms
+step:108/1480 train_time:3563ms step_avg:32.99ms
+step:109/1480 train_time:3593ms step_avg:32.96ms
+step:110/1480 train_time:3629ms step_avg:32.99ms
+step:111/1480 train_time:3659ms step_avg:32.96ms
+step:112/1480 train_time:3694ms step_avg:32.98ms
+step:113/1480 train_time:3724ms step_avg:32.96ms
+step:114/1480 train_time:3760ms step_avg:32.98ms
+step:115/1480 train_time:3790ms step_avg:32.96ms
+step:116/1480 train_time:3826ms step_avg:32.98ms
+step:117/1480 train_time:3856ms step_avg:32.96ms
+step:118/1480 train_time:3892ms step_avg:32.98ms
+step:119/1480 train_time:3922ms step_avg:32.96ms
+step:120/1480 train_time:3958ms step_avg:32.98ms
+step:121/1480 train_time:3988ms step_avg:32.96ms
+step:122/1480 train_time:4024ms step_avg:32.98ms
+step:123/1480 train_time:4054ms step_avg:32.96ms
+step:124/1480 train_time:4090ms step_avg:32.98ms
+step:125/1480 train_time:4120ms step_avg:32.96ms
+step:126/1480 train_time:4156ms step_avg:32.98ms
+step:127/1480 train_time:4187ms step_avg:32.97ms
+step:128/1480 train_time:4222ms step_avg:32.99ms
+step:129/1480 train_time:4253ms step_avg:32.97ms
+step:130/1480 train_time:4289ms step_avg:32.99ms
+step:131/1480 train_time:4319ms step_avg:32.97ms
+step:132/1480 train_time:4355ms step_avg:32.99ms
+step:133/1480 train_time:4386ms step_avg:32.97ms
+step:134/1480 train_time:4422ms step_avg:33.00ms
+step:135/1480 train_time:4452ms step_avg:32.98ms
+step:136/1480 train_time:4488ms step_avg:33.00ms
+step:137/1480 train_time:4518ms step_avg:32.98ms
+step:138/1480 train_time:4554ms step_avg:33.00ms
+step:139/1480 train_time:4585ms step_avg:32.98ms
+step:140/1480 train_time:4621ms step_avg:33.01ms
+step:141/1480 train_time:4651ms step_avg:32.99ms
+step:142/1480 train_time:4687ms step_avg:33.01ms
+step:143/1480 train_time:4717ms step_avg:32.99ms
+step:144/1480 train_time:4753ms step_avg:33.01ms
+step:145/1480 train_time:4783ms step_avg:32.99ms
+step:146/1480 train_time:4819ms step_avg:33.01ms
+step:147/1480 train_time:4850ms step_avg:32.99ms
+step:148/1480 train_time:4886ms step_avg:33.01ms
+step:149/1480 train_time:4916ms step_avg:32.99ms
+step:150/1480 train_time:4952ms step_avg:33.01ms
+step:151/1480 train_time:4983ms step_avg:33.00ms
+step:152/1480 train_time:5018ms step_avg:33.01ms
+step:153/1480 train_time:5049ms step_avg:33.00ms
+step:154/1480 train_time:5084ms step_avg:33.02ms
+step:155/1480 train_time:5115ms step_avg:33.00ms
+step:156/1480 train_time:5151ms step_avg:33.02ms
+step:157/1480 train_time:5181ms step_avg:33.00ms
+step:158/1480 train_time:5217ms step_avg:33.02ms
+step:159/1480 train_time:5247ms step_avg:33.00ms
+step:160/1480 train_time:5283ms step_avg:33.02ms
+step:161/1480 train_time:5313ms step_avg:33.00ms
+step:162/1480 train_time:5349ms step_avg:33.02ms
+step:163/1480 train_time:5379ms step_avg:33.00ms
+step:164/1480 train_time:5414ms step_avg:33.02ms
+step:165/1480 train_time:5444ms step_avg:33.00ms
+step:166/1480 train_time:5480ms step_avg:33.01ms
+step:167/1480 train_time:5510ms step_avg:32.99ms
+step:168/1480 train_time:5547ms step_avg:33.02ms
+step:169/1480 train_time:5579ms step_avg:33.01ms
+step:170/1480 train_time:5617ms step_avg:33.04ms
+step:171/1480 train_time:5649ms step_avg:33.04ms
+step:172/1480 train_time:5687ms step_avg:33.06ms
+step:173/1480 train_time:5719ms step_avg:33.06ms
+step:174/1480 train_time:5756ms step_avg:33.08ms
+step:175/1480 train_time:5788ms step_avg:33.08ms
+step:176/1480 train_time:5826ms step_avg:33.10ms
+step:177/1480 train_time:5857ms step_avg:33.09ms
+step:178/1480 train_time:5895ms step_avg:33.12ms
+step:179/1480 train_time:5926ms step_avg:33.11ms
+step:180/1480 train_time:5961ms step_avg:33.11ms
+step:181/1480 train_time:5989ms step_avg:33.09ms
+step:182/1480 train_time:6024ms step_avg:33.10ms
+step:183/1480 train_time:6053ms step_avg:33.08ms
+step:184/1480 train_time:6087ms step_avg:33.08ms
+step:185/1480 train_time:6117ms step_avg:33.06ms
+step:186/1480 train_time:6151ms step_avg:33.07ms
+step:187/1480 train_time:6181ms step_avg:33.05ms
+step:188/1480 train_time:6216ms step_avg:33.06ms
+step:189/1480 train_time:6245ms step_avg:33.04ms
+step:190/1480 train_time:6281ms step_avg:33.06ms
+step:191/1480 train_time:6312ms step_avg:33.05ms
+step:192/1480 train_time:6349ms step_avg:33.07ms
+step:193/1480 train_time:6380ms step_avg:33.06ms
+step:194/1480 train_time:6415ms step_avg:33.07ms
+step:195/1480 train_time:6446ms step_avg:33.06ms
+step:196/1480 train_time:6482ms step_avg:33.07ms
+step:197/1480 train_time:6512ms step_avg:33.06ms
+step:198/1480 train_time:6549ms step_avg:33.07ms
+step:199/1480 train_time:6579ms step_avg:33.06ms
+step:200/1480 train_time:6615ms step_avg:33.08ms
+step:201/1480 train_time:6646ms step_avg:33.06ms
+step:202/1480 train_time:6682ms step_avg:33.08ms
+step:203/1480 train_time:6712ms step_avg:33.07ms
+step:204/1480 train_time:6749ms step_avg:33.08ms
+step:205/1480 train_time:6779ms step_avg:33.07ms
+step:206/1480 train_time:6815ms step_avg:33.08ms
+step:207/1480 train_time:6845ms step_avg:33.07ms
+step:208/1480 train_time:6881ms step_avg:33.08ms
+step:209/1480 train_time:6912ms step_avg:33.07ms
+step:210/1480 train_time:6948ms step_avg:33.09ms
+step:211/1480 train_time:6979ms step_avg:33.08ms
+step:212/1480 train_time:7015ms step_avg:33.09ms
+step:213/1480 train_time:7046ms step_avg:33.08ms
+step:214/1480 train_time:7081ms step_avg:33.09ms
+step:215/1480 train_time:7112ms step_avg:33.08ms
+step:216/1480 train_time:7148ms step_avg:33.09ms
+step:217/1480 train_time:7179ms step_avg:33.08ms
+step:218/1480 train_time:7215ms step_avg:33.10ms
+step:219/1480 train_time:7245ms step_avg:33.08ms
+step:220/1480 train_time:7281ms step_avg:33.10ms
+step:221/1480 train_time:7312ms step_avg:33.09ms
+step:222/1480 train_time:7348ms step_avg:33.10ms
+step:223/1480 train_time:7379ms step_avg:33.09ms
+step:224/1480 train_time:7415ms step_avg:33.10ms
+step:225/1480 train_time:7445ms step_avg:33.09ms
+step:226/1480 train_time:7481ms step_avg:33.10ms
+step:227/1480 train_time:7512ms step_avg:33.09ms
+step:228/1480 train_time:7548ms step_avg:33.10ms
+step:229/1480 train_time:7578ms step_avg:33.09ms
+step:230/1480 train_time:7614ms step_avg:33.10ms
+step:231/1480 train_time:7644ms step_avg:33.09ms
+step:232/1480 train_time:7679ms step_avg:33.10ms
+step:233/1480 train_time:7710ms step_avg:33.09ms
+step:234/1480 train_time:7746ms step_avg:33.10ms
+step:235/1480 train_time:7777ms step_avg:33.09ms
+step:236/1480 train_time:7813ms step_avg:33.10ms
+step:237/1480 train_time:7843ms step_avg:33.09ms
+step:238/1480 train_time:7878ms step_avg:33.10ms
+step:239/1480 train_time:7909ms step_avg:33.09ms
+step:240/1480 train_time:7944ms step_avg:33.10ms
+step:241/1480 train_time:7975ms step_avg:33.09ms
+step:242/1480 train_time:8011ms step_avg:33.10ms
+step:243/1480 train_time:8041ms step_avg:33.09ms
+step:244/1480 train_time:8077ms step_avg:33.10ms
+step:245/1480 train_time:8107ms step_avg:33.09ms
+step:246/1480 train_time:8143ms step_avg:33.10ms
+step:247/1480 train_time:8173ms step_avg:33.09ms
+step:248/1480 train_time:8209ms step_avg:33.10ms
+step:249/1480 train_time:8240ms step_avg:33.09ms
+step:250/1480 train_time:8275ms step_avg:33.10ms
+step:250/1480 val_loss:4.4912 train_time:8319ms step_avg:33.28ms
+step:251/1480 train_time:8336ms step_avg:33.21ms
+step:252/1480 train_time:8354ms step_avg:33.15ms
+step:253/1480 train_time:8374ms step_avg:33.10ms
+step:254/1480 train_time:8411ms step_avg:33.11ms
+step:255/1480 train_time:8442ms step_avg:33.11ms
+step:256/1480 train_time:8479ms step_avg:33.12ms
+step:257/1480 train_time:8509ms step_avg:33.11ms
+step:258/1480 train_time:8546ms step_avg:33.12ms
+step:259/1480 train_time:8577ms step_avg:33.12ms
+step:260/1480 train_time:8613ms step_avg:33.13ms
+step:261/1480 train_time:8644ms step_avg:33.12ms
+step:262/1480 train_time:8681ms step_avg:33.13ms
+step:263/1480 train_time:8711ms step_avg:33.12ms
+step:264/1480 train_time:8748ms step_avg:33.13ms
+step:265/1480 train_time:8778ms step_avg:33.12ms
+step:266/1480 train_time:8812ms step_avg:33.13ms
+step:267/1480 train_time:8843ms step_avg:33.12ms
+step:268/1480 train_time:8878ms step_avg:33.13ms
+step:269/1480 train_time:8908ms step_avg:33.11ms
+step:270/1480 train_time:8945ms step_avg:33.13ms
+step:271/1480 train_time:8976ms step_avg:33.12ms
+step:272/1480 train_time:9012ms step_avg:33.13ms
+step:273/1480 train_time:9042ms step_avg:33.12ms
+step:274/1480 train_time:9078ms step_avg:33.13ms
+step:275/1480 train_time:9108ms step_avg:33.12ms
+step:276/1480 train_time:9144ms step_avg:33.13ms
+step:277/1480 train_time:9174ms step_avg:33.12ms
+step:278/1480 train_time:9210ms step_avg:33.13ms
+step:279/1480 train_time:9240ms step_avg:33.12ms
+step:280/1480 train_time:9276ms step_avg:33.13ms
+step:281/1480 train_time:9306ms step_avg:33.12ms
+step:282/1480 train_time:9342ms step_avg:33.13ms
+step:283/1480 train_time:9372ms step_avg:33.12ms
+step:284/1480 train_time:9408ms step_avg:33.13ms
+step:285/1480 train_time:9439ms step_avg:33.12ms
+step:286/1480 train_time:9475ms step_avg:33.13ms
+step:287/1480 train_time:9506ms step_avg:33.12ms
+step:288/1480 train_time:9542ms step_avg:33.13ms
+step:289/1480 train_time:9573ms step_avg:33.12ms
+step:290/1480 train_time:9609ms step_avg:33.13ms
+step:291/1480 train_time:9640ms step_avg:33.13ms
+step:292/1480 train_time:9677ms step_avg:33.14ms
+step:293/1480 train_time:9707ms step_avg:33.13ms
+step:294/1480 train_time:9744ms step_avg:33.14ms
+step:295/1480 train_time:9774ms step_avg:33.13ms
+step:296/1480 train_time:9811ms step_avg:33.14ms
+step:297/1480 train_time:9842ms step_avg:33.14ms
+step:298/1480 train_time:9879ms step_avg:33.15ms
+step:299/1480 train_time:9909ms step_avg:33.14ms
+step:300/1480 train_time:9946ms step_avg:33.15ms
+step:301/1480 train_time:9977ms step_avg:33.15ms
+step:302/1480 train_time:10013ms step_avg:33.16ms
+step:303/1480 train_time:10044ms step_avg:33.15ms
+step:304/1480 train_time:10080ms step_avg:33.16ms
+step:305/1480 train_time:10111ms step_avg:33.15ms
+step:306/1480 train_time:10147ms step_avg:33.16ms
+step:307/1480 train_time:10178ms step_avg:33.15ms
+step:308/1480 train_time:10215ms step_avg:33.17ms
+step:309/1480 train_time:10245ms step_avg:33.16ms
+step:310/1480 train_time:10282ms step_avg:33.17ms
+step:311/1480 train_time:10312ms step_avg:33.16ms
+step:312/1480 train_time:10348ms step_avg:33.17ms
+step:313/1480 train_time:10379ms step_avg:33.16ms
+step:314/1480 train_time:10416ms step_avg:33.17ms
+step:315/1480 train_time:10446ms step_avg:33.16ms
+step:316/1480 train_time:10482ms step_avg:33.17ms
+step:317/1480 train_time:10513ms step_avg:33.16ms
+step:318/1480 train_time:10549ms step_avg:33.17ms
+step:319/1480 train_time:10580ms step_avg:33.17ms
+step:320/1480 train_time:10617ms step_avg:33.18ms
+step:321/1480 train_time:10647ms step_avg:33.17ms
+step:322/1480 train_time:10683ms step_avg:33.18ms
+step:323/1480 train_time:10713ms step_avg:33.17ms
+step:324/1480 train_time:10749ms step_avg:33.18ms
+step:325/1480 train_time:10780ms step_avg:33.17ms
+step:326/1480 train_time:10816ms step_avg:33.18ms
+step:327/1480 train_time:10846ms step_avg:33.17ms
+step:328/1480 train_time:10883ms step_avg:33.18ms
+step:329/1480 train_time:10913ms step_avg:33.17ms
+step:330/1480 train_time:10949ms step_avg:33.18ms
+step:331/1480 train_time:10979ms step_avg:33.17ms
+step:332/1480 train_time:11016ms step_avg:33.18ms
+step:333/1480 train_time:11046ms step_avg:33.17ms
+step:334/1480 train_time:11082ms step_avg:33.18ms
+step:335/1480 train_time:11113ms step_avg:33.17ms
+step:336/1480 train_time:11149ms step_avg:33.18ms
+step:337/1480 train_time:11180ms step_avg:33.17ms
+step:338/1480 train_time:11216ms step_avg:33.18ms
+step:339/1480 train_time:11246ms step_avg:33.17ms
+step:340/1480 train_time:11282ms step_avg:33.18ms
+step:341/1480 train_time:11312ms step_avg:33.17ms
+step:342/1480 train_time:11348ms step_avg:33.18ms
+step:343/1480 train_time:11379ms step_avg:33.17ms
+step:344/1480 train_time:11415ms step_avg:33.18ms
+step:345/1480 train_time:11445ms step_avg:33.17ms
+step:346/1480 train_time:11481ms step_avg:33.18ms
+step:347/1480 train_time:11511ms step_avg:33.17ms
+step:348/1480 train_time:11547ms step_avg:33.18ms
+step:349/1480 train_time:11578ms step_avg:33.17ms
+step:350/1480 train_time:11614ms step_avg:33.18ms
+step:351/1480 train_time:11644ms step_avg:33.17ms
+step:352/1480 train_time:11680ms step_avg:33.18ms
+step:353/1480 train_time:11710ms step_avg:33.17ms
+step:354/1480 train_time:11746ms step_avg:33.18ms
+step:355/1480 train_time:11777ms step_avg:33.18ms
+step:356/1480 train_time:11813ms step_avg:33.18ms
+step:357/1480 train_time:11844ms step_avg:33.18ms
+step:358/1480 train_time:11880ms step_avg:33.18ms
+step:359/1480 train_time:11910ms step_avg:33.18ms
+step:360/1480 train_time:11946ms step_avg:33.18ms
+step:361/1480 train_time:11977ms step_avg:33.18ms
+step:362/1480 train_time:12012ms step_avg:33.18ms
+step:363/1480 train_time:12043ms step_avg:33.18ms
+step:364/1480 train_time:12079ms step_avg:33.18ms
+step:365/1480 train_time:12109ms step_avg:33.17ms
+step:366/1480 train_time:12145ms step_avg:33.18ms
+step:367/1480 train_time:12175ms step_avg:33.17ms
+step:368/1480 train_time:12210ms step_avg:33.18ms
+step:369/1480 train_time:12240ms step_avg:33.17ms
+step:370/1480 train_time:12276ms step_avg:33.18ms
+step:371/1480 train_time:12307ms step_avg:33.17ms
+step:372/1480 train_time:12342ms step_avg:33.18ms
+step:373/1480 train_time:12372ms step_avg:33.17ms
+step:374/1480 train_time:12408ms step_avg:33.18ms
+step:375/1480 train_time:12439ms step_avg:33.17ms
+step:376/1480 train_time:12476ms step_avg:33.18ms
+step:377/1480 train_time:12507ms step_avg:33.18ms
+step:378/1480 train_time:12545ms step_avg:33.19ms
+step:379/1480 train_time:12577ms step_avg:33.18ms
+step:380/1480 train_time:12614ms step_avg:33.20ms
+step:381/1480 train_time:12646ms step_avg:33.19ms
+step:382/1480 train_time:12684ms step_avg:33.20ms
+step:383/1480 train_time:12715ms step_avg:33.20ms
+step:384/1480 train_time:12753ms step_avg:33.21ms
+step:385/1480 train_time:12785ms step_avg:33.21ms
+step:386/1480 train_time:12823ms step_avg:33.22ms
+step:387/1480 train_time:12855ms step_avg:33.22ms
+step:388/1480 train_time:12892ms step_avg:33.23ms
+step:389/1480 train_time:12924ms step_avg:33.22ms
+step:390/1480 train_time:12961ms step_avg:33.23ms
+step:391/1480 train_time:12993ms step_avg:33.23ms
+step:392/1480 train_time:13031ms step_avg:33.24ms
+step:393/1480 train_time:13062ms step_avg:33.24ms
+step:394/1480 train_time:13100ms step_avg:33.25ms
+step:395/1480 train_time:13132ms step_avg:33.24ms
+step:396/1480 train_time:13169ms step_avg:33.25ms
+step:397/1480 train_time:13200ms step_avg:33.25ms
+step:398/1480 train_time:13238ms step_avg:33.26ms
+step:399/1480 train_time:13269ms step_avg:33.26ms
+step:400/1480 train_time:13306ms step_avg:33.26ms
+step:401/1480 train_time:13337ms step_avg:33.26ms
+step:402/1480 train_time:13374ms step_avg:33.27ms
+step:403/1480 train_time:13406ms step_avg:33.26ms
+step:404/1480 train_time:13442ms step_avg:33.27ms
+step:405/1480 train_time:13474ms step_avg:33.27ms
+step:406/1480 train_time:13511ms step_avg:33.28ms
+step:407/1480 train_time:13542ms step_avg:33.27ms
+step:408/1480 train_time:13579ms step_avg:33.28ms
+step:409/1480 train_time:13610ms step_avg:33.28ms
+step:410/1480 train_time:13646ms step_avg:33.28ms
+step:411/1480 train_time:13678ms step_avg:33.28ms
+step:412/1480 train_time:13714ms step_avg:33.29ms
+step:413/1480 train_time:13745ms step_avg:33.28ms
+step:414/1480 train_time:13781ms step_avg:33.29ms
+step:415/1480 train_time:13812ms step_avg:33.28ms
+step:416/1480 train_time:13849ms step_avg:33.29ms
+step:417/1480 train_time:13880ms step_avg:33.29ms
+step:418/1480 train_time:13917ms step_avg:33.29ms
+step:419/1480 train_time:13948ms step_avg:33.29ms
+step:420/1480 train_time:13984ms step_avg:33.30ms
+step:421/1480 train_time:14015ms step_avg:33.29ms
+step:422/1480 train_time:14052ms step_avg:33.30ms
+step:423/1480 train_time:14083ms step_avg:33.29ms
+step:424/1480 train_time:14120ms step_avg:33.30ms
+step:425/1480 train_time:14150ms step_avg:33.30ms
+step:426/1480 train_time:14187ms step_avg:33.30ms
+step:427/1480 train_time:14218ms step_avg:33.30ms
+step:428/1480 train_time:14255ms step_avg:33.31ms
+step:429/1480 train_time:14285ms step_avg:33.30ms
+step:430/1480 train_time:14322ms step_avg:33.31ms
+step:431/1480 train_time:14352ms step_avg:33.30ms
+step:432/1480 train_time:14389ms step_avg:33.31ms
+step:433/1480 train_time:14420ms step_avg:33.30ms
+step:434/1480 train_time:14457ms step_avg:33.31ms
+step:435/1480 train_time:14488ms step_avg:33.31ms
+step:436/1480 train_time:14524ms step_avg:33.31ms
+step:437/1480 train_time:14555ms step_avg:33.31ms
+step:438/1480 train_time:14592ms step_avg:33.31ms
+step:439/1480 train_time:14623ms step_avg:33.31ms
+step:440/1480 train_time:14660ms step_avg:33.32ms
+step:441/1480 train_time:14690ms step_avg:33.31ms
+step:442/1480 train_time:14727ms step_avg:33.32ms
+step:443/1480 train_time:14758ms step_avg:33.31ms
+step:444/1480 train_time:14794ms step_avg:33.32ms
+step:445/1480 train_time:14825ms step_avg:33.32ms
+step:446/1480 train_time:14861ms step_avg:33.32ms
+step:447/1480 train_time:14892ms step_avg:33.31ms
+step:448/1480 train_time:14928ms step_avg:33.32ms
+step:449/1480 train_time:14959ms step_avg:33.32ms
+step:450/1480 train_time:14995ms step_avg:33.32ms
+step:451/1480 train_time:15026ms step_avg:33.32ms
+step:452/1480 train_time:15063ms step_avg:33.32ms
+step:453/1480 train_time:15093ms step_avg:33.32ms
+step:454/1480 train_time:15129ms step_avg:33.32ms
+step:455/1480 train_time:15160ms step_avg:33.32ms
+step:456/1480 train_time:15196ms step_avg:33.33ms
+step:457/1480 train_time:15227ms step_avg:33.32ms
+step:458/1480 train_time:15263ms step_avg:33.33ms
+step:459/1480 train_time:15294ms step_avg:33.32ms
+step:460/1480 train_time:15330ms step_avg:33.33ms
+step:461/1480 train_time:15360ms step_avg:33.32ms
+step:462/1480 train_time:15397ms step_avg:33.33ms
+step:463/1480 train_time:15427ms step_avg:33.32ms
+step:464/1480 train_time:15463ms step_avg:33.33ms
+step:465/1480 train_time:15494ms step_avg:33.32ms
+step:466/1480 train_time:15530ms step_avg:33.33ms
+step:467/1480 train_time:15560ms step_avg:33.32ms
+step:468/1480 train_time:15597ms step_avg:33.33ms
+step:469/1480 train_time:15627ms step_avg:33.32ms
+step:470/1480 train_time:15663ms step_avg:33.33ms
+step:471/1480 train_time:15694ms step_avg:33.32ms
+step:472/1480 train_time:15730ms step_avg:33.33ms
+step:473/1480 train_time:15760ms step_avg:33.32ms
+step:474/1480 train_time:15796ms step_avg:33.33ms
+step:475/1480 train_time:15827ms step_avg:33.32ms
+step:476/1480 train_time:15863ms step_avg:33.33ms
+step:477/1480 train_time:15893ms step_avg:33.32ms
+step:478/1480 train_time:15930ms step_avg:33.33ms
+step:479/1480 train_time:15960ms step_avg:33.32ms
+step:480/1480 train_time:15996ms step_avg:33.33ms
+step:481/1480 train_time:16029ms step_avg:33.32ms
+step:482/1480 train_time:16090ms step_avg:33.38ms
+step:483/1480 train_time:16147ms step_avg:33.43ms
+step:484/1480 train_time:16209ms step_avg:33.49ms
+step:485/1480 train_time:16268ms step_avg:33.54ms
+step:486/1480 train_time:16332ms step_avg:33.60ms
+step:487/1480 train_time:16391ms step_avg:33.66ms
+step:488/1480 train_time:16453ms step_avg:33.72ms
+step:489/1480 train_time:16513ms step_avg:33.77ms
+step:490/1480 train_time:16577ms step_avg:33.83ms
+step:491/1480 train_time:16633ms step_avg:33.88ms
+step:492/1480 train_time:16699ms step_avg:33.94ms
+step:493/1480 train_time:16757ms step_avg:33.99ms
+step:494/1480 train_time:16820ms step_avg:34.05ms
+step:495/1480 train_time:16877ms step_avg:34.10ms
+step:496/1480 train_time:16941ms step_avg:34.15ms
+step:497/1480 train_time:16998ms step_avg:34.20ms
+step:498/1480 train_time:17063ms step_avg:34.26ms
+step:499/1480 train_time:17122ms step_avg:34.31ms
+step:500/1480 train_time:17188ms step_avg:34.38ms
+step:500/1480 val_loss:4.2146 train_time:17268ms step_avg:34.54ms
+step:501/1480 train_time:17286ms step_avg:34.50ms
+step:502/1480 train_time:17314ms step_avg:34.49ms
+step:503/1480 train_time:17372ms step_avg:34.54ms
+step:504/1480 train_time:17440ms step_avg:34.60ms
+step:505/1480 train_time:17499ms step_avg:34.65ms
+step:506/1480 train_time:17563ms step_avg:34.71ms
+step:507/1480 train_time:17621ms step_avg:34.76ms
+step:508/1480 train_time:17684ms step_avg:34.81ms
+step:509/1480 train_time:17741ms step_avg:34.85ms
+step:510/1480 train_time:17805ms step_avg:34.91ms
+step:511/1480 train_time:17862ms step_avg:34.96ms
+step:512/1480 train_time:17926ms step_avg:35.01ms
+step:513/1480 train_time:17984ms step_avg:35.06ms
+step:514/1480 train_time:18049ms step_avg:35.11ms
+step:515/1480 train_time:18108ms step_avg:35.16ms
+step:516/1480 train_time:18175ms step_avg:35.22ms
+step:517/1480 train_time:18235ms step_avg:35.27ms
+step:518/1480 train_time:18300ms step_avg:35.33ms
+step:519/1480 train_time:18358ms step_avg:35.37ms
+step:520/1480 train_time:18422ms step_avg:35.43ms
+step:521/1480 train_time:18480ms step_avg:35.47ms
+step:522/1480 train_time:18543ms step_avg:35.52ms
+step:523/1480 train_time:18600ms step_avg:35.56ms
+step:524/1480 train_time:18663ms step_avg:35.62ms
+step:525/1480 train_time:18720ms step_avg:35.66ms
+step:526/1480 train_time:18784ms step_avg:35.71ms
+step:527/1480 train_time:18841ms step_avg:35.75ms
+step:528/1480 train_time:18905ms step_avg:35.81ms
+step:529/1480 train_time:18962ms step_avg:35.85ms
+step:530/1480 train_time:19025ms step_avg:35.90ms
+step:531/1480 train_time:19083ms step_avg:35.94ms
+step:532/1480 train_time:19147ms step_avg:35.99ms
+step:533/1480 train_time:19205ms step_avg:36.03ms
+step:534/1480 train_time:19269ms step_avg:36.08ms
+step:535/1480 train_time:19329ms step_avg:36.13ms
+step:536/1480 train_time:19394ms step_avg:36.18ms
+step:537/1480 train_time:19454ms step_avg:36.23ms
+step:538/1480 train_time:19520ms step_avg:36.28ms
+step:539/1480 train_time:19579ms step_avg:36.33ms
+step:540/1480 train_time:19643ms step_avg:36.38ms
+step:541/1480 train_time:19701ms step_avg:36.42ms
+step:542/1480 train_time:19766ms step_avg:36.47ms
+step:543/1480 train_time:19825ms step_avg:36.51ms
+step:544/1480 train_time:19890ms step_avg:36.56ms
+step:545/1480 train_time:19950ms step_avg:36.61ms
+step:546/1480 train_time:20015ms step_avg:36.66ms
+step:547/1480 train_time:20075ms step_avg:36.70ms
+step:548/1480 train_time:20140ms step_avg:36.75ms
+step:549/1480 train_time:20198ms step_avg:36.79ms
+step:550/1480 train_time:20262ms step_avg:36.84ms
+step:551/1480 train_time:20320ms step_avg:36.88ms
+step:552/1480 train_time:20383ms step_avg:36.93ms
+step:553/1480 train_time:20441ms step_avg:36.96ms
+step:554/1480 train_time:20504ms step_avg:37.01ms
+step:555/1480 train_time:20563ms step_avg:37.05ms
+step:556/1480 train_time:20627ms step_avg:37.10ms
+step:557/1480 train_time:20686ms step_avg:37.14ms
+step:558/1480 train_time:20750ms step_avg:37.19ms
+step:559/1480 train_time:20810ms step_avg:37.23ms
+step:560/1480 train_time:20877ms step_avg:37.28ms
+step:561/1480 train_time:20933ms step_avg:37.31ms
+step:562/1480 train_time:20996ms step_avg:37.36ms
+step:563/1480 train_time:21059ms step_avg:37.41ms
+step:564/1480 train_time:21130ms step_avg:37.46ms
+step:565/1480 train_time:21189ms step_avg:37.50ms
+step:566/1480 train_time:21254ms step_avg:37.55ms
+step:567/1480 train_time:21313ms step_avg:37.59ms
+step:568/1480 train_time:21378ms step_avg:37.64ms
+step:569/1480 train_time:21436ms step_avg:37.67ms
+step:570/1480 train_time:21501ms step_avg:37.72ms
+step:571/1480 train_time:21559ms step_avg:37.76ms
+step:572/1480 train_time:21624ms step_avg:37.80ms
+step:573/1480 train_time:21682ms step_avg:37.84ms
+step:574/1480 train_time:21748ms step_avg:37.89ms
+step:575/1480 train_time:21809ms step_avg:37.93ms
+step:576/1480 train_time:21876ms step_avg:37.98ms
+step:577/1480 train_time:21937ms step_avg:38.02ms
+step:578/1480 train_time:22003ms step_avg:38.07ms
+step:579/1480 train_time:22062ms step_avg:38.10ms
+step:580/1480 train_time:22129ms step_avg:38.15ms
+step:581/1480 train_time:22189ms step_avg:38.19ms
+step:582/1480 train_time:22257ms step_avg:38.24ms
+step:583/1480 train_time:22318ms step_avg:38.28ms
+step:584/1480 train_time:22384ms step_avg:38.33ms
+step:585/1480 train_time:22443ms step_avg:38.36ms
+step:586/1480 train_time:22508ms step_avg:38.41ms
+step:587/1480 train_time:22568ms step_avg:38.45ms
+step:588/1480 train_time:22635ms step_avg:38.49ms
+step:589/1480 train_time:22696ms step_avg:38.53ms
+step:590/1480 train_time:22761ms step_avg:38.58ms
+step:591/1480 train_time:22820ms step_avg:38.61ms
+step:592/1480 train_time:22885ms step_avg:38.66ms
+step:593/1480 train_time:22944ms step_avg:38.69ms
+step:594/1480 train_time:23009ms step_avg:38.74ms
+step:595/1480 train_time:23068ms step_avg:38.77ms
+step:596/1480 train_time:23134ms step_avg:38.81ms
+step:597/1480 train_time:23191ms step_avg:38.85ms
+step:598/1480 train_time:23250ms step_avg:38.88ms
+step:599/1480 train_time:23305ms step_avg:38.91ms
+step:600/1480 train_time:23370ms step_avg:38.95ms
+step:601/1480 train_time:23427ms step_avg:38.98ms
+step:602/1480 train_time:23488ms step_avg:39.02ms
+step:603/1480 train_time:23546ms step_avg:39.05ms
+step:604/1480 train_time:23613ms step_avg:39.09ms
+step:605/1480 train_time:23672ms step_avg:39.13ms
+step:606/1480 train_time:23737ms step_avg:39.17ms
+step:607/1480 train_time:23796ms step_avg:39.20ms
+step:608/1480 train_time:23861ms step_avg:39.24ms
+step:609/1480 train_time:23919ms step_avg:39.28ms
+step:610/1480 train_time:23983ms step_avg:39.32ms
+step:611/1480 train_time:24043ms step_avg:39.35ms
+step:612/1480 train_time:24108ms step_avg:39.39ms
+step:613/1480 train_time:24165ms step_avg:39.42ms
+step:614/1480 train_time:24230ms step_avg:39.46ms
+step:615/1480 train_time:24287ms step_avg:39.49ms
+step:616/1480 train_time:24350ms step_avg:39.53ms
+step:617/1480 train_time:24408ms step_avg:39.56ms
+step:618/1480 train_time:24474ms step_avg:39.60ms
+step:619/1480 train_time:24533ms step_avg:39.63ms
+step:620/1480 train_time:24599ms step_avg:39.68ms
+step:621/1480 train_time:24657ms step_avg:39.71ms
+step:622/1480 train_time:24722ms step_avg:39.75ms
+step:623/1480 train_time:24780ms step_avg:39.78ms
+step:624/1480 train_time:24844ms step_avg:39.81ms
+step:625/1480 train_time:24902ms step_avg:39.84ms
+step:626/1480 train_time:24966ms step_avg:39.88ms
+step:627/1480 train_time:25024ms step_avg:39.91ms
+step:628/1480 train_time:25089ms step_avg:39.95ms
+step:629/1480 train_time:25146ms step_avg:39.98ms
+step:630/1480 train_time:25211ms step_avg:40.02ms
+step:631/1480 train_time:25271ms step_avg:40.05ms
+step:632/1480 train_time:25337ms step_avg:40.09ms
+step:633/1480 train_time:25396ms step_avg:40.12ms
+step:634/1480 train_time:25462ms step_avg:40.16ms
+step:635/1480 train_time:25519ms step_avg:40.19ms
+step:636/1480 train_time:25582ms step_avg:40.22ms
+step:637/1480 train_time:25639ms step_avg:40.25ms
+step:638/1480 train_time:25701ms step_avg:40.28ms
+step:639/1480 train_time:25758ms step_avg:40.31ms
+step:640/1480 train_time:25821ms step_avg:40.35ms
+step:641/1480 train_time:25879ms step_avg:40.37ms
+step:642/1480 train_time:25944ms step_avg:40.41ms
+step:643/1480 train_time:26002ms step_avg:40.44ms
+step:644/1480 train_time:26064ms step_avg:40.47ms
+step:645/1480 train_time:26123ms step_avg:40.50ms
+step:646/1480 train_time:26185ms step_avg:40.53ms
+step:647/1480 train_time:26242ms step_avg:40.56ms
+step:648/1480 train_time:26307ms step_avg:40.60ms
+step:649/1480 train_time:26366ms step_avg:40.63ms
+step:650/1480 train_time:26431ms step_avg:40.66ms
+step:651/1480 train_time:26490ms step_avg:40.69ms
+step:652/1480 train_time:26554ms step_avg:40.73ms
+step:653/1480 train_time:26613ms step_avg:40.76ms
+step:654/1480 train_time:26677ms step_avg:40.79ms
+step:655/1480 train_time:26735ms step_avg:40.82ms
+step:656/1480 train_time:26800ms step_avg:40.85ms
+step:657/1480 train_time:26861ms step_avg:40.88ms
+step:658/1480 train_time:26936ms step_avg:40.94ms
+step:659/1480 train_time:27004ms step_avg:40.98ms
+step:660/1480 train_time:27073ms step_avg:41.02ms
+step:661/1480 train_time:27127ms step_avg:41.04ms
+step:662/1480 train_time:27186ms step_avg:41.07ms
+step:663/1480 train_time:27244ms step_avg:41.09ms
+step:664/1480 train_time:27310ms step_avg:41.13ms
+step:665/1480 train_time:27365ms step_avg:41.15ms
+step:666/1480 train_time:27428ms step_avg:41.18ms
+step:667/1480 train_time:27489ms step_avg:41.21ms
+step:668/1480 train_time:27556ms step_avg:41.25ms
+step:669/1480 train_time:27617ms step_avg:41.28ms
+step:670/1480 train_time:27682ms step_avg:41.32ms
+step:671/1480 train_time:27740ms step_avg:41.34ms
+step:672/1480 train_time:27805ms step_avg:41.38ms
+step:673/1480 train_time:27862ms step_avg:41.40ms
+step:674/1480 train_time:27927ms step_avg:41.43ms
+step:675/1480 train_time:27984ms step_avg:41.46ms
+step:676/1480 train_time:28047ms step_avg:41.49ms
+step:677/1480 train_time:28104ms step_avg:41.51ms
+step:678/1480 train_time:28167ms step_avg:41.54ms
+step:679/1480 train_time:28224ms step_avg:41.57ms
+step:680/1480 train_time:28287ms step_avg:41.60ms
+step:681/1480 train_time:28347ms step_avg:41.63ms
+step:682/1480 train_time:28412ms step_avg:41.66ms
+step:683/1480 train_time:28470ms step_avg:41.68ms
+step:684/1480 train_time:28534ms step_avg:41.72ms
+step:685/1480 train_time:28592ms step_avg:41.74ms
+step:686/1480 train_time:28657ms step_avg:41.77ms
+step:687/1480 train_time:28715ms step_avg:41.80ms
+step:688/1480 train_time:28779ms step_avg:41.83ms
+step:689/1480 train_time:28837ms step_avg:41.85ms
+step:690/1480 train_time:28900ms step_avg:41.88ms
+step:691/1480 train_time:28958ms step_avg:41.91ms
+step:692/1480 train_time:29021ms step_avg:41.94ms
+step:693/1480 train_time:29079ms step_avg:41.96ms
+step:694/1480 train_time:29142ms step_avg:41.99ms
+step:695/1480 train_time:29198ms step_avg:42.01ms
+step:696/1480 train_time:29261ms step_avg:42.04ms
+step:697/1480 train_time:29321ms step_avg:42.07ms
+step:698/1480 train_time:29390ms step_avg:42.11ms
+step:699/1480 train_time:29456ms step_avg:42.14ms
+step:700/1480 train_time:29525ms step_avg:42.18ms
+step:701/1480 train_time:29589ms step_avg:42.21ms
+step:702/1480 train_time:29659ms step_avg:42.25ms
+step:703/1480 train_time:29720ms step_avg:42.28ms
+step:704/1480 train_time:29780ms step_avg:42.30ms
+step:705/1480 train_time:29834ms step_avg:42.32ms
+step:706/1480 train_time:29895ms step_avg:42.34ms
+step:707/1480 train_time:29955ms step_avg:42.37ms
+step:708/1480 train_time:30022ms step_avg:42.40ms
+step:709/1480 train_time:30086ms step_avg:42.43ms
+step:710/1480 train_time:30152ms step_avg:42.47ms
+step:711/1480 train_time:30211ms step_avg:42.49ms
+step:712/1480 train_time:30278ms step_avg:42.52ms
+step:713/1480 train_time:30336ms step_avg:42.55ms
+step:714/1480 train_time:30401ms step_avg:42.58ms
+step:715/1480 train_time:30459ms step_avg:42.60ms
+step:716/1480 train_time:30524ms step_avg:42.63ms
+step:717/1480 train_time:30583ms step_avg:42.65ms
+step:718/1480 train_time:30646ms step_avg:42.68ms
+step:719/1480 train_time:30703ms step_avg:42.70ms
+step:720/1480 train_time:30768ms step_avg:42.73ms
+step:721/1480 train_time:30831ms step_avg:42.76ms
+step:722/1480 train_time:30899ms step_avg:42.80ms
+step:723/1480 train_time:30958ms step_avg:42.82ms
+step:724/1480 train_time:31025ms step_avg:42.85ms
+step:725/1480 train_time:31086ms step_avg:42.88ms
+step:726/1480 train_time:31152ms step_avg:42.91ms
+step:727/1480 train_time:31213ms step_avg:42.93ms
+step:728/1480 train_time:31281ms step_avg:42.97ms
+step:729/1480 train_time:31340ms step_avg:42.99ms
+step:730/1480 train_time:31406ms step_avg:43.02ms
+step:731/1480 train_time:31466ms step_avg:43.04ms
+step:732/1480 train_time:31532ms step_avg:43.08ms
+step:733/1480 train_time:31589ms step_avg:43.10ms
+step:734/1480 train_time:31648ms step_avg:43.12ms
+step:735/1480 train_time:31706ms step_avg:43.14ms
+step:736/1480 train_time:31769ms step_avg:43.16ms
+step:737/1480 train_time:31828ms step_avg:43.19ms
+step:738/1480 train_time:31889ms step_avg:43.21ms
+step:739/1480 train_time:31948ms step_avg:43.23ms
+step:740/1480 train_time:32012ms step_avg:43.26ms
+step:741/1480 train_time:32070ms step_avg:43.28ms
+step:742/1480 train_time:32133ms step_avg:43.31ms
+step:743/1480 train_time:32192ms step_avg:43.33ms
+step:744/1480 train_time:32260ms step_avg:43.36ms
+step:745/1480 train_time:32320ms step_avg:43.38ms
+step:746/1480 train_time:32387ms step_avg:43.41ms
+step:747/1480 train_time:32451ms step_avg:43.44ms
+step:748/1480 train_time:32519ms step_avg:43.47ms
+step:749/1480 train_time:32581ms step_avg:43.50ms
+step:750/1480 train_time:32648ms step_avg:43.53ms
+step:750/1480 val_loss:3.7999 train_time:32733ms step_avg:43.64ms
+step:751/1480 train_time:32751ms step_avg:43.61ms
+step:752/1480 train_time:32779ms step_avg:43.59ms
+step:753/1480 train_time:32835ms step_avg:43.60ms
+step:754/1480 train_time:32895ms step_avg:43.63ms
+step:755/1480 train_time:32948ms step_avg:43.64ms
+step:756/1480 train_time:33009ms step_avg:43.66ms
+step:757/1480 train_time:33066ms step_avg:43.68ms
+step:758/1480 train_time:33128ms step_avg:43.70ms
+step:759/1480 train_time:33185ms step_avg:43.72ms
+step:760/1480 train_time:33250ms step_avg:43.75ms
+step:761/1480 train_time:33307ms step_avg:43.77ms
+step:762/1480 train_time:33371ms step_avg:43.79ms
+step:763/1480 train_time:33429ms step_avg:43.81ms
+step:764/1480 train_time:33493ms step_avg:43.84ms
+step:765/1480 train_time:33551ms step_avg:43.86ms
+step:766/1480 train_time:33617ms step_avg:43.89ms
+step:767/1480 train_time:33678ms step_avg:43.91ms
+step:768/1480 train_time:33744ms step_avg:43.94ms
+step:769/1480 train_time:33806ms step_avg:43.96ms
+step:770/1480 train_time:33872ms step_avg:43.99ms
+step:771/1480 train_time:33931ms step_avg:44.01ms
+step:772/1480 train_time:33999ms step_avg:44.04ms
+step:773/1480 train_time:34059ms step_avg:44.06ms
+step:774/1480 train_time:34126ms step_avg:44.09ms
+step:775/1480 train_time:34186ms step_avg:44.11ms
+step:776/1480 train_time:34252ms step_avg:44.14ms
+step:777/1480 train_time:34312ms step_avg:44.16ms
+step:778/1480 train_time:34378ms step_avg:44.19ms
+step:779/1480 train_time:34437ms step_avg:44.21ms
+step:780/1480 train_time:34503ms step_avg:44.23ms
+step:781/1480 train_time:34562ms step_avg:44.25ms
+step:782/1480 train_time:34627ms step_avg:44.28ms
+step:783/1480 train_time:34686ms step_avg:44.30ms
+step:784/1480 train_time:34751ms step_avg:44.33ms
+step:785/1480 train_time:34809ms step_avg:44.34ms
+step:786/1480 train_time:34875ms step_avg:44.37ms
+step:787/1480 train_time:34932ms step_avg:44.39ms
+step:788/1480 train_time:34997ms step_avg:44.41ms
+step:789/1480 train_time:35056ms step_avg:44.43ms
+step:790/1480 train_time:35122ms step_avg:44.46ms
+step:791/1480 train_time:35182ms step_avg:44.48ms
+step:792/1480 train_time:35247ms step_avg:44.50ms
+step:793/1480 train_time:35304ms step_avg:44.52ms
+step:794/1480 train_time:35369ms step_avg:44.54ms
+step:795/1480 train_time:35426ms step_avg:44.56ms
+step:796/1480 train_time:35491ms step_avg:44.59ms
+step:797/1480 train_time:35549ms step_avg:44.60ms
+step:798/1480 train_time:35612ms step_avg:44.63ms
+step:799/1480 train_time:35671ms step_avg:44.64ms
+step:800/1480 train_time:35734ms step_avg:44.67ms
+step:801/1480 train_time:35793ms step_avg:44.68ms
+step:802/1480 train_time:35857ms step_avg:44.71ms
+step:803/1480 train_time:35915ms step_avg:44.73ms
+step:804/1480 train_time:35980ms step_avg:44.75ms
+step:805/1480 train_time:36039ms step_avg:44.77ms
+step:806/1480 train_time:36104ms step_avg:44.79ms
+step:807/1480 train_time:36163ms step_avg:44.81ms
+step:808/1480 train_time:36228ms step_avg:44.84ms
+step:809/1480 train_time:36286ms step_avg:44.85ms
+step:810/1480 train_time:36351ms step_avg:44.88ms
+step:811/1480 train_time:36408ms step_avg:44.89ms
+step:812/1480 train_time:36472ms step_avg:44.92ms
+step:813/1480 train_time:36531ms step_avg:44.93ms
+step:814/1480 train_time:36596ms step_avg:44.96ms
+step:815/1480 train_time:36655ms step_avg:44.98ms
+step:816/1480 train_time:36721ms step_avg:45.00ms
+step:817/1480 train_time:36781ms step_avg:45.02ms
+step:818/1480 train_time:36845ms step_avg:45.04ms
+step:819/1480 train_time:36904ms step_avg:45.06ms
+step:820/1480 train_time:36968ms step_avg:45.08ms
+step:821/1480 train_time:37026ms step_avg:45.10ms
+step:822/1480 train_time:37091ms step_avg:45.12ms
+step:823/1480 train_time:37150ms step_avg:45.14ms
+step:824/1480 train_time:37213ms step_avg:45.16ms
+step:825/1480 train_time:37272ms step_avg:45.18ms
+step:826/1480 train_time:37337ms step_avg:45.20ms
+step:827/1480 train_time:37396ms step_avg:45.22ms
+step:828/1480 train_time:37460ms step_avg:45.24ms
+step:829/1480 train_time:37520ms step_avg:45.26ms
+step:830/1480 train_time:37585ms step_avg:45.28ms
+step:831/1480 train_time:37644ms step_avg:45.30ms
+step:832/1480 train_time:37708ms step_avg:45.32ms
+step:833/1480 train_time:37766ms step_avg:45.34ms
+step:834/1480 train_time:37830ms step_avg:45.36ms
+step:835/1480 train_time:37888ms step_avg:45.38ms
+step:836/1480 train_time:37953ms step_avg:45.40ms
+step:837/1480 train_time:38013ms step_avg:45.42ms
+step:838/1480 train_time:38078ms step_avg:45.44ms
+step:839/1480 train_time:38137ms step_avg:45.45ms
+step:840/1480 train_time:38201ms step_avg:45.48ms
+step:841/1480 train_time:38261ms step_avg:45.49ms
+step:842/1480 train_time:38327ms step_avg:45.52ms
+step:843/1480 train_time:38386ms step_avg:45.53ms
+step:844/1480 train_time:38449ms step_avg:45.56ms
+step:845/1480 train_time:38507ms step_avg:45.57ms
+step:846/1480 train_time:38570ms step_avg:45.59ms
+step:847/1480 train_time:38628ms step_avg:45.61ms
+step:848/1480 train_time:38693ms step_avg:45.63ms
+step:849/1480 train_time:38752ms step_avg:45.64ms
+step:850/1480 train_time:38816ms step_avg:45.67ms
+step:851/1480 train_time:38874ms step_avg:45.68ms
+step:852/1480 train_time:38939ms step_avg:45.70ms
+step:853/1480 train_time:38998ms step_avg:45.72ms
+step:854/1480 train_time:39061ms step_avg:45.74ms
+step:855/1480 train_time:39120ms step_avg:45.75ms
+step:856/1480 train_time:39183ms step_avg:45.77ms
+step:857/1480 train_time:39241ms step_avg:45.79ms
+step:858/1480 train_time:39304ms step_avg:45.81ms
+step:859/1480 train_time:39362ms step_avg:45.82ms
+step:860/1480 train_time:39425ms step_avg:45.84ms
+step:861/1480 train_time:39482ms step_avg:45.86ms
+step:862/1480 train_time:39546ms step_avg:45.88ms
+step:863/1480 train_time:39607ms step_avg:45.89ms
+step:864/1480 train_time:39672ms step_avg:45.92ms
+step:865/1480 train_time:39731ms step_avg:45.93ms
+step:866/1480 train_time:39795ms step_avg:45.95ms
+step:867/1480 train_time:39853ms step_avg:45.97ms
+step:868/1480 train_time:39918ms step_avg:45.99ms
+step:869/1480 train_time:39976ms step_avg:46.00ms
+step:870/1480 train_time:40041ms step_avg:46.02ms
+step:871/1480 train_time:40102ms step_avg:46.04ms
+step:872/1480 train_time:40167ms step_avg:46.06ms
+step:873/1480 train_time:40225ms step_avg:46.08ms
+step:874/1480 train_time:40288ms step_avg:46.10ms
+step:875/1480 train_time:40346ms step_avg:46.11ms
+step:876/1480 train_time:40411ms step_avg:46.13ms
+step:877/1480 train_time:40470ms step_avg:46.15ms
+step:878/1480 train_time:40535ms step_avg:46.17ms
+step:879/1480 train_time:40595ms step_avg:46.18ms
+step:880/1480 train_time:40660ms step_avg:46.20ms
+step:881/1480 train_time:40720ms step_avg:46.22ms
+step:882/1480 train_time:40785ms step_avg:46.24ms
+step:883/1480 train_time:40845ms step_avg:46.26ms
+step:884/1480 train_time:40910ms step_avg:46.28ms
+step:885/1480 train_time:40969ms step_avg:46.29ms
+step:886/1480 train_time:41034ms step_avg:46.31ms
+step:887/1480 train_time:41093ms step_avg:46.33ms
+step:888/1480 train_time:41159ms step_avg:46.35ms
+step:889/1480 train_time:41219ms step_avg:46.37ms
+step:890/1480 train_time:41286ms step_avg:46.39ms
+step:891/1480 train_time:41345ms step_avg:46.40ms
+step:892/1480 train_time:41410ms step_avg:46.42ms
+step:893/1480 train_time:41468ms step_avg:46.44ms
+step:894/1480 train_time:41532ms step_avg:46.46ms
+step:895/1480 train_time:41592ms step_avg:46.47ms
+step:896/1480 train_time:41657ms step_avg:46.49ms
+step:897/1480 train_time:41716ms step_avg:46.51ms
+step:898/1480 train_time:41780ms step_avg:46.53ms
+step:899/1480 train_time:41840ms step_avg:46.54ms
+step:900/1480 train_time:41905ms step_avg:46.56ms
+step:901/1480 train_time:41964ms step_avg:46.58ms
+step:902/1480 train_time:42028ms step_avg:46.59ms
+step:903/1480 train_time:42088ms step_avg:46.61ms
+step:904/1480 train_time:42154ms step_avg:46.63ms
+step:905/1480 train_time:42211ms step_avg:46.64ms
+step:906/1480 train_time:42276ms step_avg:46.66ms
+step:907/1480 train_time:42337ms step_avg:46.68ms
+step:908/1480 train_time:42401ms step_avg:46.70ms
+step:909/1480 train_time:42461ms step_avg:46.71ms
+step:910/1480 train_time:42525ms step_avg:46.73ms
+step:911/1480 train_time:42583ms step_avg:46.74ms
+step:912/1480 train_time:42648ms step_avg:46.76ms
+step:913/1480 train_time:42706ms step_avg:46.78ms
+step:914/1480 train_time:42771ms step_avg:46.79ms
+step:915/1480 train_time:42828ms step_avg:46.81ms
+step:916/1480 train_time:42892ms step_avg:46.83ms
+step:917/1480 train_time:42951ms step_avg:46.84ms
+step:918/1480 train_time:43015ms step_avg:46.86ms
+step:919/1480 train_time:43073ms step_avg:46.87ms
+step:920/1480 train_time:43137ms step_avg:46.89ms
+step:921/1480 train_time:43195ms step_avg:46.90ms
+step:922/1480 train_time:43260ms step_avg:46.92ms
+step:923/1480 train_time:43318ms step_avg:46.93ms
+step:924/1480 train_time:43382ms step_avg:46.95ms
+step:925/1480 train_time:43441ms step_avg:46.96ms
+step:926/1480 train_time:43505ms step_avg:46.98ms
+step:927/1480 train_time:43564ms step_avg:46.99ms
+step:928/1480 train_time:43628ms step_avg:47.01ms
+step:929/1480 train_time:43686ms step_avg:47.02ms
+step:930/1480 train_time:43749ms step_avg:47.04ms
+step:931/1480 train_time:43807ms step_avg:47.05ms
+step:932/1480 train_time:43872ms step_avg:47.07ms
+step:933/1480 train_time:43930ms step_avg:47.08ms
+step:934/1480 train_time:43995ms step_avg:47.10ms
+step:935/1480 train_time:44054ms step_avg:47.12ms
+step:936/1480 train_time:44120ms step_avg:47.14ms
+step:937/1480 train_time:44180ms step_avg:47.15ms
+step:938/1480 train_time:44245ms step_avg:47.17ms
+step:939/1480 train_time:44304ms step_avg:47.18ms
+step:940/1480 train_time:44369ms step_avg:47.20ms
+step:941/1480 train_time:44427ms step_avg:47.21ms
+step:942/1480 train_time:44491ms step_avg:47.23ms
+step:943/1480 train_time:44549ms step_avg:47.24ms
+step:944/1480 train_time:44613ms step_avg:47.26ms
+step:945/1480 train_time:44671ms step_avg:47.27ms
+step:946/1480 train_time:44736ms step_avg:47.29ms
+step:947/1480 train_time:44793ms step_avg:47.30ms
+step:948/1480 train_time:44857ms step_avg:47.32ms
+step:949/1480 train_time:44916ms step_avg:47.33ms
+step:950/1480 train_time:44981ms step_avg:47.35ms
+step:951/1480 train_time:45041ms step_avg:47.36ms
+step:952/1480 train_time:45106ms step_avg:47.38ms
+step:953/1480 train_time:45164ms step_avg:47.39ms
+step:954/1480 train_time:45228ms step_avg:47.41ms
+step:955/1480 train_time:45288ms step_avg:47.42ms
+step:956/1480 train_time:45359ms step_avg:47.45ms
+step:957/1480 train_time:45425ms step_avg:47.47ms
+step:958/1480 train_time:45496ms step_avg:47.49ms
+step:959/1480 train_time:45559ms step_avg:47.51ms
+step:960/1480 train_time:45630ms step_avg:47.53ms
+step:961/1480 train_time:45693ms step_avg:47.55ms
+step:962/1480 train_time:45778ms step_avg:47.59ms
+step:963/1480 train_time:45860ms step_avg:47.62ms
+step:964/1480 train_time:45951ms step_avg:47.67ms
+step:965/1480 train_time:46036ms step_avg:47.71ms
+step:966/1480 train_time:46130ms step_avg:47.75ms
+step:967/1480 train_time:46218ms step_avg:47.80ms
+step:968/1480 train_time:46312ms step_avg:47.84ms
+step:969/1480 train_time:46397ms step_avg:47.88ms
+step:970/1480 train_time:46489ms step_avg:47.93ms
+step:971/1480 train_time:46574ms step_avg:47.96ms
+step:972/1480 train_time:46665ms step_avg:48.01ms
+step:973/1480 train_time:46753ms step_avg:48.05ms
+step:974/1480 train_time:46843ms step_avg:48.09ms
+step:975/1480 train_time:46928ms step_avg:48.13ms
+step:976/1480 train_time:47021ms step_avg:48.18ms
+step:977/1480 train_time:47109ms step_avg:48.22ms
+step:978/1480 train_time:47202ms step_avg:48.26ms
+step:979/1480 train_time:47289ms step_avg:48.30ms
+step:980/1480 train_time:47381ms step_avg:48.35ms
+step:981/1480 train_time:47471ms step_avg:48.39ms
+step:982/1480 train_time:47564ms step_avg:48.44ms
+step:983/1480 train_time:47652ms step_avg:48.48ms
+step:984/1480 train_time:47744ms step_avg:48.52ms
+step:985/1480 train_time:47832ms step_avg:48.56ms
+step:986/1480 train_time:47923ms step_avg:48.60ms
+step:987/1480 train_time:48010ms step_avg:48.64ms
+step:988/1480 train_time:48101ms step_avg:48.69ms
+step:989/1480 train_time:48188ms step_avg:48.72ms
+step:990/1480 train_time:48282ms step_avg:48.77ms
+step:991/1480 train_time:48371ms step_avg:48.81ms
+step:992/1480 train_time:48463ms step_avg:48.85ms
+step:993/1480 train_time:48551ms step_avg:48.89ms
+step:994/1480 train_time:48643ms step_avg:48.94ms
+step:995/1480 train_time:48729ms step_avg:48.97ms
+step:996/1480 train_time:48825ms step_avg:49.02ms
+step:997/1480 train_time:48916ms step_avg:49.06ms
+step:998/1480 train_time:49011ms step_avg:49.11ms
+step:999/1480 train_time:49102ms step_avg:49.15ms
+step:1000/1480 train_time:49198ms step_avg:49.20ms
+step:1000/1480 val_loss:3.5105 train_time:49316ms step_avg:49.32ms
+step:1001/1480 train_time:49333ms step_avg:49.28ms
+step:1002/1480 train_time:49384ms step_avg:49.29ms
+step:1003/1480 train_time:49475ms step_avg:49.33ms
+step:1004/1480 train_time:49570ms step_avg:49.37ms
+step:1005/1480 train_time:49658ms step_avg:49.41ms
+step:1006/1480 train_time:49752ms step_avg:49.46ms
+step:1007/1480 train_time:49842ms step_avg:49.50ms
+step:1008/1480 train_time:49933ms step_avg:49.54ms
+step:1009/1480 train_time:50021ms step_avg:49.58ms
+step:1010/1480 train_time:50115ms step_avg:49.62ms
+step:1011/1480 train_time:50203ms step_avg:49.66ms
+step:1012/1480 train_time:50296ms step_avg:49.70ms
+step:1013/1480 train_time:50384ms step_avg:49.74ms
+step:1014/1480 train_time:50476ms step_avg:49.78ms
+step:1015/1480 train_time:50564ms step_avg:49.82ms
+step:1016/1480 train_time:50657ms step_avg:49.86ms
+step:1017/1480 train_time:50745ms step_avg:49.90ms
+step:1018/1480 train_time:50836ms step_avg:49.94ms
+step:1019/1480 train_time:50924ms step_avg:49.97ms
+step:1020/1480 train_time:51016ms step_avg:50.02ms
+step:1021/1480 train_time:51104ms step_avg:50.05ms
+step:1022/1480 train_time:51197ms step_avg:50.09ms
+step:1023/1480 train_time:51282ms step_avg:50.13ms
+step:1024/1480 train_time:51376ms step_avg:50.17ms
+step:1025/1480 train_time:51465ms step_avg:50.21ms
+step:1026/1480 train_time:51558ms step_avg:50.25ms
+step:1027/1480 train_time:51646ms step_avg:50.29ms
+step:1028/1480 train_time:51739ms step_avg:50.33ms
+step:1029/1480 train_time:51825ms step_avg:50.36ms
+step:1030/1480 train_time:51921ms step_avg:50.41ms
+step:1031/1480 train_time:52010ms step_avg:50.45ms
+step:1032/1480 train_time:52104ms step_avg:50.49ms
+step:1033/1480 train_time:52191ms step_avg:50.52ms
+step:1034/1480 train_time:52285ms step_avg:50.57ms
+step:1035/1480 train_time:52372ms step_avg:50.60ms
+step:1036/1480 train_time:52467ms step_avg:50.64ms
+step:1037/1480 train_time:52553ms step_avg:50.68ms
+step:1038/1480 train_time:52648ms step_avg:50.72ms
+step:1039/1480 train_time:52735ms step_avg:50.76ms
+step:1040/1480 train_time:52829ms step_avg:50.80ms
+step:1041/1480 train_time:52916ms step_avg:50.83ms
+step:1042/1480 train_time:53009ms step_avg:50.87ms
+step:1043/1480 train_time:53096ms step_avg:50.91ms
+step:1044/1480 train_time:53190ms step_avg:50.95ms
+step:1045/1480 train_time:53275ms step_avg:50.98ms
+step:1046/1480 train_time:53367ms step_avg:51.02ms
+step:1047/1480 train_time:53451ms step_avg:51.05ms
+step:1048/1480 train_time:53542ms step_avg:51.09ms
+step:1049/1480 train_time:53625ms step_avg:51.12ms
+step:1050/1480 train_time:53719ms step_avg:51.16ms
+step:1051/1480 train_time:53805ms step_avg:51.19ms
+step:1052/1480 train_time:53898ms step_avg:51.23ms
+step:1053/1480 train_time:53986ms step_avg:51.27ms
+step:1054/1480 train_time:54080ms step_avg:51.31ms
+step:1055/1480 train_time:54167ms step_avg:51.34ms
+step:1056/1480 train_time:54262ms step_avg:51.38ms
+step:1057/1480 train_time:54347ms step_avg:51.42ms
+step:1058/1480 train_time:54441ms step_avg:51.46ms
+step:1059/1480 train_time:54527ms step_avg:51.49ms
+step:1060/1480 train_time:54621ms step_avg:51.53ms
+step:1061/1480 train_time:54708ms step_avg:51.56ms
+step:1062/1480 train_time:54801ms step_avg:51.60ms
+step:1063/1480 train_time:54888ms step_avg:51.64ms
+step:1064/1480 train_time:54981ms step_avg:51.67ms
+step:1065/1480 train_time:55068ms step_avg:51.71ms
+step:1066/1480 train_time:55161ms step_avg:51.75ms
+step:1067/1480 train_time:55247ms step_avg:51.78ms
+step:1068/1480 train_time:55340ms step_avg:51.82ms
+step:1069/1480 train_time:55427ms step_avg:51.85ms
+step:1070/1480 train_time:55521ms step_avg:51.89ms
+step:1071/1480 train_time:55608ms step_avg:51.92ms
+step:1072/1480 train_time:55702ms step_avg:51.96ms
+step:1073/1480 train_time:55787ms step_avg:51.99ms
+step:1074/1480 train_time:55881ms step_avg:52.03ms
+step:1075/1480 train_time:55968ms step_avg:52.06ms
+step:1076/1480 train_time:56062ms step_avg:52.10ms
+step:1077/1480 train_time:56148ms step_avg:52.13ms
+step:1078/1480 train_time:56243ms step_avg:52.17ms
+step:1079/1480 train_time:56329ms step_avg:52.21ms
+step:1080/1480 train_time:56424ms step_avg:52.24ms
+step:1081/1480 train_time:56511ms step_avg:52.28ms
+step:1082/1480 train_time:56606ms step_avg:52.32ms
+step:1083/1480 train_time:56692ms step_avg:52.35ms
+step:1084/1480 train_time:56787ms step_avg:52.39ms
+step:1085/1480 train_time:56872ms step_avg:52.42ms
+step:1086/1480 train_time:56967ms step_avg:52.46ms
+step:1087/1480 train_time:57053ms step_avg:52.49ms
+step:1088/1480 train_time:57146ms step_avg:52.52ms
+step:1089/1480 train_time:57231ms step_avg:52.55ms
+step:1090/1480 train_time:57325ms step_avg:52.59ms
+step:1091/1480 train_time:57411ms step_avg:52.62ms
+step:1092/1480 train_time:57505ms step_avg:52.66ms
+step:1093/1480 train_time:57590ms step_avg:52.69ms
+step:1094/1480 train_time:57681ms step_avg:52.72ms
+step:1095/1480 train_time:57765ms step_avg:52.75ms
+step:1096/1480 train_time:57855ms step_avg:52.79ms
+step:1097/1480 train_time:57941ms step_avg:52.82ms
+step:1098/1480 train_time:58036ms step_avg:52.86ms
+step:1099/1480 train_time:58125ms step_avg:52.89ms
+step:1100/1480 train_time:58220ms step_avg:52.93ms
+step:1101/1480 train_time:58308ms step_avg:52.96ms
+step:1102/1480 train_time:58404ms step_avg:53.00ms
+step:1103/1480 train_time:58492ms step_avg:53.03ms
+step:1104/1480 train_time:58588ms step_avg:53.07ms
+step:1105/1480 train_time:58677ms step_avg:53.10ms
+step:1106/1480 train_time:58773ms step_avg:53.14ms
+step:1107/1480 train_time:58855ms step_avg:53.17ms
+step:1108/1480 train_time:58943ms step_avg:53.20ms
+step:1109/1480 train_time:59033ms step_avg:53.23ms
+step:1110/1480 train_time:59125ms step_avg:53.27ms
+step:1111/1480 train_time:59210ms step_avg:53.29ms
+step:1112/1480 train_time:59303ms step_avg:53.33ms
+step:1113/1480 train_time:59390ms step_avg:53.36ms
+step:1114/1480 train_time:59484ms step_avg:53.40ms
+step:1115/1480 train_time:59568ms step_avg:53.42ms
+step:1116/1480 train_time:59662ms step_avg:53.46ms
+step:1117/1480 train_time:59749ms step_avg:53.49ms
+step:1118/1480 train_time:59844ms step_avg:53.53ms
+step:1119/1480 train_time:59930ms step_avg:53.56ms
+step:1120/1480 train_time:60027ms step_avg:53.60ms
+step:1121/1480 train_time:60116ms step_avg:53.63ms
+step:1122/1480 train_time:60212ms step_avg:53.67ms
+step:1123/1480 train_time:60303ms step_avg:53.70ms
+step:1124/1480 train_time:60397ms step_avg:53.73ms
+step:1125/1480 train_time:60487ms step_avg:53.77ms
+step:1126/1480 train_time:60583ms step_avg:53.80ms
+step:1127/1480 train_time:60671ms step_avg:53.83ms
+step:1128/1480 train_time:60768ms step_avg:53.87ms
+step:1129/1480 train_time:60855ms step_avg:53.90ms
+step:1130/1480 train_time:60949ms step_avg:53.94ms
+step:1131/1480 train_time:61039ms step_avg:53.97ms
+step:1132/1480 train_time:61132ms step_avg:54.00ms
+step:1133/1480 train_time:61220ms step_avg:54.03ms
+step:1134/1480 train_time:61314ms step_avg:54.07ms
+step:1135/1480 train_time:61403ms step_avg:54.10ms
+step:1136/1480 train_time:61497ms step_avg:54.13ms
+step:1137/1480 train_time:61585ms step_avg:54.16ms
+step:1138/1480 train_time:61678ms step_avg:54.20ms
+step:1139/1480 train_time:61765ms step_avg:54.23ms
+step:1140/1480 train_time:61857ms step_avg:54.26ms
+step:1141/1480 train_time:61944ms step_avg:54.29ms
+step:1142/1480 train_time:62037ms step_avg:54.32ms
+step:1143/1480 train_time:62125ms step_avg:54.35ms
+step:1144/1480 train_time:62217ms step_avg:54.39ms
+step:1145/1480 train_time:62303ms step_avg:54.41ms
+step:1146/1480 train_time:62396ms step_avg:54.45ms
+step:1147/1480 train_time:62483ms step_avg:54.48ms
+step:1148/1480 train_time:62575ms step_avg:54.51ms
+step:1149/1480 train_time:62664ms step_avg:54.54ms
+step:1150/1480 train_time:62756ms step_avg:54.57ms
+step:1151/1480 train_time:62843ms step_avg:54.60ms
+step:1152/1480 train_time:62935ms step_avg:54.63ms
+step:1153/1480 train_time:63023ms step_avg:54.66ms
+step:1154/1480 train_time:63115ms step_avg:54.69ms
+step:1155/1480 train_time:63201ms step_avg:54.72ms
+step:1156/1480 train_time:63294ms step_avg:54.75ms
+step:1157/1480 train_time:63381ms step_avg:54.78ms
+step:1158/1480 train_time:63474ms step_avg:54.81ms
+step:1159/1480 train_time:63560ms step_avg:54.84ms
+step:1160/1480 train_time:63652ms step_avg:54.87ms
+step:1161/1480 train_time:63739ms step_avg:54.90ms
+step:1162/1480 train_time:63833ms step_avg:54.93ms
+step:1163/1480 train_time:63921ms step_avg:54.96ms
+step:1164/1480 train_time:64013ms step_avg:54.99ms
+step:1165/1480 train_time:64100ms step_avg:55.02ms
+step:1166/1480 train_time:64193ms step_avg:55.05ms
+step:1167/1480 train_time:64279ms step_avg:55.08ms
+step:1168/1480 train_time:64371ms step_avg:55.11ms
+step:1169/1480 train_time:64457ms step_avg:55.14ms
+step:1170/1480 train_time:64548ms step_avg:55.17ms
+step:1171/1480 train_time:64633ms step_avg:55.19ms
+step:1172/1480 train_time:64725ms step_avg:55.23ms
+step:1173/1480 train_time:64809ms step_avg:55.25ms
+step:1174/1480 train_time:64902ms step_avg:55.28ms
+step:1175/1480 train_time:64994ms step_avg:55.31ms
+step:1176/1480 train_time:65099ms step_avg:55.36ms
+step:1177/1480 train_time:65196ms step_avg:55.39ms
+step:1178/1480 train_time:65300ms step_avg:55.43ms
+step:1179/1480 train_time:65389ms step_avg:55.46ms
+step:1180/1480 train_time:65474ms step_avg:55.49ms
+step:1181/1480 train_time:65555ms step_avg:55.51ms
+step:1182/1480 train_time:65645ms step_avg:55.54ms
+step:1183/1480 train_time:65736ms step_avg:55.57ms
+step:1184/1480 train_time:65830ms step_avg:55.60ms
+step:1185/1480 train_time:65917ms step_avg:55.63ms
+step:1186/1480 train_time:66009ms step_avg:55.66ms
+step:1187/1480 train_time:66095ms step_avg:55.68ms
+step:1188/1480 train_time:66189ms step_avg:55.71ms
+step:1189/1480 train_time:66276ms step_avg:55.74ms
+step:1190/1480 train_time:66371ms step_avg:55.77ms
+step:1191/1480 train_time:66460ms step_avg:55.80ms
+step:1192/1480 train_time:66554ms step_avg:55.83ms
+step:1193/1480 train_time:66641ms step_avg:55.86ms
+step:1194/1480 train_time:66736ms step_avg:55.89ms
+step:1195/1480 train_time:66824ms step_avg:55.92ms
+step:1196/1480 train_time:66915ms step_avg:55.95ms
+step:1197/1480 train_time:67004ms step_avg:55.98ms
+step:1198/1480 train_time:67096ms step_avg:56.01ms
+step:1199/1480 train_time:67184ms step_avg:56.03ms
+step:1200/1480 train_time:67276ms step_avg:56.06ms
+step:1201/1480 train_time:67364ms step_avg:56.09ms
+step:1202/1480 train_time:67456ms step_avg:56.12ms
+step:1203/1480 train_time:67543ms step_avg:56.15ms
+step:1204/1480 train_time:67635ms step_avg:56.18ms
+step:1205/1480 train_time:67723ms step_avg:56.20ms
+step:1206/1480 train_time:67815ms step_avg:56.23ms
+step:1207/1480 train_time:67904ms step_avg:56.26ms
+step:1208/1480 train_time:67997ms step_avg:56.29ms
+step:1209/1480 train_time:68084ms step_avg:56.31ms
+step:1210/1480 train_time:68177ms step_avg:56.34ms
+step:1211/1480 train_time:68265ms step_avg:56.37ms
+step:1212/1480 train_time:68357ms step_avg:56.40ms
+step:1213/1480 train_time:68443ms step_avg:56.42ms
+step:1214/1480 train_time:68534ms step_avg:56.45ms
+step:1215/1480 train_time:68619ms step_avg:56.48ms
+step:1216/1480 train_time:68710ms step_avg:56.50ms
+step:1217/1480 train_time:68794ms step_avg:56.53ms
+step:1218/1480 train_time:68886ms step_avg:56.56ms
+step:1219/1480 train_time:68974ms step_avg:56.58ms
+step:1220/1480 train_time:69069ms step_avg:56.61ms
+step:1221/1480 train_time:69158ms step_avg:56.64ms
+step:1222/1480 train_time:69252ms step_avg:56.67ms
+step:1223/1480 train_time:69342ms step_avg:56.70ms
+step:1224/1480 train_time:69435ms step_avg:56.73ms
+step:1225/1480 train_time:69525ms step_avg:56.76ms
+step:1226/1480 train_time:69621ms step_avg:56.79ms
+step:1227/1480 train_time:69709ms step_avg:56.81ms
+step:1228/1480 train_time:69805ms step_avg:56.84ms
+step:1229/1480 train_time:69892ms step_avg:56.87ms
+step:1230/1480 train_time:69988ms step_avg:56.90ms
+step:1231/1480 train_time:70075ms step_avg:56.93ms
+step:1232/1480 train_time:70169ms step_avg:56.96ms
+step:1233/1480 train_time:70257ms step_avg:56.98ms
+step:1234/1480 train_time:70351ms step_avg:57.01ms
+step:1235/1480 train_time:70439ms step_avg:57.04ms
+step:1236/1480 train_time:70533ms step_avg:57.07ms
+step:1237/1480 train_time:70620ms step_avg:57.09ms
+step:1238/1480 train_time:70714ms step_avg:57.12ms
+step:1239/1480 train_time:70800ms step_avg:57.14ms
+step:1240/1480 train_time:70894ms step_avg:57.17ms
+step:1241/1480 train_time:70982ms step_avg:57.20ms
+step:1242/1480 train_time:71074ms step_avg:57.23ms
+step:1243/1480 train_time:71162ms step_avg:57.25ms
+step:1244/1480 train_time:71255ms step_avg:57.28ms
+step:1245/1480 train_time:71343ms step_avg:57.30ms
+step:1246/1480 train_time:71434ms step_avg:57.33ms
+step:1247/1480 train_time:71522ms step_avg:57.36ms
+step:1248/1480 train_time:71614ms step_avg:57.38ms
+step:1249/1480 train_time:71701ms step_avg:57.41ms
+step:1250/1480 train_time:71793ms step_avg:57.43ms
+step:1250/1480 val_loss:3.3679 train_time:71903ms step_avg:57.52ms
+step:1251/1480 train_time:71921ms step_avg:57.49ms
+step:1252/1480 train_time:71972ms step_avg:57.49ms
+step:1253/1480 train_time:72059ms step_avg:57.51ms
+step:1254/1480 train_time:72153ms step_avg:57.54ms
+step:1255/1480 train_time:72239ms step_avg:57.56ms
+step:1256/1480 train_time:72335ms step_avg:57.59ms
+step:1257/1480 train_time:72420ms step_avg:57.61ms
+step:1258/1480 train_time:72515ms step_avg:57.64ms
+step:1259/1480 train_time:72602ms step_avg:57.67ms
+step:1260/1480 train_time:72696ms step_avg:57.70ms
+step:1261/1480 train_time:72782ms step_avg:57.72ms
+step:1262/1480 train_time:72876ms step_avg:57.75ms
+step:1263/1480 train_time:72963ms step_avg:57.77ms
+step:1264/1480 train_time:73057ms step_avg:57.80ms
+step:1265/1480 train_time:73143ms step_avg:57.82ms
+step:1266/1480 train_time:73238ms step_avg:57.85ms
+step:1267/1480 train_time:73324ms step_avg:57.87ms
+step:1268/1480 train_time:73418ms step_avg:57.90ms
+step:1269/1480 train_time:73503ms step_avg:57.92ms
+step:1270/1480 train_time:73596ms step_avg:57.95ms
+step:1271/1480 train_time:73683ms step_avg:57.97ms
+step:1272/1480 train_time:73778ms step_avg:58.00ms
+step:1273/1480 train_time:73864ms step_avg:58.02ms
+step:1274/1480 train_time:73957ms step_avg:58.05ms
+step:1275/1480 train_time:74041ms step_avg:58.07ms
+step:1276/1480 train_time:74135ms step_avg:58.10ms
+step:1277/1480 train_time:74220ms step_avg:58.12ms
+step:1278/1480 train_time:74313ms step_avg:58.15ms
+step:1279/1480 train_time:74399ms step_avg:58.17ms
+step:1280/1480 train_time:74489ms step_avg:58.19ms
+step:1281/1480 train_time:74572ms step_avg:58.21ms
+step:1282/1480 train_time:74662ms step_avg:58.24ms
+step:1283/1480 train_time:74749ms step_avg:58.26ms
+step:1284/1480 train_time:74845ms step_avg:58.29ms
+step:1285/1480 train_time:74936ms step_avg:58.32ms
+step:1286/1480 train_time:75033ms step_avg:58.35ms
+step:1287/1480 train_time:75123ms step_avg:58.37ms
+step:1288/1480 train_time:75220ms step_avg:58.40ms
+step:1289/1480 train_time:75309ms step_avg:58.42ms
+step:1290/1480 train_time:75406ms step_avg:58.45ms
+step:1291/1480 train_time:75498ms step_avg:58.48ms
+step:1292/1480 train_time:75594ms step_avg:58.51ms
+step:1293/1480 train_time:75684ms step_avg:58.53ms
+step:1294/1480 train_time:75779ms step_avg:58.56ms
+step:1295/1480 train_time:75861ms step_avg:58.58ms
+step:1296/1480 train_time:75950ms step_avg:58.60ms
+step:1297/1480 train_time:76040ms step_avg:58.63ms
+step:1298/1480 train_time:76134ms step_avg:58.65ms
+step:1299/1480 train_time:76227ms step_avg:58.68ms
+step:1300/1480 train_time:76321ms step_avg:58.71ms
+step:1301/1480 train_time:76405ms step_avg:58.73ms
+step:1302/1480 train_time:76500ms step_avg:58.76ms
+step:1303/1480 train_time:76585ms step_avg:58.78ms
+step:1304/1480 train_time:76682ms step_avg:58.81ms
+step:1305/1480 train_time:76770ms step_avg:58.83ms
+step:1306/1480 train_time:76866ms step_avg:58.86ms
+step:1307/1480 train_time:76954ms step_avg:58.88ms
+step:1308/1480 train_time:77046ms step_avg:58.90ms
+step:1309/1480 train_time:77133ms step_avg:58.93ms
+step:1310/1480 train_time:77228ms step_avg:58.95ms
+step:1311/1480 train_time:77316ms step_avg:58.97ms
+step:1312/1480 train_time:77408ms step_avg:59.00ms
+step:1313/1480 train_time:77497ms step_avg:59.02ms
+step:1314/1480 train_time:77590ms step_avg:59.05ms
+step:1315/1480 train_time:77677ms step_avg:59.07ms
+step:1316/1480 train_time:77770ms step_avg:59.10ms
+step:1317/1480 train_time:77858ms step_avg:59.12ms
+step:1318/1480 train_time:77950ms step_avg:59.14ms
+step:1319/1480 train_time:78037ms step_avg:59.16ms
+step:1320/1480 train_time:78128ms step_avg:59.19ms
+step:1321/1480 train_time:78215ms step_avg:59.21ms
+step:1322/1480 train_time:78308ms step_avg:59.23ms
+step:1323/1480 train_time:78396ms step_avg:59.26ms
+step:1324/1480 train_time:78487ms step_avg:59.28ms
+step:1325/1480 train_time:78573ms step_avg:59.30ms
+step:1326/1480 train_time:78665ms step_avg:59.32ms
+step:1327/1480 train_time:78751ms step_avg:59.35ms
+step:1328/1480 train_time:78845ms step_avg:59.37ms
+step:1329/1480 train_time:78933ms step_avg:59.39ms
+step:1330/1480 train_time:79026ms step_avg:59.42ms
+step:1331/1480 train_time:79114ms step_avg:59.44ms
+step:1332/1480 train_time:79208ms step_avg:59.47ms
+step:1333/1480 train_time:79297ms step_avg:59.49ms
+step:1334/1480 train_time:79390ms step_avg:59.51ms
+step:1335/1480 train_time:79478ms step_avg:59.53ms
+step:1336/1480 train_time:79573ms step_avg:59.56ms
+step:1337/1480 train_time:79660ms step_avg:59.58ms
+step:1338/1480 train_time:79753ms step_avg:59.61ms
+step:1339/1480 train_time:79839ms step_avg:59.63ms
+step:1340/1480 train_time:79934ms step_avg:59.65ms
+step:1341/1480 train_time:80020ms step_avg:59.67ms
+step:1342/1480 train_time:80114ms step_avg:59.70ms
+step:1343/1480 train_time:80201ms step_avg:59.72ms
+step:1344/1480 train_time:80294ms step_avg:59.74ms
+step:1345/1480 train_time:80380ms step_avg:59.76ms
+step:1346/1480 train_time:80474ms step_avg:59.79ms
+step:1347/1480 train_time:80561ms step_avg:59.81ms
+step:1348/1480 train_time:80654ms step_avg:59.83ms
+step:1349/1480 train_time:80738ms step_avg:59.85ms
+step:1350/1480 train_time:80828ms step_avg:59.87ms
+step:1351/1480 train_time:80911ms step_avg:59.89ms
+step:1352/1480 train_time:81000ms step_avg:59.91ms
+step:1353/1480 train_time:81088ms step_avg:59.93ms
+step:1354/1480 train_time:81182ms step_avg:59.96ms
+step:1355/1480 train_time:81270ms step_avg:59.98ms
+step:1356/1480 train_time:81363ms step_avg:60.00ms
+step:1357/1480 train_time:81449ms step_avg:60.02ms
+step:1358/1480 train_time:81544ms step_avg:60.05ms
+step:1359/1480 train_time:81634ms step_avg:60.07ms
+step:1360/1480 train_time:81725ms step_avg:60.09ms
+step:1361/1480 train_time:81812ms step_avg:60.11ms
+step:1362/1480 train_time:81905ms step_avg:60.14ms
+step:1363/1480 train_time:81991ms step_avg:60.15ms
+step:1364/1480 train_time:82084ms step_avg:60.18ms
+step:1365/1480 train_time:82172ms step_avg:60.20ms
+step:1366/1480 train_time:82262ms step_avg:60.22ms
+step:1367/1480 train_time:82348ms step_avg:60.24ms
+step:1368/1480 train_time:82439ms step_avg:60.26ms
+step:1369/1480 train_time:82523ms step_avg:60.28ms
+step:1370/1480 train_time:82616ms step_avg:60.30ms
+step:1371/1480 train_time:82706ms step_avg:60.33ms
+step:1372/1480 train_time:82802ms step_avg:60.35ms
+step:1373/1480 train_time:82892ms step_avg:60.37ms
+step:1374/1480 train_time:82987ms step_avg:60.40ms
+step:1375/1480 train_time:83077ms step_avg:60.42ms
+step:1376/1480 train_time:83173ms step_avg:60.45ms
+step:1377/1480 train_time:83262ms step_avg:60.47ms
+step:1378/1480 train_time:83357ms step_avg:60.49ms
+step:1379/1480 train_time:83443ms step_avg:60.51ms
+step:1380/1480 train_time:83538ms step_avg:60.54ms
+step:1381/1480 train_time:83626ms step_avg:60.55ms
+step:1382/1480 train_time:83721ms step_avg:60.58ms
+step:1383/1480 train_time:83808ms step_avg:60.60ms
+step:1384/1480 train_time:83903ms step_avg:60.62ms
+step:1385/1480 train_time:83992ms step_avg:60.64ms
+step:1386/1480 train_time:84085ms step_avg:60.67ms
+step:1387/1480 train_time:84174ms step_avg:60.69ms
+step:1388/1480 train_time:84265ms step_avg:60.71ms
+step:1389/1480 train_time:84353ms step_avg:60.73ms
+step:1390/1480 train_time:84447ms step_avg:60.75ms
+step:1391/1480 train_time:84534ms step_avg:60.77ms
+step:1392/1480 train_time:84626ms step_avg:60.79ms
+step:1393/1480 train_time:84714ms step_avg:60.81ms
+step:1394/1480 train_time:84807ms step_avg:60.84ms
+step:1395/1480 train_time:84895ms step_avg:60.86ms
+step:1396/1480 train_time:84987ms step_avg:60.88ms
+step:1397/1480 train_time:85075ms step_avg:60.90ms
+step:1398/1480 train_time:85167ms step_avg:60.92ms
+step:1399/1480 train_time:85256ms step_avg:60.94ms
+step:1400/1480 train_time:85348ms step_avg:60.96ms
+step:1401/1480 train_time:85434ms step_avg:60.98ms
+step:1402/1480 train_time:85526ms step_avg:61.00ms
+step:1403/1480 train_time:85613ms step_avg:61.02ms
+step:1404/1480 train_time:85704ms step_avg:61.04ms
+step:1405/1480 train_time:85791ms step_avg:61.06ms
+step:1406/1480 train_time:85882ms step_avg:61.08ms
+step:1407/1480 train_time:85966ms step_avg:61.10ms
+step:1408/1480 train_time:86057ms step_avg:61.12ms
+step:1409/1480 train_time:86142ms step_avg:61.14ms
+step:1410/1480 train_time:86236ms step_avg:61.16ms
+step:1411/1480 train_time:86322ms step_avg:61.18ms
+step:1412/1480 train_time:86415ms step_avg:61.20ms
+step:1413/1480 train_time:86503ms step_avg:61.22ms
+step:1414/1480 train_time:86598ms step_avg:61.24ms
+step:1415/1480 train_time:86682ms step_avg:61.26ms
+step:1416/1480 train_time:86779ms step_avg:61.28ms
+step:1417/1480 train_time:86867ms step_avg:61.30ms
+step:1418/1480 train_time:86961ms step_avg:61.33ms
+step:1419/1480 train_time:87052ms step_avg:61.35ms
+step:1420/1480 train_time:87145ms step_avg:61.37ms
+step:1421/1480 train_time:87231ms step_avg:61.39ms
+step:1422/1480 train_time:87322ms step_avg:61.41ms
+step:1423/1480 train_time:87411ms step_avg:61.43ms
+step:1424/1480 train_time:87506ms step_avg:61.45ms
+step:1425/1480 train_time:87592ms step_avg:61.47ms
+step:1426/1480 train_time:87684ms step_avg:61.49ms
+step:1427/1480 train_time:87770ms step_avg:61.51ms
+step:1428/1480 train_time:87863ms step_avg:61.53ms
+step:1429/1480 train_time:87948ms step_avg:61.55ms
+step:1430/1480 train_time:88041ms step_avg:61.57ms
+step:1431/1480 train_time:88128ms step_avg:61.59ms
+step:1432/1480 train_time:88223ms step_avg:61.61ms
+step:1433/1480 train_time:88312ms step_avg:61.63ms
+step:1434/1480 train_time:88401ms step_avg:61.65ms
+step:1435/1480 train_time:88487ms step_avg:61.66ms
+step:1436/1480 train_time:88579ms step_avg:61.68ms
+step:1437/1480 train_time:88662ms step_avg:61.70ms
+step:1438/1480 train_time:88756ms step_avg:61.72ms
+step:1439/1480 train_time:88844ms step_avg:61.74ms
+step:1440/1480 train_time:88939ms step_avg:61.76ms
+step:1441/1480 train_time:89031ms step_avg:61.78ms
+step:1442/1480 train_time:89130ms step_avg:61.81ms
+step:1443/1480 train_time:89221ms step_avg:61.83ms
+step:1444/1480 train_time:89317ms step_avg:61.85ms
+step:1445/1480 train_time:89406ms step_avg:61.87ms
+step:1446/1480 train_time:89502ms step_avg:61.90ms
+step:1447/1480 train_time:89592ms step_avg:61.92ms
+step:1448/1480 train_time:89688ms step_avg:61.94ms
+step:1449/1480 train_time:89779ms step_avg:61.96ms
+step:1450/1480 train_time:89874ms step_avg:61.98ms
+step:1451/1480 train_time:89964ms step_avg:62.00ms
+step:1452/1480 train_time:90059ms step_avg:62.02ms
+step:1453/1480 train_time:90146ms step_avg:62.04ms
+step:1454/1480 train_time:90242ms step_avg:62.06ms
+step:1455/1480 train_time:90331ms step_avg:62.08ms
+step:1456/1480 train_time:90425ms step_avg:62.11ms
+step:1457/1480 train_time:90514ms step_avg:62.12ms
+step:1458/1480 train_time:90608ms step_avg:62.15ms
+step:1459/1480 train_time:90695ms step_avg:62.16ms
+step:1460/1480 train_time:90788ms step_avg:62.18ms
+step:1461/1480 train_time:90877ms step_avg:62.20ms
+step:1462/1480 train_time:90973ms step_avg:62.22ms
+step:1463/1480 train_time:91060ms step_avg:62.24ms
+step:1464/1480 train_time:91155ms step_avg:62.26ms
+step:1465/1480 train_time:91241ms step_avg:62.28ms
+step:1466/1480 train_time:91336ms step_avg:62.30ms
+step:1467/1480 train_time:91422ms step_avg:62.32ms
+step:1468/1480 train_time:91516ms step_avg:62.34ms
+step:1469/1480 train_time:91602ms step_avg:62.36ms
+step:1470/1480 train_time:91696ms step_avg:62.38ms
+step:1471/1480 train_time:91782ms step_avg:62.39ms
+step:1472/1480 train_time:91876ms step_avg:62.42ms
+step:1473/1480 train_time:91963ms step_avg:62.43ms
+step:1474/1480 train_time:92057ms step_avg:62.45ms
+step:1475/1480 train_time:92142ms step_avg:62.47ms
+step:1476/1480 train_time:92236ms step_avg:62.49ms
+step:1477/1480 train_time:92322ms step_avg:62.51ms
+step:1478/1480 train_time:92417ms step_avg:62.53ms
+step:1479/1480 train_time:92504ms step_avg:62.54ms
+step:1480/1480 train_time:92598ms step_avg:62.57ms
+step:1480/1480 val_loss:3.2796 train_time:92710ms step_avg:62.64ms
+peak memory allocated: 31307 MiB reserved: 47242 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk1-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk1-1480.txt
@@ -1,0 +1,4463 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # QK bank: per-head-pair Muon groups for Q, K weights
+        # Each pair of adjacent heads gets its own independent polar express orthogonalization
+        self._num_attn_layers = num_attn_layers
+        num_qk_groups = num_attn_layers * 2 * (num_heads // 2)  # 10 * 2 * 3 = 60
+        self._num_qk_groups = num_qk_groups
+        num_qk_padded = next_multiple_of_n(num_qk_groups, n=world_size)  # 64
+        self.qk_bank = nn.Parameter(torch.empty(num_qk_padded, head_dim * 2, model_dim))
+        self.qk_bank.reshape = (num_qk_padded, head_dim * 2, model_dim)
+
+        # VO bank: per-layer Muon groups for V and O weights
+        num_vo_real = num_attn_layers * 2  # 20
+        num_vo_padded = next_multiple_of_n(num_vo_real, n=world_size)  # 24
+        self.vo_bank = nn.Parameter(torch.empty(num_vo_padded, hdim, hdim))
+        self.vo_bank.reshape = (num_vo_padded, hdim, hdim)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.qk_bank[:num_qk_groups].uniform_(-bound, bound)
+            self.qk_bank[num_qk_groups:].zero_()
+            self.vo_bank[:num_vo_real].uniform_(-bound, bound)
+            self.vo_bank[num_vo_real:].zero_()
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from qk_bank/vo_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        qk_all = self.qk_bank[:self._num_qk_groups].view(self._num_attn_layers, -1, self.qk_bank.shape[-1])
+        vo_flat = self.vo_bank[:self._num_attn_layers * 2].view(self._num_attn_layers, 2, *self.vo_bank.shape[1:]).flatten(1, 2)
+        attn_weights = torch.cat([qk_all, vo_flat], dim=1).unbind(0)
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            attn_idx = i - (i > 6) if i != 6 else None
+            qkvo_w = attn_weights[attn_idx] if attn_idx is not None else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "qk_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "vo_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "qk_bank", "vo_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.qk_bank.data = model.qk_bank.data.bfloat16()
+model.vo_bank.data = model.vo_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 15:30:10 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   37C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   33C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   36C    P0            111W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   34C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   37C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   63C    P0            144W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          113111      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          113112      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          113113      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          113114      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          113115      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          113116      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          113117      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          113118      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8308 train_time:0ms step_avg:0.06ms
+step:1/1480 train_time:102ms step_avg:101.91ms
+step:2/1480 train_time:130ms step_avg:65.06ms
+step:3/1480 train_time:152ms step_avg:50.75ms
+step:4/1480 train_time:177ms step_avg:44.13ms
+step:5/1480 train_time:196ms step_avg:39.12ms
+step:6/1480 train_time:225ms step_avg:37.44ms
+step:7/1480 train_time:252ms step_avg:36.02ms
+step:8/1480 train_time:288ms step_avg:36.02ms
+step:9/1480 train_time:316ms step_avg:35.07ms
+step:10/1480 train_time:350ms step_avg:35.02ms
+step:11/1480 train_time:378ms step_avg:34.38ms
+step:12/1480 train_time:413ms step_avg:34.42ms
+step:13/1480 train_time:442ms step_avg:34.01ms
+step:14/1480 train_time:477ms step_avg:34.05ms
+step:15/1480 train_time:505ms step_avg:33.66ms
+step:16/1480 train_time:539ms step_avg:33.72ms
+step:17/1480 train_time:568ms step_avg:33.40ms
+step:18/1480 train_time:602ms step_avg:33.45ms
+step:19/1480 train_time:631ms step_avg:33.19ms
+step:20/1480 train_time:665ms step_avg:33.26ms
+step:21/1480 train_time:694ms step_avg:33.06ms
+step:22/1480 train_time:729ms step_avg:33.15ms
+step:23/1480 train_time:757ms step_avg:32.93ms
+step:24/1480 train_time:792ms step_avg:33.01ms
+step:25/1480 train_time:821ms step_avg:32.83ms
+step:26/1480 train_time:856ms step_avg:32.91ms
+step:27/1480 train_time:884ms step_avg:32.76ms
+step:28/1480 train_time:919ms step_avg:32.81ms
+step:29/1480 train_time:947ms step_avg:32.67ms
+step:30/1480 train_time:982ms step_avg:32.72ms
+step:31/1480 train_time:1011ms step_avg:32.60ms
+step:32/1480 train_time:1047ms step_avg:32.73ms
+step:33/1480 train_time:1078ms step_avg:32.68ms
+step:34/1480 train_time:1116ms step_avg:32.83ms
+step:35/1480 train_time:1147ms step_avg:32.76ms
+step:36/1480 train_time:1182ms step_avg:32.82ms
+step:37/1480 train_time:1211ms step_avg:32.73ms
+step:38/1480 train_time:1246ms step_avg:32.79ms
+step:39/1480 train_time:1275ms step_avg:32.69ms
+step:40/1480 train_time:1310ms step_avg:32.75ms
+step:41/1480 train_time:1339ms step_avg:32.65ms
+step:42/1480 train_time:1374ms step_avg:32.71ms
+step:43/1480 train_time:1403ms step_avg:32.62ms
+step:44/1480 train_time:1438ms step_avg:32.67ms
+step:45/1480 train_time:1466ms step_avg:32.58ms
+step:46/1480 train_time:1501ms step_avg:32.63ms
+step:47/1480 train_time:1530ms step_avg:32.55ms
+step:48/1480 train_time:1564ms step_avg:32.59ms
+step:49/1480 train_time:1594ms step_avg:32.53ms
+step:50/1480 train_time:1629ms step_avg:32.58ms
+step:51/1480 train_time:1658ms step_avg:32.51ms
+step:52/1480 train_time:1693ms step_avg:32.55ms
+step:53/1480 train_time:1722ms step_avg:32.49ms
+step:54/1480 train_time:1756ms step_avg:32.52ms
+step:55/1480 train_time:1784ms step_avg:32.44ms
+step:56/1480 train_time:1819ms step_avg:32.48ms
+step:57/1480 train_time:1847ms step_avg:32.40ms
+step:58/1480 train_time:1881ms step_avg:32.44ms
+step:59/1480 train_time:1910ms step_avg:32.37ms
+step:60/1480 train_time:1945ms step_avg:32.41ms
+step:61/1480 train_time:1973ms step_avg:32.35ms
+step:62/1480 train_time:2008ms step_avg:32.39ms
+step:63/1480 train_time:2038ms step_avg:32.34ms
+step:64/1480 train_time:2073ms step_avg:32.40ms
+step:65/1480 train_time:2102ms step_avg:32.35ms
+step:66/1480 train_time:2138ms step_avg:32.40ms
+step:67/1480 train_time:2167ms step_avg:32.35ms
+step:68/1480 train_time:2203ms step_avg:32.39ms
+step:69/1480 train_time:2232ms step_avg:32.35ms
+step:70/1480 train_time:2268ms step_avg:32.39ms
+step:71/1480 train_time:2297ms step_avg:32.36ms
+step:72/1480 train_time:2333ms step_avg:32.40ms
+step:73/1480 train_time:2362ms step_avg:32.36ms
+step:74/1480 train_time:2398ms step_avg:32.41ms
+step:75/1480 train_time:2428ms step_avg:32.37ms
+step:76/1480 train_time:2463ms step_avg:32.40ms
+step:77/1480 train_time:2493ms step_avg:32.37ms
+step:78/1480 train_time:2529ms step_avg:32.42ms
+step:79/1480 train_time:2558ms step_avg:32.38ms
+step:80/1480 train_time:2594ms step_avg:32.42ms
+step:81/1480 train_time:2623ms step_avg:32.39ms
+step:82/1480 train_time:2659ms step_avg:32.42ms
+step:83/1480 train_time:2688ms step_avg:32.39ms
+step:84/1480 train_time:2723ms step_avg:32.41ms
+step:85/1480 train_time:2752ms step_avg:32.38ms
+step:86/1480 train_time:2788ms step_avg:32.41ms
+step:87/1480 train_time:2817ms step_avg:32.38ms
+step:88/1480 train_time:2853ms step_avg:32.42ms
+step:89/1480 train_time:2882ms step_avg:32.38ms
+step:90/1480 train_time:2917ms step_avg:32.41ms
+step:91/1480 train_time:2946ms step_avg:32.38ms
+step:92/1480 train_time:2981ms step_avg:32.41ms
+step:93/1480 train_time:3011ms step_avg:32.37ms
+step:94/1480 train_time:3046ms step_avg:32.41ms
+step:95/1480 train_time:3075ms step_avg:32.37ms
+step:96/1480 train_time:3111ms step_avg:32.40ms
+step:97/1480 train_time:3140ms step_avg:32.37ms
+step:98/1480 train_time:3175ms step_avg:32.40ms
+step:99/1480 train_time:3204ms step_avg:32.37ms
+step:100/1480 train_time:3239ms step_avg:32.39ms
+step:101/1480 train_time:3269ms step_avg:32.36ms
+step:102/1480 train_time:3304ms step_avg:32.39ms
+step:103/1480 train_time:3334ms step_avg:32.36ms
+step:104/1480 train_time:3370ms step_avg:32.40ms
+step:105/1480 train_time:3400ms step_avg:32.38ms
+step:106/1480 train_time:3436ms step_avg:32.41ms
+step:107/1480 train_time:3465ms step_avg:32.39ms
+step:108/1480 train_time:3501ms step_avg:32.42ms
+step:109/1480 train_time:3531ms step_avg:32.40ms
+step:110/1480 train_time:3566ms step_avg:32.41ms
+step:111/1480 train_time:3595ms step_avg:32.38ms
+step:112/1480 train_time:3630ms step_avg:32.41ms
+step:113/1480 train_time:3660ms step_avg:32.39ms
+step:114/1480 train_time:3696ms step_avg:32.42ms
+step:115/1480 train_time:3726ms step_avg:32.40ms
+step:116/1480 train_time:3765ms step_avg:32.46ms
+step:117/1480 train_time:3798ms step_avg:32.47ms
+step:118/1480 train_time:3838ms step_avg:32.53ms
+step:119/1480 train_time:3870ms step_avg:32.52ms
+step:120/1480 train_time:3908ms step_avg:32.57ms
+step:121/1480 train_time:3939ms step_avg:32.55ms
+step:122/1480 train_time:3974ms step_avg:32.57ms
+step:123/1480 train_time:4003ms step_avg:32.54ms
+step:124/1480 train_time:4037ms step_avg:32.56ms
+step:125/1480 train_time:4066ms step_avg:32.52ms
+step:126/1480 train_time:4100ms step_avg:32.54ms
+step:127/1480 train_time:4129ms step_avg:32.51ms
+step:128/1480 train_time:4164ms step_avg:32.53ms
+step:129/1480 train_time:4195ms step_avg:32.52ms
+step:130/1480 train_time:4230ms step_avg:32.54ms
+step:131/1480 train_time:4260ms step_avg:32.52ms
+step:132/1480 train_time:4297ms step_avg:32.55ms
+step:133/1480 train_time:4327ms step_avg:32.53ms
+step:134/1480 train_time:4363ms step_avg:32.56ms
+step:135/1480 train_time:4393ms step_avg:32.54ms
+step:136/1480 train_time:4428ms step_avg:32.56ms
+step:137/1480 train_time:4458ms step_avg:32.54ms
+step:138/1480 train_time:4494ms step_avg:32.57ms
+step:139/1480 train_time:4524ms step_avg:32.55ms
+step:140/1480 train_time:4560ms step_avg:32.57ms
+step:141/1480 train_time:4590ms step_avg:32.55ms
+step:142/1480 train_time:4626ms step_avg:32.58ms
+step:143/1480 train_time:4655ms step_avg:32.56ms
+step:144/1480 train_time:4692ms step_avg:32.58ms
+step:145/1480 train_time:4722ms step_avg:32.56ms
+step:146/1480 train_time:4758ms step_avg:32.59ms
+step:147/1480 train_time:4787ms step_avg:32.56ms
+step:148/1480 train_time:4823ms step_avg:32.59ms
+step:149/1480 train_time:4852ms step_avg:32.57ms
+step:150/1480 train_time:4888ms step_avg:32.59ms
+step:151/1480 train_time:4918ms step_avg:32.57ms
+step:152/1480 train_time:4954ms step_avg:32.60ms
+step:153/1480 train_time:4984ms step_avg:32.57ms
+step:154/1480 train_time:5020ms step_avg:32.60ms
+step:155/1480 train_time:5049ms step_avg:32.58ms
+step:156/1480 train_time:5085ms step_avg:32.59ms
+step:157/1480 train_time:5115ms step_avg:32.58ms
+step:158/1480 train_time:5150ms step_avg:32.60ms
+step:159/1480 train_time:5180ms step_avg:32.58ms
+step:160/1480 train_time:5216ms step_avg:32.60ms
+step:161/1480 train_time:5245ms step_avg:32.58ms
+step:162/1480 train_time:5281ms step_avg:32.60ms
+step:163/1480 train_time:5311ms step_avg:32.58ms
+step:164/1480 train_time:5346ms step_avg:32.60ms
+step:165/1480 train_time:5376ms step_avg:32.58ms
+step:166/1480 train_time:5411ms step_avg:32.60ms
+step:167/1480 train_time:5441ms step_avg:32.58ms
+step:168/1480 train_time:5477ms step_avg:32.60ms
+step:169/1480 train_time:5507ms step_avg:32.58ms
+step:170/1480 train_time:5542ms step_avg:32.60ms
+step:171/1480 train_time:5572ms step_avg:32.58ms
+step:172/1480 train_time:5607ms step_avg:32.60ms
+step:173/1480 train_time:5637ms step_avg:32.58ms
+step:174/1480 train_time:5672ms step_avg:32.60ms
+step:175/1480 train_time:5702ms step_avg:32.58ms
+step:176/1480 train_time:5737ms step_avg:32.60ms
+step:177/1480 train_time:5766ms step_avg:32.58ms
+step:178/1480 train_time:5802ms step_avg:32.60ms
+step:179/1480 train_time:5832ms step_avg:32.58ms
+step:180/1480 train_time:5867ms step_avg:32.60ms
+step:181/1480 train_time:5897ms step_avg:32.58ms
+step:182/1480 train_time:5933ms step_avg:32.60ms
+step:183/1480 train_time:5962ms step_avg:32.58ms
+step:184/1480 train_time:6001ms step_avg:32.61ms
+step:185/1480 train_time:6034ms step_avg:32.62ms
+step:186/1480 train_time:6073ms step_avg:32.65ms
+step:187/1480 train_time:6106ms step_avg:32.65ms
+step:188/1480 train_time:6145ms step_avg:32.69ms
+step:189/1480 train_time:6177ms step_avg:32.68ms
+step:190/1480 train_time:6212ms step_avg:32.70ms
+step:191/1480 train_time:6240ms step_avg:32.67ms
+step:192/1480 train_time:6276ms step_avg:32.69ms
+step:193/1480 train_time:6304ms step_avg:32.66ms
+step:194/1480 train_time:6339ms step_avg:32.67ms
+step:195/1480 train_time:6367ms step_avg:32.65ms
+step:196/1480 train_time:6402ms step_avg:32.66ms
+step:197/1480 train_time:6431ms step_avg:32.64ms
+step:198/1480 train_time:6466ms step_avg:32.66ms
+step:199/1480 train_time:6495ms step_avg:32.64ms
+step:200/1480 train_time:6531ms step_avg:32.65ms
+step:201/1480 train_time:6560ms step_avg:32.64ms
+step:202/1480 train_time:6596ms step_avg:32.65ms
+step:203/1480 train_time:6625ms step_avg:32.64ms
+step:204/1480 train_time:6660ms step_avg:32.65ms
+step:205/1480 train_time:6689ms step_avg:32.63ms
+step:206/1480 train_time:6724ms step_avg:32.64ms
+step:207/1480 train_time:6754ms step_avg:32.63ms
+step:208/1480 train_time:6789ms step_avg:32.64ms
+step:209/1480 train_time:6821ms step_avg:32.64ms
+step:210/1480 train_time:6859ms step_avg:32.66ms
+step:211/1480 train_time:6890ms step_avg:32.65ms
+step:212/1480 train_time:6927ms step_avg:32.67ms
+step:213/1480 train_time:6958ms step_avg:32.67ms
+step:214/1480 train_time:6996ms step_avg:32.69ms
+step:215/1480 train_time:7027ms step_avg:32.69ms
+step:216/1480 train_time:7065ms step_avg:32.71ms
+step:217/1480 train_time:7096ms step_avg:32.70ms
+step:218/1480 train_time:7132ms step_avg:32.72ms
+step:219/1480 train_time:7163ms step_avg:32.71ms
+step:220/1480 train_time:7200ms step_avg:32.73ms
+step:221/1480 train_time:7232ms step_avg:32.72ms
+step:222/1480 train_time:7269ms step_avg:32.74ms
+step:223/1480 train_time:7299ms step_avg:32.73ms
+step:224/1480 train_time:7336ms step_avg:32.75ms
+step:225/1480 train_time:7366ms step_avg:32.74ms
+step:226/1480 train_time:7403ms step_avg:32.76ms
+step:227/1480 train_time:7434ms step_avg:32.75ms
+step:228/1480 train_time:7470ms step_avg:32.77ms
+step:229/1480 train_time:7501ms step_avg:32.75ms
+step:230/1480 train_time:7537ms step_avg:32.77ms
+step:231/1480 train_time:7568ms step_avg:32.76ms
+step:232/1480 train_time:7604ms step_avg:32.78ms
+step:233/1480 train_time:7635ms step_avg:32.77ms
+step:234/1480 train_time:7672ms step_avg:32.78ms
+step:235/1480 train_time:7702ms step_avg:32.77ms
+step:236/1480 train_time:7738ms step_avg:32.79ms
+step:237/1480 train_time:7769ms step_avg:32.78ms
+step:238/1480 train_time:7805ms step_avg:32.79ms
+step:239/1480 train_time:7835ms step_avg:32.78ms
+step:240/1480 train_time:7870ms step_avg:32.79ms
+step:241/1480 train_time:7898ms step_avg:32.77ms
+step:242/1480 train_time:7933ms step_avg:32.78ms
+step:243/1480 train_time:7961ms step_avg:32.76ms
+step:244/1480 train_time:7996ms step_avg:32.77ms
+step:245/1480 train_time:8026ms step_avg:32.76ms
+step:246/1480 train_time:8063ms step_avg:32.78ms
+step:247/1480 train_time:8096ms step_avg:32.78ms
+step:248/1480 train_time:8133ms step_avg:32.80ms
+step:249/1480 train_time:8164ms step_avg:32.79ms
+step:250/1480 train_time:8201ms step_avg:32.80ms
+step:250/1480 val_loss:4.5031 train_time:8246ms step_avg:32.98ms
+step:251/1480 train_time:8274ms step_avg:32.97ms
+step:252/1480 train_time:8297ms step_avg:32.92ms
+step:253/1480 train_time:8314ms step_avg:32.86ms
+step:254/1480 train_time:8335ms step_avg:32.82ms
+step:255/1480 train_time:8364ms step_avg:32.80ms
+step:256/1480 train_time:8399ms step_avg:32.81ms
+step:257/1480 train_time:8428ms step_avg:32.79ms
+step:258/1480 train_time:8463ms step_avg:32.80ms
+step:259/1480 train_time:8491ms step_avg:32.79ms
+step:260/1480 train_time:8527ms step_avg:32.79ms
+step:261/1480 train_time:8556ms step_avg:32.78ms
+step:262/1480 train_time:8591ms step_avg:32.79ms
+step:263/1480 train_time:8620ms step_avg:32.77ms
+step:264/1480 train_time:8657ms step_avg:32.79ms
+step:265/1480 train_time:8685ms step_avg:32.77ms
+step:266/1480 train_time:8722ms step_avg:32.79ms
+step:267/1480 train_time:8753ms step_avg:32.78ms
+step:268/1480 train_time:8791ms step_avg:32.80ms
+step:269/1480 train_time:8822ms step_avg:32.80ms
+step:270/1480 train_time:8860ms step_avg:32.81ms
+step:271/1480 train_time:8891ms step_avg:32.81ms
+step:272/1480 train_time:8929ms step_avg:32.83ms
+step:273/1480 train_time:8960ms step_avg:32.82ms
+step:274/1480 train_time:8997ms step_avg:32.84ms
+step:275/1480 train_time:9028ms step_avg:32.83ms
+step:276/1480 train_time:9066ms step_avg:32.85ms
+step:277/1480 train_time:9097ms step_avg:32.84ms
+step:278/1480 train_time:9131ms step_avg:32.85ms
+step:279/1480 train_time:9160ms step_avg:32.83ms
+step:280/1480 train_time:9195ms step_avg:32.84ms
+step:281/1480 train_time:9223ms step_avg:32.82ms
+step:282/1480 train_time:9260ms step_avg:32.84ms
+step:283/1480 train_time:9289ms step_avg:32.82ms
+step:284/1480 train_time:9327ms step_avg:32.84ms
+step:285/1480 train_time:9360ms step_avg:32.84ms
+step:286/1480 train_time:9398ms step_avg:32.86ms
+step:287/1480 train_time:9430ms step_avg:32.86ms
+step:288/1480 train_time:9469ms step_avg:32.88ms
+step:289/1480 train_time:9500ms step_avg:32.87ms
+step:290/1480 train_time:9537ms step_avg:32.89ms
+step:291/1480 train_time:9569ms step_avg:32.88ms
+step:292/1480 train_time:9608ms step_avg:32.90ms
+step:293/1480 train_time:9639ms step_avg:32.90ms
+step:294/1480 train_time:9677ms step_avg:32.91ms
+step:295/1480 train_time:9709ms step_avg:32.91ms
+step:296/1480 train_time:9744ms step_avg:32.92ms
+step:297/1480 train_time:9773ms step_avg:32.91ms
+step:298/1480 train_time:9808ms step_avg:32.91ms
+step:299/1480 train_time:9836ms step_avg:32.90ms
+step:300/1480 train_time:9870ms step_avg:32.90ms
+step:301/1480 train_time:9898ms step_avg:32.88ms
+step:302/1480 train_time:9933ms step_avg:32.89ms
+step:303/1480 train_time:9962ms step_avg:32.88ms
+step:304/1480 train_time:9997ms step_avg:32.89ms
+step:305/1480 train_time:10027ms step_avg:32.87ms
+step:306/1480 train_time:10062ms step_avg:32.88ms
+step:307/1480 train_time:10091ms step_avg:32.87ms
+step:308/1480 train_time:10126ms step_avg:32.88ms
+step:309/1480 train_time:10156ms step_avg:32.87ms
+step:310/1480 train_time:10192ms step_avg:32.88ms
+step:311/1480 train_time:10221ms step_avg:32.87ms
+step:312/1480 train_time:10257ms step_avg:32.87ms
+step:313/1480 train_time:10287ms step_avg:32.87ms
+step:314/1480 train_time:10322ms step_avg:32.87ms
+step:315/1480 train_time:10352ms step_avg:32.86ms
+step:316/1480 train_time:10389ms step_avg:32.88ms
+step:317/1480 train_time:10418ms step_avg:32.86ms
+step:318/1480 train_time:10454ms step_avg:32.87ms
+step:319/1480 train_time:10484ms step_avg:32.87ms
+step:320/1480 train_time:10520ms step_avg:32.88ms
+step:321/1480 train_time:10550ms step_avg:32.87ms
+step:322/1480 train_time:10587ms step_avg:32.88ms
+step:323/1480 train_time:10616ms step_avg:32.87ms
+step:324/1480 train_time:10652ms step_avg:32.88ms
+step:325/1480 train_time:10682ms step_avg:32.87ms
+step:326/1480 train_time:10717ms step_avg:32.88ms
+step:327/1480 train_time:10748ms step_avg:32.87ms
+step:328/1480 train_time:10784ms step_avg:32.88ms
+step:329/1480 train_time:10813ms step_avg:32.87ms
+step:330/1480 train_time:10849ms step_avg:32.88ms
+step:331/1480 train_time:10879ms step_avg:32.87ms
+step:332/1480 train_time:10914ms step_avg:32.87ms
+step:333/1480 train_time:10945ms step_avg:32.87ms
+step:334/1480 train_time:10980ms step_avg:32.88ms
+step:335/1480 train_time:11010ms step_avg:32.87ms
+step:336/1480 train_time:11046ms step_avg:32.88ms
+step:337/1480 train_time:11075ms step_avg:32.86ms
+step:338/1480 train_time:11112ms step_avg:32.88ms
+step:339/1480 train_time:11142ms step_avg:32.87ms
+step:340/1480 train_time:11177ms step_avg:32.87ms
+step:341/1480 train_time:11207ms step_avg:32.87ms
+step:342/1480 train_time:11243ms step_avg:32.87ms
+step:343/1480 train_time:11273ms step_avg:32.86ms
+step:344/1480 train_time:11308ms step_avg:32.87ms
+step:345/1480 train_time:11338ms step_avg:32.86ms
+step:346/1480 train_time:11373ms step_avg:32.87ms
+step:347/1480 train_time:11404ms step_avg:32.86ms
+step:348/1480 train_time:11440ms step_avg:32.87ms
+step:349/1480 train_time:11470ms step_avg:32.87ms
+step:350/1480 train_time:11507ms step_avg:32.88ms
+step:351/1480 train_time:11536ms step_avg:32.87ms
+step:352/1480 train_time:11572ms step_avg:32.88ms
+step:353/1480 train_time:11602ms step_avg:32.87ms
+step:354/1480 train_time:11639ms step_avg:32.88ms
+step:355/1480 train_time:11668ms step_avg:32.87ms
+step:356/1480 train_time:11705ms step_avg:32.88ms
+step:357/1480 train_time:11734ms step_avg:32.87ms
+step:358/1480 train_time:11771ms step_avg:32.88ms
+step:359/1480 train_time:11801ms step_avg:32.87ms
+step:360/1480 train_time:11836ms step_avg:32.88ms
+step:361/1480 train_time:11867ms step_avg:32.87ms
+step:362/1480 train_time:11903ms step_avg:32.88ms
+step:363/1480 train_time:11933ms step_avg:32.87ms
+step:364/1480 train_time:11969ms step_avg:32.88ms
+step:365/1480 train_time:11999ms step_avg:32.87ms
+step:366/1480 train_time:12035ms step_avg:32.88ms
+step:367/1480 train_time:12065ms step_avg:32.87ms
+step:368/1480 train_time:12102ms step_avg:32.88ms
+step:369/1480 train_time:12131ms step_avg:32.88ms
+step:370/1480 train_time:12167ms step_avg:32.88ms
+step:371/1480 train_time:12197ms step_avg:32.88ms
+step:372/1480 train_time:12234ms step_avg:32.89ms
+step:373/1480 train_time:12264ms step_avg:32.88ms
+step:374/1480 train_time:12301ms step_avg:32.89ms
+step:375/1480 train_time:12330ms step_avg:32.88ms
+step:376/1480 train_time:12366ms step_avg:32.89ms
+step:377/1480 train_time:12396ms step_avg:32.88ms
+step:378/1480 train_time:12432ms step_avg:32.89ms
+step:379/1480 train_time:12462ms step_avg:32.88ms
+step:380/1480 train_time:12499ms step_avg:32.89ms
+step:381/1480 train_time:12529ms step_avg:32.88ms
+step:382/1480 train_time:12565ms step_avg:32.89ms
+step:383/1480 train_time:12595ms step_avg:32.89ms
+step:384/1480 train_time:12631ms step_avg:32.89ms
+step:385/1480 train_time:12661ms step_avg:32.89ms
+step:386/1480 train_time:12697ms step_avg:32.89ms
+step:387/1480 train_time:12727ms step_avg:32.89ms
+step:388/1480 train_time:12763ms step_avg:32.89ms
+step:389/1480 train_time:12793ms step_avg:32.89ms
+step:390/1480 train_time:12829ms step_avg:32.90ms
+step:391/1480 train_time:12859ms step_avg:32.89ms
+step:392/1480 train_time:12895ms step_avg:32.90ms
+step:393/1480 train_time:12925ms step_avg:32.89ms
+step:394/1480 train_time:12962ms step_avg:32.90ms
+step:395/1480 train_time:12992ms step_avg:32.89ms
+step:396/1480 train_time:13028ms step_avg:32.90ms
+step:397/1480 train_time:13058ms step_avg:32.89ms
+step:398/1480 train_time:13093ms step_avg:32.90ms
+step:399/1480 train_time:13123ms step_avg:32.89ms
+step:400/1480 train_time:13159ms step_avg:32.90ms
+step:401/1480 train_time:13189ms step_avg:32.89ms
+step:402/1480 train_time:13225ms step_avg:32.90ms
+step:403/1480 train_time:13255ms step_avg:32.89ms
+step:404/1480 train_time:13291ms step_avg:32.90ms
+step:405/1480 train_time:13321ms step_avg:32.89ms
+step:406/1480 train_time:13357ms step_avg:32.90ms
+step:407/1480 train_time:13387ms step_avg:32.89ms
+step:408/1480 train_time:13423ms step_avg:32.90ms
+step:409/1480 train_time:13453ms step_avg:32.89ms
+step:410/1480 train_time:13489ms step_avg:32.90ms
+step:411/1480 train_time:13519ms step_avg:32.89ms
+step:412/1480 train_time:13555ms step_avg:32.90ms
+step:413/1480 train_time:13585ms step_avg:32.89ms
+step:414/1480 train_time:13621ms step_avg:32.90ms
+step:415/1480 train_time:13651ms step_avg:32.89ms
+step:416/1480 train_time:13687ms step_avg:32.90ms
+step:417/1480 train_time:13717ms step_avg:32.90ms
+step:418/1480 train_time:13753ms step_avg:32.90ms
+step:419/1480 train_time:13783ms step_avg:32.89ms
+step:420/1480 train_time:13819ms step_avg:32.90ms
+step:421/1480 train_time:13849ms step_avg:32.89ms
+step:422/1480 train_time:13885ms step_avg:32.90ms
+step:423/1480 train_time:13915ms step_avg:32.90ms
+step:424/1480 train_time:13951ms step_avg:32.90ms
+step:425/1480 train_time:13980ms step_avg:32.89ms
+step:426/1480 train_time:14016ms step_avg:32.90ms
+step:427/1480 train_time:14047ms step_avg:32.90ms
+step:428/1480 train_time:14085ms step_avg:32.91ms
+step:429/1480 train_time:14116ms step_avg:32.90ms
+step:430/1480 train_time:14153ms step_avg:32.91ms
+step:431/1480 train_time:14184ms step_avg:32.91ms
+step:432/1480 train_time:14221ms step_avg:32.92ms
+step:433/1480 train_time:14252ms step_avg:32.92ms
+step:434/1480 train_time:14289ms step_avg:32.92ms
+step:435/1480 train_time:14320ms step_avg:32.92ms
+step:436/1480 train_time:14357ms step_avg:32.93ms
+step:437/1480 train_time:14388ms step_avg:32.93ms
+step:438/1480 train_time:14426ms step_avg:32.94ms
+step:439/1480 train_time:14457ms step_avg:32.93ms
+step:440/1480 train_time:14494ms step_avg:32.94ms
+step:441/1480 train_time:14525ms step_avg:32.94ms
+step:442/1480 train_time:14562ms step_avg:32.95ms
+step:443/1480 train_time:14592ms step_avg:32.94ms
+step:444/1480 train_time:14629ms step_avg:32.95ms
+step:445/1480 train_time:14660ms step_avg:32.94ms
+step:446/1480 train_time:14697ms step_avg:32.95ms
+step:447/1480 train_time:14728ms step_avg:32.95ms
+step:448/1480 train_time:14765ms step_avg:32.96ms
+step:449/1480 train_time:14795ms step_avg:32.95ms
+step:450/1480 train_time:14831ms step_avg:32.96ms
+step:451/1480 train_time:14862ms step_avg:32.95ms
+step:452/1480 train_time:14899ms step_avg:32.96ms
+step:453/1480 train_time:14929ms step_avg:32.96ms
+step:454/1480 train_time:14966ms step_avg:32.96ms
+step:455/1480 train_time:14997ms step_avg:32.96ms
+step:456/1480 train_time:15033ms step_avg:32.97ms
+step:457/1480 train_time:15064ms step_avg:32.96ms
+step:458/1480 train_time:15100ms step_avg:32.97ms
+step:459/1480 train_time:15130ms step_avg:32.96ms
+step:460/1480 train_time:15167ms step_avg:32.97ms
+step:461/1480 train_time:15197ms step_avg:32.97ms
+step:462/1480 train_time:15233ms step_avg:32.97ms
+step:463/1480 train_time:15264ms step_avg:32.97ms
+step:464/1480 train_time:15300ms step_avg:32.97ms
+step:465/1480 train_time:15330ms step_avg:32.97ms
+step:466/1480 train_time:15366ms step_avg:32.98ms
+step:467/1480 train_time:15397ms step_avg:32.97ms
+step:468/1480 train_time:15432ms step_avg:32.98ms
+step:469/1480 train_time:15462ms step_avg:32.97ms
+step:470/1480 train_time:15497ms step_avg:32.97ms
+step:471/1480 train_time:15526ms step_avg:32.96ms
+step:472/1480 train_time:15562ms step_avg:32.97ms
+step:473/1480 train_time:15593ms step_avg:32.97ms
+step:474/1480 train_time:15630ms step_avg:32.97ms
+step:475/1480 train_time:15661ms step_avg:32.97ms
+step:476/1480 train_time:15698ms step_avg:32.98ms
+step:477/1480 train_time:15729ms step_avg:32.98ms
+step:478/1480 train_time:15767ms step_avg:32.98ms
+step:479/1480 train_time:15798ms step_avg:32.98ms
+step:480/1480 train_time:15835ms step_avg:32.99ms
+step:481/1480 train_time:15869ms step_avg:32.99ms
+step:482/1480 train_time:15932ms step_avg:33.05ms
+step:483/1480 train_time:15990ms step_avg:33.11ms
+step:484/1480 train_time:16057ms step_avg:33.17ms
+step:485/1480 train_time:16115ms step_avg:33.23ms
+step:486/1480 train_time:16179ms step_avg:33.29ms
+step:487/1480 train_time:16238ms step_avg:33.34ms
+step:488/1480 train_time:16302ms step_avg:33.41ms
+step:489/1480 train_time:16360ms step_avg:33.46ms
+step:490/1480 train_time:16424ms step_avg:33.52ms
+step:491/1480 train_time:16483ms step_avg:33.57ms
+step:492/1480 train_time:16550ms step_avg:33.64ms
+step:493/1480 train_time:16608ms step_avg:33.69ms
+step:494/1480 train_time:16670ms step_avg:33.75ms
+step:495/1480 train_time:16728ms step_avg:33.79ms
+step:496/1480 train_time:16791ms step_avg:33.85ms
+step:497/1480 train_time:16849ms step_avg:33.90ms
+step:498/1480 train_time:16911ms step_avg:33.96ms
+step:499/1480 train_time:16969ms step_avg:34.01ms
+step:500/1480 train_time:17032ms step_avg:34.06ms
+step:500/1480 val_loss:4.2112 train_time:17107ms step_avg:34.21ms
+step:501/1480 train_time:17128ms step_avg:34.19ms
+step:502/1480 train_time:17153ms step_avg:34.17ms
+step:503/1480 train_time:17210ms step_avg:34.21ms
+step:504/1480 train_time:17275ms step_avg:34.28ms
+step:505/1480 train_time:17331ms step_avg:34.32ms
+step:506/1480 train_time:17395ms step_avg:34.38ms
+step:507/1480 train_time:17452ms step_avg:34.42ms
+step:508/1480 train_time:17515ms step_avg:34.48ms
+step:509/1480 train_time:17571ms step_avg:34.52ms
+step:510/1480 train_time:17634ms step_avg:34.58ms
+step:511/1480 train_time:17691ms step_avg:34.62ms
+step:512/1480 train_time:17755ms step_avg:34.68ms
+step:513/1480 train_time:17812ms step_avg:34.72ms
+step:514/1480 train_time:17875ms step_avg:34.78ms
+step:515/1480 train_time:17932ms step_avg:34.82ms
+step:516/1480 train_time:17996ms step_avg:34.88ms
+step:517/1480 train_time:18057ms step_avg:34.93ms
+step:518/1480 train_time:18121ms step_avg:34.98ms
+step:519/1480 train_time:18181ms step_avg:35.03ms
+step:520/1480 train_time:18245ms step_avg:35.09ms
+step:521/1480 train_time:18304ms step_avg:35.13ms
+step:522/1480 train_time:18368ms step_avg:35.19ms
+step:523/1480 train_time:18427ms step_avg:35.23ms
+step:524/1480 train_time:18493ms step_avg:35.29ms
+step:525/1480 train_time:18552ms step_avg:35.34ms
+step:526/1480 train_time:18616ms step_avg:35.39ms
+step:527/1480 train_time:18673ms step_avg:35.43ms
+step:528/1480 train_time:18737ms step_avg:35.49ms
+step:529/1480 train_time:18795ms step_avg:35.53ms
+step:530/1480 train_time:18858ms step_avg:35.58ms
+step:531/1480 train_time:18916ms step_avg:35.62ms
+step:532/1480 train_time:18979ms step_avg:35.67ms
+step:533/1480 train_time:19036ms step_avg:35.71ms
+step:534/1480 train_time:19098ms step_avg:35.76ms
+step:535/1480 train_time:19156ms step_avg:35.80ms
+step:536/1480 train_time:19219ms step_avg:35.86ms
+step:537/1480 train_time:19277ms step_avg:35.90ms
+step:538/1480 train_time:19340ms step_avg:35.95ms
+step:539/1480 train_time:19398ms step_avg:35.99ms
+step:540/1480 train_time:19462ms step_avg:36.04ms
+step:541/1480 train_time:19521ms step_avg:36.08ms
+step:542/1480 train_time:19586ms step_avg:36.14ms
+step:543/1480 train_time:19645ms step_avg:36.18ms
+step:544/1480 train_time:19709ms step_avg:36.23ms
+step:545/1480 train_time:19768ms step_avg:36.27ms
+step:546/1480 train_time:19833ms step_avg:36.32ms
+step:547/1480 train_time:19890ms step_avg:36.36ms
+step:548/1480 train_time:19955ms step_avg:36.41ms
+step:549/1480 train_time:20013ms step_avg:36.45ms
+step:550/1480 train_time:20077ms step_avg:36.50ms
+step:551/1480 train_time:20134ms step_avg:36.54ms
+step:552/1480 train_time:20197ms step_avg:36.59ms
+step:553/1480 train_time:20255ms step_avg:36.63ms
+step:554/1480 train_time:20318ms step_avg:36.68ms
+step:555/1480 train_time:20375ms step_avg:36.71ms
+step:556/1480 train_time:20438ms step_avg:36.76ms
+step:557/1480 train_time:20496ms step_avg:36.80ms
+step:558/1480 train_time:20560ms step_avg:36.85ms
+step:559/1480 train_time:20619ms step_avg:36.89ms
+step:560/1480 train_time:20685ms step_avg:36.94ms
+step:561/1480 train_time:20744ms step_avg:36.98ms
+step:562/1480 train_time:20810ms step_avg:37.03ms
+step:563/1480 train_time:20870ms step_avg:37.07ms
+step:564/1480 train_time:20935ms step_avg:37.12ms
+step:565/1480 train_time:20993ms step_avg:37.16ms
+step:566/1480 train_time:21058ms step_avg:37.20ms
+step:567/1480 train_time:21116ms step_avg:37.24ms
+step:568/1480 train_time:21180ms step_avg:37.29ms
+step:569/1480 train_time:21239ms step_avg:37.33ms
+step:570/1480 train_time:21304ms step_avg:37.38ms
+step:571/1480 train_time:21363ms step_avg:37.41ms
+step:572/1480 train_time:21427ms step_avg:37.46ms
+step:573/1480 train_time:21487ms step_avg:37.50ms
+step:574/1480 train_time:21552ms step_avg:37.55ms
+step:575/1480 train_time:21611ms step_avg:37.58ms
+step:576/1480 train_time:21676ms step_avg:37.63ms
+step:577/1480 train_time:21734ms step_avg:37.67ms
+step:578/1480 train_time:21798ms step_avg:37.71ms
+step:579/1480 train_time:21857ms step_avg:37.75ms
+step:580/1480 train_time:21920ms step_avg:37.79ms
+step:581/1480 train_time:21979ms step_avg:37.83ms
+step:582/1480 train_time:22044ms step_avg:37.88ms
+step:583/1480 train_time:22102ms step_avg:37.91ms
+step:584/1480 train_time:22167ms step_avg:37.96ms
+step:585/1480 train_time:22226ms step_avg:37.99ms
+step:586/1480 train_time:22290ms step_avg:38.04ms
+step:587/1480 train_time:22349ms step_avg:38.07ms
+step:588/1480 train_time:22415ms step_avg:38.12ms
+step:589/1480 train_time:22472ms step_avg:38.15ms
+step:590/1480 train_time:22537ms step_avg:38.20ms
+step:591/1480 train_time:22594ms step_avg:38.23ms
+step:592/1480 train_time:22659ms step_avg:38.28ms
+step:593/1480 train_time:22717ms step_avg:38.31ms
+step:594/1480 train_time:22781ms step_avg:38.35ms
+step:595/1480 train_time:22839ms step_avg:38.38ms
+step:596/1480 train_time:22904ms step_avg:38.43ms
+step:597/1480 train_time:22962ms step_avg:38.46ms
+step:598/1480 train_time:23026ms step_avg:38.50ms
+step:599/1480 train_time:23085ms step_avg:38.54ms
+step:600/1480 train_time:23149ms step_avg:38.58ms
+step:601/1480 train_time:23208ms step_avg:38.62ms
+step:602/1480 train_time:23273ms step_avg:38.66ms
+step:603/1480 train_time:23331ms step_avg:38.69ms
+step:604/1480 train_time:23396ms step_avg:38.74ms
+step:605/1480 train_time:23453ms step_avg:38.77ms
+step:606/1480 train_time:23518ms step_avg:38.81ms
+step:607/1480 train_time:23576ms step_avg:38.84ms
+step:608/1480 train_time:23639ms step_avg:38.88ms
+step:609/1480 train_time:23697ms step_avg:38.91ms
+step:610/1480 train_time:23762ms step_avg:38.95ms
+step:611/1480 train_time:23820ms step_avg:38.99ms
+step:612/1480 train_time:23884ms step_avg:39.03ms
+step:613/1480 train_time:23942ms step_avg:39.06ms
+step:614/1480 train_time:24008ms step_avg:39.10ms
+step:615/1480 train_time:24068ms step_avg:39.13ms
+step:616/1480 train_time:24132ms step_avg:39.18ms
+step:617/1480 train_time:24190ms step_avg:39.21ms
+step:618/1480 train_time:24253ms step_avg:39.24ms
+step:619/1480 train_time:24311ms step_avg:39.27ms
+step:620/1480 train_time:24376ms step_avg:39.32ms
+step:621/1480 train_time:24434ms step_avg:39.35ms
+step:622/1480 train_time:24498ms step_avg:39.39ms
+step:623/1480 train_time:24556ms step_avg:39.42ms
+step:624/1480 train_time:24620ms step_avg:39.46ms
+step:625/1480 train_time:24679ms step_avg:39.49ms
+step:626/1480 train_time:24743ms step_avg:39.52ms
+step:627/1480 train_time:24801ms step_avg:39.55ms
+step:628/1480 train_time:24865ms step_avg:39.59ms
+step:629/1480 train_time:24923ms step_avg:39.62ms
+step:630/1480 train_time:24988ms step_avg:39.66ms
+step:631/1480 train_time:25048ms step_avg:39.70ms
+step:632/1480 train_time:25115ms step_avg:39.74ms
+step:633/1480 train_time:25172ms step_avg:39.77ms
+step:634/1480 train_time:25236ms step_avg:39.80ms
+step:635/1480 train_time:25293ms step_avg:39.83ms
+step:636/1480 train_time:25357ms step_avg:39.87ms
+step:637/1480 train_time:25414ms step_avg:39.90ms
+step:638/1480 train_time:25478ms step_avg:39.93ms
+step:639/1480 train_time:25535ms step_avg:39.96ms
+step:640/1480 train_time:25597ms step_avg:40.00ms
+step:641/1480 train_time:25654ms step_avg:40.02ms
+step:642/1480 train_time:25716ms step_avg:40.06ms
+step:643/1480 train_time:25773ms step_avg:40.08ms
+step:644/1480 train_time:25836ms step_avg:40.12ms
+step:645/1480 train_time:25894ms step_avg:40.14ms
+step:646/1480 train_time:25957ms step_avg:40.18ms
+step:647/1480 train_time:26015ms step_avg:40.21ms
+step:648/1480 train_time:26079ms step_avg:40.25ms
+step:649/1480 train_time:26138ms step_avg:40.27ms
+step:650/1480 train_time:26202ms step_avg:40.31ms
+step:651/1480 train_time:26261ms step_avg:40.34ms
+step:652/1480 train_time:26326ms step_avg:40.38ms
+step:653/1480 train_time:26385ms step_avg:40.41ms
+step:654/1480 train_time:26450ms step_avg:40.44ms
+step:655/1480 train_time:26510ms step_avg:40.47ms
+step:656/1480 train_time:26574ms step_avg:40.51ms
+step:657/1480 train_time:26632ms step_avg:40.54ms
+step:658/1480 train_time:26697ms step_avg:40.57ms
+step:659/1480 train_time:26754ms step_avg:40.60ms
+step:660/1480 train_time:26818ms step_avg:40.63ms
+step:661/1480 train_time:26873ms step_avg:40.66ms
+step:662/1480 train_time:26936ms step_avg:40.69ms
+step:663/1480 train_time:26994ms step_avg:40.71ms
+step:664/1480 train_time:27064ms step_avg:40.76ms
+step:665/1480 train_time:27128ms step_avg:40.79ms
+step:666/1480 train_time:27196ms step_avg:40.84ms
+step:667/1480 train_time:27259ms step_avg:40.87ms
+step:668/1480 train_time:27327ms step_avg:40.91ms
+step:669/1480 train_time:27390ms step_avg:40.94ms
+step:670/1480 train_time:27459ms step_avg:40.98ms
+step:671/1480 train_time:27521ms step_avg:41.02ms
+step:672/1480 train_time:27589ms step_avg:41.06ms
+step:673/1480 train_time:27644ms step_avg:41.08ms
+step:674/1480 train_time:27702ms step_avg:41.10ms
+step:675/1480 train_time:27758ms step_avg:41.12ms
+step:676/1480 train_time:27818ms step_avg:41.15ms
+step:677/1480 train_time:27875ms step_avg:41.17ms
+step:678/1480 train_time:27938ms step_avg:41.21ms
+step:679/1480 train_time:27995ms step_avg:41.23ms
+step:680/1480 train_time:28059ms step_avg:41.26ms
+step:681/1480 train_time:28117ms step_avg:41.29ms
+step:682/1480 train_time:28180ms step_avg:41.32ms
+step:683/1480 train_time:28236ms step_avg:41.34ms
+step:684/1480 train_time:28299ms step_avg:41.37ms
+step:685/1480 train_time:28356ms step_avg:41.40ms
+step:686/1480 train_time:28419ms step_avg:41.43ms
+step:687/1480 train_time:28479ms step_avg:41.45ms
+step:688/1480 train_time:28545ms step_avg:41.49ms
+step:689/1480 train_time:28604ms step_avg:41.52ms
+step:690/1480 train_time:28668ms step_avg:41.55ms
+step:691/1480 train_time:28726ms step_avg:41.57ms
+step:692/1480 train_time:28790ms step_avg:41.60ms
+step:693/1480 train_time:28849ms step_avg:41.63ms
+step:694/1480 train_time:28912ms step_avg:41.66ms
+step:695/1480 train_time:28969ms step_avg:41.68ms
+step:696/1480 train_time:29032ms step_avg:41.71ms
+step:697/1480 train_time:29090ms step_avg:41.74ms
+step:698/1480 train_time:29153ms step_avg:41.77ms
+step:699/1480 train_time:29210ms step_avg:41.79ms
+step:700/1480 train_time:29274ms step_avg:41.82ms
+step:701/1480 train_time:29332ms step_avg:41.84ms
+step:702/1480 train_time:29397ms step_avg:41.88ms
+step:703/1480 train_time:29455ms step_avg:41.90ms
+step:704/1480 train_time:29518ms step_avg:41.93ms
+step:705/1480 train_time:29574ms step_avg:41.95ms
+step:706/1480 train_time:29638ms step_avg:41.98ms
+step:707/1480 train_time:29695ms step_avg:42.00ms
+step:708/1480 train_time:29759ms step_avg:42.03ms
+step:709/1480 train_time:29818ms step_avg:42.06ms
+step:710/1480 train_time:29882ms step_avg:42.09ms
+step:711/1480 train_time:29940ms step_avg:42.11ms
+step:712/1480 train_time:30005ms step_avg:42.14ms
+step:713/1480 train_time:30065ms step_avg:42.17ms
+step:714/1480 train_time:30132ms step_avg:42.20ms
+step:715/1480 train_time:30192ms step_avg:42.23ms
+step:716/1480 train_time:30259ms step_avg:42.26ms
+step:717/1480 train_time:30318ms step_avg:42.28ms
+step:718/1480 train_time:30384ms step_avg:42.32ms
+step:719/1480 train_time:30444ms step_avg:42.34ms
+step:720/1480 train_time:30510ms step_avg:42.37ms
+step:721/1480 train_time:30570ms step_avg:42.40ms
+step:722/1480 train_time:30637ms step_avg:42.43ms
+step:723/1480 train_time:30693ms step_avg:42.45ms
+step:724/1480 train_time:30753ms step_avg:42.48ms
+step:725/1480 train_time:30809ms step_avg:42.49ms
+step:726/1480 train_time:30875ms step_avg:42.53ms
+step:727/1480 train_time:30933ms step_avg:42.55ms
+step:728/1480 train_time:30995ms step_avg:42.58ms
+step:729/1480 train_time:31054ms step_avg:42.60ms
+step:730/1480 train_time:31117ms step_avg:42.63ms
+step:731/1480 train_time:31174ms step_avg:42.65ms
+step:732/1480 train_time:31238ms step_avg:42.68ms
+step:733/1480 train_time:31299ms step_avg:42.70ms
+step:734/1480 train_time:31372ms step_avg:42.74ms
+step:735/1480 train_time:31437ms step_avg:42.77ms
+step:736/1480 train_time:31508ms step_avg:42.81ms
+step:737/1480 train_time:31574ms step_avg:42.84ms
+step:738/1480 train_time:31644ms step_avg:42.88ms
+step:739/1480 train_time:31705ms step_avg:42.90ms
+step:740/1480 train_time:31765ms step_avg:42.93ms
+step:741/1480 train_time:31818ms step_avg:42.94ms
+step:742/1480 train_time:31878ms step_avg:42.96ms
+step:743/1480 train_time:31935ms step_avg:42.98ms
+step:744/1480 train_time:31995ms step_avg:43.00ms
+step:745/1480 train_time:32054ms step_avg:43.03ms
+step:746/1480 train_time:32117ms step_avg:43.05ms
+step:747/1480 train_time:32177ms step_avg:43.07ms
+step:748/1480 train_time:32243ms step_avg:43.11ms
+step:749/1480 train_time:32303ms step_avg:43.13ms
+step:750/1480 train_time:32367ms step_avg:43.16ms
+step:750/1480 val_loss:3.8006 train_time:32445ms step_avg:43.26ms
+step:751/1480 train_time:32465ms step_avg:43.23ms
+step:752/1480 train_time:32490ms step_avg:43.21ms
+step:753/1480 train_time:32548ms step_avg:43.22ms
+step:754/1480 train_time:32613ms step_avg:43.25ms
+step:755/1480 train_time:32672ms step_avg:43.27ms
+step:756/1480 train_time:32734ms step_avg:43.30ms
+step:757/1480 train_time:32793ms step_avg:43.32ms
+step:758/1480 train_time:32857ms step_avg:43.35ms
+step:759/1480 train_time:32915ms step_avg:43.37ms
+step:760/1480 train_time:32982ms step_avg:43.40ms
+step:761/1480 train_time:33040ms step_avg:43.42ms
+step:762/1480 train_time:33103ms step_avg:43.44ms
+step:763/1480 train_time:33161ms step_avg:43.46ms
+step:764/1480 train_time:33225ms step_avg:43.49ms
+step:765/1480 train_time:33282ms step_avg:43.51ms
+step:766/1480 train_time:33345ms step_avg:43.53ms
+step:767/1480 train_time:33401ms step_avg:43.55ms
+step:768/1480 train_time:33464ms step_avg:43.57ms
+step:769/1480 train_time:33522ms step_avg:43.59ms
+step:770/1480 train_time:33584ms step_avg:43.62ms
+step:771/1480 train_time:33643ms step_avg:43.64ms
+step:772/1480 train_time:33707ms step_avg:43.66ms
+step:773/1480 train_time:33767ms step_avg:43.68ms
+step:774/1480 train_time:33831ms step_avg:43.71ms
+step:775/1480 train_time:33889ms step_avg:43.73ms
+step:776/1480 train_time:33954ms step_avg:43.75ms
+step:777/1480 train_time:34012ms step_avg:43.77ms
+step:778/1480 train_time:34080ms step_avg:43.80ms
+step:779/1480 train_time:34139ms step_avg:43.82ms
+step:780/1480 train_time:34203ms step_avg:43.85ms
+step:781/1480 train_time:34261ms step_avg:43.87ms
+step:782/1480 train_time:34325ms step_avg:43.89ms
+step:783/1480 train_time:34382ms step_avg:43.91ms
+step:784/1480 train_time:34446ms step_avg:43.94ms
+step:785/1480 train_time:34503ms step_avg:43.95ms
+step:786/1480 train_time:34567ms step_avg:43.98ms
+step:787/1480 train_time:34624ms step_avg:44.00ms
+step:788/1480 train_time:34687ms step_avg:44.02ms
+step:789/1480 train_time:34744ms step_avg:44.04ms
+step:790/1480 train_time:34806ms step_avg:44.06ms
+step:791/1480 train_time:34863ms step_avg:44.08ms
+step:792/1480 train_time:34927ms step_avg:44.10ms
+step:793/1480 train_time:34984ms step_avg:44.12ms
+step:794/1480 train_time:35046ms step_avg:44.14ms
+step:795/1480 train_time:35105ms step_avg:44.16ms
+step:796/1480 train_time:35169ms step_avg:44.18ms
+step:797/1480 train_time:35227ms step_avg:44.20ms
+step:798/1480 train_time:35290ms step_avg:44.22ms
+step:799/1480 train_time:35347ms step_avg:44.24ms
+step:800/1480 train_time:35411ms step_avg:44.26ms
+step:801/1480 train_time:35471ms step_avg:44.28ms
+step:802/1480 train_time:35535ms step_avg:44.31ms
+step:803/1480 train_time:35593ms step_avg:44.32ms
+step:804/1480 train_time:35655ms step_avg:44.35ms
+step:805/1480 train_time:35713ms step_avg:44.36ms
+step:806/1480 train_time:35775ms step_avg:44.39ms
+step:807/1480 train_time:35833ms step_avg:44.40ms
+step:808/1480 train_time:35900ms step_avg:44.43ms
+step:809/1480 train_time:35962ms step_avg:44.45ms
+step:810/1480 train_time:36029ms step_avg:44.48ms
+step:811/1480 train_time:36088ms step_avg:44.50ms
+step:812/1480 train_time:36155ms step_avg:44.53ms
+step:813/1480 train_time:36215ms step_avg:44.55ms
+step:814/1480 train_time:36282ms step_avg:44.57ms
+step:815/1480 train_time:36341ms step_avg:44.59ms
+step:816/1480 train_time:36407ms step_avg:44.62ms
+step:817/1480 train_time:36464ms step_avg:44.63ms
+step:818/1480 train_time:36523ms step_avg:44.65ms
+step:819/1480 train_time:36579ms step_avg:44.66ms
+step:820/1480 train_time:36643ms step_avg:44.69ms
+step:821/1480 train_time:36703ms step_avg:44.70ms
+step:822/1480 train_time:36772ms step_avg:44.73ms
+step:823/1480 train_time:36832ms step_avg:44.75ms
+step:824/1480 train_time:36896ms step_avg:44.78ms
+step:825/1480 train_time:36955ms step_avg:44.79ms
+step:826/1480 train_time:37018ms step_avg:44.82ms
+step:827/1480 train_time:37075ms step_avg:44.83ms
+step:828/1480 train_time:37139ms step_avg:44.85ms
+step:829/1480 train_time:37198ms step_avg:44.87ms
+step:830/1480 train_time:37263ms step_avg:44.90ms
+step:831/1480 train_time:37324ms step_avg:44.91ms
+step:832/1480 train_time:37388ms step_avg:44.94ms
+step:833/1480 train_time:37447ms step_avg:44.95ms
+step:834/1480 train_time:37512ms step_avg:44.98ms
+step:835/1480 train_time:37571ms step_avg:44.99ms
+step:836/1480 train_time:37636ms step_avg:45.02ms
+step:837/1480 train_time:37697ms step_avg:45.04ms
+step:838/1480 train_time:37762ms step_avg:45.06ms
+step:839/1480 train_time:37820ms step_avg:45.08ms
+step:840/1480 train_time:37885ms step_avg:45.10ms
+step:841/1480 train_time:37944ms step_avg:45.12ms
+step:842/1480 train_time:38009ms step_avg:45.14ms
+step:843/1480 train_time:38069ms step_avg:45.16ms
+step:844/1480 train_time:38134ms step_avg:45.18ms
+step:845/1480 train_time:38195ms step_avg:45.20ms
+step:846/1480 train_time:38262ms step_avg:45.23ms
+step:847/1480 train_time:38322ms step_avg:45.24ms
+step:848/1480 train_time:38387ms step_avg:45.27ms
+step:849/1480 train_time:38446ms step_avg:45.28ms
+step:850/1480 train_time:38513ms step_avg:45.31ms
+step:851/1480 train_time:38573ms step_avg:45.33ms
+step:852/1480 train_time:38638ms step_avg:45.35ms
+step:853/1480 train_time:38699ms step_avg:45.37ms
+step:854/1480 train_time:38765ms step_avg:45.39ms
+step:855/1480 train_time:38823ms step_avg:45.41ms
+step:856/1480 train_time:38887ms step_avg:45.43ms
+step:857/1480 train_time:38945ms step_avg:45.44ms
+step:858/1480 train_time:39010ms step_avg:45.47ms
+step:859/1480 train_time:39069ms step_avg:45.48ms
+step:860/1480 train_time:39134ms step_avg:45.50ms
+step:861/1480 train_time:39194ms step_avg:45.52ms
+step:862/1480 train_time:39260ms step_avg:45.54ms
+step:863/1480 train_time:39320ms step_avg:45.56ms
+step:864/1480 train_time:39384ms step_avg:45.58ms
+step:865/1480 train_time:39442ms step_avg:45.60ms
+step:866/1480 train_time:39506ms step_avg:45.62ms
+step:867/1480 train_time:39564ms step_avg:45.63ms
+step:868/1480 train_time:39628ms step_avg:45.65ms
+step:869/1480 train_time:39686ms step_avg:45.67ms
+step:870/1480 train_time:39751ms step_avg:45.69ms
+step:871/1480 train_time:39810ms step_avg:45.71ms
+step:872/1480 train_time:39875ms step_avg:45.73ms
+step:873/1480 train_time:39933ms step_avg:45.74ms
+step:874/1480 train_time:39998ms step_avg:45.76ms
+step:875/1480 train_time:40057ms step_avg:45.78ms
+step:876/1480 train_time:40122ms step_avg:45.80ms
+step:877/1480 train_time:40180ms step_avg:45.82ms
+step:878/1480 train_time:40244ms step_avg:45.84ms
+step:879/1480 train_time:40302ms step_avg:45.85ms
+step:880/1480 train_time:40366ms step_avg:45.87ms
+step:881/1480 train_time:40424ms step_avg:45.88ms
+step:882/1480 train_time:40488ms step_avg:45.90ms
+step:883/1480 train_time:40546ms step_avg:45.92ms
+step:884/1480 train_time:40609ms step_avg:45.94ms
+step:885/1480 train_time:40668ms step_avg:45.95ms
+step:886/1480 train_time:40732ms step_avg:45.97ms
+step:887/1480 train_time:40789ms step_avg:45.99ms
+step:888/1480 train_time:40854ms step_avg:46.01ms
+step:889/1480 train_time:40913ms step_avg:46.02ms
+step:890/1480 train_time:40977ms step_avg:46.04ms
+step:891/1480 train_time:41036ms step_avg:46.06ms
+step:892/1480 train_time:41104ms step_avg:46.08ms
+step:893/1480 train_time:41161ms step_avg:46.09ms
+step:894/1480 train_time:41225ms step_avg:46.11ms
+step:895/1480 train_time:41285ms step_avg:46.13ms
+step:896/1480 train_time:41349ms step_avg:46.15ms
+step:897/1480 train_time:41407ms step_avg:46.16ms
+step:898/1480 train_time:41470ms step_avg:46.18ms
+step:899/1480 train_time:41528ms step_avg:46.19ms
+step:900/1480 train_time:41592ms step_avg:46.21ms
+step:901/1480 train_time:41651ms step_avg:46.23ms
+step:902/1480 train_time:41715ms step_avg:46.25ms
+step:903/1480 train_time:41776ms step_avg:46.26ms
+step:904/1480 train_time:41841ms step_avg:46.28ms
+step:905/1480 train_time:41898ms step_avg:46.30ms
+step:906/1480 train_time:41963ms step_avg:46.32ms
+step:907/1480 train_time:42021ms step_avg:46.33ms
+step:908/1480 train_time:42084ms step_avg:46.35ms
+step:909/1480 train_time:42142ms step_avg:46.36ms
+step:910/1480 train_time:42204ms step_avg:46.38ms
+step:911/1480 train_time:42262ms step_avg:46.39ms
+step:912/1480 train_time:42325ms step_avg:46.41ms
+step:913/1480 train_time:42386ms step_avg:46.42ms
+step:914/1480 train_time:42459ms step_avg:46.45ms
+step:915/1480 train_time:42525ms step_avg:46.48ms
+step:916/1480 train_time:42594ms step_avg:46.50ms
+step:917/1480 train_time:42648ms step_avg:46.51ms
+step:918/1480 train_time:42708ms step_avg:46.52ms
+step:919/1480 train_time:42764ms step_avg:46.53ms
+step:920/1480 train_time:42827ms step_avg:46.55ms
+step:921/1480 train_time:42889ms step_avg:46.57ms
+step:922/1480 train_time:42958ms step_avg:46.59ms
+step:923/1480 train_time:43022ms step_avg:46.61ms
+step:924/1480 train_time:43094ms step_avg:46.64ms
+step:925/1480 train_time:43157ms step_avg:46.66ms
+step:926/1480 train_time:43225ms step_avg:46.68ms
+step:927/1480 train_time:43284ms step_avg:46.69ms
+step:928/1480 train_time:43348ms step_avg:46.71ms
+step:929/1480 train_time:43407ms step_avg:46.72ms
+step:930/1480 train_time:43470ms step_avg:46.74ms
+step:931/1480 train_time:43528ms step_avg:46.75ms
+step:932/1480 train_time:43592ms step_avg:46.77ms
+step:933/1480 train_time:43650ms step_avg:46.78ms
+step:934/1480 train_time:43714ms step_avg:46.80ms
+step:935/1480 train_time:43773ms step_avg:46.82ms
+step:936/1480 train_time:43839ms step_avg:46.84ms
+step:937/1480 train_time:43899ms step_avg:46.85ms
+step:938/1480 train_time:43963ms step_avg:46.87ms
+step:939/1480 train_time:44023ms step_avg:46.88ms
+step:940/1480 train_time:44087ms step_avg:46.90ms
+step:941/1480 train_time:44144ms step_avg:46.91ms
+step:942/1480 train_time:44207ms step_avg:46.93ms
+step:943/1480 train_time:44266ms step_avg:46.94ms
+step:944/1480 train_time:44330ms step_avg:46.96ms
+step:945/1480 train_time:44388ms step_avg:46.97ms
+step:946/1480 train_time:44453ms step_avg:46.99ms
+step:947/1480 train_time:44512ms step_avg:47.00ms
+step:948/1480 train_time:44577ms step_avg:47.02ms
+step:949/1480 train_time:44635ms step_avg:47.03ms
+step:950/1480 train_time:44700ms step_avg:47.05ms
+step:951/1480 train_time:44758ms step_avg:47.06ms
+step:952/1480 train_time:44823ms step_avg:47.08ms
+step:953/1480 train_time:44881ms step_avg:47.09ms
+step:954/1480 train_time:44945ms step_avg:47.11ms
+step:955/1480 train_time:45002ms step_avg:47.12ms
+step:956/1480 train_time:45067ms step_avg:47.14ms
+step:957/1480 train_time:45126ms step_avg:47.15ms
+step:958/1480 train_time:45190ms step_avg:47.17ms
+step:959/1480 train_time:45250ms step_avg:47.18ms
+step:960/1480 train_time:45317ms step_avg:47.20ms
+step:961/1480 train_time:45379ms step_avg:47.22ms
+step:962/1480 train_time:45471ms step_avg:47.27ms
+step:963/1480 train_time:45557ms step_avg:47.31ms
+step:964/1480 train_time:45652ms step_avg:47.36ms
+step:965/1480 train_time:45738ms step_avg:47.40ms
+step:966/1480 train_time:45834ms step_avg:47.45ms
+step:967/1480 train_time:45920ms step_avg:47.49ms
+step:968/1480 train_time:46014ms step_avg:47.54ms
+step:969/1480 train_time:46101ms step_avg:47.58ms
+step:970/1480 train_time:46194ms step_avg:47.62ms
+step:971/1480 train_time:46281ms step_avg:47.66ms
+step:972/1480 train_time:46374ms step_avg:47.71ms
+step:973/1480 train_time:46458ms step_avg:47.75ms
+step:974/1480 train_time:46550ms step_avg:47.79ms
+step:975/1480 train_time:46635ms step_avg:47.83ms
+step:976/1480 train_time:46727ms step_avg:47.88ms
+step:977/1480 train_time:46812ms step_avg:47.91ms
+step:978/1480 train_time:46902ms step_avg:47.96ms
+step:979/1480 train_time:46989ms step_avg:48.00ms
+step:980/1480 train_time:47080ms step_avg:48.04ms
+step:981/1480 train_time:47165ms step_avg:48.08ms
+step:982/1480 train_time:47255ms step_avg:48.12ms
+step:983/1480 train_time:47340ms step_avg:48.16ms
+step:984/1480 train_time:47436ms step_avg:48.21ms
+step:985/1480 train_time:47523ms step_avg:48.25ms
+step:986/1480 train_time:47617ms step_avg:48.29ms
+step:987/1480 train_time:47705ms step_avg:48.33ms
+step:988/1480 train_time:47800ms step_avg:48.38ms
+step:989/1480 train_time:47888ms step_avg:48.42ms
+step:990/1480 train_time:47981ms step_avg:48.47ms
+step:991/1480 train_time:48069ms step_avg:48.51ms
+step:992/1480 train_time:48163ms step_avg:48.55ms
+step:993/1480 train_time:48250ms step_avg:48.59ms
+step:994/1480 train_time:48344ms step_avg:48.64ms
+step:995/1480 train_time:48433ms step_avg:48.68ms
+step:996/1480 train_time:48527ms step_avg:48.72ms
+step:997/1480 train_time:48614ms step_avg:48.76ms
+step:998/1480 train_time:48708ms step_avg:48.81ms
+step:999/1480 train_time:48794ms step_avg:48.84ms
+step:1000/1480 train_time:48889ms step_avg:48.89ms
+step:1000/1480 val_loss:3.5128 train_time:49000ms step_avg:49.00ms
+step:1001/1480 train_time:49026ms step_avg:48.98ms
+step:1002/1480 train_time:49071ms step_avg:48.97ms
+step:1003/1480 train_time:49154ms step_avg:49.01ms
+step:1004/1480 train_time:49249ms step_avg:49.05ms
+step:1005/1480 train_time:49336ms step_avg:49.09ms
+step:1006/1480 train_time:49427ms step_avg:49.13ms
+step:1007/1480 train_time:49514ms step_avg:49.17ms
+step:1008/1480 train_time:49605ms step_avg:49.21ms
+step:1009/1480 train_time:49692ms step_avg:49.25ms
+step:1010/1480 train_time:49786ms step_avg:49.29ms
+step:1011/1480 train_time:49871ms step_avg:49.33ms
+step:1012/1480 train_time:49963ms step_avg:49.37ms
+step:1013/1480 train_time:50048ms step_avg:49.41ms
+step:1014/1480 train_time:50141ms step_avg:49.45ms
+step:1015/1480 train_time:50225ms step_avg:49.48ms
+step:1016/1480 train_time:50317ms step_avg:49.52ms
+step:1017/1480 train_time:50402ms step_avg:49.56ms
+step:1018/1480 train_time:50493ms step_avg:49.60ms
+step:1019/1480 train_time:50577ms step_avg:49.63ms
+step:1020/1480 train_time:50668ms step_avg:49.67ms
+step:1021/1480 train_time:50757ms step_avg:49.71ms
+step:1022/1480 train_time:50850ms step_avg:49.76ms
+step:1023/1480 train_time:50938ms step_avg:49.79ms
+step:1024/1480 train_time:51031ms step_avg:49.84ms
+step:1025/1480 train_time:51118ms step_avg:49.87ms
+step:1026/1480 train_time:51212ms step_avg:49.91ms
+step:1027/1480 train_time:51299ms step_avg:49.95ms
+step:1028/1480 train_time:51394ms step_avg:49.99ms
+step:1029/1480 train_time:51480ms step_avg:50.03ms
+step:1030/1480 train_time:51572ms step_avg:50.07ms
+step:1031/1480 train_time:51657ms step_avg:50.10ms
+step:1032/1480 train_time:51748ms step_avg:50.14ms
+step:1033/1480 train_time:51833ms step_avg:50.18ms
+step:1034/1480 train_time:51923ms step_avg:50.22ms
+step:1035/1480 train_time:52008ms step_avg:50.25ms
+step:1036/1480 train_time:52102ms step_avg:50.29ms
+step:1037/1480 train_time:52192ms step_avg:50.33ms
+step:1038/1480 train_time:52286ms step_avg:50.37ms
+step:1039/1480 train_time:52376ms step_avg:50.41ms
+step:1040/1480 train_time:52471ms step_avg:50.45ms
+step:1041/1480 train_time:52559ms step_avg:50.49ms
+step:1042/1480 train_time:52654ms step_avg:50.53ms
+step:1043/1480 train_time:52741ms step_avg:50.57ms
+step:1044/1480 train_time:52835ms step_avg:50.61ms
+step:1045/1480 train_time:52921ms step_avg:50.64ms
+step:1046/1480 train_time:53017ms step_avg:50.68ms
+step:1047/1480 train_time:53102ms step_avg:50.72ms
+step:1048/1480 train_time:53198ms step_avg:50.76ms
+step:1049/1480 train_time:53285ms step_avg:50.80ms
+step:1050/1480 train_time:53381ms step_avg:50.84ms
+step:1051/1480 train_time:53468ms step_avg:50.87ms
+step:1052/1480 train_time:53562ms step_avg:50.91ms
+step:1053/1480 train_time:53648ms step_avg:50.95ms
+step:1054/1480 train_time:53742ms step_avg:50.99ms
+step:1055/1480 train_time:53829ms step_avg:51.02ms
+step:1056/1480 train_time:53922ms step_avg:51.06ms
+step:1057/1480 train_time:54010ms step_avg:51.10ms
+step:1058/1480 train_time:54103ms step_avg:51.14ms
+step:1059/1480 train_time:54190ms step_avg:51.17ms
+step:1060/1480 train_time:54283ms step_avg:51.21ms
+step:1061/1480 train_time:54369ms step_avg:51.24ms
+step:1062/1480 train_time:54461ms step_avg:51.28ms
+step:1063/1480 train_time:54548ms step_avg:51.31ms
+step:1064/1480 train_time:54641ms step_avg:51.35ms
+step:1065/1480 train_time:54727ms step_avg:51.39ms
+step:1066/1480 train_time:54819ms step_avg:51.43ms
+step:1067/1480 train_time:54904ms step_avg:51.46ms
+step:1068/1480 train_time:54997ms step_avg:51.50ms
+step:1069/1480 train_time:55082ms step_avg:51.53ms
+step:1070/1480 train_time:55174ms step_avg:51.56ms
+step:1071/1480 train_time:55258ms step_avg:51.59ms
+step:1072/1480 train_time:55354ms step_avg:51.64ms
+step:1073/1480 train_time:55442ms step_avg:51.67ms
+step:1074/1480 train_time:55539ms step_avg:51.71ms
+step:1075/1480 train_time:55629ms step_avg:51.75ms
+step:1076/1480 train_time:55725ms step_avg:51.79ms
+step:1077/1480 train_time:55816ms step_avg:51.83ms
+step:1078/1480 train_time:55912ms step_avg:51.87ms
+step:1079/1480 train_time:55994ms step_avg:51.89ms
+step:1080/1480 train_time:56081ms step_avg:51.93ms
+step:1081/1480 train_time:56169ms step_avg:51.96ms
+step:1082/1480 train_time:56261ms step_avg:52.00ms
+step:1083/1480 train_time:56346ms step_avg:52.03ms
+step:1084/1480 train_time:56437ms step_avg:52.06ms
+step:1085/1480 train_time:56523ms step_avg:52.10ms
+step:1086/1480 train_time:56615ms step_avg:52.13ms
+step:1087/1480 train_time:56702ms step_avg:52.16ms
+step:1088/1480 train_time:56795ms step_avg:52.20ms
+step:1089/1480 train_time:56884ms step_avg:52.23ms
+step:1090/1480 train_time:56979ms step_avg:52.27ms
+step:1091/1480 train_time:57067ms step_avg:52.31ms
+step:1092/1480 train_time:57162ms step_avg:52.35ms
+step:1093/1480 train_time:57250ms step_avg:52.38ms
+step:1094/1480 train_time:57344ms step_avg:52.42ms
+step:1095/1480 train_time:57427ms step_avg:52.44ms
+step:1096/1480 train_time:57520ms step_avg:52.48ms
+step:1097/1480 train_time:57607ms step_avg:52.51ms
+step:1098/1480 train_time:57699ms step_avg:52.55ms
+step:1099/1480 train_time:57786ms step_avg:52.58ms
+step:1100/1480 train_time:57880ms step_avg:52.62ms
+step:1101/1480 train_time:57966ms step_avg:52.65ms
+step:1102/1480 train_time:58059ms step_avg:52.69ms
+step:1103/1480 train_time:58144ms step_avg:52.71ms
+step:1104/1480 train_time:58241ms step_avg:52.75ms
+step:1105/1480 train_time:58331ms step_avg:52.79ms
+step:1106/1480 train_time:58427ms step_avg:52.83ms
+step:1107/1480 train_time:58518ms step_avg:52.86ms
+step:1108/1480 train_time:58614ms step_avg:52.90ms
+step:1109/1480 train_time:58703ms step_avg:52.93ms
+step:1110/1480 train_time:58801ms step_avg:52.97ms
+step:1111/1480 train_time:58890ms step_avg:53.01ms
+step:1112/1480 train_time:58986ms step_avg:53.04ms
+step:1113/1480 train_time:59069ms step_avg:53.07ms
+step:1114/1480 train_time:59157ms step_avg:53.10ms
+step:1115/1480 train_time:59244ms step_avg:53.13ms
+step:1116/1480 train_time:59335ms step_avg:53.17ms
+step:1117/1480 train_time:59422ms step_avg:53.20ms
+step:1118/1480 train_time:59517ms step_avg:53.24ms
+step:1119/1480 train_time:59602ms step_avg:53.26ms
+step:1120/1480 train_time:59695ms step_avg:53.30ms
+step:1121/1480 train_time:59780ms step_avg:53.33ms
+step:1122/1480 train_time:59874ms step_avg:53.36ms
+step:1123/1480 train_time:59960ms step_avg:53.39ms
+step:1124/1480 train_time:60055ms step_avg:53.43ms
+step:1125/1480 train_time:60143ms step_avg:53.46ms
+step:1126/1480 train_time:60239ms step_avg:53.50ms
+step:1127/1480 train_time:60328ms step_avg:53.53ms
+step:1128/1480 train_time:60424ms step_avg:53.57ms
+step:1129/1480 train_time:60513ms step_avg:53.60ms
+step:1130/1480 train_time:60608ms step_avg:53.64ms
+step:1131/1480 train_time:60698ms step_avg:53.67ms
+step:1132/1480 train_time:60791ms step_avg:53.70ms
+step:1133/1480 train_time:60880ms step_avg:53.73ms
+step:1134/1480 train_time:60975ms step_avg:53.77ms
+step:1135/1480 train_time:61061ms step_avg:53.80ms
+step:1136/1480 train_time:61156ms step_avg:53.83ms
+step:1137/1480 train_time:61242ms step_avg:53.86ms
+step:1138/1480 train_time:61337ms step_avg:53.90ms
+step:1139/1480 train_time:61422ms step_avg:53.93ms
+step:1140/1480 train_time:61516ms step_avg:53.96ms
+step:1141/1480 train_time:61602ms step_avg:53.99ms
+step:1142/1480 train_time:61697ms step_avg:54.03ms
+step:1143/1480 train_time:61782ms step_avg:54.05ms
+step:1144/1480 train_time:61877ms step_avg:54.09ms
+step:1145/1480 train_time:61961ms step_avg:54.11ms
+step:1146/1480 train_time:62056ms step_avg:54.15ms
+step:1147/1480 train_time:62138ms step_avg:54.17ms
+step:1148/1480 train_time:62233ms step_avg:54.21ms
+step:1149/1480 train_time:62323ms step_avg:54.24ms
+step:1150/1480 train_time:62415ms step_avg:54.27ms
+step:1151/1480 train_time:62504ms step_avg:54.30ms
+step:1152/1480 train_time:62598ms step_avg:54.34ms
+step:1153/1480 train_time:62684ms step_avg:54.37ms
+step:1154/1480 train_time:62774ms step_avg:54.40ms
+step:1155/1480 train_time:62862ms step_avg:54.43ms
+step:1156/1480 train_time:62958ms step_avg:54.46ms
+step:1157/1480 train_time:63043ms step_avg:54.49ms
+step:1158/1480 train_time:63139ms step_avg:54.52ms
+step:1159/1480 train_time:63228ms step_avg:54.55ms
+step:1160/1480 train_time:63323ms step_avg:54.59ms
+step:1161/1480 train_time:63410ms step_avg:54.62ms
+step:1162/1480 train_time:63505ms step_avg:54.65ms
+step:1163/1480 train_time:63594ms step_avg:54.68ms
+step:1164/1480 train_time:63687ms step_avg:54.71ms
+step:1165/1480 train_time:63777ms step_avg:54.74ms
+step:1166/1480 train_time:63871ms step_avg:54.78ms
+step:1167/1480 train_time:63957ms step_avg:54.80ms
+step:1168/1480 train_time:64051ms step_avg:54.84ms
+step:1169/1480 train_time:64137ms step_avg:54.87ms
+step:1170/1480 train_time:64232ms step_avg:54.90ms
+step:1171/1480 train_time:64318ms step_avg:54.93ms
+step:1172/1480 train_time:64412ms step_avg:54.96ms
+step:1173/1480 train_time:64499ms step_avg:54.99ms
+step:1174/1480 train_time:64593ms step_avg:55.02ms
+step:1175/1480 train_time:64679ms step_avg:55.05ms
+step:1176/1480 train_time:64772ms step_avg:55.08ms
+step:1177/1480 train_time:64858ms step_avg:55.10ms
+step:1178/1480 train_time:64952ms step_avg:55.14ms
+step:1179/1480 train_time:65038ms step_avg:55.16ms
+step:1180/1480 train_time:65131ms step_avg:55.20ms
+step:1181/1480 train_time:65217ms step_avg:55.22ms
+step:1182/1480 train_time:65309ms step_avg:55.25ms
+step:1183/1480 train_time:65395ms step_avg:55.28ms
+step:1184/1480 train_time:65485ms step_avg:55.31ms
+step:1185/1480 train_time:65570ms step_avg:55.33ms
+step:1186/1480 train_time:65660ms step_avg:55.36ms
+step:1187/1480 train_time:65745ms step_avg:55.39ms
+step:1188/1480 train_time:65837ms step_avg:55.42ms
+step:1189/1480 train_time:65924ms step_avg:55.44ms
+step:1190/1480 train_time:66019ms step_avg:55.48ms
+step:1191/1480 train_time:66106ms step_avg:55.50ms
+step:1192/1480 train_time:66201ms step_avg:55.54ms
+step:1193/1480 train_time:66288ms step_avg:55.56ms
+step:1194/1480 train_time:66382ms step_avg:55.60ms
+step:1195/1480 train_time:66469ms step_avg:55.62ms
+step:1196/1480 train_time:66562ms step_avg:55.65ms
+step:1197/1480 train_time:66648ms step_avg:55.68ms
+step:1198/1480 train_time:66740ms step_avg:55.71ms
+step:1199/1480 train_time:66830ms step_avg:55.74ms
+step:1200/1480 train_time:66924ms step_avg:55.77ms
+step:1201/1480 train_time:67011ms step_avg:55.80ms
+step:1202/1480 train_time:67106ms step_avg:55.83ms
+step:1203/1480 train_time:67193ms step_avg:55.85ms
+step:1204/1480 train_time:67288ms step_avg:55.89ms
+step:1205/1480 train_time:67376ms step_avg:55.91ms
+step:1206/1480 train_time:67467ms step_avg:55.94ms
+step:1207/1480 train_time:67554ms step_avg:55.97ms
+step:1208/1480 train_time:67648ms step_avg:56.00ms
+step:1209/1480 train_time:67734ms step_avg:56.02ms
+step:1210/1480 train_time:67829ms step_avg:56.06ms
+step:1211/1480 train_time:67917ms step_avg:56.08ms
+step:1212/1480 train_time:68010ms step_avg:56.11ms
+step:1213/1480 train_time:68098ms step_avg:56.14ms
+step:1214/1480 train_time:68191ms step_avg:56.17ms
+step:1215/1480 train_time:68279ms step_avg:56.20ms
+step:1216/1480 train_time:68373ms step_avg:56.23ms
+step:1217/1480 train_time:68458ms step_avg:56.25ms
+step:1218/1480 train_time:68550ms step_avg:56.28ms
+step:1219/1480 train_time:68636ms step_avg:56.31ms
+step:1220/1480 train_time:68727ms step_avg:56.33ms
+step:1221/1480 train_time:68811ms step_avg:56.36ms
+step:1222/1480 train_time:68901ms step_avg:56.38ms
+step:1223/1480 train_time:68986ms step_avg:56.41ms
+step:1224/1480 train_time:69076ms step_avg:56.43ms
+step:1225/1480 train_time:69161ms step_avg:56.46ms
+step:1226/1480 train_time:69254ms step_avg:56.49ms
+step:1227/1480 train_time:69339ms step_avg:56.51ms
+step:1228/1480 train_time:69432ms step_avg:56.54ms
+step:1229/1480 train_time:69517ms step_avg:56.56ms
+step:1230/1480 train_time:69608ms step_avg:56.59ms
+step:1231/1480 train_time:69693ms step_avg:56.62ms
+step:1232/1480 train_time:69784ms step_avg:56.64ms
+step:1233/1480 train_time:69870ms step_avg:56.67ms
+step:1234/1480 train_time:69960ms step_avg:56.69ms
+step:1235/1480 train_time:70043ms step_avg:56.71ms
+step:1236/1480 train_time:70138ms step_avg:56.75ms
+step:1237/1480 train_time:70224ms step_avg:56.77ms
+step:1238/1480 train_time:70318ms step_avg:56.80ms
+step:1239/1480 train_time:70406ms step_avg:56.82ms
+step:1240/1480 train_time:70502ms step_avg:56.86ms
+step:1241/1480 train_time:70592ms step_avg:56.88ms
+step:1242/1480 train_time:70687ms step_avg:56.91ms
+step:1243/1480 train_time:70778ms step_avg:56.94ms
+step:1244/1480 train_time:70875ms step_avg:56.97ms
+step:1245/1480 train_time:70963ms step_avg:57.00ms
+step:1246/1480 train_time:71058ms step_avg:57.03ms
+step:1247/1480 train_time:71146ms step_avg:57.05ms
+step:1248/1480 train_time:71241ms step_avg:57.08ms
+step:1249/1480 train_time:71327ms step_avg:57.11ms
+step:1250/1480 train_time:71415ms step_avg:57.13ms
+step:1250/1480 val_loss:3.3702 train_time:71528ms step_avg:57.22ms
+step:1251/1480 train_time:71554ms step_avg:57.20ms
+step:1252/1480 train_time:71596ms step_avg:57.19ms
+step:1253/1480 train_time:71683ms step_avg:57.21ms
+step:1254/1480 train_time:71774ms step_avg:57.24ms
+step:1255/1480 train_time:71863ms step_avg:57.26ms
+step:1256/1480 train_time:71959ms step_avg:57.29ms
+step:1257/1480 train_time:72046ms step_avg:57.32ms
+step:1258/1480 train_time:72141ms step_avg:57.35ms
+step:1259/1480 train_time:72228ms step_avg:57.37ms
+step:1260/1480 train_time:72321ms step_avg:57.40ms
+step:1261/1480 train_time:72406ms step_avg:57.42ms
+step:1262/1480 train_time:72501ms step_avg:57.45ms
+step:1263/1480 train_time:72587ms step_avg:57.47ms
+step:1264/1480 train_time:72682ms step_avg:57.50ms
+step:1265/1480 train_time:72768ms step_avg:57.52ms
+step:1266/1480 train_time:72863ms step_avg:57.55ms
+step:1267/1480 train_time:72950ms step_avg:57.58ms
+step:1268/1480 train_time:73044ms step_avg:57.61ms
+step:1269/1480 train_time:73131ms step_avg:57.63ms
+step:1270/1480 train_time:73224ms step_avg:57.66ms
+step:1271/1480 train_time:73312ms step_avg:57.68ms
+step:1272/1480 train_time:73404ms step_avg:57.71ms
+step:1273/1480 train_time:73492ms step_avg:57.73ms
+step:1274/1480 train_time:73585ms step_avg:57.76ms
+step:1275/1480 train_time:73672ms step_avg:57.78ms
+step:1276/1480 train_time:73766ms step_avg:57.81ms
+step:1277/1480 train_time:73853ms step_avg:57.83ms
+step:1278/1480 train_time:73947ms step_avg:57.86ms
+step:1279/1480 train_time:74034ms step_avg:57.88ms
+step:1280/1480 train_time:74127ms step_avg:57.91ms
+step:1281/1480 train_time:74214ms step_avg:57.93ms
+step:1282/1480 train_time:74306ms step_avg:57.96ms
+step:1283/1480 train_time:74392ms step_avg:57.98ms
+step:1284/1480 train_time:74486ms step_avg:58.01ms
+step:1285/1480 train_time:74571ms step_avg:58.03ms
+step:1286/1480 train_time:74664ms step_avg:58.06ms
+step:1287/1480 train_time:74750ms step_avg:58.08ms
+step:1288/1480 train_time:74841ms step_avg:58.11ms
+step:1289/1480 train_time:74925ms step_avg:58.13ms
+step:1290/1480 train_time:75017ms step_avg:58.15ms
+step:1291/1480 train_time:75100ms step_avg:58.17ms
+step:1292/1480 train_time:75191ms step_avg:58.20ms
+step:1293/1480 train_time:75276ms step_avg:58.22ms
+step:1294/1480 train_time:75367ms step_avg:58.24ms
+step:1295/1480 train_time:75454ms step_avg:58.27ms
+step:1296/1480 train_time:75546ms step_avg:58.29ms
+step:1297/1480 train_time:75632ms step_avg:58.31ms
+step:1298/1480 train_time:75726ms step_avg:58.34ms
+step:1299/1480 train_time:75812ms step_avg:58.36ms
+step:1300/1480 train_time:75907ms step_avg:58.39ms
+step:1301/1480 train_time:75997ms step_avg:58.41ms
+step:1302/1480 train_time:76092ms step_avg:58.44ms
+step:1303/1480 train_time:76182ms step_avg:58.47ms
+step:1304/1480 train_time:76277ms step_avg:58.49ms
+step:1305/1480 train_time:76365ms step_avg:58.52ms
+step:1306/1480 train_time:76459ms step_avg:58.54ms
+step:1307/1480 train_time:76547ms step_avg:58.57ms
+step:1308/1480 train_time:76642ms step_avg:58.59ms
+step:1309/1480 train_time:76728ms step_avg:58.62ms
+step:1310/1480 train_time:76824ms step_avg:58.64ms
+step:1311/1480 train_time:76910ms step_avg:58.67ms
+step:1312/1480 train_time:77005ms step_avg:58.69ms
+step:1313/1480 train_time:77092ms step_avg:58.71ms
+step:1314/1480 train_time:77186ms step_avg:58.74ms
+step:1315/1480 train_time:77274ms step_avg:58.76ms
+step:1316/1480 train_time:77367ms step_avg:58.79ms
+step:1317/1480 train_time:77454ms step_avg:58.81ms
+step:1318/1480 train_time:77547ms step_avg:58.84ms
+step:1319/1480 train_time:77635ms step_avg:58.86ms
+step:1320/1480 train_time:77728ms step_avg:58.88ms
+step:1321/1480 train_time:77815ms step_avg:58.91ms
+step:1322/1480 train_time:77908ms step_avg:58.93ms
+step:1323/1480 train_time:77995ms step_avg:58.95ms
+step:1324/1480 train_time:78087ms step_avg:58.98ms
+step:1325/1480 train_time:78174ms step_avg:59.00ms
+step:1326/1480 train_time:78268ms step_avg:59.03ms
+step:1327/1480 train_time:78354ms step_avg:59.05ms
+step:1328/1480 train_time:78447ms step_avg:59.07ms
+step:1329/1480 train_time:78534ms step_avg:59.09ms
+step:1330/1480 train_time:78627ms step_avg:59.12ms
+step:1331/1480 train_time:78714ms step_avg:59.14ms
+step:1332/1480 train_time:78805ms step_avg:59.16ms
+step:1333/1480 train_time:78890ms step_avg:59.18ms
+step:1334/1480 train_time:78983ms step_avg:59.21ms
+step:1335/1480 train_time:79068ms step_avg:59.23ms
+step:1336/1480 train_time:79161ms step_avg:59.25ms
+step:1337/1480 train_time:79244ms step_avg:59.27ms
+step:1338/1480 train_time:79337ms step_avg:59.30ms
+step:1339/1480 train_time:79422ms step_avg:59.31ms
+step:1340/1480 train_time:79512ms step_avg:59.34ms
+step:1341/1480 train_time:79598ms step_avg:59.36ms
+step:1342/1480 train_time:79687ms step_avg:59.38ms
+step:1343/1480 train_time:79773ms step_avg:59.40ms
+step:1344/1480 train_time:79866ms step_avg:59.42ms
+step:1345/1480 train_time:79951ms step_avg:59.44ms
+step:1346/1480 train_time:80044ms step_avg:59.47ms
+step:1347/1480 train_time:80129ms step_avg:59.49ms
+step:1348/1480 train_time:80222ms step_avg:59.51ms
+step:1349/1480 train_time:80305ms step_avg:59.53ms
+step:1350/1480 train_time:80399ms step_avg:59.55ms
+step:1351/1480 train_time:80483ms step_avg:59.57ms
+step:1352/1480 train_time:80575ms step_avg:59.60ms
+step:1353/1480 train_time:80660ms step_avg:59.62ms
+step:1354/1480 train_time:80750ms step_avg:59.64ms
+step:1355/1480 train_time:80839ms step_avg:59.66ms
+step:1356/1480 train_time:80933ms step_avg:59.68ms
+step:1357/1480 train_time:81023ms step_avg:59.71ms
+step:1358/1480 train_time:81118ms step_avg:59.73ms
+step:1359/1480 train_time:81205ms step_avg:59.75ms
+step:1360/1480 train_time:81300ms step_avg:59.78ms
+step:1361/1480 train_time:81388ms step_avg:59.80ms
+step:1362/1480 train_time:81484ms step_avg:59.83ms
+step:1363/1480 train_time:81571ms step_avg:59.85ms
+step:1364/1480 train_time:81667ms step_avg:59.87ms
+step:1365/1480 train_time:81754ms step_avg:59.89ms
+step:1366/1480 train_time:81849ms step_avg:59.92ms
+step:1367/1480 train_time:81938ms step_avg:59.94ms
+step:1368/1480 train_time:82030ms step_avg:59.96ms
+step:1369/1480 train_time:82118ms step_avg:59.98ms
+step:1370/1480 train_time:82211ms step_avg:60.01ms
+step:1371/1480 train_time:82298ms step_avg:60.03ms
+step:1372/1480 train_time:82392ms step_avg:60.05ms
+step:1373/1480 train_time:82479ms step_avg:60.07ms
+step:1374/1480 train_time:82572ms step_avg:60.10ms
+step:1375/1480 train_time:82660ms step_avg:60.12ms
+step:1376/1480 train_time:82752ms step_avg:60.14ms
+step:1377/1480 train_time:82840ms step_avg:60.16ms
+step:1378/1480 train_time:82931ms step_avg:60.18ms
+step:1379/1480 train_time:83020ms step_avg:60.20ms
+step:1380/1480 train_time:83111ms step_avg:60.23ms
+step:1381/1480 train_time:83199ms step_avg:60.25ms
+step:1382/1480 train_time:83291ms step_avg:60.27ms
+step:1383/1480 train_time:83378ms step_avg:60.29ms
+step:1384/1480 train_time:83469ms step_avg:60.31ms
+step:1385/1480 train_time:83556ms step_avg:60.33ms
+step:1386/1480 train_time:83648ms step_avg:60.35ms
+step:1387/1480 train_time:83736ms step_avg:60.37ms
+step:1388/1480 train_time:83827ms step_avg:60.39ms
+step:1389/1480 train_time:83913ms step_avg:60.41ms
+step:1390/1480 train_time:84005ms step_avg:60.43ms
+step:1391/1480 train_time:84090ms step_avg:60.45ms
+step:1392/1480 train_time:84183ms step_avg:60.48ms
+step:1393/1480 train_time:84267ms step_avg:60.49ms
+step:1394/1480 train_time:84360ms step_avg:60.52ms
+step:1395/1480 train_time:84445ms step_avg:60.53ms
+step:1396/1480 train_time:84538ms step_avg:60.56ms
+step:1397/1480 train_time:84623ms step_avg:60.57ms
+step:1398/1480 train_time:84715ms step_avg:60.60ms
+step:1399/1480 train_time:84801ms step_avg:60.62ms
+step:1400/1480 train_time:84889ms step_avg:60.64ms
+step:1401/1480 train_time:84974ms step_avg:60.65ms
+step:1402/1480 train_time:85067ms step_avg:60.68ms
+step:1403/1480 train_time:85152ms step_avg:60.69ms
+step:1404/1480 train_time:85247ms step_avg:60.72ms
+step:1405/1480 train_time:85337ms step_avg:60.74ms
+step:1406/1480 train_time:85433ms step_avg:60.76ms
+step:1407/1480 train_time:85523ms step_avg:60.78ms
+step:1408/1480 train_time:85617ms step_avg:60.81ms
+step:1409/1480 train_time:85705ms step_avg:60.83ms
+step:1410/1480 train_time:85801ms step_avg:60.85ms
+step:1411/1480 train_time:85889ms step_avg:60.87ms
+step:1412/1480 train_time:85985ms step_avg:60.90ms
+step:1413/1480 train_time:86067ms step_avg:60.91ms
+step:1414/1480 train_time:86158ms step_avg:60.93ms
+step:1415/1480 train_time:86247ms step_avg:60.95ms
+step:1416/1480 train_time:86339ms step_avg:60.97ms
+step:1417/1480 train_time:86428ms step_avg:60.99ms
+step:1418/1480 train_time:86522ms step_avg:61.02ms
+step:1419/1480 train_time:86607ms step_avg:61.03ms
+step:1420/1480 train_time:86701ms step_avg:61.06ms
+step:1421/1480 train_time:86790ms step_avg:61.08ms
+step:1422/1480 train_time:86883ms step_avg:61.10ms
+step:1423/1480 train_time:86970ms step_avg:61.12ms
+step:1424/1480 train_time:87065ms step_avg:61.14ms
+step:1425/1480 train_time:87152ms step_avg:61.16ms
+step:1426/1480 train_time:87246ms step_avg:61.18ms
+step:1427/1480 train_time:87332ms step_avg:61.20ms
+step:1428/1480 train_time:87427ms step_avg:61.22ms
+step:1429/1480 train_time:87514ms step_avg:61.24ms
+step:1430/1480 train_time:87607ms step_avg:61.26ms
+step:1431/1480 train_time:87695ms step_avg:61.28ms
+step:1432/1480 train_time:87786ms step_avg:61.30ms
+step:1433/1480 train_time:87874ms step_avg:61.32ms
+step:1434/1480 train_time:87968ms step_avg:61.34ms
+step:1435/1480 train_time:88057ms step_avg:61.36ms
+step:1436/1480 train_time:88151ms step_avg:61.39ms
+step:1437/1480 train_time:88240ms step_avg:61.41ms
+step:1438/1480 train_time:88335ms step_avg:61.43ms
+step:1439/1480 train_time:88423ms step_avg:61.45ms
+step:1440/1480 train_time:88518ms step_avg:61.47ms
+step:1441/1480 train_time:88608ms step_avg:61.49ms
+step:1442/1480 train_time:88704ms step_avg:61.51ms
+step:1443/1480 train_time:88790ms step_avg:61.53ms
+step:1444/1480 train_time:88885ms step_avg:61.55ms
+step:1445/1480 train_time:88972ms step_avg:61.57ms
+step:1446/1480 train_time:89066ms step_avg:61.60ms
+step:1447/1480 train_time:89154ms step_avg:61.61ms
+step:1448/1480 train_time:89248ms step_avg:61.64ms
+step:1449/1480 train_time:89335ms step_avg:61.65ms
+step:1450/1480 train_time:89428ms step_avg:61.67ms
+step:1451/1480 train_time:89516ms step_avg:61.69ms
+step:1452/1480 train_time:89609ms step_avg:61.71ms
+step:1453/1480 train_time:89696ms step_avg:61.73ms
+step:1454/1480 train_time:89789ms step_avg:61.75ms
+step:1455/1480 train_time:89877ms step_avg:61.77ms
+step:1456/1480 train_time:89970ms step_avg:61.79ms
+step:1457/1480 train_time:90057ms step_avg:61.81ms
+step:1458/1480 train_time:90150ms step_avg:61.83ms
+step:1459/1480 train_time:90236ms step_avg:61.85ms
+step:1460/1480 train_time:90328ms step_avg:61.87ms
+step:1461/1480 train_time:90413ms step_avg:61.88ms
+step:1462/1480 train_time:90504ms step_avg:61.90ms
+step:1463/1480 train_time:90588ms step_avg:61.92ms
+step:1464/1480 train_time:90679ms step_avg:61.94ms
+step:1465/1480 train_time:90766ms step_avg:61.96ms
+step:1466/1480 train_time:90859ms step_avg:61.98ms
+step:1467/1480 train_time:90945ms step_avg:61.99ms
+step:1468/1480 train_time:91039ms step_avg:62.02ms
+step:1469/1480 train_time:91125ms step_avg:62.03ms
+step:1470/1480 train_time:91217ms step_avg:62.05ms
+step:1471/1480 train_time:91301ms step_avg:62.07ms
+step:1472/1480 train_time:91395ms step_avg:62.09ms
+step:1473/1480 train_time:91483ms step_avg:62.11ms
+step:1474/1480 train_time:91578ms step_avg:62.13ms
+step:1475/1480 train_time:91665ms step_avg:62.15ms
+step:1476/1480 train_time:91760ms step_avg:62.17ms
+step:1477/1480 train_time:91847ms step_avg:62.18ms
+step:1478/1480 train_time:91942ms step_avg:62.21ms
+step:1479/1480 train_time:92027ms step_avg:62.22ms
+step:1480/1480 train_time:92123ms step_avg:62.25ms
+step:1480/1480 val_loss:3.2796 train_time:92235ms step_avg:62.32ms
+peak memory allocated: 31345 MiB reserved: 47242 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk2-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk2-1480.txt
@@ -1,0 +1,4463 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # QK bank: per-head-pair Muon groups for Q, K weights
+        # Each pair of adjacent heads gets its own independent polar express orthogonalization
+        self._num_attn_layers = num_attn_layers
+        num_qk_groups = num_attn_layers * 2 * (num_heads // 2)  # 10 * 2 * 3 = 60
+        self._num_qk_groups = num_qk_groups
+        num_qk_padded = next_multiple_of_n(num_qk_groups, n=world_size)  # 64
+        self.qk_bank = nn.Parameter(torch.empty(num_qk_padded, head_dim * 2, model_dim))
+        self.qk_bank.reshape = (num_qk_padded, head_dim * 2, model_dim)
+
+        # VO bank: per-layer Muon groups for V and O weights
+        num_vo_real = num_attn_layers * 2  # 20
+        num_vo_padded = next_multiple_of_n(num_vo_real, n=world_size)  # 24
+        self.vo_bank = nn.Parameter(torch.empty(num_vo_padded, hdim, hdim))
+        self.vo_bank.reshape = (num_vo_padded, hdim, hdim)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.qk_bank[:num_qk_groups].uniform_(-bound, bound)
+            self.qk_bank[num_qk_groups:].zero_()
+            self.vo_bank[:num_vo_real].uniform_(-bound, bound)
+            self.vo_bank[num_vo_real:].zero_()
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from qk_bank/vo_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        qk_all = self.qk_bank[:self._num_qk_groups].view(self._num_attn_layers, -1, self.qk_bank.shape[-1])
+        vo_flat = self.vo_bank[:self._num_attn_layers * 2].view(self._num_attn_layers, 2, *self.vo_bank.shape[1:]).flatten(1, 2)
+        attn_weights = torch.cat([qk_all, vo_flat], dim=1).unbind(0)
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            attn_idx = i - (i > 6) if i != 6 else None
+            qkvo_w = attn_weights[attn_idx] if attn_idx is not None else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "qk_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "vo_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "qk_bank", "vo_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.qk_bank.data = model.qk_bank.data.bfloat16()
+model.vo_bank.data = model.vo_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 15:47:33 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   38C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   38C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   34C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   38C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   65C    P0            148W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          179142      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          179143      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          179144      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          179145      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          179146      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          179147      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          179148      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          179149      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8289 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:69ms step_avg:69.17ms
+step:2/1480 train_time:90ms step_avg:44.85ms
+step:3/1480 train_time:107ms step_avg:35.52ms
+step:4/1480 train_time:139ms step_avg:34.80ms
+step:5/1480 train_time:168ms step_avg:33.51ms
+step:6/1480 train_time:203ms step_avg:33.77ms
+step:7/1480 train_time:231ms step_avg:33.06ms
+step:8/1480 train_time:268ms step_avg:33.46ms
+step:9/1480 train_time:295ms step_avg:32.75ms
+step:10/1480 train_time:330ms step_avg:32.95ms
+step:11/1480 train_time:358ms step_avg:32.58ms
+step:12/1480 train_time:392ms step_avg:32.71ms
+step:13/1480 train_time:422ms step_avg:32.45ms
+step:14/1480 train_time:456ms step_avg:32.57ms
+step:15/1480 train_time:485ms step_avg:32.32ms
+step:16/1480 train_time:520ms step_avg:32.47ms
+step:17/1480 train_time:548ms step_avg:32.26ms
+step:18/1480 train_time:584ms step_avg:32.42ms
+step:19/1480 train_time:612ms step_avg:32.23ms
+step:20/1480 train_time:647ms step_avg:32.35ms
+step:21/1480 train_time:676ms step_avg:32.19ms
+step:22/1480 train_time:710ms step_avg:32.29ms
+step:23/1480 train_time:740ms step_avg:32.17ms
+step:24/1480 train_time:775ms step_avg:32.28ms
+step:25/1480 train_time:804ms step_avg:32.17ms
+step:26/1480 train_time:839ms step_avg:32.29ms
+step:27/1480 train_time:869ms step_avg:32.17ms
+step:28/1480 train_time:904ms step_avg:32.28ms
+step:29/1480 train_time:934ms step_avg:32.19ms
+step:30/1480 train_time:969ms step_avg:32.29ms
+step:31/1480 train_time:999ms step_avg:32.22ms
+step:32/1480 train_time:1034ms step_avg:32.33ms
+step:33/1480 train_time:1064ms step_avg:32.25ms
+step:34/1480 train_time:1100ms step_avg:32.36ms
+step:35/1480 train_time:1130ms step_avg:32.28ms
+step:36/1480 train_time:1166ms step_avg:32.39ms
+step:37/1480 train_time:1195ms step_avg:32.30ms
+step:38/1480 train_time:1230ms step_avg:32.37ms
+step:39/1480 train_time:1259ms step_avg:32.28ms
+step:40/1480 train_time:1294ms step_avg:32.34ms
+step:41/1480 train_time:1323ms step_avg:32.28ms
+step:42/1480 train_time:1359ms step_avg:32.35ms
+step:43/1480 train_time:1387ms step_avg:32.27ms
+step:44/1480 train_time:1423ms step_avg:32.34ms
+step:45/1480 train_time:1452ms step_avg:32.27ms
+step:46/1480 train_time:1487ms step_avg:32.32ms
+step:47/1480 train_time:1516ms step_avg:32.25ms
+step:48/1480 train_time:1550ms step_avg:32.30ms
+step:49/1480 train_time:1580ms step_avg:32.24ms
+step:50/1480 train_time:1614ms step_avg:32.29ms
+step:51/1480 train_time:1644ms step_avg:32.23ms
+step:52/1480 train_time:1680ms step_avg:32.30ms
+step:53/1480 train_time:1710ms step_avg:32.27ms
+step:54/1480 train_time:1747ms step_avg:32.35ms
+step:55/1480 train_time:1778ms step_avg:32.33ms
+step:56/1480 train_time:1814ms step_avg:32.39ms
+step:57/1480 train_time:1845ms step_avg:32.37ms
+step:58/1480 train_time:1882ms step_avg:32.45ms
+step:59/1480 train_time:1912ms step_avg:32.41ms
+step:60/1480 train_time:1949ms step_avg:32.48ms
+step:61/1480 train_time:1980ms step_avg:32.45ms
+step:62/1480 train_time:2015ms step_avg:32.51ms
+step:63/1480 train_time:2046ms step_avg:32.48ms
+step:64/1480 train_time:2084ms step_avg:32.56ms
+step:65/1480 train_time:2114ms step_avg:32.53ms
+step:66/1480 train_time:2150ms step_avg:32.58ms
+step:67/1480 train_time:2181ms step_avg:32.56ms
+step:68/1480 train_time:2217ms step_avg:32.60ms
+step:69/1480 train_time:2247ms step_avg:32.57ms
+step:70/1480 train_time:2284ms step_avg:32.63ms
+step:71/1480 train_time:2315ms step_avg:32.60ms
+step:72/1480 train_time:2351ms step_avg:32.65ms
+step:73/1480 train_time:2382ms step_avg:32.62ms
+step:74/1480 train_time:2417ms step_avg:32.66ms
+step:75/1480 train_time:2448ms step_avg:32.64ms
+step:76/1480 train_time:2485ms step_avg:32.69ms
+step:77/1480 train_time:2515ms step_avg:32.66ms
+step:78/1480 train_time:2550ms step_avg:32.70ms
+step:79/1480 train_time:2581ms step_avg:32.67ms
+step:80/1480 train_time:2617ms step_avg:32.71ms
+step:81/1480 train_time:2647ms step_avg:32.68ms
+step:82/1480 train_time:2684ms step_avg:32.73ms
+step:83/1480 train_time:2713ms step_avg:32.69ms
+step:84/1480 train_time:2749ms step_avg:32.73ms
+step:85/1480 train_time:2779ms step_avg:32.70ms
+step:86/1480 train_time:2814ms step_avg:32.73ms
+step:87/1480 train_time:2845ms step_avg:32.70ms
+step:88/1480 train_time:2881ms step_avg:32.74ms
+step:89/1480 train_time:2911ms step_avg:32.71ms
+step:90/1480 train_time:2947ms step_avg:32.74ms
+step:91/1480 train_time:2977ms step_avg:32.71ms
+step:92/1480 train_time:3012ms step_avg:32.74ms
+step:93/1480 train_time:3043ms step_avg:32.72ms
+step:94/1480 train_time:3078ms step_avg:32.75ms
+step:95/1480 train_time:3108ms step_avg:32.72ms
+step:96/1480 train_time:3144ms step_avg:32.75ms
+step:97/1480 train_time:3175ms step_avg:32.73ms
+step:98/1480 train_time:3210ms step_avg:32.76ms
+step:99/1480 train_time:3240ms step_avg:32.73ms
+step:100/1480 train_time:3276ms step_avg:32.76ms
+step:101/1480 train_time:3306ms step_avg:32.73ms
+step:102/1480 train_time:3342ms step_avg:32.76ms
+step:103/1480 train_time:3372ms step_avg:32.74ms
+step:104/1480 train_time:3407ms step_avg:32.76ms
+step:105/1480 train_time:3438ms step_avg:32.74ms
+step:106/1480 train_time:3473ms step_avg:32.77ms
+step:107/1480 train_time:3503ms step_avg:32.74ms
+step:108/1480 train_time:3538ms step_avg:32.76ms
+step:109/1480 train_time:3567ms step_avg:32.72ms
+step:110/1480 train_time:3602ms step_avg:32.74ms
+step:111/1480 train_time:3631ms step_avg:32.71ms
+step:112/1480 train_time:3665ms step_avg:32.73ms
+step:113/1480 train_time:3696ms step_avg:32.71ms
+step:114/1480 train_time:3732ms step_avg:32.74ms
+step:115/1480 train_time:3762ms step_avg:32.71ms
+step:116/1480 train_time:3798ms step_avg:32.74ms
+step:117/1480 train_time:3827ms step_avg:32.71ms
+step:118/1480 train_time:3863ms step_avg:32.74ms
+step:119/1480 train_time:3893ms step_avg:32.72ms
+step:120/1480 train_time:3928ms step_avg:32.73ms
+step:121/1480 train_time:3958ms step_avg:32.71ms
+step:122/1480 train_time:3993ms step_avg:32.73ms
+step:123/1480 train_time:4023ms step_avg:32.71ms
+step:124/1480 train_time:4059ms step_avg:32.73ms
+step:125/1480 train_time:4088ms step_avg:32.70ms
+step:126/1480 train_time:4123ms step_avg:32.72ms
+step:127/1480 train_time:4155ms step_avg:32.71ms
+step:128/1480 train_time:4190ms step_avg:32.73ms
+step:129/1480 train_time:4220ms step_avg:32.71ms
+step:130/1480 train_time:4255ms step_avg:32.73ms
+step:131/1480 train_time:4285ms step_avg:32.71ms
+step:132/1480 train_time:4320ms step_avg:32.73ms
+step:133/1480 train_time:4350ms step_avg:32.71ms
+step:134/1480 train_time:4386ms step_avg:32.73ms
+step:135/1480 train_time:4416ms step_avg:32.71ms
+step:136/1480 train_time:4452ms step_avg:32.73ms
+step:137/1480 train_time:4483ms step_avg:32.72ms
+step:138/1480 train_time:4519ms step_avg:32.75ms
+step:139/1480 train_time:4550ms step_avg:32.73ms
+step:140/1480 train_time:4586ms step_avg:32.76ms
+step:141/1480 train_time:4616ms step_avg:32.74ms
+step:142/1480 train_time:4651ms step_avg:32.76ms
+step:143/1480 train_time:4682ms step_avg:32.74ms
+step:144/1480 train_time:4719ms step_avg:32.77ms
+step:145/1480 train_time:4748ms step_avg:32.74ms
+step:146/1480 train_time:4784ms step_avg:32.77ms
+step:147/1480 train_time:4814ms step_avg:32.75ms
+step:148/1480 train_time:4850ms step_avg:32.77ms
+step:149/1480 train_time:4880ms step_avg:32.75ms
+step:150/1480 train_time:4916ms step_avg:32.77ms
+step:151/1480 train_time:4946ms step_avg:32.75ms
+step:152/1480 train_time:4982ms step_avg:32.77ms
+step:153/1480 train_time:5011ms step_avg:32.75ms
+step:154/1480 train_time:5047ms step_avg:32.77ms
+step:155/1480 train_time:5077ms step_avg:32.75ms
+step:156/1480 train_time:5112ms step_avg:32.77ms
+step:157/1480 train_time:5142ms step_avg:32.75ms
+step:158/1480 train_time:5178ms step_avg:32.77ms
+step:159/1480 train_time:5208ms step_avg:32.75ms
+step:160/1480 train_time:5244ms step_avg:32.77ms
+step:161/1480 train_time:5273ms step_avg:32.75ms
+step:162/1480 train_time:5309ms step_avg:32.77ms
+step:163/1480 train_time:5339ms step_avg:32.76ms
+step:164/1480 train_time:5374ms step_avg:32.77ms
+step:165/1480 train_time:5405ms step_avg:32.75ms
+step:166/1480 train_time:5440ms step_avg:32.77ms
+step:167/1480 train_time:5470ms step_avg:32.75ms
+step:168/1480 train_time:5506ms step_avg:32.77ms
+step:169/1480 train_time:5536ms step_avg:32.76ms
+step:170/1480 train_time:5571ms step_avg:32.77ms
+step:171/1480 train_time:5602ms step_avg:32.76ms
+step:172/1480 train_time:5639ms step_avg:32.78ms
+step:173/1480 train_time:5669ms step_avg:32.77ms
+step:174/1480 train_time:5706ms step_avg:32.79ms
+step:175/1480 train_time:5737ms step_avg:32.78ms
+step:176/1480 train_time:5772ms step_avg:32.80ms
+step:177/1480 train_time:5803ms step_avg:32.79ms
+step:178/1480 train_time:5840ms step_avg:32.81ms
+step:179/1480 train_time:5870ms step_avg:32.79ms
+step:180/1480 train_time:5907ms step_avg:32.82ms
+step:181/1480 train_time:5938ms step_avg:32.81ms
+step:182/1480 train_time:5974ms step_avg:32.82ms
+step:183/1480 train_time:6005ms step_avg:32.81ms
+step:184/1480 train_time:6041ms step_avg:32.83ms
+step:185/1480 train_time:6071ms step_avg:32.82ms
+step:186/1480 train_time:6108ms step_avg:32.84ms
+step:187/1480 train_time:6139ms step_avg:32.83ms
+step:188/1480 train_time:6174ms step_avg:32.84ms
+step:189/1480 train_time:6205ms step_avg:32.83ms
+step:190/1480 train_time:6242ms step_avg:32.85ms
+step:191/1480 train_time:6272ms step_avg:32.84ms
+step:192/1480 train_time:6309ms step_avg:32.86ms
+step:193/1480 train_time:6339ms step_avg:32.84ms
+step:194/1480 train_time:6375ms step_avg:32.86ms
+step:195/1480 train_time:6405ms step_avg:32.85ms
+step:196/1480 train_time:6441ms step_avg:32.86ms
+step:197/1480 train_time:6471ms step_avg:32.85ms
+step:198/1480 train_time:6507ms step_avg:32.87ms
+step:199/1480 train_time:6538ms step_avg:32.85ms
+step:200/1480 train_time:6574ms step_avg:32.87ms
+step:201/1480 train_time:6604ms step_avg:32.86ms
+step:202/1480 train_time:6640ms step_avg:32.87ms
+step:203/1480 train_time:6670ms step_avg:32.86ms
+step:204/1480 train_time:6706ms step_avg:32.87ms
+step:205/1480 train_time:6737ms step_avg:32.86ms
+step:206/1480 train_time:6772ms step_avg:32.87ms
+step:207/1480 train_time:6803ms step_avg:32.86ms
+step:208/1480 train_time:6839ms step_avg:32.88ms
+step:209/1480 train_time:6869ms step_avg:32.86ms
+step:210/1480 train_time:6905ms step_avg:32.88ms
+step:211/1480 train_time:6936ms step_avg:32.87ms
+step:212/1480 train_time:6971ms step_avg:32.88ms
+step:213/1480 train_time:7002ms step_avg:32.87ms
+step:214/1480 train_time:7038ms step_avg:32.89ms
+step:215/1480 train_time:7068ms step_avg:32.87ms
+step:216/1480 train_time:7104ms step_avg:32.89ms
+step:217/1480 train_time:7135ms step_avg:32.88ms
+step:218/1480 train_time:7170ms step_avg:32.89ms
+step:219/1480 train_time:7201ms step_avg:32.88ms
+step:220/1480 train_time:7237ms step_avg:32.89ms
+step:221/1480 train_time:7267ms step_avg:32.88ms
+step:222/1480 train_time:7304ms step_avg:32.90ms
+step:223/1480 train_time:7334ms step_avg:32.89ms
+step:224/1480 train_time:7370ms step_avg:32.90ms
+step:225/1480 train_time:7401ms step_avg:32.89ms
+step:226/1480 train_time:7436ms step_avg:32.90ms
+step:227/1480 train_time:7467ms step_avg:32.89ms
+step:228/1480 train_time:7503ms step_avg:32.91ms
+step:229/1480 train_time:7533ms step_avg:32.90ms
+step:230/1480 train_time:7569ms step_avg:32.91ms
+step:231/1480 train_time:7599ms step_avg:32.90ms
+step:232/1480 train_time:7634ms step_avg:32.91ms
+step:233/1480 train_time:7665ms step_avg:32.90ms
+step:234/1480 train_time:7700ms step_avg:32.91ms
+step:235/1480 train_time:7731ms step_avg:32.90ms
+step:236/1480 train_time:7766ms step_avg:32.91ms
+step:237/1480 train_time:7796ms step_avg:32.90ms
+step:238/1480 train_time:7832ms step_avg:32.91ms
+step:239/1480 train_time:7862ms step_avg:32.90ms
+step:240/1480 train_time:7897ms step_avg:32.91ms
+step:241/1480 train_time:7928ms step_avg:32.89ms
+step:242/1480 train_time:7964ms step_avg:32.91ms
+step:243/1480 train_time:7994ms step_avg:32.90ms
+step:244/1480 train_time:8030ms step_avg:32.91ms
+step:245/1480 train_time:8060ms step_avg:32.90ms
+step:246/1480 train_time:8096ms step_avg:32.91ms
+step:247/1480 train_time:8126ms step_avg:32.90ms
+step:248/1480 train_time:8163ms step_avg:32.92ms
+step:249/1480 train_time:8193ms step_avg:32.90ms
+step:250/1480 train_time:8229ms step_avg:32.92ms
+step:250/1480 val_loss:4.5056 train_time:8273ms step_avg:33.09ms
+step:251/1480 train_time:8290ms step_avg:33.03ms
+step:252/1480 train_time:8308ms step_avg:32.97ms
+step:253/1480 train_time:8329ms step_avg:32.92ms
+step:254/1480 train_time:8367ms step_avg:32.94ms
+step:255/1480 train_time:8398ms step_avg:32.93ms
+step:256/1480 train_time:8436ms step_avg:32.95ms
+step:257/1480 train_time:8467ms step_avg:32.94ms
+step:258/1480 train_time:8501ms step_avg:32.95ms
+step:259/1480 train_time:8530ms step_avg:32.93ms
+step:260/1480 train_time:8565ms step_avg:32.94ms
+step:261/1480 train_time:8593ms step_avg:32.92ms
+step:262/1480 train_time:8629ms step_avg:32.94ms
+step:263/1480 train_time:8658ms step_avg:32.92ms
+step:264/1480 train_time:8694ms step_avg:32.93ms
+step:265/1480 train_time:8723ms step_avg:32.92ms
+step:266/1480 train_time:8758ms step_avg:32.92ms
+step:267/1480 train_time:8788ms step_avg:32.91ms
+step:268/1480 train_time:8825ms step_avg:32.93ms
+step:269/1480 train_time:8854ms step_avg:32.91ms
+step:270/1480 train_time:8889ms step_avg:32.92ms
+step:271/1480 train_time:8919ms step_avg:32.91ms
+step:272/1480 train_time:8955ms step_avg:32.92ms
+step:273/1480 train_time:8985ms step_avg:32.91ms
+step:274/1480 train_time:9021ms step_avg:32.92ms
+step:275/1480 train_time:9051ms step_avg:32.91ms
+step:276/1480 train_time:9088ms step_avg:32.93ms
+step:277/1480 train_time:9118ms step_avg:32.92ms
+step:278/1480 train_time:9153ms step_avg:32.92ms
+step:279/1480 train_time:9183ms step_avg:32.92ms
+step:280/1480 train_time:9219ms step_avg:32.92ms
+step:281/1480 train_time:9249ms step_avg:32.92ms
+step:282/1480 train_time:9286ms step_avg:32.93ms
+step:283/1480 train_time:9316ms step_avg:32.92ms
+step:284/1480 train_time:9353ms step_avg:32.93ms
+step:285/1480 train_time:9384ms step_avg:32.92ms
+step:286/1480 train_time:9420ms step_avg:32.94ms
+step:287/1480 train_time:9451ms step_avg:32.93ms
+step:288/1480 train_time:9488ms step_avg:32.94ms
+step:289/1480 train_time:9519ms step_avg:32.94ms
+step:290/1480 train_time:9555ms step_avg:32.95ms
+step:291/1480 train_time:9585ms step_avg:32.94ms
+step:292/1480 train_time:9622ms step_avg:32.95ms
+step:293/1480 train_time:9653ms step_avg:32.94ms
+step:294/1480 train_time:9690ms step_avg:32.96ms
+step:295/1480 train_time:9720ms step_avg:32.95ms
+step:296/1480 train_time:9756ms step_avg:32.96ms
+step:297/1480 train_time:9787ms step_avg:32.95ms
+step:298/1480 train_time:9823ms step_avg:32.96ms
+step:299/1480 train_time:9854ms step_avg:32.96ms
+step:300/1480 train_time:9891ms step_avg:32.97ms
+step:301/1480 train_time:9921ms step_avg:32.96ms
+step:302/1480 train_time:9957ms step_avg:32.97ms
+step:303/1480 train_time:9988ms step_avg:32.96ms
+step:304/1480 train_time:10025ms step_avg:32.98ms
+step:305/1480 train_time:10056ms step_avg:32.97ms
+step:306/1480 train_time:10092ms step_avg:32.98ms
+step:307/1480 train_time:10122ms step_avg:32.97ms
+step:308/1480 train_time:10158ms step_avg:32.98ms
+step:309/1480 train_time:10189ms step_avg:32.97ms
+step:310/1480 train_time:10225ms step_avg:32.98ms
+step:311/1480 train_time:10256ms step_avg:32.98ms
+step:312/1480 train_time:10292ms step_avg:32.99ms
+step:313/1480 train_time:10322ms step_avg:32.98ms
+step:314/1480 train_time:10358ms step_avg:32.99ms
+step:315/1480 train_time:10389ms step_avg:32.98ms
+step:316/1480 train_time:10425ms step_avg:32.99ms
+step:317/1480 train_time:10456ms step_avg:32.98ms
+step:318/1480 train_time:10492ms step_avg:32.99ms
+step:319/1480 train_time:10522ms step_avg:32.98ms
+step:320/1480 train_time:10558ms step_avg:32.99ms
+step:321/1480 train_time:10588ms step_avg:32.98ms
+step:322/1480 train_time:10624ms step_avg:33.00ms
+step:323/1480 train_time:10655ms step_avg:32.99ms
+step:324/1480 train_time:10690ms step_avg:32.99ms
+step:325/1480 train_time:10721ms step_avg:32.99ms
+step:326/1480 train_time:10756ms step_avg:32.99ms
+step:327/1480 train_time:10787ms step_avg:32.99ms
+step:328/1480 train_time:10823ms step_avg:33.00ms
+step:329/1480 train_time:10853ms step_avg:32.99ms
+step:330/1480 train_time:10889ms step_avg:33.00ms
+step:331/1480 train_time:10919ms step_avg:32.99ms
+step:332/1480 train_time:10954ms step_avg:33.00ms
+step:333/1480 train_time:10985ms step_avg:32.99ms
+step:334/1480 train_time:11020ms step_avg:32.99ms
+step:335/1480 train_time:11051ms step_avg:32.99ms
+step:336/1480 train_time:11087ms step_avg:33.00ms
+step:337/1480 train_time:11117ms step_avg:32.99ms
+step:338/1480 train_time:11152ms step_avg:33.00ms
+step:339/1480 train_time:11182ms step_avg:32.99ms
+step:340/1480 train_time:11218ms step_avg:32.99ms
+step:341/1480 train_time:11249ms step_avg:32.99ms
+step:342/1480 train_time:11285ms step_avg:33.00ms
+step:343/1480 train_time:11314ms step_avg:32.99ms
+step:344/1480 train_time:11350ms step_avg:33.00ms
+step:345/1480 train_time:11380ms step_avg:32.99ms
+step:346/1480 train_time:11416ms step_avg:32.99ms
+step:347/1480 train_time:11446ms step_avg:32.99ms
+step:348/1480 train_time:11482ms step_avg:32.99ms
+step:349/1480 train_time:11512ms step_avg:32.99ms
+step:350/1480 train_time:11548ms step_avg:32.99ms
+step:351/1480 train_time:11578ms step_avg:32.99ms
+step:352/1480 train_time:11614ms step_avg:32.99ms
+step:353/1480 train_time:11644ms step_avg:32.99ms
+step:354/1480 train_time:11680ms step_avg:32.99ms
+step:355/1480 train_time:11710ms step_avg:32.99ms
+step:356/1480 train_time:11746ms step_avg:33.00ms
+step:357/1480 train_time:11776ms step_avg:32.99ms
+step:358/1480 train_time:11812ms step_avg:32.99ms
+step:359/1480 train_time:11842ms step_avg:32.99ms
+step:360/1480 train_time:11878ms step_avg:32.99ms
+step:361/1480 train_time:11908ms step_avg:32.99ms
+step:362/1480 train_time:11944ms step_avg:32.99ms
+step:363/1480 train_time:11974ms step_avg:32.99ms
+step:364/1480 train_time:12010ms step_avg:32.99ms
+step:365/1480 train_time:12040ms step_avg:32.99ms
+step:366/1480 train_time:12076ms step_avg:32.99ms
+step:367/1480 train_time:12106ms step_avg:32.99ms
+step:368/1480 train_time:12142ms step_avg:32.99ms
+step:369/1480 train_time:12172ms step_avg:32.99ms
+step:370/1480 train_time:12209ms step_avg:33.00ms
+step:371/1480 train_time:12239ms step_avg:32.99ms
+step:372/1480 train_time:12274ms step_avg:33.00ms
+step:373/1480 train_time:12305ms step_avg:32.99ms
+step:374/1480 train_time:12341ms step_avg:33.00ms
+step:375/1480 train_time:12371ms step_avg:32.99ms
+step:376/1480 train_time:12408ms step_avg:33.00ms
+step:377/1480 train_time:12438ms step_avg:32.99ms
+step:378/1480 train_time:12473ms step_avg:33.00ms
+step:379/1480 train_time:12504ms step_avg:32.99ms
+step:380/1480 train_time:12540ms step_avg:33.00ms
+step:381/1480 train_time:12570ms step_avg:32.99ms
+step:382/1480 train_time:12606ms step_avg:33.00ms
+step:383/1480 train_time:12636ms step_avg:32.99ms
+step:384/1480 train_time:12672ms step_avg:33.00ms
+step:385/1480 train_time:12703ms step_avg:32.99ms
+step:386/1480 train_time:12738ms step_avg:33.00ms
+step:387/1480 train_time:12769ms step_avg:32.99ms
+step:388/1480 train_time:12804ms step_avg:33.00ms
+step:389/1480 train_time:12834ms step_avg:32.99ms
+step:390/1480 train_time:12870ms step_avg:33.00ms
+step:391/1480 train_time:12900ms step_avg:32.99ms
+step:392/1480 train_time:12936ms step_avg:33.00ms
+step:393/1480 train_time:12966ms step_avg:32.99ms
+step:394/1480 train_time:13002ms step_avg:33.00ms
+step:395/1480 train_time:13032ms step_avg:32.99ms
+step:396/1480 train_time:13068ms step_avg:33.00ms
+step:397/1480 train_time:13098ms step_avg:32.99ms
+step:398/1480 train_time:13134ms step_avg:33.00ms
+step:399/1480 train_time:13164ms step_avg:32.99ms
+step:400/1480 train_time:13200ms step_avg:33.00ms
+step:401/1480 train_time:13230ms step_avg:32.99ms
+step:402/1480 train_time:13266ms step_avg:33.00ms
+step:403/1480 train_time:13296ms step_avg:32.99ms
+step:404/1480 train_time:13332ms step_avg:33.00ms
+step:405/1480 train_time:13362ms step_avg:32.99ms
+step:406/1480 train_time:13398ms step_avg:33.00ms
+step:407/1480 train_time:13429ms step_avg:33.00ms
+step:408/1480 train_time:13466ms step_avg:33.01ms
+step:409/1480 train_time:13497ms step_avg:33.00ms
+step:410/1480 train_time:13533ms step_avg:33.01ms
+step:411/1480 train_time:13565ms step_avg:33.00ms
+step:412/1480 train_time:13601ms step_avg:33.01ms
+step:413/1480 train_time:13632ms step_avg:33.01ms
+step:414/1480 train_time:13669ms step_avg:33.02ms
+step:415/1480 train_time:13700ms step_avg:33.01ms
+step:416/1480 train_time:13737ms step_avg:33.02ms
+step:417/1480 train_time:13768ms step_avg:33.02ms
+step:418/1480 train_time:13805ms step_avg:33.03ms
+step:419/1480 train_time:13836ms step_avg:33.02ms
+step:420/1480 train_time:13872ms step_avg:33.03ms
+step:421/1480 train_time:13903ms step_avg:33.02ms
+step:422/1480 train_time:13939ms step_avg:33.03ms
+step:423/1480 train_time:13970ms step_avg:33.03ms
+step:424/1480 train_time:14007ms step_avg:33.04ms
+step:425/1480 train_time:14038ms step_avg:33.03ms
+step:426/1480 train_time:14074ms step_avg:33.04ms
+step:427/1480 train_time:14105ms step_avg:33.03ms
+step:428/1480 train_time:14141ms step_avg:33.04ms
+step:429/1480 train_time:14172ms step_avg:33.03ms
+step:430/1480 train_time:14209ms step_avg:33.04ms
+step:431/1480 train_time:14239ms step_avg:33.04ms
+step:432/1480 train_time:14275ms step_avg:33.04ms
+step:433/1480 train_time:14306ms step_avg:33.04ms
+step:434/1480 train_time:14343ms step_avg:33.05ms
+step:435/1480 train_time:14373ms step_avg:33.04ms
+step:436/1480 train_time:14410ms step_avg:33.05ms
+step:437/1480 train_time:14440ms step_avg:33.04ms
+step:438/1480 train_time:14476ms step_avg:33.05ms
+step:439/1480 train_time:14507ms step_avg:33.05ms
+step:440/1480 train_time:14544ms step_avg:33.05ms
+step:441/1480 train_time:14574ms step_avg:33.05ms
+step:442/1480 train_time:14610ms step_avg:33.05ms
+step:443/1480 train_time:14640ms step_avg:33.05ms
+step:444/1480 train_time:14676ms step_avg:33.05ms
+step:445/1480 train_time:14707ms step_avg:33.05ms
+step:446/1480 train_time:14743ms step_avg:33.06ms
+step:447/1480 train_time:14773ms step_avg:33.05ms
+step:448/1480 train_time:14810ms step_avg:33.06ms
+step:449/1480 train_time:14840ms step_avg:33.05ms
+step:450/1480 train_time:14876ms step_avg:33.06ms
+step:451/1480 train_time:14907ms step_avg:33.05ms
+step:452/1480 train_time:14943ms step_avg:33.06ms
+step:453/1480 train_time:14973ms step_avg:33.05ms
+step:454/1480 train_time:15010ms step_avg:33.06ms
+step:455/1480 train_time:15040ms step_avg:33.05ms
+step:456/1480 train_time:15076ms step_avg:33.06ms
+step:457/1480 train_time:15107ms step_avg:33.06ms
+step:458/1480 train_time:15142ms step_avg:33.06ms
+step:459/1480 train_time:15173ms step_avg:33.06ms
+step:460/1480 train_time:15209ms step_avg:33.06ms
+step:461/1480 train_time:15239ms step_avg:33.06ms
+step:462/1480 train_time:15275ms step_avg:33.06ms
+step:463/1480 train_time:15306ms step_avg:33.06ms
+step:464/1480 train_time:15342ms step_avg:33.06ms
+step:465/1480 train_time:15372ms step_avg:33.06ms
+step:466/1480 train_time:15409ms step_avg:33.07ms
+step:467/1480 train_time:15439ms step_avg:33.06ms
+step:468/1480 train_time:15475ms step_avg:33.07ms
+step:469/1480 train_time:15505ms step_avg:33.06ms
+step:470/1480 train_time:15541ms step_avg:33.07ms
+step:471/1480 train_time:15571ms step_avg:33.06ms
+step:472/1480 train_time:15608ms step_avg:33.07ms
+step:473/1480 train_time:15638ms step_avg:33.06ms
+step:474/1480 train_time:15674ms step_avg:33.07ms
+step:475/1480 train_time:15704ms step_avg:33.06ms
+step:476/1480 train_time:15740ms step_avg:33.07ms
+step:477/1480 train_time:15770ms step_avg:33.06ms
+step:478/1480 train_time:15807ms step_avg:33.07ms
+step:479/1480 train_time:15837ms step_avg:33.06ms
+step:480/1480 train_time:15872ms step_avg:33.07ms
+step:481/1480 train_time:15905ms step_avg:33.07ms
+step:482/1480 train_time:15965ms step_avg:33.12ms
+step:483/1480 train_time:16022ms step_avg:33.17ms
+step:484/1480 train_time:16088ms step_avg:33.24ms
+step:485/1480 train_time:16148ms step_avg:33.30ms
+step:486/1480 train_time:16214ms step_avg:33.36ms
+step:487/1480 train_time:16274ms step_avg:33.42ms
+step:488/1480 train_time:16339ms step_avg:33.48ms
+step:489/1480 train_time:16399ms step_avg:33.54ms
+step:490/1480 train_time:16464ms step_avg:33.60ms
+step:491/1480 train_time:16522ms step_avg:33.65ms
+step:492/1480 train_time:16587ms step_avg:33.71ms
+step:493/1480 train_time:16648ms step_avg:33.77ms
+step:494/1480 train_time:16712ms step_avg:33.83ms
+step:495/1480 train_time:16771ms step_avg:33.88ms
+step:496/1480 train_time:16834ms step_avg:33.94ms
+step:497/1480 train_time:16893ms step_avg:33.99ms
+step:498/1480 train_time:16960ms step_avg:34.06ms
+step:499/1480 train_time:17019ms step_avg:34.11ms
+step:500/1480 train_time:17084ms step_avg:34.17ms
+step:500/1480 val_loss:4.2093 train_time:17162ms step_avg:34.32ms
+step:501/1480 train_time:17179ms step_avg:34.29ms
+step:502/1480 train_time:17208ms step_avg:34.28ms
+step:503/1480 train_time:17265ms step_avg:34.32ms
+step:504/1480 train_time:17326ms step_avg:34.38ms
+step:505/1480 train_time:17385ms step_avg:34.43ms
+step:506/1480 train_time:17449ms step_avg:34.48ms
+step:507/1480 train_time:17507ms step_avg:34.53ms
+step:508/1480 train_time:17572ms step_avg:34.59ms
+step:509/1480 train_time:17630ms step_avg:34.64ms
+step:510/1480 train_time:17693ms step_avg:34.69ms
+step:511/1480 train_time:17751ms step_avg:34.74ms
+step:512/1480 train_time:17815ms step_avg:34.80ms
+step:513/1480 train_time:17874ms step_avg:34.84ms
+step:514/1480 train_time:17939ms step_avg:34.90ms
+step:515/1480 train_time:17998ms step_avg:34.95ms
+step:516/1480 train_time:18064ms step_avg:35.01ms
+step:517/1480 train_time:18123ms step_avg:35.05ms
+step:518/1480 train_time:18188ms step_avg:35.11ms
+step:519/1480 train_time:18246ms step_avg:35.16ms
+step:520/1480 train_time:18310ms step_avg:35.21ms
+step:521/1480 train_time:18369ms step_avg:35.26ms
+step:522/1480 train_time:18432ms step_avg:35.31ms
+step:523/1480 train_time:18489ms step_avg:35.35ms
+step:524/1480 train_time:18553ms step_avg:35.41ms
+step:525/1480 train_time:18611ms step_avg:35.45ms
+step:526/1480 train_time:18675ms step_avg:35.50ms
+step:527/1480 train_time:18733ms step_avg:35.55ms
+step:528/1480 train_time:18798ms step_avg:35.60ms
+step:529/1480 train_time:18857ms step_avg:35.65ms
+step:530/1480 train_time:18923ms step_avg:35.70ms
+step:531/1480 train_time:18982ms step_avg:35.75ms
+step:532/1480 train_time:19046ms step_avg:35.80ms
+step:533/1480 train_time:19105ms step_avg:35.84ms
+step:534/1480 train_time:19170ms step_avg:35.90ms
+step:535/1480 train_time:19228ms step_avg:35.94ms
+step:536/1480 train_time:19292ms step_avg:35.99ms
+step:537/1480 train_time:19349ms step_avg:36.03ms
+step:538/1480 train_time:19414ms step_avg:36.09ms
+step:539/1480 train_time:19473ms step_avg:36.13ms
+step:540/1480 train_time:19537ms step_avg:36.18ms
+step:541/1480 train_time:19596ms step_avg:36.22ms
+step:542/1480 train_time:19661ms step_avg:36.27ms
+step:543/1480 train_time:19720ms step_avg:36.32ms
+step:544/1480 train_time:19785ms step_avg:36.37ms
+step:545/1480 train_time:19843ms step_avg:36.41ms
+step:546/1480 train_time:19908ms step_avg:36.46ms
+step:547/1480 train_time:19966ms step_avg:36.50ms
+step:548/1480 train_time:20031ms step_avg:36.55ms
+step:549/1480 train_time:20087ms step_avg:36.59ms
+step:550/1480 train_time:20152ms step_avg:36.64ms
+step:551/1480 train_time:20209ms step_avg:36.68ms
+step:552/1480 train_time:20274ms step_avg:36.73ms
+step:553/1480 train_time:20333ms step_avg:36.77ms
+step:554/1480 train_time:20398ms step_avg:36.82ms
+step:555/1480 train_time:20457ms step_avg:36.86ms
+step:556/1480 train_time:20523ms step_avg:36.91ms
+step:557/1480 train_time:20581ms step_avg:36.95ms
+step:558/1480 train_time:20645ms step_avg:37.00ms
+step:559/1480 train_time:20703ms step_avg:37.04ms
+step:560/1480 train_time:20766ms step_avg:37.08ms
+step:561/1480 train_time:20825ms step_avg:37.12ms
+step:562/1480 train_time:20891ms step_avg:37.17ms
+step:563/1480 train_time:20950ms step_avg:37.21ms
+step:564/1480 train_time:21014ms step_avg:37.26ms
+step:565/1480 train_time:21072ms step_avg:37.30ms
+step:566/1480 train_time:21135ms step_avg:37.34ms
+step:567/1480 train_time:21192ms step_avg:37.38ms
+step:568/1480 train_time:21257ms step_avg:37.42ms
+step:569/1480 train_time:21315ms step_avg:37.46ms
+step:570/1480 train_time:21381ms step_avg:37.51ms
+step:571/1480 train_time:21439ms step_avg:37.55ms
+step:572/1480 train_time:21504ms step_avg:37.59ms
+step:573/1480 train_time:21563ms step_avg:37.63ms
+step:574/1480 train_time:21629ms step_avg:37.68ms
+step:575/1480 train_time:21686ms step_avg:37.72ms
+step:576/1480 train_time:21751ms step_avg:37.76ms
+step:577/1480 train_time:21808ms step_avg:37.80ms
+step:578/1480 train_time:21873ms step_avg:37.84ms
+step:579/1480 train_time:21931ms step_avg:37.88ms
+step:580/1480 train_time:21995ms step_avg:37.92ms
+step:581/1480 train_time:22054ms step_avg:37.96ms
+step:582/1480 train_time:22119ms step_avg:38.01ms
+step:583/1480 train_time:22178ms step_avg:38.04ms
+step:584/1480 train_time:22243ms step_avg:38.09ms
+step:585/1480 train_time:22301ms step_avg:38.12ms
+step:586/1480 train_time:22366ms step_avg:38.17ms
+step:587/1480 train_time:22426ms step_avg:38.20ms
+step:588/1480 train_time:22490ms step_avg:38.25ms
+step:589/1480 train_time:22547ms step_avg:38.28ms
+step:590/1480 train_time:22612ms step_avg:38.33ms
+step:591/1480 train_time:22670ms step_avg:38.36ms
+step:592/1480 train_time:22736ms step_avg:38.40ms
+step:593/1480 train_time:22795ms step_avg:38.44ms
+step:594/1480 train_time:22861ms step_avg:38.49ms
+step:595/1480 train_time:22921ms step_avg:38.52ms
+step:596/1480 train_time:22985ms step_avg:38.57ms
+step:597/1480 train_time:23042ms step_avg:38.60ms
+step:598/1480 train_time:23106ms step_avg:38.64ms
+step:599/1480 train_time:23165ms step_avg:38.67ms
+step:600/1480 train_time:23231ms step_avg:38.72ms
+step:601/1480 train_time:23289ms step_avg:38.75ms
+step:602/1480 train_time:23353ms step_avg:38.79ms
+step:603/1480 train_time:23412ms step_avg:38.83ms
+step:604/1480 train_time:23479ms step_avg:38.87ms
+step:605/1480 train_time:23537ms step_avg:38.90ms
+step:606/1480 train_time:23601ms step_avg:38.95ms
+step:607/1480 train_time:23660ms step_avg:38.98ms
+step:608/1480 train_time:23724ms step_avg:39.02ms
+step:609/1480 train_time:23782ms step_avg:39.05ms
+step:610/1480 train_time:23845ms step_avg:39.09ms
+step:611/1480 train_time:23905ms step_avg:39.12ms
+step:612/1480 train_time:23975ms step_avg:39.17ms
+step:613/1480 train_time:24038ms step_avg:39.21ms
+step:614/1480 train_time:24108ms step_avg:39.26ms
+step:615/1480 train_time:24174ms step_avg:39.31ms
+step:616/1480 train_time:24243ms step_avg:39.36ms
+step:617/1480 train_time:24305ms step_avg:39.39ms
+step:618/1480 train_time:24365ms step_avg:39.43ms
+step:619/1480 train_time:24420ms step_avg:39.45ms
+step:620/1480 train_time:24479ms step_avg:39.48ms
+step:621/1480 train_time:24533ms step_avg:39.51ms
+step:622/1480 train_time:24596ms step_avg:39.54ms
+step:623/1480 train_time:24655ms step_avg:39.57ms
+step:624/1480 train_time:24720ms step_avg:39.62ms
+step:625/1480 train_time:24779ms step_avg:39.65ms
+step:626/1480 train_time:24841ms step_avg:39.68ms
+step:627/1480 train_time:24898ms step_avg:39.71ms
+step:628/1480 train_time:24963ms step_avg:39.75ms
+step:629/1480 train_time:25021ms step_avg:39.78ms
+step:630/1480 train_time:25086ms step_avg:39.82ms
+step:631/1480 train_time:25144ms step_avg:39.85ms
+step:632/1480 train_time:25207ms step_avg:39.88ms
+step:633/1480 train_time:25265ms step_avg:39.91ms
+step:634/1480 train_time:25329ms step_avg:39.95ms
+step:635/1480 train_time:25386ms step_avg:39.98ms
+step:636/1480 train_time:25451ms step_avg:40.02ms
+step:637/1480 train_time:25510ms step_avg:40.05ms
+step:638/1480 train_time:25574ms step_avg:40.08ms
+step:639/1480 train_time:25632ms step_avg:40.11ms
+step:640/1480 train_time:25696ms step_avg:40.15ms
+step:641/1480 train_time:25754ms step_avg:40.18ms
+step:642/1480 train_time:25819ms step_avg:40.22ms
+step:643/1480 train_time:25878ms step_avg:40.25ms
+step:644/1480 train_time:25941ms step_avg:40.28ms
+step:645/1480 train_time:26000ms step_avg:40.31ms
+step:646/1480 train_time:26065ms step_avg:40.35ms
+step:647/1480 train_time:26124ms step_avg:40.38ms
+step:648/1480 train_time:26189ms step_avg:40.41ms
+step:649/1480 train_time:26247ms step_avg:40.44ms
+step:650/1480 train_time:26312ms step_avg:40.48ms
+step:651/1480 train_time:26371ms step_avg:40.51ms
+step:652/1480 train_time:26434ms step_avg:40.54ms
+step:653/1480 train_time:26493ms step_avg:40.57ms
+step:654/1480 train_time:26559ms step_avg:40.61ms
+step:655/1480 train_time:26618ms step_avg:40.64ms
+step:656/1480 train_time:26684ms step_avg:40.68ms
+step:657/1480 train_time:26743ms step_avg:40.70ms
+step:658/1480 train_time:26807ms step_avg:40.74ms
+step:659/1480 train_time:26865ms step_avg:40.77ms
+step:660/1480 train_time:26927ms step_avg:40.80ms
+step:661/1480 train_time:26985ms step_avg:40.82ms
+step:662/1480 train_time:27048ms step_avg:40.86ms
+step:663/1480 train_time:27105ms step_avg:40.88ms
+step:664/1480 train_time:27168ms step_avg:40.92ms
+step:665/1480 train_time:27226ms step_avg:40.94ms
+step:666/1480 train_time:27288ms step_avg:40.97ms
+step:667/1480 train_time:27346ms step_avg:41.00ms
+step:668/1480 train_time:27410ms step_avg:41.03ms
+step:669/1480 train_time:27469ms step_avg:41.06ms
+step:670/1480 train_time:27534ms step_avg:41.09ms
+step:671/1480 train_time:27592ms step_avg:41.12ms
+step:672/1480 train_time:27658ms step_avg:41.16ms
+step:673/1480 train_time:27718ms step_avg:41.19ms
+step:674/1480 train_time:27784ms step_avg:41.22ms
+step:675/1480 train_time:27843ms step_avg:41.25ms
+step:676/1480 train_time:27910ms step_avg:41.29ms
+step:677/1480 train_time:27969ms step_avg:41.31ms
+step:678/1480 train_time:28033ms step_avg:41.35ms
+step:679/1480 train_time:28092ms step_avg:41.37ms
+step:680/1480 train_time:28157ms step_avg:41.41ms
+step:681/1480 train_time:28216ms step_avg:41.43ms
+step:682/1480 train_time:28282ms step_avg:41.47ms
+step:683/1480 train_time:28341ms step_avg:41.50ms
+step:684/1480 train_time:28408ms step_avg:41.53ms
+step:685/1480 train_time:28467ms step_avg:41.56ms
+step:686/1480 train_time:28532ms step_avg:41.59ms
+step:687/1480 train_time:28590ms step_avg:41.62ms
+step:688/1480 train_time:28654ms step_avg:41.65ms
+step:689/1480 train_time:28714ms step_avg:41.67ms
+step:690/1480 train_time:28779ms step_avg:41.71ms
+step:691/1480 train_time:28838ms step_avg:41.73ms
+step:692/1480 train_time:28904ms step_avg:41.77ms
+step:693/1480 train_time:28963ms step_avg:41.79ms
+step:694/1480 train_time:29029ms step_avg:41.83ms
+step:695/1480 train_time:29087ms step_avg:41.85ms
+step:696/1480 train_time:29152ms step_avg:41.88ms
+step:697/1480 train_time:29210ms step_avg:41.91ms
+step:698/1480 train_time:29275ms step_avg:41.94ms
+step:699/1480 train_time:29333ms step_avg:41.96ms
+step:700/1480 train_time:29398ms step_avg:42.00ms
+step:701/1480 train_time:29454ms step_avg:42.02ms
+step:702/1480 train_time:29515ms step_avg:42.04ms
+step:703/1480 train_time:29575ms step_avg:42.07ms
+step:704/1480 train_time:29637ms step_avg:42.10ms
+step:705/1480 train_time:29695ms step_avg:42.12ms
+step:706/1480 train_time:29757ms step_avg:42.15ms
+step:707/1480 train_time:29815ms step_avg:42.17ms
+step:708/1480 train_time:29880ms step_avg:42.20ms
+step:709/1480 train_time:29938ms step_avg:42.23ms
+step:710/1480 train_time:30003ms step_avg:42.26ms
+step:711/1480 train_time:30062ms step_avg:42.28ms
+step:712/1480 train_time:30126ms step_avg:42.31ms
+step:713/1480 train_time:30183ms step_avg:42.33ms
+step:714/1480 train_time:30247ms step_avg:42.36ms
+step:715/1480 train_time:30305ms step_avg:42.38ms
+step:716/1480 train_time:30369ms step_avg:42.42ms
+step:717/1480 train_time:30427ms step_avg:42.44ms
+step:718/1480 train_time:30491ms step_avg:42.47ms
+step:719/1480 train_time:30548ms step_avg:42.49ms
+step:720/1480 train_time:30612ms step_avg:42.52ms
+step:721/1480 train_time:30673ms step_avg:42.54ms
+step:722/1480 train_time:30744ms step_avg:42.58ms
+step:723/1480 train_time:30808ms step_avg:42.61ms
+step:724/1480 train_time:30877ms step_avg:42.65ms
+step:725/1480 train_time:30940ms step_avg:42.68ms
+step:726/1480 train_time:31009ms step_avg:42.71ms
+step:727/1480 train_time:31071ms step_avg:42.74ms
+step:728/1480 train_time:31131ms step_avg:42.76ms
+step:729/1480 train_time:31184ms step_avg:42.78ms
+step:730/1480 train_time:31248ms step_avg:42.81ms
+step:731/1480 train_time:31308ms step_avg:42.83ms
+step:732/1480 train_time:31370ms step_avg:42.86ms
+step:733/1480 train_time:31428ms step_avg:42.88ms
+step:734/1480 train_time:31492ms step_avg:42.90ms
+step:735/1480 train_time:31552ms step_avg:42.93ms
+step:736/1480 train_time:31619ms step_avg:42.96ms
+step:737/1480 train_time:31679ms step_avg:42.98ms
+step:738/1480 train_time:31744ms step_avg:43.01ms
+step:739/1480 train_time:31803ms step_avg:43.04ms
+step:740/1480 train_time:31869ms step_avg:43.07ms
+step:741/1480 train_time:31928ms step_avg:43.09ms
+step:742/1480 train_time:31993ms step_avg:43.12ms
+step:743/1480 train_time:32051ms step_avg:43.14ms
+step:744/1480 train_time:32116ms step_avg:43.17ms
+step:745/1480 train_time:32174ms step_avg:43.19ms
+step:746/1480 train_time:32239ms step_avg:43.22ms
+step:747/1480 train_time:32298ms step_avg:43.24ms
+step:748/1480 train_time:32364ms step_avg:43.27ms
+step:749/1480 train_time:32423ms step_avg:43.29ms
+step:750/1480 train_time:32488ms step_avg:43.32ms
+step:750/1480 val_loss:3.8044 train_time:32567ms step_avg:43.42ms
+step:751/1480 train_time:32585ms step_avg:43.39ms
+step:752/1480 train_time:32612ms step_avg:43.37ms
+step:753/1480 train_time:32672ms step_avg:43.39ms
+step:754/1480 train_time:32739ms step_avg:43.42ms
+step:755/1480 train_time:32799ms step_avg:43.44ms
+step:756/1480 train_time:32864ms step_avg:43.47ms
+step:757/1480 train_time:32922ms step_avg:43.49ms
+step:758/1480 train_time:32986ms step_avg:43.52ms
+step:759/1480 train_time:33044ms step_avg:43.54ms
+step:760/1480 train_time:33112ms step_avg:43.57ms
+step:761/1480 train_time:33171ms step_avg:43.59ms
+step:762/1480 train_time:33236ms step_avg:43.62ms
+step:763/1480 train_time:33297ms step_avg:43.64ms
+step:764/1480 train_time:33363ms step_avg:43.67ms
+step:765/1480 train_time:33423ms step_avg:43.69ms
+step:766/1480 train_time:33489ms step_avg:43.72ms
+step:767/1480 train_time:33548ms step_avg:43.74ms
+step:768/1480 train_time:33612ms step_avg:43.77ms
+step:769/1480 train_time:33671ms step_avg:43.78ms
+step:770/1480 train_time:33735ms step_avg:43.81ms
+step:771/1480 train_time:33791ms step_avg:43.83ms
+step:772/1480 train_time:33851ms step_avg:43.85ms
+step:773/1480 train_time:33908ms step_avg:43.87ms
+step:774/1480 train_time:33972ms step_avg:43.89ms
+step:775/1480 train_time:34031ms step_avg:43.91ms
+step:776/1480 train_time:34095ms step_avg:43.94ms
+step:777/1480 train_time:34153ms step_avg:43.96ms
+step:778/1480 train_time:34217ms step_avg:43.98ms
+step:779/1480 train_time:34276ms step_avg:44.00ms
+step:780/1480 train_time:34340ms step_avg:44.03ms
+step:781/1480 train_time:34398ms step_avg:44.04ms
+step:782/1480 train_time:34462ms step_avg:44.07ms
+step:783/1480 train_time:34519ms step_avg:44.09ms
+step:784/1480 train_time:34584ms step_avg:44.11ms
+step:785/1480 train_time:34642ms step_avg:44.13ms
+step:786/1480 train_time:34707ms step_avg:44.16ms
+step:787/1480 train_time:34766ms step_avg:44.17ms
+step:788/1480 train_time:34829ms step_avg:44.20ms
+step:789/1480 train_time:34887ms step_avg:44.22ms
+step:790/1480 train_time:34948ms step_avg:44.24ms
+step:791/1480 train_time:35006ms step_avg:44.25ms
+step:792/1480 train_time:35070ms step_avg:44.28ms
+step:793/1480 train_time:35129ms step_avg:44.30ms
+step:794/1480 train_time:35197ms step_avg:44.33ms
+step:795/1480 train_time:35256ms step_avg:44.35ms
+step:796/1480 train_time:35322ms step_avg:44.37ms
+step:797/1480 train_time:35381ms step_avg:44.39ms
+step:798/1480 train_time:35445ms step_avg:44.42ms
+step:799/1480 train_time:35502ms step_avg:44.43ms
+step:800/1480 train_time:35566ms step_avg:44.46ms
+step:801/1480 train_time:35624ms step_avg:44.47ms
+step:802/1480 train_time:35689ms step_avg:44.50ms
+step:803/1480 train_time:35748ms step_avg:44.52ms
+step:804/1480 train_time:35812ms step_avg:44.54ms
+step:805/1480 train_time:35871ms step_avg:44.56ms
+step:806/1480 train_time:35937ms step_avg:44.59ms
+step:807/1480 train_time:35995ms step_avg:44.60ms
+step:808/1480 train_time:36060ms step_avg:44.63ms
+step:809/1480 train_time:36117ms step_avg:44.64ms
+step:810/1480 train_time:36182ms step_avg:44.67ms
+step:811/1480 train_time:36241ms step_avg:44.69ms
+step:812/1480 train_time:36305ms step_avg:44.71ms
+step:813/1480 train_time:36363ms step_avg:44.73ms
+step:814/1480 train_time:36428ms step_avg:44.75ms
+step:815/1480 train_time:36487ms step_avg:44.77ms
+step:816/1480 train_time:36552ms step_avg:44.79ms
+step:817/1480 train_time:36611ms step_avg:44.81ms
+step:818/1480 train_time:36677ms step_avg:44.84ms
+step:819/1480 train_time:36736ms step_avg:44.86ms
+step:820/1480 train_time:36801ms step_avg:44.88ms
+step:821/1480 train_time:36858ms step_avg:44.89ms
+step:822/1480 train_time:36924ms step_avg:44.92ms
+step:823/1480 train_time:36983ms step_avg:44.94ms
+step:824/1480 train_time:37047ms step_avg:44.96ms
+step:825/1480 train_time:37107ms step_avg:44.98ms
+step:826/1480 train_time:37173ms step_avg:45.00ms
+step:827/1480 train_time:37233ms step_avg:45.02ms
+step:828/1480 train_time:37298ms step_avg:45.05ms
+step:829/1480 train_time:37358ms step_avg:45.06ms
+step:830/1480 train_time:37422ms step_avg:45.09ms
+step:831/1480 train_time:37480ms step_avg:45.10ms
+step:832/1480 train_time:37545ms step_avg:45.13ms
+step:833/1480 train_time:37609ms step_avg:45.15ms
+step:834/1480 train_time:37677ms step_avg:45.18ms
+step:835/1480 train_time:37735ms step_avg:45.19ms
+step:836/1480 train_time:37799ms step_avg:45.21ms
+step:837/1480 train_time:37857ms step_avg:45.23ms
+step:838/1480 train_time:37922ms step_avg:45.25ms
+step:839/1480 train_time:37981ms step_avg:45.27ms
+step:840/1480 train_time:38045ms step_avg:45.29ms
+step:841/1480 train_time:38104ms step_avg:45.31ms
+step:842/1480 train_time:38170ms step_avg:45.33ms
+step:843/1480 train_time:38230ms step_avg:45.35ms
+step:844/1480 train_time:38293ms step_avg:45.37ms
+step:845/1480 train_time:38351ms step_avg:45.39ms
+step:846/1480 train_time:38415ms step_avg:45.41ms
+step:847/1480 train_time:38475ms step_avg:45.43ms
+step:848/1480 train_time:38541ms step_avg:45.45ms
+step:849/1480 train_time:38598ms step_avg:45.46ms
+step:850/1480 train_time:38661ms step_avg:45.48ms
+step:851/1480 train_time:38718ms step_avg:45.50ms
+step:852/1480 train_time:38782ms step_avg:45.52ms
+step:853/1480 train_time:38839ms step_avg:45.53ms
+step:854/1480 train_time:38903ms step_avg:45.55ms
+step:855/1480 train_time:38963ms step_avg:45.57ms
+step:856/1480 train_time:39031ms step_avg:45.60ms
+step:857/1480 train_time:39090ms step_avg:45.61ms
+step:858/1480 train_time:39156ms step_avg:45.64ms
+step:859/1480 train_time:39216ms step_avg:45.65ms
+step:860/1480 train_time:39282ms step_avg:45.68ms
+step:861/1480 train_time:39342ms step_avg:45.69ms
+step:862/1480 train_time:39407ms step_avg:45.72ms
+step:863/1480 train_time:39466ms step_avg:45.73ms
+step:864/1480 train_time:39532ms step_avg:45.75ms
+step:865/1480 train_time:39593ms step_avg:45.77ms
+step:866/1480 train_time:39658ms step_avg:45.79ms
+step:867/1480 train_time:39717ms step_avg:45.81ms
+step:868/1480 train_time:39783ms step_avg:45.83ms
+step:869/1480 train_time:39842ms step_avg:45.85ms
+step:870/1480 train_time:39906ms step_avg:45.87ms
+step:871/1480 train_time:39965ms step_avg:45.88ms
+step:872/1480 train_time:40031ms step_avg:45.91ms
+step:873/1480 train_time:40090ms step_avg:45.92ms
+step:874/1480 train_time:40155ms step_avg:45.94ms
+step:875/1480 train_time:40214ms step_avg:45.96ms
+step:876/1480 train_time:40281ms step_avg:45.98ms
+step:877/1480 train_time:40340ms step_avg:46.00ms
+step:878/1480 train_time:40404ms step_avg:46.02ms
+step:879/1480 train_time:40463ms step_avg:46.03ms
+step:880/1480 train_time:40527ms step_avg:46.05ms
+step:881/1480 train_time:40586ms step_avg:46.07ms
+step:882/1480 train_time:40651ms step_avg:46.09ms
+step:883/1480 train_time:40711ms step_avg:46.11ms
+step:884/1480 train_time:40775ms step_avg:46.13ms
+step:885/1480 train_time:40835ms step_avg:46.14ms
+step:886/1480 train_time:40900ms step_avg:46.16ms
+step:887/1480 train_time:40958ms step_avg:46.18ms
+step:888/1480 train_time:41022ms step_avg:46.20ms
+step:889/1480 train_time:41080ms step_avg:46.21ms
+step:890/1480 train_time:41144ms step_avg:46.23ms
+step:891/1480 train_time:41202ms step_avg:46.24ms
+step:892/1480 train_time:41266ms step_avg:46.26ms
+step:893/1480 train_time:41324ms step_avg:46.28ms
+step:894/1480 train_time:41389ms step_avg:46.30ms
+step:895/1480 train_time:41447ms step_avg:46.31ms
+step:896/1480 train_time:41512ms step_avg:46.33ms
+step:897/1480 train_time:41571ms step_avg:46.34ms
+step:898/1480 train_time:41636ms step_avg:46.36ms
+step:899/1480 train_time:41694ms step_avg:46.38ms
+step:900/1480 train_time:41758ms step_avg:46.40ms
+step:901/1480 train_time:41816ms step_avg:46.41ms
+step:902/1480 train_time:41880ms step_avg:46.43ms
+step:903/1480 train_time:41939ms step_avg:46.44ms
+step:904/1480 train_time:42002ms step_avg:46.46ms
+step:905/1480 train_time:42059ms step_avg:46.47ms
+step:906/1480 train_time:42123ms step_avg:46.49ms
+step:907/1480 train_time:42182ms step_avg:46.51ms
+step:908/1480 train_time:42245ms step_avg:46.53ms
+step:909/1480 train_time:42303ms step_avg:46.54ms
+step:910/1480 train_time:42366ms step_avg:46.56ms
+step:911/1480 train_time:42424ms step_avg:46.57ms
+step:912/1480 train_time:42488ms step_avg:46.59ms
+step:913/1480 train_time:42546ms step_avg:46.60ms
+step:914/1480 train_time:42610ms step_avg:46.62ms
+step:915/1480 train_time:42668ms step_avg:46.63ms
+step:916/1480 train_time:42732ms step_avg:46.65ms
+step:917/1480 train_time:42791ms step_avg:46.66ms
+step:918/1480 train_time:42855ms step_avg:46.68ms
+step:919/1480 train_time:42913ms step_avg:46.69ms
+step:920/1480 train_time:42977ms step_avg:46.71ms
+step:921/1480 train_time:43035ms step_avg:46.73ms
+step:922/1480 train_time:43098ms step_avg:46.74ms
+step:923/1480 train_time:43154ms step_avg:46.75ms
+step:924/1480 train_time:43217ms step_avg:46.77ms
+step:925/1480 train_time:43274ms step_avg:46.78ms
+step:926/1480 train_time:43338ms step_avg:46.80ms
+step:927/1480 train_time:43399ms step_avg:46.82ms
+step:928/1480 train_time:43467ms step_avg:46.84ms
+step:929/1480 train_time:43531ms step_avg:46.86ms
+step:930/1480 train_time:43599ms step_avg:46.88ms
+step:931/1480 train_time:43661ms step_avg:46.90ms
+step:932/1480 train_time:43728ms step_avg:46.92ms
+step:933/1480 train_time:43791ms step_avg:46.94ms
+step:934/1480 train_time:43859ms step_avg:46.96ms
+step:935/1480 train_time:43921ms step_avg:46.97ms
+step:936/1480 train_time:43988ms step_avg:47.00ms
+step:937/1480 train_time:44043ms step_avg:47.00ms
+step:938/1480 train_time:44102ms step_avg:47.02ms
+step:939/1480 train_time:44160ms step_avg:47.03ms
+step:940/1480 train_time:44224ms step_avg:47.05ms
+step:941/1480 train_time:44284ms step_avg:47.06ms
+step:942/1480 train_time:44349ms step_avg:47.08ms
+step:943/1480 train_time:44407ms step_avg:47.09ms
+step:944/1480 train_time:44472ms step_avg:47.11ms
+step:945/1480 train_time:44533ms step_avg:47.12ms
+step:946/1480 train_time:44596ms step_avg:47.14ms
+step:947/1480 train_time:44654ms step_avg:47.15ms
+step:948/1480 train_time:44717ms step_avg:47.17ms
+step:949/1480 train_time:44775ms step_avg:47.18ms
+step:950/1480 train_time:44840ms step_avg:47.20ms
+step:951/1480 train_time:44901ms step_avg:47.21ms
+step:952/1480 train_time:44966ms step_avg:47.23ms
+step:953/1480 train_time:45025ms step_avg:47.25ms
+step:954/1480 train_time:45090ms step_avg:47.26ms
+step:955/1480 train_time:45150ms step_avg:47.28ms
+step:956/1480 train_time:45215ms step_avg:47.30ms
+step:957/1480 train_time:45275ms step_avg:47.31ms
+step:958/1480 train_time:45341ms step_avg:47.33ms
+step:959/1480 train_time:45399ms step_avg:47.34ms
+step:960/1480 train_time:45464ms step_avg:47.36ms
+step:961/1480 train_time:45526ms step_avg:47.37ms
+step:962/1480 train_time:45617ms step_avg:47.42ms
+step:963/1480 train_time:45706ms step_avg:47.46ms
+step:964/1480 train_time:45799ms step_avg:47.51ms
+step:965/1480 train_time:45886ms step_avg:47.55ms
+step:966/1480 train_time:45979ms step_avg:47.60ms
+step:967/1480 train_time:46066ms step_avg:47.64ms
+step:968/1480 train_time:46159ms step_avg:47.69ms
+step:969/1480 train_time:46248ms step_avg:47.73ms
+step:970/1480 train_time:46340ms step_avg:47.77ms
+step:971/1480 train_time:46427ms step_avg:47.81ms
+step:972/1480 train_time:46519ms step_avg:47.86ms
+step:973/1480 train_time:46607ms step_avg:47.90ms
+step:974/1480 train_time:46700ms step_avg:47.95ms
+step:975/1480 train_time:46788ms step_avg:47.99ms
+step:976/1480 train_time:46879ms step_avg:48.03ms
+step:977/1480 train_time:46966ms step_avg:48.07ms
+step:978/1480 train_time:47059ms step_avg:48.12ms
+step:979/1480 train_time:47146ms step_avg:48.16ms
+step:980/1480 train_time:47238ms step_avg:48.20ms
+step:981/1480 train_time:47325ms step_avg:48.24ms
+step:982/1480 train_time:47417ms step_avg:48.29ms
+step:983/1480 train_time:47502ms step_avg:48.32ms
+step:984/1480 train_time:47593ms step_avg:48.37ms
+step:985/1480 train_time:47678ms step_avg:48.40ms
+step:986/1480 train_time:47769ms step_avg:48.45ms
+step:987/1480 train_time:47853ms step_avg:48.48ms
+step:988/1480 train_time:47945ms step_avg:48.53ms
+step:989/1480 train_time:48033ms step_avg:48.57ms
+step:990/1480 train_time:48128ms step_avg:48.61ms
+step:991/1480 train_time:48215ms step_avg:48.65ms
+step:992/1480 train_time:48311ms step_avg:48.70ms
+step:993/1480 train_time:48398ms step_avg:48.74ms
+step:994/1480 train_time:48494ms step_avg:48.79ms
+step:995/1480 train_time:48583ms step_avg:48.83ms
+step:996/1480 train_time:48676ms step_avg:48.87ms
+step:997/1480 train_time:48764ms step_avg:48.91ms
+step:998/1480 train_time:48857ms step_avg:48.95ms
+step:999/1480 train_time:48944ms step_avg:48.99ms
+step:1000/1480 train_time:49039ms step_avg:49.04ms
+step:1000/1480 val_loss:3.5102 train_time:49153ms step_avg:49.15ms
+step:1001/1480 train_time:49171ms step_avg:49.12ms
+step:1002/1480 train_time:49222ms step_avg:49.12ms
+step:1003/1480 train_time:49309ms step_avg:49.16ms
+step:1004/1480 train_time:49405ms step_avg:49.21ms
+step:1005/1480 train_time:49492ms step_avg:49.25ms
+step:1006/1480 train_time:49585ms step_avg:49.29ms
+step:1007/1480 train_time:49675ms step_avg:49.33ms
+step:1008/1480 train_time:49766ms step_avg:49.37ms
+step:1009/1480 train_time:49853ms step_avg:49.41ms
+step:1010/1480 train_time:49947ms step_avg:49.45ms
+step:1011/1480 train_time:50029ms step_avg:49.48ms
+step:1012/1480 train_time:50118ms step_avg:49.52ms
+step:1013/1480 train_time:50206ms step_avg:49.56ms
+step:1014/1480 train_time:50298ms step_avg:49.60ms
+step:1015/1480 train_time:50385ms step_avg:49.64ms
+step:1016/1480 train_time:50477ms step_avg:49.68ms
+step:1017/1480 train_time:50564ms step_avg:49.72ms
+step:1018/1480 train_time:50657ms step_avg:49.76ms
+step:1019/1480 train_time:50743ms step_avg:49.80ms
+step:1020/1480 train_time:50840ms step_avg:49.84ms
+step:1021/1480 train_time:50930ms step_avg:49.88ms
+step:1022/1480 train_time:51028ms step_avg:49.93ms
+step:1023/1480 train_time:51119ms step_avg:49.97ms
+step:1024/1480 train_time:51216ms step_avg:50.02ms
+step:1025/1480 train_time:51306ms step_avg:50.05ms
+step:1026/1480 train_time:51403ms step_avg:50.10ms
+step:1027/1480 train_time:51493ms step_avg:50.14ms
+step:1028/1480 train_time:51588ms step_avg:50.18ms
+step:1029/1480 train_time:51670ms step_avg:50.21ms
+step:1030/1480 train_time:51758ms step_avg:50.25ms
+step:1031/1480 train_time:51844ms step_avg:50.29ms
+step:1032/1480 train_time:51937ms step_avg:50.33ms
+step:1033/1480 train_time:52022ms step_avg:50.36ms
+step:1034/1480 train_time:52115ms step_avg:50.40ms
+step:1035/1480 train_time:52204ms step_avg:50.44ms
+step:1036/1480 train_time:52297ms step_avg:50.48ms
+step:1037/1480 train_time:52383ms step_avg:50.51ms
+step:1038/1480 train_time:52476ms step_avg:50.55ms
+step:1039/1480 train_time:52562ms step_avg:50.59ms
+step:1040/1480 train_time:52656ms step_avg:50.63ms
+step:1041/1480 train_time:52745ms step_avg:50.67ms
+step:1042/1480 train_time:52840ms step_avg:50.71ms
+step:1043/1480 train_time:52928ms step_avg:50.75ms
+step:1044/1480 train_time:53024ms step_avg:50.79ms
+step:1045/1480 train_time:53112ms step_avg:50.83ms
+step:1046/1480 train_time:53207ms step_avg:50.87ms
+step:1047/1480 train_time:53296ms step_avg:50.90ms
+step:1048/1480 train_time:53391ms step_avg:50.95ms
+step:1049/1480 train_time:53478ms step_avg:50.98ms
+step:1050/1480 train_time:53573ms step_avg:51.02ms
+step:1051/1480 train_time:53659ms step_avg:51.05ms
+step:1052/1480 train_time:53753ms step_avg:51.10ms
+step:1053/1480 train_time:53839ms step_avg:51.13ms
+step:1054/1480 train_time:53932ms step_avg:51.17ms
+step:1055/1480 train_time:54020ms step_avg:51.20ms
+step:1056/1480 train_time:54114ms step_avg:51.24ms
+step:1057/1480 train_time:54200ms step_avg:51.28ms
+step:1058/1480 train_time:54293ms step_avg:51.32ms
+step:1059/1480 train_time:54379ms step_avg:51.35ms
+step:1060/1480 train_time:54472ms step_avg:51.39ms
+step:1061/1480 train_time:54558ms step_avg:51.42ms
+step:1062/1480 train_time:54651ms step_avg:51.46ms
+step:1063/1480 train_time:54738ms step_avg:51.49ms
+step:1064/1480 train_time:54831ms step_avg:51.53ms
+step:1065/1480 train_time:54917ms step_avg:51.57ms
+step:1066/1480 train_time:55010ms step_avg:51.60ms
+step:1067/1480 train_time:55096ms step_avg:51.64ms
+step:1068/1480 train_time:55190ms step_avg:51.68ms
+step:1069/1480 train_time:55277ms step_avg:51.71ms
+step:1070/1480 train_time:55369ms step_avg:51.75ms
+step:1071/1480 train_time:55456ms step_avg:51.78ms
+step:1072/1480 train_time:55549ms step_avg:51.82ms
+step:1073/1480 train_time:55634ms step_avg:51.85ms
+step:1074/1480 train_time:55727ms step_avg:51.89ms
+step:1075/1480 train_time:55814ms step_avg:51.92ms
+step:1076/1480 train_time:55905ms step_avg:51.96ms
+step:1077/1480 train_time:55993ms step_avg:51.99ms
+step:1078/1480 train_time:56085ms step_avg:52.03ms
+step:1079/1480 train_time:56170ms step_avg:52.06ms
+step:1080/1480 train_time:56262ms step_avg:52.09ms
+step:1081/1480 train_time:56348ms step_avg:52.13ms
+step:1082/1480 train_time:56442ms step_avg:52.16ms
+step:1083/1480 train_time:56528ms step_avg:52.20ms
+step:1084/1480 train_time:56619ms step_avg:52.23ms
+step:1085/1480 train_time:56703ms step_avg:52.26ms
+step:1086/1480 train_time:56794ms step_avg:52.30ms
+step:1087/1480 train_time:56881ms step_avg:52.33ms
+step:1088/1480 train_time:56973ms step_avg:52.37ms
+step:1089/1480 train_time:57056ms step_avg:52.39ms
+step:1090/1480 train_time:57147ms step_avg:52.43ms
+step:1091/1480 train_time:57235ms step_avg:52.46ms
+step:1092/1480 train_time:57326ms step_avg:52.50ms
+step:1093/1480 train_time:57412ms step_avg:52.53ms
+step:1094/1480 train_time:57504ms step_avg:52.56ms
+step:1095/1480 train_time:57593ms step_avg:52.60ms
+step:1096/1480 train_time:57690ms step_avg:52.64ms
+step:1097/1480 train_time:57782ms step_avg:52.67ms
+step:1098/1480 train_time:57881ms step_avg:52.71ms
+step:1099/1480 train_time:57971ms step_avg:52.75ms
+step:1100/1480 train_time:58068ms step_avg:52.79ms
+step:1101/1480 train_time:58160ms step_avg:52.82ms
+step:1102/1480 train_time:58257ms step_avg:52.87ms
+step:1103/1480 train_time:58347ms step_avg:52.90ms
+step:1104/1480 train_time:58435ms step_avg:52.93ms
+step:1105/1480 train_time:58514ms step_avg:52.95ms
+step:1106/1480 train_time:58603ms step_avg:52.99ms
+step:1107/1480 train_time:58688ms step_avg:53.01ms
+step:1108/1480 train_time:58780ms step_avg:53.05ms
+step:1109/1480 train_time:58867ms step_avg:53.08ms
+step:1110/1480 train_time:58963ms step_avg:53.12ms
+step:1111/1480 train_time:59049ms step_avg:53.15ms
+step:1112/1480 train_time:59141ms step_avg:53.18ms
+step:1113/1480 train_time:59229ms step_avg:53.22ms
+step:1114/1480 train_time:59325ms step_avg:53.25ms
+step:1115/1480 train_time:59416ms step_avg:53.29ms
+step:1116/1480 train_time:59510ms step_avg:53.32ms
+step:1117/1480 train_time:59600ms step_avg:53.36ms
+step:1118/1480 train_time:59695ms step_avg:53.39ms
+step:1119/1480 train_time:59783ms step_avg:53.43ms
+step:1120/1480 train_time:59878ms step_avg:53.46ms
+step:1121/1480 train_time:59967ms step_avg:53.49ms
+step:1122/1480 train_time:60062ms step_avg:53.53ms
+step:1123/1480 train_time:60150ms step_avg:53.56ms
+step:1124/1480 train_time:60244ms step_avg:53.60ms
+step:1125/1480 train_time:60333ms step_avg:53.63ms
+step:1126/1480 train_time:60427ms step_avg:53.67ms
+step:1127/1480 train_time:60516ms step_avg:53.70ms
+step:1128/1480 train_time:60610ms step_avg:53.73ms
+step:1129/1480 train_time:60698ms step_avg:53.76ms
+step:1130/1480 train_time:60791ms step_avg:53.80ms
+step:1131/1480 train_time:60880ms step_avg:53.83ms
+step:1132/1480 train_time:60973ms step_avg:53.86ms
+step:1133/1480 train_time:61058ms step_avg:53.89ms
+step:1134/1480 train_time:61153ms step_avg:53.93ms
+step:1135/1480 train_time:61239ms step_avg:53.95ms
+step:1136/1480 train_time:61331ms step_avg:53.99ms
+step:1137/1480 train_time:61420ms step_avg:54.02ms
+step:1138/1480 train_time:61514ms step_avg:54.05ms
+step:1139/1480 train_time:61601ms step_avg:54.08ms
+step:1140/1480 train_time:61694ms step_avg:54.12ms
+step:1141/1480 train_time:61780ms step_avg:54.15ms
+step:1142/1480 train_time:61873ms step_avg:54.18ms
+step:1143/1480 train_time:61958ms step_avg:54.21ms
+step:1144/1480 train_time:62048ms step_avg:54.24ms
+step:1145/1480 train_time:62137ms step_avg:54.27ms
+step:1146/1480 train_time:62229ms step_avg:54.30ms
+step:1147/1480 train_time:62315ms step_avg:54.33ms
+step:1148/1480 train_time:62409ms step_avg:54.36ms
+step:1149/1480 train_time:62495ms step_avg:54.39ms
+step:1150/1480 train_time:62586ms step_avg:54.42ms
+step:1151/1480 train_time:62672ms step_avg:54.45ms
+step:1152/1480 train_time:62763ms step_avg:54.48ms
+step:1153/1480 train_time:62848ms step_avg:54.51ms
+step:1154/1480 train_time:62939ms step_avg:54.54ms
+step:1155/1480 train_time:63026ms step_avg:54.57ms
+step:1156/1480 train_time:63117ms step_avg:54.60ms
+step:1157/1480 train_time:63201ms step_avg:54.62ms
+step:1158/1480 train_time:63296ms step_avg:54.66ms
+step:1159/1480 train_time:63381ms step_avg:54.69ms
+step:1160/1480 train_time:63474ms step_avg:54.72ms
+step:1161/1480 train_time:63560ms step_avg:54.75ms
+step:1162/1480 train_time:63653ms step_avg:54.78ms
+step:1163/1480 train_time:63748ms step_avg:54.81ms
+step:1164/1480 train_time:63855ms step_avg:54.86ms
+step:1165/1480 train_time:63945ms step_avg:54.89ms
+step:1166/1480 train_time:64031ms step_avg:54.91ms
+step:1167/1480 train_time:64114ms step_avg:54.94ms
+step:1168/1480 train_time:64202ms step_avg:54.97ms
+step:1169/1480 train_time:64288ms step_avg:54.99ms
+step:1170/1480 train_time:64383ms step_avg:55.03ms
+step:1171/1480 train_time:64469ms step_avg:55.05ms
+step:1172/1480 train_time:64565ms step_avg:55.09ms
+step:1173/1480 train_time:64657ms step_avg:55.12ms
+step:1174/1480 train_time:64753ms step_avg:55.16ms
+step:1175/1480 train_time:64841ms step_avg:55.18ms
+step:1176/1480 train_time:64937ms step_avg:55.22ms
+step:1177/1480 train_time:65024ms step_avg:55.25ms
+step:1178/1480 train_time:65119ms step_avg:55.28ms
+step:1179/1480 train_time:65207ms step_avg:55.31ms
+step:1180/1480 train_time:65303ms step_avg:55.34ms
+step:1181/1480 train_time:65384ms step_avg:55.36ms
+step:1182/1480 train_time:65475ms step_avg:55.39ms
+step:1183/1480 train_time:65564ms step_avg:55.42ms
+step:1184/1480 train_time:65657ms step_avg:55.45ms
+step:1185/1480 train_time:65743ms step_avg:55.48ms
+step:1186/1480 train_time:65838ms step_avg:55.51ms
+step:1187/1480 train_time:65921ms step_avg:55.54ms
+step:1188/1480 train_time:66014ms step_avg:55.57ms
+step:1189/1480 train_time:66100ms step_avg:55.59ms
+step:1190/1480 train_time:66194ms step_avg:55.62ms
+step:1191/1480 train_time:66283ms step_avg:55.65ms
+step:1192/1480 train_time:66378ms step_avg:55.69ms
+step:1193/1480 train_time:66465ms step_avg:55.71ms
+step:1194/1480 train_time:66562ms step_avg:55.75ms
+step:1195/1480 train_time:66652ms step_avg:55.78ms
+step:1196/1480 train_time:66747ms step_avg:55.81ms
+step:1197/1480 train_time:66836ms step_avg:55.84ms
+step:1198/1480 train_time:66931ms step_avg:55.87ms
+step:1199/1480 train_time:67019ms step_avg:55.90ms
+step:1200/1480 train_time:67112ms step_avg:55.93ms
+step:1201/1480 train_time:67200ms step_avg:55.95ms
+step:1202/1480 train_time:67295ms step_avg:55.99ms
+step:1203/1480 train_time:67383ms step_avg:56.01ms
+step:1204/1480 train_time:67478ms step_avg:56.04ms
+step:1205/1480 train_time:67565ms step_avg:56.07ms
+step:1206/1480 train_time:67659ms step_avg:56.10ms
+step:1207/1480 train_time:67746ms step_avg:56.13ms
+step:1208/1480 train_time:67842ms step_avg:56.16ms
+step:1209/1480 train_time:67929ms step_avg:56.19ms
+step:1210/1480 train_time:68024ms step_avg:56.22ms
+step:1211/1480 train_time:68111ms step_avg:56.24ms
+step:1212/1480 train_time:68204ms step_avg:56.27ms
+step:1213/1480 train_time:68292ms step_avg:56.30ms
+step:1214/1480 train_time:68385ms step_avg:56.33ms
+step:1215/1480 train_time:68474ms step_avg:56.36ms
+step:1216/1480 train_time:68566ms step_avg:56.39ms
+step:1217/1480 train_time:68653ms step_avg:56.41ms
+step:1218/1480 train_time:68744ms step_avg:56.44ms
+step:1219/1480 train_time:68831ms step_avg:56.46ms
+step:1220/1480 train_time:68924ms step_avg:56.49ms
+step:1221/1480 train_time:69010ms step_avg:56.52ms
+step:1222/1480 train_time:69103ms step_avg:56.55ms
+step:1223/1480 train_time:69190ms step_avg:56.57ms
+step:1224/1480 train_time:69284ms step_avg:56.60ms
+step:1225/1480 train_time:69369ms step_avg:56.63ms
+step:1226/1480 train_time:69461ms step_avg:56.66ms
+step:1227/1480 train_time:69546ms step_avg:56.68ms
+step:1228/1480 train_time:69640ms step_avg:56.71ms
+step:1229/1480 train_time:69723ms step_avg:56.73ms
+step:1230/1480 train_time:69815ms step_avg:56.76ms
+step:1231/1480 train_time:69900ms step_avg:56.78ms
+step:1232/1480 train_time:69991ms step_avg:56.81ms
+step:1233/1480 train_time:70076ms step_avg:56.83ms
+step:1234/1480 train_time:70168ms step_avg:56.86ms
+step:1235/1480 train_time:70253ms step_avg:56.89ms
+step:1236/1480 train_time:70343ms step_avg:56.91ms
+step:1237/1480 train_time:70427ms step_avg:56.93ms
+step:1238/1480 train_time:70517ms step_avg:56.96ms
+step:1239/1480 train_time:70603ms step_avg:56.98ms
+step:1240/1480 train_time:70696ms step_avg:57.01ms
+step:1241/1480 train_time:70780ms step_avg:57.03ms
+step:1242/1480 train_time:70873ms step_avg:57.06ms
+step:1243/1480 train_time:70961ms step_avg:57.09ms
+step:1244/1480 train_time:71056ms step_avg:57.12ms
+step:1245/1480 train_time:71142ms step_avg:57.14ms
+step:1246/1480 train_time:71236ms step_avg:57.17ms
+step:1247/1480 train_time:71322ms step_avg:57.19ms
+step:1248/1480 train_time:71416ms step_avg:57.22ms
+step:1249/1480 train_time:71502ms step_avg:57.25ms
+step:1250/1480 train_time:71596ms step_avg:57.28ms
+step:1250/1480 val_loss:3.3678 train_time:71706ms step_avg:57.36ms
+step:1251/1480 train_time:71723ms step_avg:57.33ms
+step:1252/1480 train_time:71774ms step_avg:57.33ms
+step:1253/1480 train_time:71865ms step_avg:57.35ms
+step:1254/1480 train_time:71961ms step_avg:57.39ms
+step:1255/1480 train_time:72051ms step_avg:57.41ms
+step:1256/1480 train_time:72147ms step_avg:57.44ms
+step:1257/1480 train_time:72238ms step_avg:57.47ms
+step:1258/1480 train_time:72332ms step_avg:57.50ms
+step:1259/1480 train_time:72422ms step_avg:57.52ms
+step:1260/1480 train_time:72509ms step_avg:57.55ms
+step:1261/1480 train_time:72591ms step_avg:57.57ms
+step:1262/1480 train_time:72683ms step_avg:57.59ms
+step:1263/1480 train_time:72768ms step_avg:57.62ms
+step:1264/1480 train_time:72860ms step_avg:57.64ms
+step:1265/1480 train_time:72946ms step_avg:57.67ms
+step:1266/1480 train_time:73038ms step_avg:57.69ms
+step:1267/1480 train_time:73126ms step_avg:57.72ms
+step:1268/1480 train_time:73221ms step_avg:57.75ms
+step:1269/1480 train_time:73307ms step_avg:57.77ms
+step:1270/1480 train_time:73401ms step_avg:57.80ms
+step:1271/1480 train_time:73488ms step_avg:57.82ms
+step:1272/1480 train_time:73582ms step_avg:57.85ms
+step:1273/1480 train_time:73668ms step_avg:57.87ms
+step:1274/1480 train_time:73759ms step_avg:57.90ms
+step:1275/1480 train_time:73845ms step_avg:57.92ms
+step:1276/1480 train_time:73935ms step_avg:57.94ms
+step:1277/1480 train_time:74020ms step_avg:57.96ms
+step:1278/1480 train_time:74113ms step_avg:57.99ms
+step:1279/1480 train_time:74205ms step_avg:58.02ms
+step:1280/1480 train_time:74300ms step_avg:58.05ms
+step:1281/1480 train_time:74386ms step_avg:58.07ms
+step:1282/1480 train_time:74481ms step_avg:58.10ms
+step:1283/1480 train_time:74568ms step_avg:58.12ms
+step:1284/1480 train_time:74663ms step_avg:58.15ms
+step:1285/1480 train_time:74751ms step_avg:58.17ms
+step:1286/1480 train_time:74845ms step_avg:58.20ms
+step:1287/1480 train_time:74933ms step_avg:58.22ms
+step:1288/1480 train_time:75028ms step_avg:58.25ms
+step:1289/1480 train_time:75116ms step_avg:58.27ms
+step:1290/1480 train_time:75211ms step_avg:58.30ms
+step:1291/1480 train_time:75299ms step_avg:58.33ms
+step:1292/1480 train_time:75393ms step_avg:58.35ms
+step:1293/1480 train_time:75480ms step_avg:58.38ms
+step:1294/1480 train_time:75573ms step_avg:58.40ms
+step:1295/1480 train_time:75660ms step_avg:58.42ms
+step:1296/1480 train_time:75752ms step_avg:58.45ms
+step:1297/1480 train_time:75840ms step_avg:58.47ms
+step:1298/1480 train_time:75936ms step_avg:58.50ms
+step:1299/1480 train_time:76023ms step_avg:58.52ms
+step:1300/1480 train_time:76115ms step_avg:58.55ms
+step:1301/1480 train_time:76202ms step_avg:58.57ms
+step:1302/1480 train_time:76296ms step_avg:58.60ms
+step:1303/1480 train_time:76381ms step_avg:58.62ms
+step:1304/1480 train_time:76472ms step_avg:58.64ms
+step:1305/1480 train_time:76560ms step_avg:58.67ms
+step:1306/1480 train_time:76651ms step_avg:58.69ms
+step:1307/1480 train_time:76737ms step_avg:58.71ms
+step:1308/1480 train_time:76829ms step_avg:58.74ms
+step:1309/1480 train_time:76916ms step_avg:58.76ms
+step:1310/1480 train_time:77008ms step_avg:58.78ms
+step:1311/1480 train_time:77095ms step_avg:58.81ms
+step:1312/1480 train_time:77188ms step_avg:58.83ms
+step:1313/1480 train_time:77273ms step_avg:58.85ms
+step:1314/1480 train_time:77367ms step_avg:58.88ms
+step:1315/1480 train_time:77453ms step_avg:58.90ms
+step:1316/1480 train_time:77547ms step_avg:58.93ms
+step:1317/1480 train_time:77635ms step_avg:58.95ms
+step:1318/1480 train_time:77727ms step_avg:58.97ms
+step:1319/1480 train_time:77813ms step_avg:58.99ms
+step:1320/1480 train_time:77907ms step_avg:59.02ms
+step:1321/1480 train_time:77993ms step_avg:59.04ms
+step:1322/1480 train_time:78086ms step_avg:59.07ms
+step:1323/1480 train_time:78172ms step_avg:59.09ms
+step:1324/1480 train_time:78266ms step_avg:59.11ms
+step:1325/1480 train_time:78351ms step_avg:59.13ms
+step:1326/1480 train_time:78446ms step_avg:59.16ms
+step:1327/1480 train_time:78532ms step_avg:59.18ms
+step:1328/1480 train_time:78626ms step_avg:59.21ms
+step:1329/1480 train_time:78712ms step_avg:59.23ms
+step:1330/1480 train_time:78805ms step_avg:59.25ms
+step:1331/1480 train_time:78890ms step_avg:59.27ms
+step:1332/1480 train_time:78983ms step_avg:59.30ms
+step:1333/1480 train_time:79069ms step_avg:59.32ms
+step:1334/1480 train_time:79161ms step_avg:59.34ms
+step:1335/1480 train_time:79245ms step_avg:59.36ms
+step:1336/1480 train_time:79338ms step_avg:59.38ms
+step:1337/1480 train_time:79423ms step_avg:59.40ms
+step:1338/1480 train_time:79513ms step_avg:59.43ms
+step:1339/1480 train_time:79599ms step_avg:59.45ms
+step:1340/1480 train_time:79688ms step_avg:59.47ms
+step:1341/1480 train_time:79772ms step_avg:59.49ms
+step:1342/1480 train_time:79866ms step_avg:59.51ms
+step:1343/1480 train_time:79951ms step_avg:59.53ms
+step:1344/1480 train_time:80042ms step_avg:59.56ms
+step:1345/1480 train_time:80128ms step_avg:59.57ms
+step:1346/1480 train_time:80220ms step_avg:59.60ms
+step:1347/1480 train_time:80305ms step_avg:59.62ms
+step:1348/1480 train_time:80395ms step_avg:59.64ms
+step:1349/1480 train_time:80490ms step_avg:59.67ms
+step:1350/1480 train_time:80598ms step_avg:59.70ms
+step:1351/1480 train_time:80694ms step_avg:59.73ms
+step:1352/1480 train_time:80798ms step_avg:59.76ms
+step:1353/1480 train_time:80886ms step_avg:59.78ms
+step:1354/1480 train_time:80970ms step_avg:59.80ms
+step:1355/1480 train_time:81055ms step_avg:59.82ms
+step:1356/1480 train_time:81147ms step_avg:59.84ms
+step:1357/1480 train_time:81230ms step_avg:59.86ms
+step:1358/1480 train_time:81321ms step_avg:59.88ms
+step:1359/1480 train_time:81408ms step_avg:59.90ms
+step:1360/1480 train_time:81502ms step_avg:59.93ms
+step:1361/1480 train_time:81590ms step_avg:59.95ms
+step:1362/1480 train_time:81684ms step_avg:59.97ms
+step:1363/1480 train_time:81770ms step_avg:59.99ms
+step:1364/1480 train_time:81862ms step_avg:60.02ms
+step:1365/1480 train_time:81951ms step_avg:60.04ms
+step:1366/1480 train_time:82046ms step_avg:60.06ms
+step:1367/1480 train_time:82133ms step_avg:60.08ms
+step:1368/1480 train_time:82226ms step_avg:60.11ms
+step:1369/1480 train_time:82314ms step_avg:60.13ms
+step:1370/1480 train_time:82412ms step_avg:60.15ms
+step:1371/1480 train_time:82504ms step_avg:60.18ms
+step:1372/1480 train_time:82601ms step_avg:60.21ms
+step:1373/1480 train_time:82691ms step_avg:60.23ms
+step:1374/1480 train_time:82787ms step_avg:60.25ms
+step:1375/1480 train_time:82878ms step_avg:60.27ms
+step:1376/1480 train_time:82974ms step_avg:60.30ms
+step:1377/1480 train_time:83065ms step_avg:60.32ms
+step:1378/1480 train_time:83152ms step_avg:60.34ms
+step:1379/1480 train_time:83235ms step_avg:60.36ms
+step:1380/1480 train_time:83331ms step_avg:60.38ms
+step:1381/1480 train_time:83416ms step_avg:60.40ms
+step:1382/1480 train_time:83509ms step_avg:60.43ms
+step:1383/1480 train_time:83595ms step_avg:60.44ms
+step:1384/1480 train_time:83686ms step_avg:60.47ms
+step:1385/1480 train_time:83772ms step_avg:60.49ms
+step:1386/1480 train_time:83866ms step_avg:60.51ms
+step:1387/1480 train_time:83956ms step_avg:60.53ms
+step:1388/1480 train_time:84053ms step_avg:60.56ms
+step:1389/1480 train_time:84145ms step_avg:60.58ms
+step:1390/1480 train_time:84240ms step_avg:60.60ms
+step:1391/1480 train_time:84332ms step_avg:60.63ms
+step:1392/1480 train_time:84428ms step_avg:60.65ms
+step:1393/1480 train_time:84519ms step_avg:60.67ms
+step:1394/1480 train_time:84615ms step_avg:60.70ms
+step:1395/1480 train_time:84706ms step_avg:60.72ms
+step:1396/1480 train_time:84795ms step_avg:60.74ms
+step:1397/1480 train_time:84879ms step_avg:60.76ms
+step:1398/1480 train_time:84969ms step_avg:60.78ms
+step:1399/1480 train_time:85058ms step_avg:60.80ms
+step:1400/1480 train_time:85148ms step_avg:60.82ms
+step:1401/1480 train_time:85234ms step_avg:60.84ms
+step:1402/1480 train_time:85326ms step_avg:60.86ms
+step:1403/1480 train_time:85411ms step_avg:60.88ms
+step:1404/1480 train_time:85504ms step_avg:60.90ms
+step:1405/1480 train_time:85591ms step_avg:60.92ms
+step:1406/1480 train_time:85688ms step_avg:60.94ms
+step:1407/1480 train_time:85774ms step_avg:60.96ms
+step:1408/1480 train_time:85867ms step_avg:60.99ms
+step:1409/1480 train_time:85952ms step_avg:61.00ms
+step:1410/1480 train_time:86043ms step_avg:61.02ms
+step:1411/1480 train_time:86128ms step_avg:61.04ms
+step:1412/1480 train_time:86221ms step_avg:61.06ms
+step:1413/1480 train_time:86307ms step_avg:61.08ms
+step:1414/1480 train_time:86403ms step_avg:61.11ms
+step:1415/1480 train_time:86492ms step_avg:61.13ms
+step:1416/1480 train_time:86590ms step_avg:61.15ms
+step:1417/1480 train_time:86681ms step_avg:61.17ms
+step:1418/1480 train_time:86778ms step_avg:61.20ms
+step:1419/1480 train_time:86868ms step_avg:61.22ms
+step:1420/1480 train_time:86966ms step_avg:61.24ms
+step:1421/1480 train_time:87051ms step_avg:61.26ms
+step:1422/1480 train_time:87138ms step_avg:61.28ms
+step:1423/1480 train_time:87227ms step_avg:61.30ms
+step:1424/1480 train_time:87317ms step_avg:61.32ms
+step:1425/1480 train_time:87404ms step_avg:61.34ms
+step:1426/1480 train_time:87496ms step_avg:61.36ms
+step:1427/1480 train_time:87581ms step_avg:61.37ms
+step:1428/1480 train_time:87675ms step_avg:61.40ms
+step:1429/1480 train_time:87763ms step_avg:61.42ms
+step:1430/1480 train_time:87859ms step_avg:61.44ms
+step:1431/1480 train_time:87947ms step_avg:61.46ms
+step:1432/1480 train_time:88043ms step_avg:61.48ms
+step:1433/1480 train_time:88132ms step_avg:61.50ms
+step:1434/1480 train_time:88229ms step_avg:61.53ms
+step:1435/1480 train_time:88320ms step_avg:61.55ms
+step:1436/1480 train_time:88418ms step_avg:61.57ms
+step:1437/1480 train_time:88507ms step_avg:61.59ms
+step:1438/1480 train_time:88604ms step_avg:61.62ms
+step:1439/1480 train_time:88686ms step_avg:61.63ms
+step:1440/1480 train_time:88776ms step_avg:61.65ms
+step:1441/1480 train_time:88867ms step_avg:61.67ms
+step:1442/1480 train_time:88963ms step_avg:61.69ms
+step:1443/1480 train_time:89059ms step_avg:61.72ms
+step:1444/1480 train_time:89155ms step_avg:61.74ms
+step:1445/1480 train_time:89244ms step_avg:61.76ms
+step:1446/1480 train_time:89339ms step_avg:61.78ms
+step:1447/1480 train_time:89427ms step_avg:61.80ms
+step:1448/1480 train_time:89524ms step_avg:61.83ms
+step:1449/1480 train_time:89612ms step_avg:61.84ms
+step:1450/1480 train_time:89707ms step_avg:61.87ms
+step:1451/1480 train_time:89797ms step_avg:61.89ms
+step:1452/1480 train_time:89891ms step_avg:61.91ms
+step:1453/1480 train_time:89980ms step_avg:61.93ms
+step:1454/1480 train_time:90075ms step_avg:61.95ms
+step:1455/1480 train_time:90163ms step_avg:61.97ms
+step:1456/1480 train_time:90258ms step_avg:61.99ms
+step:1457/1480 train_time:90347ms step_avg:62.01ms
+step:1458/1480 train_time:90442ms step_avg:62.03ms
+step:1459/1480 train_time:90529ms step_avg:62.05ms
+step:1460/1480 train_time:90624ms step_avg:62.07ms
+step:1461/1480 train_time:90712ms step_avg:62.09ms
+step:1462/1480 train_time:90807ms step_avg:62.11ms
+step:1463/1480 train_time:90895ms step_avg:62.13ms
+step:1464/1480 train_time:90989ms step_avg:62.15ms
+step:1465/1480 train_time:91078ms step_avg:62.17ms
+step:1466/1480 train_time:91170ms step_avg:62.19ms
+step:1467/1480 train_time:91259ms step_avg:62.21ms
+step:1468/1480 train_time:91352ms step_avg:62.23ms
+step:1469/1480 train_time:91441ms step_avg:62.25ms
+step:1470/1480 train_time:91536ms step_avg:62.27ms
+step:1471/1480 train_time:91624ms step_avg:62.29ms
+step:1472/1480 train_time:91717ms step_avg:62.31ms
+step:1473/1480 train_time:91805ms step_avg:62.33ms
+step:1474/1480 train_time:91899ms step_avg:62.35ms
+step:1475/1480 train_time:91986ms step_avg:62.36ms
+step:1476/1480 train_time:92079ms step_avg:62.38ms
+step:1477/1480 train_time:92166ms step_avg:62.40ms
+step:1478/1480 train_time:92262ms step_avg:62.42ms
+step:1479/1480 train_time:92348ms step_avg:62.44ms
+step:1480/1480 train_time:92443ms step_avg:62.46ms
+step:1480/1480 val_loss:3.2789 train_time:92554ms step_avg:62.54ms
+peak memory allocated: 31345 MiB reserved: 47242 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk3-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk3-1480.txt
@@ -1,0 +1,4463 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # QK bank: per-head-pair Muon groups for Q, K weights
+        # Each pair of adjacent heads gets its own independent polar express orthogonalization
+        self._num_attn_layers = num_attn_layers
+        num_qk_groups = num_attn_layers * 2 * (num_heads // 2)  # 10 * 2 * 3 = 60
+        self._num_qk_groups = num_qk_groups
+        num_qk_padded = next_multiple_of_n(num_qk_groups, n=world_size)  # 64
+        self.qk_bank = nn.Parameter(torch.empty(num_qk_padded, head_dim * 2, model_dim))
+        self.qk_bank.reshape = (num_qk_padded, head_dim * 2, model_dim)
+
+        # VO bank: per-layer Muon groups for V and O weights
+        num_vo_real = num_attn_layers * 2  # 20
+        num_vo_padded = next_multiple_of_n(num_vo_real, n=world_size)  # 24
+        self.vo_bank = nn.Parameter(torch.empty(num_vo_padded, hdim, hdim))
+        self.vo_bank.reshape = (num_vo_padded, hdim, hdim)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.qk_bank[:num_qk_groups].uniform_(-bound, bound)
+            self.qk_bank[num_qk_groups:].zero_()
+            self.vo_bank[:num_vo_real].uniform_(-bound, bound)
+            self.vo_bank[num_vo_real:].zero_()
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from qk_bank/vo_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        qk_all = self.qk_bank[:self._num_qk_groups].view(self._num_attn_layers, -1, self.qk_bank.shape[-1])
+        vo_flat = self.vo_bank[:self._num_attn_layers * 2].view(self._num_attn_layers, 2, *self.vo_bank.shape[1:]).flatten(1, 2)
+        attn_weights = torch.cat([qk_all, vo_flat], dim=1).unbind(0)
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            attn_idx = i - (i > 6) if i != 6 else None
+            qkvo_w = attn_weights[attn_idx] if attn_idx is not None else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "qk_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "vo_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "qk_bank", "vo_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.qk_bank.data = model.qk_bank.data.bfloat16()
+model.vo_bank.data = model.vo_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 15:59:21 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   38C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   34C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   38C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   66C    P0            153W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          219163      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          219164      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          219165      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          219166      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          219167      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          219168      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          219169      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          219170      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8301 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:79ms step_avg:79.38ms
+step:2/1480 train_time:111ms step_avg:55.39ms
+step:3/1480 train_time:134ms step_avg:44.70ms
+step:4/1480 train_time:163ms step_avg:40.67ms
+step:5/1480 train_time:182ms step_avg:36.37ms
+step:6/1480 train_time:213ms step_avg:35.53ms
+step:7/1480 train_time:242ms step_avg:34.54ms
+step:8/1480 train_time:276ms step_avg:34.54ms
+step:9/1480 train_time:306ms step_avg:33.96ms
+step:10/1480 train_time:340ms step_avg:33.97ms
+step:11/1480 train_time:369ms step_avg:33.53ms
+step:12/1480 train_time:403ms step_avg:33.55ms
+step:13/1480 train_time:432ms step_avg:33.21ms
+step:14/1480 train_time:466ms step_avg:33.29ms
+step:15/1480 train_time:495ms step_avg:33.00ms
+step:16/1480 train_time:530ms step_avg:33.11ms
+step:17/1480 train_time:558ms step_avg:32.84ms
+step:18/1480 train_time:594ms step_avg:32.98ms
+step:19/1480 train_time:622ms step_avg:32.76ms
+step:20/1480 train_time:657ms step_avg:32.86ms
+step:21/1480 train_time:687ms step_avg:32.70ms
+step:22/1480 train_time:722ms step_avg:32.80ms
+step:23/1480 train_time:751ms step_avg:32.67ms
+step:24/1480 train_time:786ms step_avg:32.75ms
+step:25/1480 train_time:817ms step_avg:32.68ms
+step:26/1480 train_time:854ms step_avg:32.86ms
+step:27/1480 train_time:885ms step_avg:32.78ms
+step:28/1480 train_time:921ms step_avg:32.89ms
+step:29/1480 train_time:952ms step_avg:32.84ms
+step:30/1480 train_time:989ms step_avg:32.96ms
+step:31/1480 train_time:1020ms step_avg:32.89ms
+step:32/1480 train_time:1056ms step_avg:33.01ms
+step:33/1480 train_time:1088ms step_avg:32.96ms
+step:34/1480 train_time:1123ms step_avg:33.04ms
+step:35/1480 train_time:1154ms step_avg:32.97ms
+step:36/1480 train_time:1191ms step_avg:33.08ms
+step:37/1480 train_time:1221ms step_avg:33.01ms
+step:38/1480 train_time:1258ms step_avg:33.10ms
+step:39/1480 train_time:1289ms step_avg:33.04ms
+step:40/1480 train_time:1325ms step_avg:33.12ms
+step:41/1480 train_time:1355ms step_avg:33.05ms
+step:42/1480 train_time:1392ms step_avg:33.14ms
+step:43/1480 train_time:1422ms step_avg:33.08ms
+step:44/1480 train_time:1458ms step_avg:33.15ms
+step:45/1480 train_time:1489ms step_avg:33.10ms
+step:46/1480 train_time:1525ms step_avg:33.16ms
+step:47/1480 train_time:1556ms step_avg:33.11ms
+step:48/1480 train_time:1593ms step_avg:33.18ms
+step:49/1480 train_time:1624ms step_avg:33.14ms
+step:50/1480 train_time:1659ms step_avg:33.18ms
+step:51/1480 train_time:1690ms step_avg:33.14ms
+step:52/1480 train_time:1725ms step_avg:33.18ms
+step:53/1480 train_time:1756ms step_avg:33.13ms
+step:54/1480 train_time:1793ms step_avg:33.20ms
+step:55/1480 train_time:1823ms step_avg:33.15ms
+step:56/1480 train_time:1859ms step_avg:33.19ms
+step:57/1480 train_time:1889ms step_avg:33.14ms
+step:58/1480 train_time:1924ms step_avg:33.18ms
+step:59/1480 train_time:1955ms step_avg:33.13ms
+step:60/1480 train_time:1992ms step_avg:33.19ms
+step:61/1480 train_time:2021ms step_avg:33.14ms
+step:62/1480 train_time:2056ms step_avg:33.16ms
+step:63/1480 train_time:2085ms step_avg:33.09ms
+step:64/1480 train_time:2119ms step_avg:33.11ms
+step:65/1480 train_time:2148ms step_avg:33.05ms
+step:66/1480 train_time:2182ms step_avg:33.06ms
+step:67/1480 train_time:2211ms step_avg:33.01ms
+step:68/1480 train_time:2247ms step_avg:33.04ms
+step:69/1480 train_time:2278ms step_avg:33.01ms
+step:70/1480 train_time:2315ms step_avg:33.07ms
+step:71/1480 train_time:2345ms step_avg:33.03ms
+step:72/1480 train_time:2381ms step_avg:33.07ms
+step:73/1480 train_time:2412ms step_avg:33.05ms
+step:74/1480 train_time:2449ms step_avg:33.09ms
+step:75/1480 train_time:2479ms step_avg:33.05ms
+step:76/1480 train_time:2516ms step_avg:33.10ms
+step:77/1480 train_time:2546ms step_avg:33.06ms
+step:78/1480 train_time:2582ms step_avg:33.10ms
+step:79/1480 train_time:2613ms step_avg:33.08ms
+step:80/1480 train_time:2649ms step_avg:33.12ms
+step:81/1480 train_time:2679ms step_avg:33.07ms
+step:82/1480 train_time:2715ms step_avg:33.11ms
+step:83/1480 train_time:2745ms step_avg:33.08ms
+step:84/1480 train_time:2781ms step_avg:33.11ms
+step:85/1480 train_time:2812ms step_avg:33.09ms
+step:86/1480 train_time:2849ms step_avg:33.12ms
+step:87/1480 train_time:2879ms step_avg:33.09ms
+step:88/1480 train_time:2915ms step_avg:33.12ms
+step:89/1480 train_time:2945ms step_avg:33.09ms
+step:90/1480 train_time:2980ms step_avg:33.11ms
+step:91/1480 train_time:3011ms step_avg:33.09ms
+step:92/1480 train_time:3046ms step_avg:33.11ms
+step:93/1480 train_time:3077ms step_avg:33.08ms
+step:94/1480 train_time:3113ms step_avg:33.12ms
+step:95/1480 train_time:3143ms step_avg:33.08ms
+step:96/1480 train_time:3179ms step_avg:33.11ms
+step:97/1480 train_time:3209ms step_avg:33.08ms
+step:98/1480 train_time:3244ms step_avg:33.11ms
+step:99/1480 train_time:3274ms step_avg:33.07ms
+step:100/1480 train_time:3311ms step_avg:33.11ms
+step:101/1480 train_time:3340ms step_avg:33.07ms
+step:102/1480 train_time:3376ms step_avg:33.10ms
+step:103/1480 train_time:3406ms step_avg:33.07ms
+step:104/1480 train_time:3443ms step_avg:33.11ms
+step:105/1480 train_time:3472ms step_avg:33.07ms
+step:106/1480 train_time:3509ms step_avg:33.10ms
+step:107/1480 train_time:3537ms step_avg:33.06ms
+step:108/1480 train_time:3575ms step_avg:33.10ms
+step:109/1480 train_time:3603ms step_avg:33.06ms
+step:110/1480 train_time:3641ms step_avg:33.10ms
+step:111/1480 train_time:3669ms step_avg:33.05ms
+step:112/1480 train_time:3706ms step_avg:33.09ms
+step:113/1480 train_time:3734ms step_avg:33.05ms
+step:114/1480 train_time:3769ms step_avg:33.06ms
+step:115/1480 train_time:3799ms step_avg:33.03ms
+step:116/1480 train_time:3835ms step_avg:33.06ms
+step:117/1480 train_time:3865ms step_avg:33.03ms
+step:118/1480 train_time:3900ms step_avg:33.05ms
+step:119/1480 train_time:3930ms step_avg:33.03ms
+step:120/1480 train_time:3965ms step_avg:33.04ms
+step:121/1480 train_time:3995ms step_avg:33.02ms
+step:122/1480 train_time:4031ms step_avg:33.04ms
+step:123/1480 train_time:4061ms step_avg:33.02ms
+step:124/1480 train_time:4097ms step_avg:33.04ms
+step:125/1480 train_time:4127ms step_avg:33.01ms
+step:126/1480 train_time:4162ms step_avg:33.03ms
+step:127/1480 train_time:4192ms step_avg:33.01ms
+step:128/1480 train_time:4227ms step_avg:33.03ms
+step:129/1480 train_time:4257ms step_avg:33.00ms
+step:130/1480 train_time:4293ms step_avg:33.03ms
+step:131/1480 train_time:4323ms step_avg:33.00ms
+step:132/1480 train_time:4359ms step_avg:33.02ms
+step:133/1480 train_time:4389ms step_avg:33.00ms
+step:134/1480 train_time:4424ms step_avg:33.02ms
+step:135/1480 train_time:4454ms step_avg:32.99ms
+step:136/1480 train_time:4492ms step_avg:33.03ms
+step:137/1480 train_time:4525ms step_avg:33.03ms
+step:138/1480 train_time:4563ms step_avg:33.07ms
+step:139/1480 train_time:4596ms step_avg:33.06ms
+step:140/1480 train_time:4634ms step_avg:33.10ms
+step:141/1480 train_time:4666ms step_avg:33.09ms
+step:142/1480 train_time:4702ms step_avg:33.12ms
+step:143/1480 train_time:4734ms step_avg:33.11ms
+step:144/1480 train_time:4772ms step_avg:33.14ms
+step:145/1480 train_time:4802ms step_avg:33.12ms
+step:146/1480 train_time:4839ms step_avg:33.14ms
+step:147/1480 train_time:4871ms step_avg:33.13ms
+step:148/1480 train_time:4908ms step_avg:33.16ms
+step:149/1480 train_time:4939ms step_avg:33.15ms
+step:150/1480 train_time:4977ms step_avg:33.18ms
+step:151/1480 train_time:5010ms step_avg:33.18ms
+step:152/1480 train_time:5047ms step_avg:33.21ms
+step:153/1480 train_time:5078ms step_avg:33.19ms
+step:154/1480 train_time:5113ms step_avg:33.20ms
+step:155/1480 train_time:5141ms step_avg:33.17ms
+step:156/1480 train_time:5176ms step_avg:33.18ms
+step:157/1480 train_time:5205ms step_avg:33.15ms
+step:158/1480 train_time:5239ms step_avg:33.16ms
+step:159/1480 train_time:5268ms step_avg:33.13ms
+step:160/1480 train_time:5302ms step_avg:33.14ms
+step:161/1480 train_time:5332ms step_avg:33.12ms
+step:162/1480 train_time:5368ms step_avg:33.14ms
+step:163/1480 train_time:5398ms step_avg:33.11ms
+step:164/1480 train_time:5433ms step_avg:33.13ms
+step:165/1480 train_time:5463ms step_avg:33.11ms
+step:166/1480 train_time:5499ms step_avg:33.13ms
+step:167/1480 train_time:5529ms step_avg:33.11ms
+step:168/1480 train_time:5564ms step_avg:33.12ms
+step:169/1480 train_time:5594ms step_avg:33.10ms
+step:170/1480 train_time:5631ms step_avg:33.12ms
+step:171/1480 train_time:5660ms step_avg:33.10ms
+step:172/1480 train_time:5696ms step_avg:33.12ms
+step:173/1480 train_time:5726ms step_avg:33.10ms
+step:174/1480 train_time:5761ms step_avg:33.11ms
+step:175/1480 train_time:5792ms step_avg:33.10ms
+step:176/1480 train_time:5827ms step_avg:33.11ms
+step:177/1480 train_time:5857ms step_avg:33.09ms
+step:178/1480 train_time:5893ms step_avg:33.11ms
+step:179/1480 train_time:5924ms step_avg:33.09ms
+step:180/1480 train_time:5960ms step_avg:33.11ms
+step:181/1480 train_time:5991ms step_avg:33.10ms
+step:182/1480 train_time:6026ms step_avg:33.11ms
+step:183/1480 train_time:6057ms step_avg:33.10ms
+step:184/1480 train_time:6093ms step_avg:33.12ms
+step:185/1480 train_time:6124ms step_avg:33.10ms
+step:186/1480 train_time:6160ms step_avg:33.12ms
+step:187/1480 train_time:6191ms step_avg:33.11ms
+step:188/1480 train_time:6227ms step_avg:33.12ms
+step:189/1480 train_time:6257ms step_avg:33.11ms
+step:190/1480 train_time:6294ms step_avg:33.13ms
+step:191/1480 train_time:6324ms step_avg:33.11ms
+step:192/1480 train_time:6360ms step_avg:33.13ms
+step:193/1480 train_time:6391ms step_avg:33.12ms
+step:194/1480 train_time:6427ms step_avg:33.13ms
+step:195/1480 train_time:6458ms step_avg:33.12ms
+step:196/1480 train_time:6494ms step_avg:33.13ms
+step:197/1480 train_time:6525ms step_avg:33.12ms
+step:198/1480 train_time:6560ms step_avg:33.13ms
+step:199/1480 train_time:6591ms step_avg:33.12ms
+step:200/1480 train_time:6626ms step_avg:33.13ms
+step:201/1480 train_time:6656ms step_avg:33.12ms
+step:202/1480 train_time:6693ms step_avg:33.13ms
+step:203/1480 train_time:6724ms step_avg:33.12ms
+step:204/1480 train_time:6759ms step_avg:33.13ms
+step:205/1480 train_time:6790ms step_avg:33.12ms
+step:206/1480 train_time:6825ms step_avg:33.13ms
+step:207/1480 train_time:6856ms step_avg:33.12ms
+step:208/1480 train_time:6892ms step_avg:33.14ms
+step:209/1480 train_time:6923ms step_avg:33.12ms
+step:210/1480 train_time:6958ms step_avg:33.13ms
+step:211/1480 train_time:6989ms step_avg:33.12ms
+step:212/1480 train_time:7024ms step_avg:33.13ms
+step:213/1480 train_time:7054ms step_avg:33.12ms
+step:214/1480 train_time:7090ms step_avg:33.13ms
+step:215/1480 train_time:7120ms step_avg:33.12ms
+step:216/1480 train_time:7156ms step_avg:33.13ms
+step:217/1480 train_time:7186ms step_avg:33.12ms
+step:218/1480 train_time:7221ms step_avg:33.13ms
+step:219/1480 train_time:7252ms step_avg:33.11ms
+step:220/1480 train_time:7288ms step_avg:33.13ms
+step:221/1480 train_time:7318ms step_avg:33.11ms
+step:222/1480 train_time:7354ms step_avg:33.13ms
+step:223/1480 train_time:7384ms step_avg:33.11ms
+step:224/1480 train_time:7420ms step_avg:33.12ms
+step:225/1480 train_time:7450ms step_avg:33.11ms
+step:226/1480 train_time:7485ms step_avg:33.12ms
+step:227/1480 train_time:7516ms step_avg:33.11ms
+step:228/1480 train_time:7552ms step_avg:33.12ms
+step:229/1480 train_time:7582ms step_avg:33.11ms
+step:230/1480 train_time:7618ms step_avg:33.12ms
+step:231/1480 train_time:7648ms step_avg:33.11ms
+step:232/1480 train_time:7683ms step_avg:33.12ms
+step:233/1480 train_time:7713ms step_avg:33.10ms
+step:234/1480 train_time:7749ms step_avg:33.12ms
+step:235/1480 train_time:7778ms step_avg:33.10ms
+step:236/1480 train_time:7814ms step_avg:33.11ms
+step:237/1480 train_time:7844ms step_avg:33.10ms
+step:238/1480 train_time:7879ms step_avg:33.11ms
+step:239/1480 train_time:7910ms step_avg:33.10ms
+step:240/1480 train_time:7945ms step_avg:33.10ms
+step:241/1480 train_time:7977ms step_avg:33.10ms
+step:242/1480 train_time:8016ms step_avg:33.12ms
+step:243/1480 train_time:8048ms step_avg:33.12ms
+step:244/1480 train_time:8085ms step_avg:33.13ms
+step:245/1480 train_time:8117ms step_avg:33.13ms
+step:246/1480 train_time:8154ms step_avg:33.15ms
+step:247/1480 train_time:8185ms step_avg:33.14ms
+step:248/1480 train_time:8221ms step_avg:33.15ms
+step:249/1480 train_time:8253ms step_avg:33.14ms
+step:250/1480 train_time:8290ms step_avg:33.16ms
+step:250/1480 val_loss:4.5122 train_time:8336ms step_avg:33.34ms
+step:251/1480 train_time:8353ms step_avg:33.28ms
+step:252/1480 train_time:8371ms step_avg:33.22ms
+step:253/1480 train_time:8392ms step_avg:33.17ms
+step:254/1480 train_time:8433ms step_avg:33.20ms
+step:255/1480 train_time:8469ms step_avg:33.21ms
+step:256/1480 train_time:8510ms step_avg:33.24ms
+step:257/1480 train_time:8545ms step_avg:33.25ms
+step:258/1480 train_time:8586ms step_avg:33.28ms
+step:259/1480 train_time:8616ms step_avg:33.27ms
+step:260/1480 train_time:8651ms step_avg:33.27ms
+step:261/1480 train_time:8679ms step_avg:33.25ms
+step:262/1480 train_time:8714ms step_avg:33.26ms
+step:263/1480 train_time:8743ms step_avg:33.24ms
+step:264/1480 train_time:8777ms step_avg:33.25ms
+step:265/1480 train_time:8807ms step_avg:33.23ms
+step:266/1480 train_time:8843ms step_avg:33.24ms
+step:267/1480 train_time:8873ms step_avg:33.23ms
+step:268/1480 train_time:8910ms step_avg:33.25ms
+step:269/1480 train_time:8941ms step_avg:33.24ms
+step:270/1480 train_time:8980ms step_avg:33.26ms
+step:271/1480 train_time:9013ms step_avg:33.26ms
+step:272/1480 train_time:9053ms step_avg:33.28ms
+step:273/1480 train_time:9087ms step_avg:33.29ms
+step:274/1480 train_time:9127ms step_avg:33.31ms
+step:275/1480 train_time:9160ms step_avg:33.31ms
+step:276/1480 train_time:9198ms step_avg:33.33ms
+step:277/1480 train_time:9231ms step_avg:33.33ms
+step:278/1480 train_time:9270ms step_avg:33.35ms
+step:279/1480 train_time:9303ms step_avg:33.34ms
+step:280/1480 train_time:9341ms step_avg:33.36ms
+step:281/1480 train_time:9374ms step_avg:33.36ms
+step:282/1480 train_time:9412ms step_avg:33.38ms
+step:283/1480 train_time:9442ms step_avg:33.36ms
+step:284/1480 train_time:9476ms step_avg:33.37ms
+step:285/1480 train_time:9505ms step_avg:33.35ms
+step:286/1480 train_time:9540ms step_avg:33.36ms
+step:287/1480 train_time:9568ms step_avg:33.34ms
+step:288/1480 train_time:9602ms step_avg:33.34ms
+step:289/1480 train_time:9633ms step_avg:33.33ms
+step:290/1480 train_time:9667ms step_avg:33.34ms
+step:291/1480 train_time:9697ms step_avg:33.32ms
+step:292/1480 train_time:9731ms step_avg:33.33ms
+step:293/1480 train_time:9761ms step_avg:33.31ms
+step:294/1480 train_time:9796ms step_avg:33.32ms
+step:295/1480 train_time:9826ms step_avg:33.31ms
+step:296/1480 train_time:9864ms step_avg:33.32ms
+step:297/1480 train_time:9896ms step_avg:33.32ms
+step:298/1480 train_time:9933ms step_avg:33.33ms
+step:299/1480 train_time:9966ms step_avg:33.33ms
+step:300/1480 train_time:10004ms step_avg:33.35ms
+step:301/1480 train_time:10036ms step_avg:33.34ms
+step:302/1480 train_time:10070ms step_avg:33.34ms
+step:303/1480 train_time:10099ms step_avg:33.33ms
+step:304/1480 train_time:10136ms step_avg:33.34ms
+step:305/1480 train_time:10166ms step_avg:33.33ms
+step:306/1480 train_time:10203ms step_avg:33.34ms
+step:307/1480 train_time:10237ms step_avg:33.34ms
+step:308/1480 train_time:10275ms step_avg:33.36ms
+step:309/1480 train_time:10307ms step_avg:33.36ms
+step:310/1480 train_time:10345ms step_avg:33.37ms
+step:311/1480 train_time:10376ms step_avg:33.36ms
+step:312/1480 train_time:10413ms step_avg:33.37ms
+step:313/1480 train_time:10445ms step_avg:33.37ms
+step:314/1480 train_time:10482ms step_avg:33.38ms
+step:315/1480 train_time:10513ms step_avg:33.38ms
+step:316/1480 train_time:10550ms step_avg:33.39ms
+step:317/1480 train_time:10582ms step_avg:33.38ms
+step:318/1480 train_time:10619ms step_avg:33.39ms
+step:319/1480 train_time:10649ms step_avg:33.38ms
+step:320/1480 train_time:10684ms step_avg:33.39ms
+step:321/1480 train_time:10714ms step_avg:33.38ms
+step:322/1480 train_time:10750ms step_avg:33.38ms
+step:323/1480 train_time:10779ms step_avg:33.37ms
+step:324/1480 train_time:10815ms step_avg:33.38ms
+step:325/1480 train_time:10846ms step_avg:33.37ms
+step:326/1480 train_time:10884ms step_avg:33.39ms
+step:327/1480 train_time:10916ms step_avg:33.38ms
+step:328/1480 train_time:10953ms step_avg:33.39ms
+step:329/1480 train_time:10986ms step_avg:33.39ms
+step:330/1480 train_time:11024ms step_avg:33.41ms
+step:331/1480 train_time:11056ms step_avg:33.40ms
+step:332/1480 train_time:11092ms step_avg:33.41ms
+step:333/1480 train_time:11124ms step_avg:33.40ms
+step:334/1480 train_time:11162ms step_avg:33.42ms
+step:335/1480 train_time:11193ms step_avg:33.41ms
+step:336/1480 train_time:11229ms step_avg:33.42ms
+step:337/1480 train_time:11261ms step_avg:33.41ms
+step:338/1480 train_time:11298ms step_avg:33.42ms
+step:339/1480 train_time:11329ms step_avg:33.42ms
+step:340/1480 train_time:11366ms step_avg:33.43ms
+step:341/1480 train_time:11398ms step_avg:33.42ms
+step:342/1480 train_time:11434ms step_avg:33.43ms
+step:343/1480 train_time:11465ms step_avg:33.43ms
+step:344/1480 train_time:11500ms step_avg:33.43ms
+step:345/1480 train_time:11529ms step_avg:33.42ms
+step:346/1480 train_time:11563ms step_avg:33.42ms
+step:347/1480 train_time:11592ms step_avg:33.41ms
+step:348/1480 train_time:11627ms step_avg:33.41ms
+step:349/1480 train_time:11657ms step_avg:33.40ms
+step:350/1480 train_time:11694ms step_avg:33.41ms
+step:351/1480 train_time:11724ms step_avg:33.40ms
+step:352/1480 train_time:11760ms step_avg:33.41ms
+step:353/1480 train_time:11790ms step_avg:33.40ms
+step:354/1480 train_time:11826ms step_avg:33.41ms
+step:355/1480 train_time:11857ms step_avg:33.40ms
+step:356/1480 train_time:11892ms step_avg:33.40ms
+step:357/1480 train_time:11923ms step_avg:33.40ms
+step:358/1480 train_time:11961ms step_avg:33.41ms
+step:359/1480 train_time:11992ms step_avg:33.40ms
+step:360/1480 train_time:12028ms step_avg:33.41ms
+step:361/1480 train_time:12060ms step_avg:33.41ms
+step:362/1480 train_time:12096ms step_avg:33.41ms
+step:363/1480 train_time:12127ms step_avg:33.41ms
+step:364/1480 train_time:12165ms step_avg:33.42ms
+step:365/1480 train_time:12196ms step_avg:33.41ms
+step:366/1480 train_time:12232ms step_avg:33.42ms
+step:367/1480 train_time:12264ms step_avg:33.42ms
+step:368/1480 train_time:12301ms step_avg:33.43ms
+step:369/1480 train_time:12332ms step_avg:33.42ms
+step:370/1480 train_time:12369ms step_avg:33.43ms
+step:371/1480 train_time:12400ms step_avg:33.42ms
+step:372/1480 train_time:12437ms step_avg:33.43ms
+step:373/1480 train_time:12468ms step_avg:33.43ms
+step:374/1480 train_time:12505ms step_avg:33.44ms
+step:375/1480 train_time:12536ms step_avg:33.43ms
+step:376/1480 train_time:12572ms step_avg:33.44ms
+step:377/1480 train_time:12604ms step_avg:33.43ms
+step:378/1480 train_time:12640ms step_avg:33.44ms
+step:379/1480 train_time:12671ms step_avg:33.43ms
+step:380/1480 train_time:12708ms step_avg:33.44ms
+step:381/1480 train_time:12739ms step_avg:33.44ms
+step:382/1480 train_time:12775ms step_avg:33.44ms
+step:383/1480 train_time:12806ms step_avg:33.44ms
+step:384/1480 train_time:12843ms step_avg:33.45ms
+step:385/1480 train_time:12873ms step_avg:33.44ms
+step:386/1480 train_time:12909ms step_avg:33.44ms
+step:387/1480 train_time:12940ms step_avg:33.44ms
+step:388/1480 train_time:12976ms step_avg:33.44ms
+step:389/1480 train_time:13007ms step_avg:33.44ms
+step:390/1480 train_time:13043ms step_avg:33.44ms
+step:391/1480 train_time:13074ms step_avg:33.44ms
+step:392/1480 train_time:13109ms step_avg:33.44ms
+step:393/1480 train_time:13140ms step_avg:33.44ms
+step:394/1480 train_time:13176ms step_avg:33.44ms
+step:395/1480 train_time:13206ms step_avg:33.43ms
+step:396/1480 train_time:13242ms step_avg:33.44ms
+step:397/1480 train_time:13273ms step_avg:33.43ms
+step:398/1480 train_time:13308ms step_avg:33.44ms
+step:399/1480 train_time:13339ms step_avg:33.43ms
+step:400/1480 train_time:13375ms step_avg:33.44ms
+step:401/1480 train_time:13406ms step_avg:33.43ms
+step:402/1480 train_time:13442ms step_avg:33.44ms
+step:403/1480 train_time:13472ms step_avg:33.43ms
+step:404/1480 train_time:13508ms step_avg:33.44ms
+step:405/1480 train_time:13539ms step_avg:33.43ms
+step:406/1480 train_time:13575ms step_avg:33.44ms
+step:407/1480 train_time:13605ms step_avg:33.43ms
+step:408/1480 train_time:13643ms step_avg:33.44ms
+step:409/1480 train_time:13672ms step_avg:33.43ms
+step:410/1480 train_time:13708ms step_avg:33.43ms
+step:411/1480 train_time:13739ms step_avg:33.43ms
+step:412/1480 train_time:13774ms step_avg:33.43ms
+step:413/1480 train_time:13805ms step_avg:33.43ms
+step:414/1480 train_time:13841ms step_avg:33.43ms
+step:415/1480 train_time:13871ms step_avg:33.42ms
+step:416/1480 train_time:13907ms step_avg:33.43ms
+step:417/1480 train_time:13938ms step_avg:33.42ms
+step:418/1480 train_time:13974ms step_avg:33.43ms
+step:419/1480 train_time:14004ms step_avg:33.42ms
+step:420/1480 train_time:14040ms step_avg:33.43ms
+step:421/1480 train_time:14070ms step_avg:33.42ms
+step:422/1480 train_time:14107ms step_avg:33.43ms
+step:423/1480 train_time:14137ms step_avg:33.42ms
+step:424/1480 train_time:14173ms step_avg:33.43ms
+step:425/1480 train_time:14203ms step_avg:33.42ms
+step:426/1480 train_time:14239ms step_avg:33.43ms
+step:427/1480 train_time:14269ms step_avg:33.42ms
+step:428/1480 train_time:14305ms step_avg:33.42ms
+step:429/1480 train_time:14335ms step_avg:33.42ms
+step:430/1480 train_time:14371ms step_avg:33.42ms
+step:431/1480 train_time:14401ms step_avg:33.41ms
+step:432/1480 train_time:14438ms step_avg:33.42ms
+step:433/1480 train_time:14467ms step_avg:33.41ms
+step:434/1480 train_time:14503ms step_avg:33.42ms
+step:435/1480 train_time:14533ms step_avg:33.41ms
+step:436/1480 train_time:14569ms step_avg:33.42ms
+step:437/1480 train_time:14599ms step_avg:33.41ms
+step:438/1480 train_time:14635ms step_avg:33.41ms
+step:439/1480 train_time:14665ms step_avg:33.41ms
+step:440/1480 train_time:14702ms step_avg:33.41ms
+step:441/1480 train_time:14732ms step_avg:33.41ms
+step:442/1480 train_time:14768ms step_avg:33.41ms
+step:443/1480 train_time:14798ms step_avg:33.40ms
+step:444/1480 train_time:14834ms step_avg:33.41ms
+step:445/1480 train_time:14864ms step_avg:33.40ms
+step:446/1480 train_time:14901ms step_avg:33.41ms
+step:447/1480 train_time:14931ms step_avg:33.40ms
+step:448/1480 train_time:14967ms step_avg:33.41ms
+step:449/1480 train_time:14997ms step_avg:33.40ms
+step:450/1480 train_time:15033ms step_avg:33.41ms
+step:451/1480 train_time:15064ms step_avg:33.40ms
+step:452/1480 train_time:15101ms step_avg:33.41ms
+step:453/1480 train_time:15132ms step_avg:33.40ms
+step:454/1480 train_time:15168ms step_avg:33.41ms
+step:455/1480 train_time:15200ms step_avg:33.41ms
+step:456/1480 train_time:15236ms step_avg:33.41ms
+step:457/1480 train_time:15267ms step_avg:33.41ms
+step:458/1480 train_time:15305ms step_avg:33.42ms
+step:459/1480 train_time:15336ms step_avg:33.41ms
+step:460/1480 train_time:15373ms step_avg:33.42ms
+step:461/1480 train_time:15404ms step_avg:33.42ms
+step:462/1480 train_time:15442ms step_avg:33.42ms
+step:463/1480 train_time:15473ms step_avg:33.42ms
+step:464/1480 train_time:15510ms step_avg:33.43ms
+step:465/1480 train_time:15542ms step_avg:33.42ms
+step:466/1480 train_time:15579ms step_avg:33.43ms
+step:467/1480 train_time:15610ms step_avg:33.43ms
+step:468/1480 train_time:15646ms step_avg:33.43ms
+step:469/1480 train_time:15678ms step_avg:33.43ms
+step:470/1480 train_time:15714ms step_avg:33.43ms
+step:471/1480 train_time:15745ms step_avg:33.43ms
+step:472/1480 train_time:15782ms step_avg:33.44ms
+step:473/1480 train_time:15813ms step_avg:33.43ms
+step:474/1480 train_time:15850ms step_avg:33.44ms
+step:475/1480 train_time:15882ms step_avg:33.44ms
+step:476/1480 train_time:15919ms step_avg:33.44ms
+step:477/1480 train_time:15950ms step_avg:33.44ms
+step:478/1480 train_time:15987ms step_avg:33.45ms
+step:479/1480 train_time:16018ms step_avg:33.44ms
+step:480/1480 train_time:16055ms step_avg:33.45ms
+step:481/1480 train_time:16088ms step_avg:33.45ms
+step:482/1480 train_time:16151ms step_avg:33.51ms
+step:483/1480 train_time:16209ms step_avg:33.56ms
+step:484/1480 train_time:16275ms step_avg:33.63ms
+step:485/1480 train_time:16334ms step_avg:33.68ms
+step:486/1480 train_time:16399ms step_avg:33.74ms
+step:487/1480 train_time:16457ms step_avg:33.79ms
+step:488/1480 train_time:16520ms step_avg:33.85ms
+step:489/1480 train_time:16578ms step_avg:33.90ms
+step:490/1480 train_time:16641ms step_avg:33.96ms
+step:491/1480 train_time:16698ms step_avg:34.01ms
+step:492/1480 train_time:16760ms step_avg:34.07ms
+step:493/1480 train_time:16818ms step_avg:34.11ms
+step:494/1480 train_time:16881ms step_avg:34.17ms
+step:495/1480 train_time:16939ms step_avg:34.22ms
+step:496/1480 train_time:17001ms step_avg:34.28ms
+step:497/1480 train_time:17058ms step_avg:34.32ms
+step:498/1480 train_time:17122ms step_avg:34.38ms
+step:499/1480 train_time:17180ms step_avg:34.43ms
+step:500/1480 train_time:17244ms step_avg:34.49ms
+step:500/1480 val_loss:4.1936 train_time:17321ms step_avg:34.64ms
+step:501/1480 train_time:17339ms step_avg:34.61ms
+step:502/1480 train_time:17367ms step_avg:34.60ms
+step:503/1480 train_time:17425ms step_avg:34.64ms
+step:504/1480 train_time:17490ms step_avg:34.70ms
+step:505/1480 train_time:17550ms step_avg:34.75ms
+step:506/1480 train_time:17614ms step_avg:34.81ms
+step:507/1480 train_time:17673ms step_avg:34.86ms
+step:508/1480 train_time:17741ms step_avg:34.92ms
+step:509/1480 train_time:17801ms step_avg:34.97ms
+step:510/1480 train_time:17864ms step_avg:35.03ms
+step:511/1480 train_time:17923ms step_avg:35.07ms
+step:512/1480 train_time:17987ms step_avg:35.13ms
+step:513/1480 train_time:18046ms step_avg:35.18ms
+step:514/1480 train_time:18110ms step_avg:35.23ms
+step:515/1480 train_time:18168ms step_avg:35.28ms
+step:516/1480 train_time:18233ms step_avg:35.33ms
+step:517/1480 train_time:18291ms step_avg:35.38ms
+step:518/1480 train_time:18354ms step_avg:35.43ms
+step:519/1480 train_time:18412ms step_avg:35.48ms
+step:520/1480 train_time:18476ms step_avg:35.53ms
+step:521/1480 train_time:18534ms step_avg:35.57ms
+step:522/1480 train_time:18597ms step_avg:35.63ms
+step:523/1480 train_time:18655ms step_avg:35.67ms
+step:524/1480 train_time:18721ms step_avg:35.73ms
+step:525/1480 train_time:18781ms step_avg:35.77ms
+step:526/1480 train_time:18846ms step_avg:35.83ms
+step:527/1480 train_time:18903ms step_avg:35.87ms
+step:528/1480 train_time:18968ms step_avg:35.92ms
+step:529/1480 train_time:19026ms step_avg:35.97ms
+step:530/1480 train_time:19090ms step_avg:36.02ms
+step:531/1480 train_time:19147ms step_avg:36.06ms
+step:532/1480 train_time:19211ms step_avg:36.11ms
+step:533/1480 train_time:19269ms step_avg:36.15ms
+step:534/1480 train_time:19332ms step_avg:36.20ms
+step:535/1480 train_time:19390ms step_avg:36.24ms
+step:536/1480 train_time:19452ms step_avg:36.29ms
+step:537/1480 train_time:19509ms step_avg:36.33ms
+step:538/1480 train_time:19571ms step_avg:36.38ms
+step:539/1480 train_time:19632ms step_avg:36.42ms
+step:540/1480 train_time:19701ms step_avg:36.48ms
+step:541/1480 train_time:19765ms step_avg:36.53ms
+step:542/1480 train_time:19834ms step_avg:36.59ms
+step:543/1480 train_time:19897ms step_avg:36.64ms
+step:544/1480 train_time:19966ms step_avg:36.70ms
+step:545/1480 train_time:20027ms step_avg:36.75ms
+step:546/1480 train_time:20087ms step_avg:36.79ms
+step:547/1480 train_time:20141ms step_avg:36.82ms
+step:548/1480 train_time:20201ms step_avg:36.86ms
+step:549/1480 train_time:20258ms step_avg:36.90ms
+step:550/1480 train_time:20322ms step_avg:36.95ms
+step:551/1480 train_time:20382ms step_avg:36.99ms
+step:552/1480 train_time:20448ms step_avg:37.04ms
+step:553/1480 train_time:20505ms step_avg:37.08ms
+step:554/1480 train_time:20569ms step_avg:37.13ms
+step:555/1480 train_time:20627ms step_avg:37.17ms
+step:556/1480 train_time:20692ms step_avg:37.22ms
+step:557/1480 train_time:20749ms step_avg:37.25ms
+step:558/1480 train_time:20813ms step_avg:37.30ms
+step:559/1480 train_time:20871ms step_avg:37.34ms
+step:560/1480 train_time:20935ms step_avg:37.38ms
+step:561/1480 train_time:20993ms step_avg:37.42ms
+step:562/1480 train_time:21056ms step_avg:37.47ms
+step:563/1480 train_time:21116ms step_avg:37.51ms
+step:564/1480 train_time:21182ms step_avg:37.56ms
+step:565/1480 train_time:21241ms step_avg:37.59ms
+step:566/1480 train_time:21304ms step_avg:37.64ms
+step:567/1480 train_time:21361ms step_avg:37.67ms
+step:568/1480 train_time:21424ms step_avg:37.72ms
+step:569/1480 train_time:21485ms step_avg:37.76ms
+step:570/1480 train_time:21553ms step_avg:37.81ms
+step:571/1480 train_time:21616ms step_avg:37.86ms
+step:572/1480 train_time:21685ms step_avg:37.91ms
+step:573/1480 train_time:21747ms step_avg:37.95ms
+step:574/1480 train_time:21815ms step_avg:38.01ms
+step:575/1480 train_time:21877ms step_avg:38.05ms
+step:576/1480 train_time:21946ms step_avg:38.10ms
+step:577/1480 train_time:22007ms step_avg:38.14ms
+step:578/1480 train_time:22074ms step_avg:38.19ms
+step:579/1480 train_time:22136ms step_avg:38.23ms
+step:580/1480 train_time:22203ms step_avg:38.28ms
+step:581/1480 train_time:22264ms step_avg:38.32ms
+step:582/1480 train_time:22326ms step_avg:38.36ms
+step:583/1480 train_time:22380ms step_avg:38.39ms
+step:584/1480 train_time:22441ms step_avg:38.43ms
+step:585/1480 train_time:22496ms step_avg:38.46ms
+step:586/1480 train_time:22560ms step_avg:38.50ms
+step:587/1480 train_time:22618ms step_avg:38.53ms
+step:588/1480 train_time:22683ms step_avg:38.58ms
+step:589/1480 train_time:22741ms step_avg:38.61ms
+step:590/1480 train_time:22805ms step_avg:38.65ms
+step:591/1480 train_time:22863ms step_avg:38.69ms
+step:592/1480 train_time:22927ms step_avg:38.73ms
+step:593/1480 train_time:22985ms step_avg:38.76ms
+step:594/1480 train_time:23049ms step_avg:38.80ms
+step:595/1480 train_time:23107ms step_avg:38.84ms
+step:596/1480 train_time:23172ms step_avg:38.88ms
+step:597/1480 train_time:23230ms step_avg:38.91ms
+step:598/1480 train_time:23295ms step_avg:38.95ms
+step:599/1480 train_time:23353ms step_avg:38.99ms
+step:600/1480 train_time:23418ms step_avg:39.03ms
+step:601/1480 train_time:23477ms step_avg:39.06ms
+step:602/1480 train_time:23542ms step_avg:39.11ms
+step:603/1480 train_time:23601ms step_avg:39.14ms
+step:604/1480 train_time:23665ms step_avg:39.18ms
+step:605/1480 train_time:23726ms step_avg:39.22ms
+step:606/1480 train_time:23795ms step_avg:39.27ms
+step:607/1480 train_time:23857ms step_avg:39.30ms
+step:608/1480 train_time:23924ms step_avg:39.35ms
+step:609/1480 train_time:23987ms step_avg:39.39ms
+step:610/1480 train_time:24054ms step_avg:39.43ms
+step:611/1480 train_time:24116ms step_avg:39.47ms
+step:612/1480 train_time:24183ms step_avg:39.51ms
+step:613/1480 train_time:24245ms step_avg:39.55ms
+step:614/1480 train_time:24312ms step_avg:39.60ms
+step:615/1480 train_time:24373ms step_avg:39.63ms
+step:616/1480 train_time:24439ms step_avg:39.67ms
+step:617/1480 train_time:24501ms step_avg:39.71ms
+step:618/1480 train_time:24563ms step_avg:39.75ms
+step:619/1480 train_time:24617ms step_avg:39.77ms
+step:620/1480 train_time:24677ms step_avg:39.80ms
+step:621/1480 train_time:24731ms step_avg:39.83ms
+step:622/1480 train_time:24793ms step_avg:39.86ms
+step:623/1480 train_time:24849ms step_avg:39.89ms
+step:624/1480 train_time:24911ms step_avg:39.92ms
+step:625/1480 train_time:24968ms step_avg:39.95ms
+step:626/1480 train_time:25036ms step_avg:39.99ms
+step:627/1480 train_time:25096ms step_avg:40.03ms
+step:628/1480 train_time:25161ms step_avg:40.07ms
+step:629/1480 train_time:25219ms step_avg:40.09ms
+step:630/1480 train_time:25284ms step_avg:40.13ms
+step:631/1480 train_time:25343ms step_avg:40.16ms
+step:632/1480 train_time:25406ms step_avg:40.20ms
+step:633/1480 train_time:25465ms step_avg:40.23ms
+step:634/1480 train_time:25530ms step_avg:40.27ms
+step:635/1480 train_time:25588ms step_avg:40.30ms
+step:636/1480 train_time:25652ms step_avg:40.33ms
+step:637/1480 train_time:25710ms step_avg:40.36ms
+step:638/1480 train_time:25774ms step_avg:40.40ms
+step:639/1480 train_time:25833ms step_avg:40.43ms
+step:640/1480 train_time:25898ms step_avg:40.47ms
+step:641/1480 train_time:25957ms step_avg:40.49ms
+step:642/1480 train_time:26022ms step_avg:40.53ms
+step:643/1480 train_time:26083ms step_avg:40.56ms
+step:644/1480 train_time:26148ms step_avg:40.60ms
+step:645/1480 train_time:26206ms step_avg:40.63ms
+step:646/1480 train_time:26271ms step_avg:40.67ms
+step:647/1480 train_time:26330ms step_avg:40.70ms
+step:648/1480 train_time:26394ms step_avg:40.73ms
+step:649/1480 train_time:26451ms step_avg:40.76ms
+step:650/1480 train_time:26516ms step_avg:40.79ms
+step:651/1480 train_time:26574ms step_avg:40.82ms
+step:652/1480 train_time:26640ms step_avg:40.86ms
+step:653/1480 train_time:26698ms step_avg:40.88ms
+step:654/1480 train_time:26760ms step_avg:40.92ms
+step:655/1480 train_time:26817ms step_avg:40.94ms
+step:656/1480 train_time:26880ms step_avg:40.98ms
+step:657/1480 train_time:26937ms step_avg:41.00ms
+step:658/1480 train_time:27001ms step_avg:41.03ms
+step:659/1480 train_time:27059ms step_avg:41.06ms
+step:660/1480 train_time:27124ms step_avg:41.10ms
+step:661/1480 train_time:27185ms step_avg:41.13ms
+step:662/1480 train_time:27249ms step_avg:41.16ms
+step:663/1480 train_time:27306ms step_avg:41.19ms
+step:664/1480 train_time:27371ms step_avg:41.22ms
+step:665/1480 train_time:27430ms step_avg:41.25ms
+step:666/1480 train_time:27494ms step_avg:41.28ms
+step:667/1480 train_time:27553ms step_avg:41.31ms
+step:668/1480 train_time:27617ms step_avg:41.34ms
+step:669/1480 train_time:27675ms step_avg:41.37ms
+step:670/1480 train_time:27738ms step_avg:41.40ms
+step:671/1480 train_time:27796ms step_avg:41.43ms
+step:672/1480 train_time:27861ms step_avg:41.46ms
+step:673/1480 train_time:27920ms step_avg:41.49ms
+step:674/1480 train_time:27985ms step_avg:41.52ms
+step:675/1480 train_time:28045ms step_avg:41.55ms
+step:676/1480 train_time:28109ms step_avg:41.58ms
+step:677/1480 train_time:28167ms step_avg:41.61ms
+step:678/1480 train_time:28232ms step_avg:41.64ms
+step:679/1480 train_time:28291ms step_avg:41.67ms
+step:680/1480 train_time:28356ms step_avg:41.70ms
+step:681/1480 train_time:28415ms step_avg:41.73ms
+step:682/1480 train_time:28480ms step_avg:41.76ms
+step:683/1480 train_time:28540ms step_avg:41.79ms
+step:684/1480 train_time:28604ms step_avg:41.82ms
+step:685/1480 train_time:28662ms step_avg:41.84ms
+step:686/1480 train_time:28725ms step_avg:41.87ms
+step:687/1480 train_time:28783ms step_avg:41.90ms
+step:688/1480 train_time:28846ms step_avg:41.93ms
+step:689/1480 train_time:28904ms step_avg:41.95ms
+step:690/1480 train_time:28967ms step_avg:41.98ms
+step:691/1480 train_time:29025ms step_avg:42.00ms
+step:692/1480 train_time:29089ms step_avg:42.04ms
+step:693/1480 train_time:29147ms step_avg:42.06ms
+step:694/1480 train_time:29210ms step_avg:42.09ms
+step:695/1480 train_time:29268ms step_avg:42.11ms
+step:696/1480 train_time:29331ms step_avg:42.14ms
+step:697/1480 train_time:29390ms step_avg:42.17ms
+step:698/1480 train_time:29454ms step_avg:42.20ms
+step:699/1480 train_time:29512ms step_avg:42.22ms
+step:700/1480 train_time:29575ms step_avg:42.25ms
+step:701/1480 train_time:29635ms step_avg:42.27ms
+step:702/1480 train_time:29698ms step_avg:42.30ms
+step:703/1480 train_time:29756ms step_avg:42.33ms
+step:704/1480 train_time:29819ms step_avg:42.36ms
+step:705/1480 train_time:29877ms step_avg:42.38ms
+step:706/1480 train_time:29941ms step_avg:42.41ms
+step:707/1480 train_time:30000ms step_avg:42.43ms
+step:708/1480 train_time:30066ms step_avg:42.47ms
+step:709/1480 train_time:30124ms step_avg:42.49ms
+step:710/1480 train_time:30188ms step_avg:42.52ms
+step:711/1480 train_time:30246ms step_avg:42.54ms
+step:712/1480 train_time:30308ms step_avg:42.57ms
+step:713/1480 train_time:30366ms step_avg:42.59ms
+step:714/1480 train_time:30427ms step_avg:42.62ms
+step:715/1480 train_time:30487ms step_avg:42.64ms
+step:716/1480 train_time:30554ms step_avg:42.67ms
+step:717/1480 train_time:30617ms step_avg:42.70ms
+step:718/1480 train_time:30687ms step_avg:42.74ms
+step:719/1480 train_time:30748ms step_avg:42.76ms
+step:720/1480 train_time:30815ms step_avg:42.80ms
+step:721/1480 train_time:30877ms step_avg:42.82ms
+step:722/1480 train_time:30945ms step_avg:42.86ms
+step:723/1480 train_time:31006ms step_avg:42.89ms
+step:724/1480 train_time:31073ms step_avg:42.92ms
+step:725/1480 train_time:31135ms step_avg:42.94ms
+step:726/1480 train_time:31201ms step_avg:42.98ms
+step:727/1480 train_time:31263ms step_avg:43.00ms
+step:728/1480 train_time:31325ms step_avg:43.03ms
+step:729/1480 train_time:31379ms step_avg:43.04ms
+step:730/1480 train_time:31440ms step_avg:43.07ms
+step:731/1480 train_time:31496ms step_avg:43.09ms
+step:732/1480 train_time:31560ms step_avg:43.12ms
+step:733/1480 train_time:31619ms step_avg:43.14ms
+step:734/1480 train_time:31684ms step_avg:43.17ms
+step:735/1480 train_time:31742ms step_avg:43.19ms
+step:736/1480 train_time:31806ms step_avg:43.21ms
+step:737/1480 train_time:31864ms step_avg:43.23ms
+step:738/1480 train_time:31929ms step_avg:43.26ms
+step:739/1480 train_time:31987ms step_avg:43.28ms
+step:740/1480 train_time:32051ms step_avg:43.31ms
+step:741/1480 train_time:32107ms step_avg:43.33ms
+step:742/1480 train_time:32174ms step_avg:43.36ms
+step:743/1480 train_time:32234ms step_avg:43.38ms
+step:744/1480 train_time:32299ms step_avg:43.41ms
+step:745/1480 train_time:32357ms step_avg:43.43ms
+step:746/1480 train_time:32423ms step_avg:43.46ms
+step:747/1480 train_time:32484ms step_avg:43.49ms
+step:748/1480 train_time:32548ms step_avg:43.51ms
+step:749/1480 train_time:32607ms step_avg:43.53ms
+step:750/1480 train_time:32671ms step_avg:43.56ms
+step:750/1480 val_loss:3.8000 train_time:32749ms step_avg:43.67ms
+step:751/1480 train_time:32767ms step_avg:43.63ms
+step:752/1480 train_time:32795ms step_avg:43.61ms
+step:753/1480 train_time:32857ms step_avg:43.63ms
+step:754/1480 train_time:32924ms step_avg:43.67ms
+step:755/1480 train_time:32987ms step_avg:43.69ms
+step:756/1480 train_time:33053ms step_avg:43.72ms
+step:757/1480 train_time:33114ms step_avg:43.74ms
+step:758/1480 train_time:33181ms step_avg:43.77ms
+step:759/1480 train_time:33243ms step_avg:43.80ms
+step:760/1480 train_time:33309ms step_avg:43.83ms
+step:761/1480 train_time:33369ms step_avg:43.85ms
+step:762/1480 train_time:33436ms step_avg:43.88ms
+step:763/1480 train_time:33498ms step_avg:43.90ms
+step:764/1480 train_time:33565ms step_avg:43.93ms
+step:765/1480 train_time:33625ms step_avg:43.95ms
+step:766/1480 train_time:33692ms step_avg:43.98ms
+step:767/1480 train_time:33749ms step_avg:44.00ms
+step:768/1480 train_time:33807ms step_avg:44.02ms
+step:769/1480 train_time:33861ms step_avg:44.03ms
+step:770/1480 train_time:33924ms step_avg:44.06ms
+step:771/1480 train_time:33981ms step_avg:44.07ms
+step:772/1480 train_time:34046ms step_avg:44.10ms
+step:773/1480 train_time:34110ms step_avg:44.13ms
+step:774/1480 train_time:34173ms step_avg:44.15ms
+step:775/1480 train_time:34233ms step_avg:44.17ms
+step:776/1480 train_time:34300ms step_avg:44.20ms
+step:777/1480 train_time:34358ms step_avg:44.22ms
+step:778/1480 train_time:34422ms step_avg:44.24ms
+step:779/1480 train_time:34480ms step_avg:44.26ms
+step:780/1480 train_time:34543ms step_avg:44.29ms
+step:781/1480 train_time:34601ms step_avg:44.30ms
+step:782/1480 train_time:34664ms step_avg:44.33ms
+step:783/1480 train_time:34722ms step_avg:44.34ms
+step:784/1480 train_time:34784ms step_avg:44.37ms
+step:785/1480 train_time:34841ms step_avg:44.38ms
+step:786/1480 train_time:34904ms step_avg:44.41ms
+step:787/1480 train_time:34963ms step_avg:44.43ms
+step:788/1480 train_time:35027ms step_avg:44.45ms
+step:789/1480 train_time:35085ms step_avg:44.47ms
+step:790/1480 train_time:35149ms step_avg:44.49ms
+step:791/1480 train_time:35207ms step_avg:44.51ms
+step:792/1480 train_time:35271ms step_avg:44.53ms
+step:793/1480 train_time:35328ms step_avg:44.55ms
+step:794/1480 train_time:35394ms step_avg:44.58ms
+step:795/1480 train_time:35454ms step_avg:44.60ms
+step:796/1480 train_time:35521ms step_avg:44.62ms
+step:797/1480 train_time:35583ms step_avg:44.65ms
+step:798/1480 train_time:35656ms step_avg:44.68ms
+step:799/1480 train_time:35723ms step_avg:44.71ms
+step:800/1480 train_time:35791ms step_avg:44.74ms
+step:801/1480 train_time:35846ms step_avg:44.75ms
+step:802/1480 train_time:35906ms step_avg:44.77ms
+step:803/1480 train_time:35963ms step_avg:44.79ms
+step:804/1480 train_time:36025ms step_avg:44.81ms
+step:805/1480 train_time:36083ms step_avg:44.82ms
+step:806/1480 train_time:36145ms step_avg:44.85ms
+step:807/1480 train_time:36204ms step_avg:44.86ms
+step:808/1480 train_time:36274ms step_avg:44.89ms
+step:809/1480 train_time:36338ms step_avg:44.92ms
+step:810/1480 train_time:36407ms step_avg:44.95ms
+step:811/1480 train_time:36469ms step_avg:44.97ms
+step:812/1480 train_time:36536ms step_avg:45.00ms
+step:813/1480 train_time:36600ms step_avg:45.02ms
+step:814/1480 train_time:36667ms step_avg:45.05ms
+step:815/1480 train_time:36730ms step_avg:45.07ms
+step:816/1480 train_time:36798ms step_avg:45.10ms
+step:817/1480 train_time:36852ms step_avg:45.11ms
+step:818/1480 train_time:36911ms step_avg:45.12ms
+step:819/1480 train_time:36966ms step_avg:45.14ms
+step:820/1480 train_time:37030ms step_avg:45.16ms
+step:821/1480 train_time:37088ms step_avg:45.17ms
+step:822/1480 train_time:37152ms step_avg:45.20ms
+step:823/1480 train_time:37210ms step_avg:45.21ms
+step:824/1480 train_time:37276ms step_avg:45.24ms
+step:825/1480 train_time:37338ms step_avg:45.26ms
+step:826/1480 train_time:37403ms step_avg:45.28ms
+step:827/1480 train_time:37462ms step_avg:45.30ms
+step:828/1480 train_time:37527ms step_avg:45.32ms
+step:829/1480 train_time:37586ms step_avg:45.34ms
+step:830/1480 train_time:37651ms step_avg:45.36ms
+step:831/1480 train_time:37711ms step_avg:45.38ms
+step:832/1480 train_time:37777ms step_avg:45.40ms
+step:833/1480 train_time:37837ms step_avg:45.42ms
+step:834/1480 train_time:37904ms step_avg:45.45ms
+step:835/1480 train_time:37962ms step_avg:45.46ms
+step:836/1480 train_time:38027ms step_avg:45.49ms
+step:837/1480 train_time:38086ms step_avg:45.50ms
+step:838/1480 train_time:38150ms step_avg:45.52ms
+step:839/1480 train_time:38208ms step_avg:45.54ms
+step:840/1480 train_time:38272ms step_avg:45.56ms
+step:841/1480 train_time:38331ms step_avg:45.58ms
+step:842/1480 train_time:38396ms step_avg:45.60ms
+step:843/1480 train_time:38454ms step_avg:45.62ms
+step:844/1480 train_time:38519ms step_avg:45.64ms
+step:845/1480 train_time:38578ms step_avg:45.65ms
+step:846/1480 train_time:38642ms step_avg:45.68ms
+step:847/1480 train_time:38701ms step_avg:45.69ms
+step:848/1480 train_time:38765ms step_avg:45.71ms
+step:849/1480 train_time:38823ms step_avg:45.73ms
+step:850/1480 train_time:38886ms step_avg:45.75ms
+step:851/1480 train_time:38942ms step_avg:45.76ms
+step:852/1480 train_time:39007ms step_avg:45.78ms
+step:853/1480 train_time:39068ms step_avg:45.80ms
+step:854/1480 train_time:39140ms step_avg:45.83ms
+step:855/1480 train_time:39203ms step_avg:45.85ms
+step:856/1480 train_time:39273ms step_avg:45.88ms
+step:857/1480 train_time:39337ms step_avg:45.90ms
+step:858/1480 train_time:39407ms step_avg:45.93ms
+step:859/1480 train_time:39468ms step_avg:45.95ms
+step:860/1480 train_time:39528ms step_avg:45.96ms
+step:861/1480 train_time:39582ms step_avg:45.97ms
+step:862/1480 train_time:39642ms step_avg:45.99ms
+step:863/1480 train_time:39697ms step_avg:46.00ms
+step:864/1480 train_time:39762ms step_avg:46.02ms
+step:865/1480 train_time:39827ms step_avg:46.04ms
+step:866/1480 train_time:39896ms step_avg:46.07ms
+step:867/1480 train_time:39958ms step_avg:46.09ms
+step:868/1480 train_time:40025ms step_avg:46.11ms
+step:869/1480 train_time:40085ms step_avg:46.13ms
+step:870/1480 train_time:40149ms step_avg:46.15ms
+step:871/1480 train_time:40208ms step_avg:46.16ms
+step:872/1480 train_time:40272ms step_avg:46.18ms
+step:873/1480 train_time:40330ms step_avg:46.20ms
+step:874/1480 train_time:40394ms step_avg:46.22ms
+step:875/1480 train_time:40453ms step_avg:46.23ms
+step:876/1480 train_time:40517ms step_avg:46.25ms
+step:877/1480 train_time:40575ms step_avg:46.27ms
+step:878/1480 train_time:40640ms step_avg:46.29ms
+step:879/1480 train_time:40699ms step_avg:46.30ms
+step:880/1480 train_time:40763ms step_avg:46.32ms
+step:881/1480 train_time:40821ms step_avg:46.33ms
+step:882/1480 train_time:40885ms step_avg:46.35ms
+step:883/1480 train_time:40943ms step_avg:46.37ms
+step:884/1480 train_time:41007ms step_avg:46.39ms
+step:885/1480 train_time:41064ms step_avg:46.40ms
+step:886/1480 train_time:41128ms step_avg:46.42ms
+step:887/1480 train_time:41186ms step_avg:46.43ms
+step:888/1480 train_time:41251ms step_avg:46.45ms
+step:889/1480 train_time:41310ms step_avg:46.47ms
+step:890/1480 train_time:41374ms step_avg:46.49ms
+step:891/1480 train_time:41433ms step_avg:46.50ms
+step:892/1480 train_time:41498ms step_avg:46.52ms
+step:893/1480 train_time:41556ms step_avg:46.53ms
+step:894/1480 train_time:41619ms step_avg:46.55ms
+step:895/1480 train_time:41678ms step_avg:46.57ms
+step:896/1480 train_time:41743ms step_avg:46.59ms
+step:897/1480 train_time:41802ms step_avg:46.60ms
+step:898/1480 train_time:41869ms step_avg:46.62ms
+step:899/1480 train_time:41929ms step_avg:46.64ms
+step:900/1480 train_time:41995ms step_avg:46.66ms
+step:901/1480 train_time:42054ms step_avg:46.67ms
+step:902/1480 train_time:42119ms step_avg:46.70ms
+step:903/1480 train_time:42180ms step_avg:46.71ms
+step:904/1480 train_time:42246ms step_avg:46.73ms
+step:905/1480 train_time:42304ms step_avg:46.74ms
+step:906/1480 train_time:42369ms step_avg:46.76ms
+step:907/1480 train_time:42428ms step_avg:46.78ms
+step:908/1480 train_time:42493ms step_avg:46.80ms
+step:909/1480 train_time:42553ms step_avg:46.81ms
+step:910/1480 train_time:42621ms step_avg:46.84ms
+step:911/1480 train_time:42681ms step_avg:46.85ms
+step:912/1480 train_time:42747ms step_avg:46.87ms
+step:913/1480 train_time:42808ms step_avg:46.89ms
+step:914/1480 train_time:42873ms step_avg:46.91ms
+step:915/1480 train_time:42932ms step_avg:46.92ms
+step:916/1480 train_time:42998ms step_avg:46.94ms
+step:917/1480 train_time:43057ms step_avg:46.95ms
+step:918/1480 train_time:43122ms step_avg:46.97ms
+step:919/1480 train_time:43177ms step_avg:46.98ms
+step:920/1480 train_time:43237ms step_avg:47.00ms
+step:921/1480 train_time:43294ms step_avg:47.01ms
+step:922/1480 train_time:43357ms step_avg:47.02ms
+step:923/1480 train_time:43415ms step_avg:47.04ms
+step:924/1480 train_time:43479ms step_avg:47.06ms
+step:925/1480 train_time:43538ms step_avg:47.07ms
+step:926/1480 train_time:43603ms step_avg:47.09ms
+step:927/1480 train_time:43661ms step_avg:47.10ms
+step:928/1480 train_time:43725ms step_avg:47.12ms
+step:929/1480 train_time:43783ms step_avg:47.13ms
+step:930/1480 train_time:43847ms step_avg:47.15ms
+step:931/1480 train_time:43904ms step_avg:47.16ms
+step:932/1480 train_time:43968ms step_avg:47.18ms
+step:933/1480 train_time:44028ms step_avg:47.19ms
+step:934/1480 train_time:44094ms step_avg:47.21ms
+step:935/1480 train_time:44152ms step_avg:47.22ms
+step:936/1480 train_time:44217ms step_avg:47.24ms
+step:937/1480 train_time:44276ms step_avg:47.25ms
+step:938/1480 train_time:44341ms step_avg:47.27ms
+step:939/1480 train_time:44399ms step_avg:47.28ms
+step:940/1480 train_time:44464ms step_avg:47.30ms
+step:941/1480 train_time:44522ms step_avg:47.31ms
+step:942/1480 train_time:44587ms step_avg:47.33ms
+step:943/1480 train_time:44645ms step_avg:47.34ms
+step:944/1480 train_time:44709ms step_avg:47.36ms
+step:945/1480 train_time:44767ms step_avg:47.37ms
+step:946/1480 train_time:44830ms step_avg:47.39ms
+step:947/1480 train_time:44887ms step_avg:47.40ms
+step:948/1480 train_time:44950ms step_avg:47.42ms
+step:949/1480 train_time:45010ms step_avg:47.43ms
+step:950/1480 train_time:45078ms step_avg:47.45ms
+step:951/1480 train_time:45141ms step_avg:47.47ms
+step:952/1480 train_time:45208ms step_avg:47.49ms
+step:953/1480 train_time:45269ms step_avg:47.50ms
+step:954/1480 train_time:45336ms step_avg:47.52ms
+step:955/1480 train_time:45398ms step_avg:47.54ms
+step:956/1480 train_time:45464ms step_avg:47.56ms
+step:957/1480 train_time:45524ms step_avg:47.57ms
+step:958/1480 train_time:45591ms step_avg:47.59ms
+step:959/1480 train_time:45653ms step_avg:47.60ms
+step:960/1480 train_time:45720ms step_avg:47.62ms
+step:961/1480 train_time:45784ms step_avg:47.64ms
+step:962/1480 train_time:45872ms step_avg:47.68ms
+step:963/1480 train_time:45955ms step_avg:47.72ms
+step:964/1480 train_time:46043ms step_avg:47.76ms
+step:965/1480 train_time:46130ms step_avg:47.80ms
+step:966/1480 train_time:46222ms step_avg:47.85ms
+step:967/1480 train_time:46309ms step_avg:47.89ms
+step:968/1480 train_time:46401ms step_avg:47.94ms
+step:969/1480 train_time:46490ms step_avg:47.98ms
+step:970/1480 train_time:46586ms step_avg:48.03ms
+step:971/1480 train_time:46676ms step_avg:48.07ms
+step:972/1480 train_time:46770ms step_avg:48.12ms
+step:973/1480 train_time:46859ms step_avg:48.16ms
+step:974/1480 train_time:46955ms step_avg:48.21ms
+step:975/1480 train_time:47043ms step_avg:48.25ms
+step:976/1480 train_time:47138ms step_avg:48.30ms
+step:977/1480 train_time:47225ms step_avg:48.34ms
+step:978/1480 train_time:47320ms step_avg:48.38ms
+step:979/1480 train_time:47407ms step_avg:48.42ms
+step:980/1480 train_time:47503ms step_avg:48.47ms
+step:981/1480 train_time:47591ms step_avg:48.51ms
+step:982/1480 train_time:47684ms step_avg:48.56ms
+step:983/1480 train_time:47772ms step_avg:48.60ms
+step:984/1480 train_time:47864ms step_avg:48.64ms
+step:985/1480 train_time:47952ms step_avg:48.68ms
+step:986/1480 train_time:48047ms step_avg:48.73ms
+step:987/1480 train_time:48133ms step_avg:48.77ms
+step:988/1480 train_time:48227ms step_avg:48.81ms
+step:989/1480 train_time:48315ms step_avg:48.85ms
+step:990/1480 train_time:48407ms step_avg:48.90ms
+step:991/1480 train_time:48494ms step_avg:48.93ms
+step:992/1480 train_time:48588ms step_avg:48.98ms
+step:993/1480 train_time:48675ms step_avg:49.02ms
+step:994/1480 train_time:48768ms step_avg:49.06ms
+step:995/1480 train_time:48855ms step_avg:49.10ms
+step:996/1480 train_time:48948ms step_avg:49.14ms
+step:997/1480 train_time:49035ms step_avg:49.18ms
+step:998/1480 train_time:49128ms step_avg:49.23ms
+step:999/1480 train_time:49215ms step_avg:49.26ms
+step:1000/1480 train_time:49309ms step_avg:49.31ms
+step:1000/1480 val_loss:3.5073 train_time:49421ms step_avg:49.42ms
+step:1001/1480 train_time:49439ms step_avg:49.39ms
+step:1002/1480 train_time:49489ms step_avg:49.39ms
+step:1003/1480 train_time:49579ms step_avg:49.43ms
+step:1004/1480 train_time:49670ms step_avg:49.47ms
+step:1005/1480 train_time:49759ms step_avg:49.51ms
+step:1006/1480 train_time:49854ms step_avg:49.56ms
+step:1007/1480 train_time:49942ms step_avg:49.59ms
+step:1008/1480 train_time:50034ms step_avg:49.64ms
+step:1009/1480 train_time:50120ms step_avg:49.67ms
+step:1010/1480 train_time:50211ms step_avg:49.71ms
+step:1011/1480 train_time:50294ms step_avg:49.75ms
+step:1012/1480 train_time:50383ms step_avg:49.79ms
+step:1013/1480 train_time:50467ms step_avg:49.82ms
+step:1014/1480 train_time:50566ms step_avg:49.87ms
+step:1015/1480 train_time:50655ms step_avg:49.91ms
+step:1016/1480 train_time:50750ms step_avg:49.95ms
+step:1017/1480 train_time:50839ms step_avg:49.99ms
+step:1018/1480 train_time:50932ms step_avg:50.03ms
+step:1019/1480 train_time:51018ms step_avg:50.07ms
+step:1020/1480 train_time:51112ms step_avg:50.11ms
+step:1021/1480 train_time:51199ms step_avg:50.15ms
+step:1022/1480 train_time:51293ms step_avg:50.19ms
+step:1023/1480 train_time:51380ms step_avg:50.22ms
+step:1024/1480 train_time:51474ms step_avg:50.27ms
+step:1025/1480 train_time:51561ms step_avg:50.30ms
+step:1026/1480 train_time:51655ms step_avg:50.35ms
+step:1027/1480 train_time:51743ms step_avg:50.38ms
+step:1028/1480 train_time:51836ms step_avg:50.42ms
+step:1029/1480 train_time:51921ms step_avg:50.46ms
+step:1030/1480 train_time:52015ms step_avg:50.50ms
+step:1031/1480 train_time:52101ms step_avg:50.53ms
+step:1032/1480 train_time:52197ms step_avg:50.58ms
+step:1033/1480 train_time:52283ms step_avg:50.61ms
+step:1034/1480 train_time:52377ms step_avg:50.65ms
+step:1035/1480 train_time:52464ms step_avg:50.69ms
+step:1036/1480 train_time:52557ms step_avg:50.73ms
+step:1037/1480 train_time:52643ms step_avg:50.76ms
+step:1038/1480 train_time:52736ms step_avg:50.80ms
+step:1039/1480 train_time:52820ms step_avg:50.84ms
+step:1040/1480 train_time:52917ms step_avg:50.88ms
+step:1041/1480 train_time:53008ms step_avg:50.92ms
+step:1042/1480 train_time:53101ms step_avg:50.96ms
+step:1043/1480 train_time:53187ms step_avg:50.99ms
+step:1044/1480 train_time:53279ms step_avg:51.03ms
+step:1045/1480 train_time:53366ms step_avg:51.07ms
+step:1046/1480 train_time:53460ms step_avg:51.11ms
+step:1047/1480 train_time:53546ms step_avg:51.14ms
+step:1048/1480 train_time:53644ms step_avg:51.19ms
+step:1049/1480 train_time:53732ms step_avg:51.22ms
+step:1050/1480 train_time:53826ms step_avg:51.26ms
+step:1051/1480 train_time:53913ms step_avg:51.30ms
+step:1052/1480 train_time:54006ms step_avg:51.34ms
+step:1053/1480 train_time:54090ms step_avg:51.37ms
+step:1054/1480 train_time:54181ms step_avg:51.41ms
+step:1055/1480 train_time:54267ms step_avg:51.44ms
+step:1056/1480 train_time:54362ms step_avg:51.48ms
+step:1057/1480 train_time:54447ms step_avg:51.51ms
+step:1058/1480 train_time:54541ms step_avg:51.55ms
+step:1059/1480 train_time:54627ms step_avg:51.58ms
+step:1060/1480 train_time:54722ms step_avg:51.62ms
+step:1061/1480 train_time:54809ms step_avg:51.66ms
+step:1062/1480 train_time:54903ms step_avg:51.70ms
+step:1063/1480 train_time:54990ms step_avg:51.73ms
+step:1064/1480 train_time:55084ms step_avg:51.77ms
+step:1065/1480 train_time:55172ms step_avg:51.80ms
+step:1066/1480 train_time:55266ms step_avg:51.84ms
+step:1067/1480 train_time:55355ms step_avg:51.88ms
+step:1068/1480 train_time:55449ms step_avg:51.92ms
+step:1069/1480 train_time:55538ms step_avg:51.95ms
+step:1070/1480 train_time:55632ms step_avg:51.99ms
+step:1071/1480 train_time:55719ms step_avg:52.03ms
+step:1072/1480 train_time:55815ms step_avg:52.07ms
+step:1073/1480 train_time:55903ms step_avg:52.10ms
+step:1074/1480 train_time:55997ms step_avg:52.14ms
+step:1075/1480 train_time:56084ms step_avg:52.17ms
+step:1076/1480 train_time:56178ms step_avg:52.21ms
+step:1077/1480 train_time:56265ms step_avg:52.24ms
+step:1078/1480 train_time:56360ms step_avg:52.28ms
+step:1079/1480 train_time:56446ms step_avg:52.31ms
+step:1080/1480 train_time:56541ms step_avg:52.35ms
+step:1081/1480 train_time:56628ms step_avg:52.38ms
+step:1082/1480 train_time:56723ms step_avg:52.42ms
+step:1083/1480 train_time:56809ms step_avg:52.46ms
+step:1084/1480 train_time:56904ms step_avg:52.49ms
+step:1085/1480 train_time:56989ms step_avg:52.52ms
+step:1086/1480 train_time:57084ms step_avg:52.56ms
+step:1087/1480 train_time:57172ms step_avg:52.60ms
+step:1088/1480 train_time:57265ms step_avg:52.63ms
+step:1089/1480 train_time:57353ms step_avg:52.67ms
+step:1090/1480 train_time:57447ms step_avg:52.70ms
+step:1091/1480 train_time:57529ms step_avg:52.73ms
+step:1092/1480 train_time:57620ms step_avg:52.77ms
+step:1093/1480 train_time:57714ms step_avg:52.80ms
+step:1094/1480 train_time:57808ms step_avg:52.84ms
+step:1095/1480 train_time:57898ms step_avg:52.87ms
+step:1096/1480 train_time:57991ms step_avg:52.91ms
+step:1097/1480 train_time:58081ms step_avg:52.95ms
+step:1098/1480 train_time:58175ms step_avg:52.98ms
+step:1099/1480 train_time:58262ms step_avg:53.01ms
+step:1100/1480 train_time:58353ms step_avg:53.05ms
+step:1101/1480 train_time:58441ms step_avg:53.08ms
+step:1102/1480 train_time:58535ms step_avg:53.12ms
+step:1103/1480 train_time:58624ms step_avg:53.15ms
+step:1104/1480 train_time:58721ms step_avg:53.19ms
+step:1105/1480 train_time:58811ms step_avg:53.22ms
+step:1106/1480 train_time:58909ms step_avg:53.26ms
+step:1107/1480 train_time:59000ms step_avg:53.30ms
+step:1108/1480 train_time:59095ms step_avg:53.34ms
+step:1109/1480 train_time:59185ms step_avg:53.37ms
+step:1110/1480 train_time:59283ms step_avg:53.41ms
+step:1111/1480 train_time:59364ms step_avg:53.43ms
+step:1112/1480 train_time:59452ms step_avg:53.46ms
+step:1113/1480 train_time:59538ms step_avg:53.49ms
+step:1114/1480 train_time:59632ms step_avg:53.53ms
+step:1115/1480 train_time:59722ms step_avg:53.56ms
+step:1116/1480 train_time:59813ms step_avg:53.60ms
+step:1117/1480 train_time:59903ms step_avg:53.63ms
+step:1118/1480 train_time:60000ms step_avg:53.67ms
+step:1119/1480 train_time:60088ms step_avg:53.70ms
+step:1120/1480 train_time:60187ms step_avg:53.74ms
+step:1121/1480 train_time:60275ms step_avg:53.77ms
+step:1122/1480 train_time:60368ms step_avg:53.80ms
+step:1123/1480 train_time:60458ms step_avg:53.84ms
+step:1124/1480 train_time:60551ms step_avg:53.87ms
+step:1125/1480 train_time:60639ms step_avg:53.90ms
+step:1126/1480 train_time:60733ms step_avg:53.94ms
+step:1127/1480 train_time:60820ms step_avg:53.97ms
+step:1128/1480 train_time:60915ms step_avg:54.00ms
+step:1129/1480 train_time:61002ms step_avg:54.03ms
+step:1130/1480 train_time:61094ms step_avg:54.07ms
+step:1131/1480 train_time:61184ms step_avg:54.10ms
+step:1132/1480 train_time:61277ms step_avg:54.13ms
+step:1133/1480 train_time:61365ms step_avg:54.16ms
+step:1134/1480 train_time:61459ms step_avg:54.20ms
+step:1135/1480 train_time:61545ms step_avg:54.23ms
+step:1136/1480 train_time:61640ms step_avg:54.26ms
+step:1137/1480 train_time:61726ms step_avg:54.29ms
+step:1138/1480 train_time:61823ms step_avg:54.33ms
+step:1139/1480 train_time:61908ms step_avg:54.35ms
+step:1140/1480 train_time:62002ms step_avg:54.39ms
+step:1141/1480 train_time:62088ms step_avg:54.42ms
+step:1142/1480 train_time:62182ms step_avg:54.45ms
+step:1143/1480 train_time:62268ms step_avg:54.48ms
+step:1144/1480 train_time:62362ms step_avg:54.51ms
+step:1145/1480 train_time:62444ms step_avg:54.54ms
+step:1146/1480 train_time:62541ms step_avg:54.57ms
+step:1147/1480 train_time:62632ms step_avg:54.61ms
+step:1148/1480 train_time:62724ms step_avg:54.64ms
+step:1149/1480 train_time:62811ms step_avg:54.67ms
+step:1150/1480 train_time:62906ms step_avg:54.70ms
+step:1151/1480 train_time:62990ms step_avg:54.73ms
+step:1152/1480 train_time:63084ms step_avg:54.76ms
+step:1153/1480 train_time:63172ms step_avg:54.79ms
+step:1154/1480 train_time:63273ms step_avg:54.83ms
+step:1155/1480 train_time:63365ms step_avg:54.86ms
+step:1156/1480 train_time:63463ms step_avg:54.90ms
+step:1157/1480 train_time:63554ms step_avg:54.93ms
+step:1158/1480 train_time:63653ms step_avg:54.97ms
+step:1159/1480 train_time:63746ms step_avg:55.00ms
+step:1160/1480 train_time:63842ms step_avg:55.04ms
+step:1161/1480 train_time:63933ms step_avg:55.07ms
+step:1162/1480 train_time:64029ms step_avg:55.10ms
+step:1163/1480 train_time:64121ms step_avg:55.13ms
+step:1164/1480 train_time:64218ms step_avg:55.17ms
+step:1165/1480 train_time:64298ms step_avg:55.19ms
+step:1166/1480 train_time:64382ms step_avg:55.22ms
+step:1167/1480 train_time:64468ms step_avg:55.24ms
+step:1168/1480 train_time:64563ms step_avg:55.28ms
+step:1169/1480 train_time:64648ms step_avg:55.30ms
+step:1170/1480 train_time:64739ms step_avg:55.33ms
+step:1171/1480 train_time:64825ms step_avg:55.36ms
+step:1172/1480 train_time:64919ms step_avg:55.39ms
+step:1173/1480 train_time:65006ms step_avg:55.42ms
+step:1174/1480 train_time:65100ms step_avg:55.45ms
+step:1175/1480 train_time:65186ms step_avg:55.48ms
+step:1176/1480 train_time:65282ms step_avg:55.51ms
+step:1177/1480 train_time:65371ms step_avg:55.54ms
+step:1178/1480 train_time:65466ms step_avg:55.57ms
+step:1179/1480 train_time:65556ms step_avg:55.60ms
+step:1180/1480 train_time:65650ms step_avg:55.64ms
+step:1181/1480 train_time:65738ms step_avg:55.66ms
+step:1182/1480 train_time:65832ms step_avg:55.70ms
+step:1183/1480 train_time:65920ms step_avg:55.72ms
+step:1184/1480 train_time:66014ms step_avg:55.75ms
+step:1185/1480 train_time:66101ms step_avg:55.78ms
+step:1186/1480 train_time:66195ms step_avg:55.81ms
+step:1187/1480 train_time:66283ms step_avg:55.84ms
+step:1188/1480 train_time:66377ms step_avg:55.87ms
+step:1189/1480 train_time:66465ms step_avg:55.90ms
+step:1190/1480 train_time:66558ms step_avg:55.93ms
+step:1191/1480 train_time:66646ms step_avg:55.96ms
+step:1192/1480 train_time:66741ms step_avg:55.99ms
+step:1193/1480 train_time:66827ms step_avg:56.02ms
+step:1194/1480 train_time:66923ms step_avg:56.05ms
+step:1195/1480 train_time:67009ms step_avg:56.07ms
+step:1196/1480 train_time:67104ms step_avg:56.11ms
+step:1197/1480 train_time:67190ms step_avg:56.13ms
+step:1198/1480 train_time:67284ms step_avg:56.16ms
+step:1199/1480 train_time:67372ms step_avg:56.19ms
+step:1200/1480 train_time:67466ms step_avg:56.22ms
+step:1201/1480 train_time:67552ms step_avg:56.25ms
+step:1202/1480 train_time:67645ms step_avg:56.28ms
+step:1203/1480 train_time:67732ms step_avg:56.30ms
+step:1204/1480 train_time:67825ms step_avg:56.33ms
+step:1205/1480 train_time:67911ms step_avg:56.36ms
+step:1206/1480 train_time:68003ms step_avg:56.39ms
+step:1207/1480 train_time:68090ms step_avg:56.41ms
+step:1208/1480 train_time:68184ms step_avg:56.44ms
+step:1209/1480 train_time:68270ms step_avg:56.47ms
+step:1210/1480 train_time:68364ms step_avg:56.50ms
+step:1211/1480 train_time:68450ms step_avg:56.52ms
+step:1212/1480 train_time:68543ms step_avg:56.55ms
+step:1213/1480 train_time:68628ms step_avg:56.58ms
+step:1214/1480 train_time:68721ms step_avg:56.61ms
+step:1215/1480 train_time:68805ms step_avg:56.63ms
+step:1216/1480 train_time:68897ms step_avg:56.66ms
+step:1217/1480 train_time:68982ms step_avg:56.68ms
+step:1218/1480 train_time:69073ms step_avg:56.71ms
+step:1219/1480 train_time:69161ms step_avg:56.74ms
+step:1220/1480 train_time:69251ms step_avg:56.76ms
+step:1221/1480 train_time:69337ms step_avg:56.79ms
+step:1222/1480 train_time:69428ms step_avg:56.82ms
+step:1223/1480 train_time:69514ms step_avg:56.84ms
+step:1224/1480 train_time:69609ms step_avg:56.87ms
+step:1225/1480 train_time:69700ms step_avg:56.90ms
+step:1226/1480 train_time:69797ms step_avg:56.93ms
+step:1227/1480 train_time:69887ms step_avg:56.96ms
+step:1228/1480 train_time:69985ms step_avg:56.99ms
+step:1229/1480 train_time:70074ms step_avg:57.02ms
+step:1230/1480 train_time:70170ms step_avg:57.05ms
+step:1231/1480 train_time:70260ms step_avg:57.08ms
+step:1232/1480 train_time:70355ms step_avg:57.11ms
+step:1233/1480 train_time:70437ms step_avg:57.13ms
+step:1234/1480 train_time:70525ms step_avg:57.15ms
+step:1235/1480 train_time:70613ms step_avg:57.18ms
+step:1236/1480 train_time:70706ms step_avg:57.21ms
+step:1237/1480 train_time:70791ms step_avg:57.23ms
+step:1238/1480 train_time:70882ms step_avg:57.26ms
+step:1239/1480 train_time:70967ms step_avg:57.28ms
+step:1240/1480 train_time:71063ms step_avg:57.31ms
+step:1241/1480 train_time:71147ms step_avg:57.33ms
+step:1242/1480 train_time:71246ms step_avg:57.36ms
+step:1243/1480 train_time:71337ms step_avg:57.39ms
+step:1244/1480 train_time:71431ms step_avg:57.42ms
+step:1245/1480 train_time:71520ms step_avg:57.45ms
+step:1246/1480 train_time:71613ms step_avg:57.47ms
+step:1247/1480 train_time:71701ms step_avg:57.50ms
+step:1248/1480 train_time:71796ms step_avg:57.53ms
+step:1249/1480 train_time:71885ms step_avg:57.55ms
+step:1250/1480 train_time:71981ms step_avg:57.59ms
+step:1250/1480 val_loss:3.3657 train_time:72096ms step_avg:57.68ms
+step:1251/1480 train_time:72114ms step_avg:57.65ms
+step:1252/1480 train_time:72164ms step_avg:57.64ms
+step:1253/1480 train_time:72255ms step_avg:57.67ms
+step:1254/1480 train_time:72352ms step_avg:57.70ms
+step:1255/1480 train_time:72443ms step_avg:57.72ms
+step:1256/1480 train_time:72537ms step_avg:57.75ms
+step:1257/1480 train_time:72625ms step_avg:57.78ms
+step:1258/1480 train_time:72720ms step_avg:57.81ms
+step:1259/1480 train_time:72804ms step_avg:57.83ms
+step:1260/1480 train_time:72890ms step_avg:57.85ms
+step:1261/1480 train_time:72977ms step_avg:57.87ms
+step:1262/1480 train_time:73071ms step_avg:57.90ms
+step:1263/1480 train_time:73155ms step_avg:57.92ms
+step:1264/1480 train_time:73250ms step_avg:57.95ms
+step:1265/1480 train_time:73339ms step_avg:57.98ms
+step:1266/1480 train_time:73432ms step_avg:58.00ms
+step:1267/1480 train_time:73519ms step_avg:58.03ms
+step:1268/1480 train_time:73611ms step_avg:58.05ms
+step:1269/1480 train_time:73696ms step_avg:58.07ms
+step:1270/1480 train_time:73787ms step_avg:58.10ms
+step:1271/1480 train_time:73871ms step_avg:58.12ms
+step:1272/1480 train_time:73962ms step_avg:58.15ms
+step:1273/1480 train_time:74049ms step_avg:58.17ms
+step:1274/1480 train_time:74144ms step_avg:58.20ms
+step:1275/1480 train_time:74229ms step_avg:58.22ms
+step:1276/1480 train_time:74319ms step_avg:58.24ms
+step:1277/1480 train_time:74407ms step_avg:58.27ms
+step:1278/1480 train_time:74498ms step_avg:58.29ms
+step:1279/1480 train_time:74589ms step_avg:58.32ms
+step:1280/1480 train_time:74681ms step_avg:58.34ms
+step:1281/1480 train_time:74767ms step_avg:58.37ms
+step:1282/1480 train_time:74860ms step_avg:58.39ms
+step:1283/1480 train_time:74949ms step_avg:58.42ms
+step:1284/1480 train_time:75045ms step_avg:58.45ms
+step:1285/1480 train_time:75135ms step_avg:58.47ms
+step:1286/1480 train_time:75231ms step_avg:58.50ms
+step:1287/1480 train_time:75321ms step_avg:58.52ms
+step:1288/1480 train_time:75416ms step_avg:58.55ms
+step:1289/1480 train_time:75498ms step_avg:58.57ms
+step:1290/1480 train_time:75588ms step_avg:58.60ms
+step:1291/1480 train_time:75678ms step_avg:58.62ms
+step:1292/1480 train_time:75772ms step_avg:58.65ms
+step:1293/1480 train_time:75859ms step_avg:58.67ms
+step:1294/1480 train_time:75950ms step_avg:58.69ms
+step:1295/1480 train_time:76037ms step_avg:58.72ms
+step:1296/1480 train_time:76128ms step_avg:58.74ms
+step:1297/1480 train_time:76213ms step_avg:58.76ms
+step:1298/1480 train_time:76306ms step_avg:58.79ms
+step:1299/1480 train_time:76391ms step_avg:58.81ms
+step:1300/1480 train_time:76484ms step_avg:58.83ms
+step:1301/1480 train_time:76571ms step_avg:58.86ms
+step:1302/1480 train_time:76665ms step_avg:58.88ms
+step:1303/1480 train_time:76752ms step_avg:58.90ms
+step:1304/1480 train_time:76849ms step_avg:58.93ms
+step:1305/1480 train_time:76935ms step_avg:58.95ms
+step:1306/1480 train_time:77031ms step_avg:58.98ms
+step:1307/1480 train_time:77123ms step_avg:59.01ms
+step:1308/1480 train_time:77225ms step_avg:59.04ms
+step:1309/1480 train_time:77315ms step_avg:59.06ms
+step:1310/1480 train_time:77400ms step_avg:59.08ms
+step:1311/1480 train_time:77487ms step_avg:59.11ms
+step:1312/1480 train_time:77577ms step_avg:59.13ms
+step:1313/1480 train_time:77665ms step_avg:59.15ms
+step:1314/1480 train_time:77757ms step_avg:59.18ms
+step:1315/1480 train_time:77841ms step_avg:59.19ms
+step:1316/1480 train_time:77933ms step_avg:59.22ms
+step:1317/1480 train_time:78021ms step_avg:59.24ms
+step:1318/1480 train_time:78112ms step_avg:59.27ms
+step:1319/1480 train_time:78201ms step_avg:59.29ms
+step:1320/1480 train_time:78294ms step_avg:59.31ms
+step:1321/1480 train_time:78381ms step_avg:59.33ms
+step:1322/1480 train_time:78473ms step_avg:59.36ms
+step:1323/1480 train_time:78561ms step_avg:59.38ms
+step:1324/1480 train_time:78653ms step_avg:59.41ms
+step:1325/1480 train_time:78738ms step_avg:59.43ms
+step:1326/1480 train_time:78828ms step_avg:59.45ms
+step:1327/1480 train_time:78913ms step_avg:59.47ms
+step:1328/1480 train_time:79007ms step_avg:59.49ms
+step:1329/1480 train_time:79093ms step_avg:59.51ms
+step:1330/1480 train_time:79189ms step_avg:59.54ms
+step:1331/1480 train_time:79278ms step_avg:59.56ms
+step:1332/1480 train_time:79374ms step_avg:59.59ms
+step:1333/1480 train_time:79464ms step_avg:59.61ms
+step:1334/1480 train_time:79559ms step_avg:59.64ms
+step:1335/1480 train_time:79647ms step_avg:59.66ms
+step:1336/1480 train_time:79743ms step_avg:59.69ms
+step:1337/1480 train_time:79831ms step_avg:59.71ms
+step:1338/1480 train_time:79928ms step_avg:59.74ms
+step:1339/1480 train_time:80011ms step_avg:59.75ms
+step:1340/1480 train_time:80105ms step_avg:59.78ms
+step:1341/1480 train_time:80195ms step_avg:59.80ms
+step:1342/1480 train_time:80288ms step_avg:59.83ms
+step:1343/1480 train_time:80376ms step_avg:59.85ms
+step:1344/1480 train_time:80472ms step_avg:59.87ms
+step:1345/1480 train_time:80561ms step_avg:59.90ms
+step:1346/1480 train_time:80652ms step_avg:59.92ms
+step:1347/1480 train_time:80738ms step_avg:59.94ms
+step:1348/1480 train_time:80830ms step_avg:59.96ms
+step:1349/1480 train_time:80914ms step_avg:59.98ms
+step:1350/1480 train_time:81006ms step_avg:60.00ms
+step:1351/1480 train_time:81090ms step_avg:60.02ms
+step:1352/1480 train_time:81180ms step_avg:60.04ms
+step:1353/1480 train_time:81269ms step_avg:60.07ms
+step:1354/1480 train_time:81361ms step_avg:60.09ms
+step:1355/1480 train_time:81446ms step_avg:60.11ms
+step:1356/1480 train_time:81540ms step_avg:60.13ms
+step:1357/1480 train_time:81629ms step_avg:60.15ms
+step:1358/1480 train_time:81721ms step_avg:60.18ms
+step:1359/1480 train_time:81808ms step_avg:60.20ms
+step:1360/1480 train_time:81902ms step_avg:60.22ms
+step:1361/1480 train_time:81989ms step_avg:60.24ms
+step:1362/1480 train_time:82082ms step_avg:60.27ms
+step:1363/1480 train_time:82166ms step_avg:60.28ms
+step:1364/1480 train_time:82258ms step_avg:60.31ms
+step:1365/1480 train_time:82343ms step_avg:60.32ms
+step:1366/1480 train_time:82434ms step_avg:60.35ms
+step:1367/1480 train_time:82522ms step_avg:60.37ms
+step:1368/1480 train_time:82614ms step_avg:60.39ms
+step:1369/1480 train_time:82699ms step_avg:60.41ms
+step:1370/1480 train_time:82792ms step_avg:60.43ms
+step:1371/1480 train_time:82879ms step_avg:60.45ms
+step:1372/1480 train_time:82972ms step_avg:60.47ms
+step:1373/1480 train_time:83058ms step_avg:60.49ms
+step:1374/1480 train_time:83150ms step_avg:60.52ms
+step:1375/1480 train_time:83235ms step_avg:60.53ms
+step:1376/1480 train_time:83326ms step_avg:60.56ms
+step:1377/1480 train_time:83412ms step_avg:60.58ms
+step:1378/1480 train_time:83506ms step_avg:60.60ms
+step:1379/1480 train_time:83592ms step_avg:60.62ms
+step:1380/1480 train_time:83687ms step_avg:60.64ms
+step:1381/1480 train_time:83777ms step_avg:60.66ms
+step:1382/1480 train_time:83874ms step_avg:60.69ms
+step:1383/1480 train_time:83965ms step_avg:60.71ms
+step:1384/1480 train_time:84062ms step_avg:60.74ms
+step:1385/1480 train_time:84152ms step_avg:60.76ms
+step:1386/1480 train_time:84249ms step_avg:60.79ms
+step:1387/1480 train_time:84340ms step_avg:60.81ms
+step:1388/1480 train_time:84435ms step_avg:60.83ms
+step:1389/1480 train_time:84517ms step_avg:60.85ms
+step:1390/1480 train_time:84606ms step_avg:60.87ms
+step:1391/1480 train_time:84691ms step_avg:60.88ms
+step:1392/1480 train_time:84785ms step_avg:60.91ms
+step:1393/1480 train_time:84873ms step_avg:60.93ms
+step:1394/1480 train_time:84967ms step_avg:60.95ms
+step:1395/1480 train_time:85054ms step_avg:60.97ms
+step:1396/1480 train_time:85148ms step_avg:60.99ms
+step:1397/1480 train_time:85234ms step_avg:61.01ms
+step:1398/1480 train_time:85331ms step_avg:61.04ms
+step:1399/1480 train_time:85425ms step_avg:61.06ms
+step:1400/1480 train_time:85523ms step_avg:61.09ms
+step:1401/1480 train_time:85614ms step_avg:61.11ms
+step:1402/1480 train_time:85712ms step_avg:61.14ms
+step:1403/1480 train_time:85804ms step_avg:61.16ms
+step:1404/1480 train_time:85903ms step_avg:61.18ms
+step:1405/1480 train_time:85995ms step_avg:61.21ms
+step:1406/1480 train_time:86094ms step_avg:61.23ms
+step:1407/1480 train_time:86174ms step_avg:61.25ms
+step:1408/1480 train_time:86258ms step_avg:61.26ms
+step:1409/1480 train_time:86347ms step_avg:61.28ms
+step:1410/1480 train_time:86446ms step_avg:61.31ms
+step:1411/1480 train_time:86536ms step_avg:61.33ms
+step:1412/1480 train_time:86632ms step_avg:61.35ms
+step:1413/1480 train_time:86723ms step_avg:61.38ms
+step:1414/1480 train_time:86819ms step_avg:61.40ms
+step:1415/1480 train_time:86908ms step_avg:61.42ms
+step:1416/1480 train_time:86993ms step_avg:61.44ms
+step:1417/1480 train_time:87075ms step_avg:61.45ms
+step:1418/1480 train_time:87170ms step_avg:61.47ms
+step:1419/1480 train_time:87256ms step_avg:61.49ms
+step:1420/1480 train_time:87347ms step_avg:61.51ms
+step:1421/1480 train_time:87432ms step_avg:61.53ms
+step:1422/1480 train_time:87523ms step_avg:61.55ms
+step:1423/1480 train_time:87611ms step_avg:61.57ms
+step:1424/1480 train_time:87704ms step_avg:61.59ms
+step:1425/1480 train_time:87789ms step_avg:61.61ms
+step:1426/1480 train_time:87881ms step_avg:61.63ms
+step:1427/1480 train_time:87966ms step_avg:61.64ms
+step:1428/1480 train_time:88058ms step_avg:61.67ms
+step:1429/1480 train_time:88142ms step_avg:61.68ms
+step:1430/1480 train_time:88233ms step_avg:61.70ms
+step:1431/1480 train_time:88321ms step_avg:61.72ms
+step:1432/1480 train_time:88414ms step_avg:61.74ms
+step:1433/1480 train_time:88503ms step_avg:61.76ms
+step:1434/1480 train_time:88597ms step_avg:61.78ms
+step:1435/1480 train_time:88687ms step_avg:61.80ms
+step:1436/1480 train_time:88782ms step_avg:61.83ms
+step:1437/1480 train_time:88873ms step_avg:61.85ms
+step:1438/1480 train_time:88973ms step_avg:61.87ms
+step:1439/1480 train_time:89066ms step_avg:61.89ms
+step:1440/1480 train_time:89162ms step_avg:61.92ms
+step:1441/1480 train_time:89255ms step_avg:61.94ms
+step:1442/1480 train_time:89355ms step_avg:61.97ms
+step:1443/1480 train_time:89438ms step_avg:61.98ms
+step:1444/1480 train_time:89527ms step_avg:62.00ms
+step:1445/1480 train_time:89611ms step_avg:62.01ms
+step:1446/1480 train_time:89707ms step_avg:62.04ms
+step:1447/1480 train_time:89793ms step_avg:62.05ms
+step:1448/1480 train_time:89889ms step_avg:62.08ms
+step:1449/1480 train_time:89976ms step_avg:62.10ms
+step:1450/1480 train_time:90069ms step_avg:62.12ms
+step:1451/1480 train_time:90157ms step_avg:62.13ms
+step:1452/1480 train_time:90250ms step_avg:62.16ms
+step:1453/1480 train_time:90336ms step_avg:62.17ms
+step:1454/1480 train_time:90430ms step_avg:62.19ms
+step:1455/1480 train_time:90517ms step_avg:62.21ms
+step:1456/1480 train_time:90610ms step_avg:62.23ms
+step:1457/1480 train_time:90695ms step_avg:62.25ms
+step:1458/1480 train_time:90787ms step_avg:62.27ms
+step:1459/1480 train_time:90871ms step_avg:62.28ms
+step:1460/1480 train_time:90964ms step_avg:62.30ms
+step:1461/1480 train_time:91051ms step_avg:62.32ms
+step:1462/1480 train_time:91146ms step_avg:62.34ms
+step:1463/1480 train_time:91230ms step_avg:62.36ms
+step:1464/1480 train_time:91323ms step_avg:62.38ms
+step:1465/1480 train_time:91408ms step_avg:62.39ms
+step:1466/1480 train_time:91500ms step_avg:62.41ms
+step:1467/1480 train_time:91589ms step_avg:62.43ms
+step:1468/1480 train_time:91685ms step_avg:62.46ms
+step:1469/1480 train_time:91772ms step_avg:62.47ms
+step:1470/1480 train_time:91869ms step_avg:62.50ms
+step:1471/1480 train_time:91956ms step_avg:62.51ms
+step:1472/1480 train_time:92051ms step_avg:62.53ms
+step:1473/1480 train_time:92137ms step_avg:62.55ms
+step:1474/1480 train_time:92230ms step_avg:62.57ms
+step:1475/1480 train_time:92316ms step_avg:62.59ms
+step:1476/1480 train_time:92407ms step_avg:62.61ms
+step:1477/1480 train_time:92492ms step_avg:62.62ms
+step:1478/1480 train_time:92584ms step_avg:62.64ms
+step:1479/1480 train_time:92670ms step_avg:62.66ms
+step:1480/1480 train_time:92764ms step_avg:62.68ms
+step:1480/1480 val_loss:3.2769 train_time:92872ms step_avg:62.75ms
+peak memory allocated: 31345 MiB reserved: 47242 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk4-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk4-1480.txt
@@ -1,0 +1,4463 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # QK bank: per-head-pair Muon groups for Q, K weights
+        # Each pair of adjacent heads gets its own independent polar express orthogonalization
+        self._num_attn_layers = num_attn_layers
+        num_qk_groups = num_attn_layers * 2 * (num_heads // 2)  # 10 * 2 * 3 = 60
+        self._num_qk_groups = num_qk_groups
+        num_qk_padded = next_multiple_of_n(num_qk_groups, n=world_size)  # 64
+        self.qk_bank = nn.Parameter(torch.empty(num_qk_padded, head_dim * 2, model_dim))
+        self.qk_bank.reshape = (num_qk_padded, head_dim * 2, model_dim)
+
+        # VO bank: per-layer Muon groups for V and O weights
+        num_vo_real = num_attn_layers * 2  # 20
+        num_vo_padded = next_multiple_of_n(num_vo_real, n=world_size)  # 24
+        self.vo_bank = nn.Parameter(torch.empty(num_vo_padded, hdim, hdim))
+        self.vo_bank.reshape = (num_vo_padded, hdim, hdim)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.qk_bank[:num_qk_groups].uniform_(-bound, bound)
+            self.qk_bank[num_qk_groups:].zero_()
+            self.vo_bank[:num_vo_real].uniform_(-bound, bound)
+            self.vo_bank[num_vo_real:].zero_()
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from qk_bank/vo_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        qk_all = self.qk_bank[:self._num_qk_groups].view(self._num_attn_layers, -1, self.qk_bank.shape[-1])
+        vo_flat = self.vo_bank[:self._num_attn_layers * 2].view(self._num_attn_layers, 2, *self.vo_bank.shape[1:]).flatten(1, 2)
+        attn_weights = torch.cat([qk_all, vo_flat], dim=1).unbind(0)
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            attn_idx = i - (i > 6) if i != 6 else None
+            qkvo_w = attn_weights[attn_idx] if attn_idx is not None else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "qk_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "vo_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "qk_bank", "vo_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.qk_bank.data = model.qk_bank.data.bfloat16()
+model.vo_bank.data = model.vo_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:03:11 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   39C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   38C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   66C    P0            151W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          237041      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          237042      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          237043      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          237044      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          237045      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          237046      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          237047      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          237048      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8301 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:75ms step_avg:75.12ms
+step:2/1480 train_time:100ms step_avg:49.77ms
+step:3/1480 train_time:119ms step_avg:39.72ms
+step:4/1480 train_time:142ms step_avg:35.52ms
+step:5/1480 train_time:170ms step_avg:34.04ms
+step:6/1480 train_time:205ms step_avg:34.17ms
+step:7/1480 train_time:234ms step_avg:33.37ms
+step:8/1480 train_time:268ms step_avg:33.53ms
+step:9/1480 train_time:297ms step_avg:32.97ms
+step:10/1480 train_time:331ms step_avg:33.11ms
+step:11/1480 train_time:360ms step_avg:32.75ms
+step:12/1480 train_time:394ms step_avg:32.85ms
+step:13/1480 train_time:424ms step_avg:32.59ms
+step:14/1480 train_time:458ms step_avg:32.69ms
+step:15/1480 train_time:487ms step_avg:32.46ms
+step:16/1480 train_time:521ms step_avg:32.58ms
+step:17/1480 train_time:550ms step_avg:32.35ms
+step:18/1480 train_time:585ms step_avg:32.49ms
+step:19/1480 train_time:613ms step_avg:32.28ms
+step:20/1480 train_time:648ms step_avg:32.39ms
+step:21/1480 train_time:677ms step_avg:32.22ms
+step:22/1480 train_time:711ms step_avg:32.32ms
+step:23/1480 train_time:740ms step_avg:32.18ms
+step:24/1480 train_time:774ms step_avg:32.27ms
+step:25/1480 train_time:804ms step_avg:32.16ms
+step:26/1480 train_time:839ms step_avg:32.26ms
+step:27/1480 train_time:868ms step_avg:32.14ms
+step:28/1480 train_time:903ms step_avg:32.24ms
+step:29/1480 train_time:932ms step_avg:32.14ms
+step:30/1480 train_time:969ms step_avg:32.28ms
+step:31/1480 train_time:999ms step_avg:32.23ms
+step:32/1480 train_time:1035ms step_avg:32.34ms
+step:33/1480 train_time:1065ms step_avg:32.27ms
+step:34/1480 train_time:1099ms step_avg:32.34ms
+step:35/1480 train_time:1129ms step_avg:32.26ms
+step:36/1480 train_time:1165ms step_avg:32.36ms
+step:37/1480 train_time:1194ms step_avg:32.27ms
+step:38/1480 train_time:1231ms step_avg:32.38ms
+step:39/1480 train_time:1259ms step_avg:32.27ms
+step:40/1480 train_time:1294ms step_avg:32.34ms
+step:41/1480 train_time:1323ms step_avg:32.28ms
+step:42/1480 train_time:1358ms step_avg:32.34ms
+step:43/1480 train_time:1388ms step_avg:32.27ms
+step:44/1480 train_time:1422ms step_avg:32.32ms
+step:45/1480 train_time:1451ms step_avg:32.25ms
+step:46/1480 train_time:1487ms step_avg:32.32ms
+step:47/1480 train_time:1516ms step_avg:32.25ms
+step:48/1480 train_time:1551ms step_avg:32.31ms
+step:49/1480 train_time:1580ms step_avg:32.24ms
+step:50/1480 train_time:1615ms step_avg:32.29ms
+step:51/1480 train_time:1644ms step_avg:32.24ms
+step:52/1480 train_time:1679ms step_avg:32.28ms
+step:53/1480 train_time:1708ms step_avg:32.23ms
+step:54/1480 train_time:1743ms step_avg:32.28ms
+step:55/1480 train_time:1772ms step_avg:32.22ms
+step:56/1480 train_time:1808ms step_avg:32.29ms
+step:57/1480 train_time:1837ms step_avg:32.23ms
+step:58/1480 train_time:1872ms step_avg:32.28ms
+step:59/1480 train_time:1901ms step_avg:32.23ms
+step:60/1480 train_time:1936ms step_avg:32.27ms
+step:61/1480 train_time:1968ms step_avg:32.26ms
+step:62/1480 train_time:2004ms step_avg:32.32ms
+step:63/1480 train_time:2035ms step_avg:32.30ms
+step:64/1480 train_time:2072ms step_avg:32.38ms
+step:65/1480 train_time:2103ms step_avg:32.36ms
+step:66/1480 train_time:2139ms step_avg:32.42ms
+step:67/1480 train_time:2170ms step_avg:32.39ms
+step:68/1480 train_time:2208ms step_avg:32.47ms
+step:69/1480 train_time:2239ms step_avg:32.45ms
+step:70/1480 train_time:2275ms step_avg:32.50ms
+step:71/1480 train_time:2306ms step_avg:32.48ms
+step:72/1480 train_time:2342ms step_avg:32.53ms
+step:73/1480 train_time:2373ms step_avg:32.50ms
+step:74/1480 train_time:2409ms step_avg:32.56ms
+step:75/1480 train_time:2441ms step_avg:32.54ms
+step:76/1480 train_time:2477ms step_avg:32.59ms
+step:77/1480 train_time:2508ms step_avg:32.57ms
+step:78/1480 train_time:2544ms step_avg:32.62ms
+step:79/1480 train_time:2574ms step_avg:32.59ms
+step:80/1480 train_time:2611ms step_avg:32.63ms
+step:81/1480 train_time:2641ms step_avg:32.61ms
+step:82/1480 train_time:2677ms step_avg:32.64ms
+step:83/1480 train_time:2708ms step_avg:32.62ms
+step:84/1480 train_time:2744ms step_avg:32.67ms
+step:85/1480 train_time:2774ms step_avg:32.63ms
+step:86/1480 train_time:2810ms step_avg:32.68ms
+step:87/1480 train_time:2841ms step_avg:32.65ms
+step:88/1480 train_time:2876ms step_avg:32.68ms
+step:89/1480 train_time:2907ms step_avg:32.66ms
+step:90/1480 train_time:2943ms step_avg:32.70ms
+step:91/1480 train_time:2973ms step_avg:32.67ms
+step:92/1480 train_time:3009ms step_avg:32.71ms
+step:93/1480 train_time:3039ms step_avg:32.68ms
+step:94/1480 train_time:3075ms step_avg:32.71ms
+step:95/1480 train_time:3106ms step_avg:32.69ms
+step:96/1480 train_time:3141ms step_avg:32.72ms
+step:97/1480 train_time:3171ms step_avg:32.69ms
+step:98/1480 train_time:3206ms step_avg:32.72ms
+step:99/1480 train_time:3235ms step_avg:32.68ms
+step:100/1480 train_time:3270ms step_avg:32.70ms
+step:101/1480 train_time:3298ms step_avg:32.66ms
+step:102/1480 train_time:3335ms step_avg:32.69ms
+step:103/1480 train_time:3364ms step_avg:32.66ms
+step:104/1480 train_time:3400ms step_avg:32.69ms
+step:105/1480 train_time:3430ms step_avg:32.66ms
+step:106/1480 train_time:3467ms step_avg:32.71ms
+step:107/1480 train_time:3498ms step_avg:32.69ms
+step:108/1480 train_time:3534ms step_avg:32.72ms
+step:109/1480 train_time:3565ms step_avg:32.71ms
+step:110/1480 train_time:3600ms step_avg:32.73ms
+step:111/1480 train_time:3631ms step_avg:32.71ms
+step:112/1480 train_time:3668ms step_avg:32.75ms
+step:113/1480 train_time:3699ms step_avg:32.73ms
+step:114/1480 train_time:3734ms step_avg:32.76ms
+step:115/1480 train_time:3765ms step_avg:32.74ms
+step:116/1480 train_time:3801ms step_avg:32.77ms
+step:117/1480 train_time:3832ms step_avg:32.75ms
+step:118/1480 train_time:3869ms step_avg:32.79ms
+step:119/1480 train_time:3900ms step_avg:32.77ms
+step:120/1480 train_time:3935ms step_avg:32.80ms
+step:121/1480 train_time:3966ms step_avg:32.78ms
+step:122/1480 train_time:4003ms step_avg:32.81ms
+step:123/1480 train_time:4033ms step_avg:32.79ms
+step:124/1480 train_time:4070ms step_avg:32.82ms
+step:125/1480 train_time:4101ms step_avg:32.81ms
+step:126/1480 train_time:4137ms step_avg:32.83ms
+step:127/1480 train_time:4168ms step_avg:32.82ms
+step:128/1480 train_time:4204ms step_avg:32.85ms
+step:129/1480 train_time:4235ms step_avg:32.83ms
+step:130/1480 train_time:4271ms step_avg:32.86ms
+step:131/1480 train_time:4302ms step_avg:32.84ms
+step:132/1480 train_time:4337ms step_avg:32.86ms
+step:133/1480 train_time:4368ms step_avg:32.84ms
+step:134/1480 train_time:4404ms step_avg:32.87ms
+step:135/1480 train_time:4434ms step_avg:32.85ms
+step:136/1480 train_time:4470ms step_avg:32.87ms
+step:137/1480 train_time:4501ms step_avg:32.85ms
+step:138/1480 train_time:4536ms step_avg:32.87ms
+step:139/1480 train_time:4567ms step_avg:32.85ms
+step:140/1480 train_time:4603ms step_avg:32.88ms
+step:141/1480 train_time:4633ms step_avg:32.85ms
+step:142/1480 train_time:4669ms step_avg:32.88ms
+step:143/1480 train_time:4699ms step_avg:32.86ms
+step:144/1480 train_time:4734ms step_avg:32.88ms
+step:145/1480 train_time:4765ms step_avg:32.86ms
+step:146/1480 train_time:4800ms step_avg:32.88ms
+step:147/1480 train_time:4830ms step_avg:32.86ms
+step:148/1480 train_time:4867ms step_avg:32.89ms
+step:149/1480 train_time:4896ms step_avg:32.86ms
+step:150/1480 train_time:4932ms step_avg:32.88ms
+step:151/1480 train_time:4962ms step_avg:32.86ms
+step:152/1480 train_time:4998ms step_avg:32.88ms
+step:153/1480 train_time:5028ms step_avg:32.86ms
+step:154/1480 train_time:5065ms step_avg:32.89ms
+step:155/1480 train_time:5094ms step_avg:32.86ms
+step:156/1480 train_time:5130ms step_avg:32.88ms
+step:157/1480 train_time:5160ms step_avg:32.87ms
+step:158/1480 train_time:5195ms step_avg:32.88ms
+step:159/1480 train_time:5226ms step_avg:32.87ms
+step:160/1480 train_time:5262ms step_avg:32.89ms
+step:161/1480 train_time:5291ms step_avg:32.87ms
+step:162/1480 train_time:5327ms step_avg:32.89ms
+step:163/1480 train_time:5357ms step_avg:32.87ms
+step:164/1480 train_time:5392ms step_avg:32.88ms
+step:165/1480 train_time:5423ms step_avg:32.86ms
+step:166/1480 train_time:5457ms step_avg:32.88ms
+step:167/1480 train_time:5487ms step_avg:32.86ms
+step:168/1480 train_time:5523ms step_avg:32.88ms
+step:169/1480 train_time:5553ms step_avg:32.86ms
+step:170/1480 train_time:5589ms step_avg:32.87ms
+step:171/1480 train_time:5618ms step_avg:32.86ms
+step:172/1480 train_time:5653ms step_avg:32.87ms
+step:173/1480 train_time:5684ms step_avg:32.85ms
+step:174/1480 train_time:5719ms step_avg:32.87ms
+step:175/1480 train_time:5749ms step_avg:32.85ms
+step:176/1480 train_time:5784ms step_avg:32.87ms
+step:177/1480 train_time:5814ms step_avg:32.85ms
+step:178/1480 train_time:5852ms step_avg:32.88ms
+step:179/1480 train_time:5886ms step_avg:32.88ms
+step:180/1480 train_time:5925ms step_avg:32.92ms
+step:181/1480 train_time:5958ms step_avg:32.92ms
+step:182/1480 train_time:5996ms step_avg:32.95ms
+step:183/1480 train_time:6029ms step_avg:32.95ms
+step:184/1480 train_time:6065ms step_avg:32.96ms
+step:185/1480 train_time:6093ms step_avg:32.94ms
+step:186/1480 train_time:6128ms step_avg:32.94ms
+step:187/1480 train_time:6156ms step_avg:32.92ms
+step:188/1480 train_time:6191ms step_avg:32.93ms
+step:189/1480 train_time:6219ms step_avg:32.91ms
+step:190/1480 train_time:6257ms step_avg:32.93ms
+step:191/1480 train_time:6286ms step_avg:32.91ms
+step:192/1480 train_time:6322ms step_avg:32.93ms
+step:193/1480 train_time:6351ms step_avg:32.90ms
+step:194/1480 train_time:6386ms step_avg:32.92ms
+step:195/1480 train_time:6417ms step_avg:32.91ms
+step:196/1480 train_time:6453ms step_avg:32.93ms
+step:197/1480 train_time:6483ms step_avg:32.91ms
+step:198/1480 train_time:6518ms step_avg:32.92ms
+step:199/1480 train_time:6547ms step_avg:32.90ms
+step:200/1480 train_time:6585ms step_avg:32.92ms
+step:201/1480 train_time:6615ms step_avg:32.91ms
+step:202/1480 train_time:6651ms step_avg:32.92ms
+step:203/1480 train_time:6680ms step_avg:32.91ms
+step:204/1480 train_time:6716ms step_avg:32.92ms
+step:205/1480 train_time:6746ms step_avg:32.91ms
+step:206/1480 train_time:6781ms step_avg:32.92ms
+step:207/1480 train_time:6811ms step_avg:32.90ms
+step:208/1480 train_time:6846ms step_avg:32.92ms
+step:209/1480 train_time:6876ms step_avg:32.90ms
+step:210/1480 train_time:6912ms step_avg:32.92ms
+step:211/1480 train_time:6943ms step_avg:32.90ms
+step:212/1480 train_time:6977ms step_avg:32.91ms
+step:213/1480 train_time:7008ms step_avg:32.90ms
+step:214/1480 train_time:7043ms step_avg:32.91ms
+step:215/1480 train_time:7073ms step_avg:32.90ms
+step:216/1480 train_time:7109ms step_avg:32.91ms
+step:217/1480 train_time:7139ms step_avg:32.90ms
+step:218/1480 train_time:7175ms step_avg:32.91ms
+step:219/1480 train_time:7206ms step_avg:32.90ms
+step:220/1480 train_time:7241ms step_avg:32.91ms
+step:221/1480 train_time:7271ms step_avg:32.90ms
+step:222/1480 train_time:7307ms step_avg:32.92ms
+step:223/1480 train_time:7338ms step_avg:32.90ms
+step:224/1480 train_time:7374ms step_avg:32.92ms
+step:225/1480 train_time:7404ms step_avg:32.91ms
+step:226/1480 train_time:7439ms step_avg:32.92ms
+step:227/1480 train_time:7470ms step_avg:32.91ms
+step:228/1480 train_time:7506ms step_avg:32.92ms
+step:229/1480 train_time:7536ms step_avg:32.91ms
+step:230/1480 train_time:7572ms step_avg:32.92ms
+step:231/1480 train_time:7602ms step_avg:32.91ms
+step:232/1480 train_time:7637ms step_avg:32.92ms
+step:233/1480 train_time:7667ms step_avg:32.91ms
+step:234/1480 train_time:7703ms step_avg:32.92ms
+step:235/1480 train_time:7734ms step_avg:32.91ms
+step:236/1480 train_time:7770ms step_avg:32.92ms
+step:237/1480 train_time:7800ms step_avg:32.91ms
+step:238/1480 train_time:7835ms step_avg:32.92ms
+step:239/1480 train_time:7866ms step_avg:32.91ms
+step:240/1480 train_time:7901ms step_avg:32.92ms
+step:241/1480 train_time:7931ms step_avg:32.91ms
+step:242/1480 train_time:7968ms step_avg:32.92ms
+step:243/1480 train_time:7998ms step_avg:32.91ms
+step:244/1480 train_time:8033ms step_avg:32.92ms
+step:245/1480 train_time:8063ms step_avg:32.91ms
+step:246/1480 train_time:8099ms step_avg:32.92ms
+step:247/1480 train_time:8131ms step_avg:32.92ms
+step:248/1480 train_time:8169ms step_avg:32.94ms
+step:249/1480 train_time:8201ms step_avg:32.93ms
+step:250/1480 train_time:8237ms step_avg:32.95ms
+step:250/1480 val_loss:4.5022 train_time:8285ms step_avg:33.14ms
+step:251/1480 train_time:8304ms step_avg:33.08ms
+step:252/1480 train_time:8325ms step_avg:33.04ms
+step:253/1480 train_time:8342ms step_avg:32.97ms
+step:254/1480 train_time:8383ms step_avg:33.01ms
+step:255/1480 train_time:8415ms step_avg:33.00ms
+step:256/1480 train_time:8453ms step_avg:33.02ms
+step:257/1480 train_time:8484ms step_avg:33.01ms
+step:258/1480 train_time:8521ms step_avg:33.03ms
+step:259/1480 train_time:8552ms step_avg:33.02ms
+step:260/1480 train_time:8588ms step_avg:33.03ms
+step:261/1480 train_time:8619ms step_avg:33.02ms
+step:262/1480 train_time:8655ms step_avg:33.03ms
+step:263/1480 train_time:8685ms step_avg:33.02ms
+step:264/1480 train_time:8720ms step_avg:33.03ms
+step:265/1480 train_time:8750ms step_avg:33.02ms
+step:266/1480 train_time:8787ms step_avg:33.03ms
+step:267/1480 train_time:8816ms step_avg:33.02ms
+step:268/1480 train_time:8852ms step_avg:33.03ms
+step:269/1480 train_time:8882ms step_avg:33.02ms
+step:270/1480 train_time:8917ms step_avg:33.03ms
+step:271/1480 train_time:8947ms step_avg:33.02ms
+step:272/1480 train_time:8984ms step_avg:33.03ms
+step:273/1480 train_time:9014ms step_avg:33.02ms
+step:274/1480 train_time:9051ms step_avg:33.03ms
+step:275/1480 train_time:9081ms step_avg:33.02ms
+step:276/1480 train_time:9116ms step_avg:33.03ms
+step:277/1480 train_time:9147ms step_avg:33.02ms
+step:278/1480 train_time:9182ms step_avg:33.03ms
+step:279/1480 train_time:9212ms step_avg:33.02ms
+step:280/1480 train_time:9248ms step_avg:33.03ms
+step:281/1480 train_time:9277ms step_avg:33.01ms
+step:282/1480 train_time:9312ms step_avg:33.02ms
+step:283/1480 train_time:9343ms step_avg:33.01ms
+step:284/1480 train_time:9379ms step_avg:33.02ms
+step:285/1480 train_time:9410ms step_avg:33.02ms
+step:286/1480 train_time:9448ms step_avg:33.04ms
+step:287/1480 train_time:9480ms step_avg:33.03ms
+step:288/1480 train_time:9516ms step_avg:33.04ms
+step:289/1480 train_time:9549ms step_avg:33.04ms
+step:290/1480 train_time:9587ms step_avg:33.06ms
+step:291/1480 train_time:9618ms step_avg:33.05ms
+step:292/1480 train_time:9655ms step_avg:33.06ms
+step:293/1480 train_time:9687ms step_avg:33.06ms
+step:294/1480 train_time:9725ms step_avg:33.08ms
+step:295/1480 train_time:9756ms step_avg:33.07ms
+step:296/1480 train_time:9793ms step_avg:33.08ms
+step:297/1480 train_time:9825ms step_avg:33.08ms
+step:298/1480 train_time:9861ms step_avg:33.09ms
+step:299/1480 train_time:9892ms step_avg:33.08ms
+step:300/1480 train_time:9930ms step_avg:33.10ms
+step:301/1480 train_time:9961ms step_avg:33.09ms
+step:302/1480 train_time:9997ms step_avg:33.10ms
+step:303/1480 train_time:10028ms step_avg:33.10ms
+step:304/1480 train_time:10065ms step_avg:33.11ms
+step:305/1480 train_time:10096ms step_avg:33.10ms
+step:306/1480 train_time:10133ms step_avg:33.11ms
+step:307/1480 train_time:10163ms step_avg:33.10ms
+step:308/1480 train_time:10199ms step_avg:33.11ms
+step:309/1480 train_time:10230ms step_avg:33.11ms
+step:310/1480 train_time:10267ms step_avg:33.12ms
+step:311/1480 train_time:10297ms step_avg:33.11ms
+step:312/1480 train_time:10334ms step_avg:33.12ms
+step:313/1480 train_time:10365ms step_avg:33.11ms
+step:314/1480 train_time:10401ms step_avg:33.12ms
+step:315/1480 train_time:10431ms step_avg:33.12ms
+step:316/1480 train_time:10468ms step_avg:33.13ms
+step:317/1480 train_time:10499ms step_avg:33.12ms
+step:318/1480 train_time:10535ms step_avg:33.13ms
+step:319/1480 train_time:10566ms step_avg:33.12ms
+step:320/1480 train_time:10602ms step_avg:33.13ms
+step:321/1480 train_time:10633ms step_avg:33.12ms
+step:322/1480 train_time:10669ms step_avg:33.13ms
+step:323/1480 train_time:10700ms step_avg:33.13ms
+step:324/1480 train_time:10736ms step_avg:33.13ms
+step:325/1480 train_time:10766ms step_avg:33.13ms
+step:326/1480 train_time:10803ms step_avg:33.14ms
+step:327/1480 train_time:10833ms step_avg:33.13ms
+step:328/1480 train_time:10870ms step_avg:33.14ms
+step:329/1480 train_time:10900ms step_avg:33.13ms
+step:330/1480 train_time:10936ms step_avg:33.14ms
+step:331/1480 train_time:10967ms step_avg:33.13ms
+step:332/1480 train_time:11003ms step_avg:33.14ms
+step:333/1480 train_time:11033ms step_avg:33.13ms
+step:334/1480 train_time:11069ms step_avg:33.14ms
+step:335/1480 train_time:11100ms step_avg:33.13ms
+step:336/1480 train_time:11136ms step_avg:33.14ms
+step:337/1480 train_time:11167ms step_avg:33.14ms
+step:338/1480 train_time:11203ms step_avg:33.14ms
+step:339/1480 train_time:11233ms step_avg:33.14ms
+step:340/1480 train_time:11269ms step_avg:33.14ms
+step:341/1480 train_time:11300ms step_avg:33.14ms
+step:342/1480 train_time:11335ms step_avg:33.14ms
+step:343/1480 train_time:11366ms step_avg:33.14ms
+step:344/1480 train_time:11403ms step_avg:33.15ms
+step:345/1480 train_time:11433ms step_avg:33.14ms
+step:346/1480 train_time:11468ms step_avg:33.15ms
+step:347/1480 train_time:11499ms step_avg:33.14ms
+step:348/1480 train_time:11535ms step_avg:33.15ms
+step:349/1480 train_time:11566ms step_avg:33.14ms
+step:350/1480 train_time:11602ms step_avg:33.15ms
+step:351/1480 train_time:11632ms step_avg:33.14ms
+step:352/1480 train_time:11668ms step_avg:33.15ms
+step:353/1480 train_time:11698ms step_avg:33.14ms
+step:354/1480 train_time:11734ms step_avg:33.15ms
+step:355/1480 train_time:11765ms step_avg:33.14ms
+step:356/1480 train_time:11800ms step_avg:33.15ms
+step:357/1480 train_time:11831ms step_avg:33.14ms
+step:358/1480 train_time:11867ms step_avg:33.15ms
+step:359/1480 train_time:11897ms step_avg:33.14ms
+step:360/1480 train_time:11933ms step_avg:33.15ms
+step:361/1480 train_time:11964ms step_avg:33.14ms
+step:362/1480 train_time:12000ms step_avg:33.15ms
+step:363/1480 train_time:12030ms step_avg:33.14ms
+step:364/1480 train_time:12066ms step_avg:33.15ms
+step:365/1480 train_time:12096ms step_avg:33.14ms
+step:366/1480 train_time:12132ms step_avg:33.15ms
+step:367/1480 train_time:12162ms step_avg:33.14ms
+step:368/1480 train_time:12201ms step_avg:33.16ms
+step:369/1480 train_time:12228ms step_avg:33.14ms
+step:370/1480 train_time:12265ms step_avg:33.15ms
+step:371/1480 train_time:12294ms step_avg:33.14ms
+step:372/1480 train_time:12330ms step_avg:33.15ms
+step:373/1480 train_time:12361ms step_avg:33.14ms
+step:374/1480 train_time:12396ms step_avg:33.15ms
+step:375/1480 train_time:12427ms step_avg:33.14ms
+step:376/1480 train_time:12462ms step_avg:33.14ms
+step:377/1480 train_time:12492ms step_avg:33.14ms
+step:378/1480 train_time:12528ms step_avg:33.14ms
+step:379/1480 train_time:12559ms step_avg:33.14ms
+step:380/1480 train_time:12594ms step_avg:33.14ms
+step:381/1480 train_time:12625ms step_avg:33.14ms
+step:382/1480 train_time:12660ms step_avg:33.14ms
+step:383/1480 train_time:12691ms step_avg:33.13ms
+step:384/1480 train_time:12727ms step_avg:33.14ms
+step:385/1480 train_time:12757ms step_avg:33.14ms
+step:386/1480 train_time:12793ms step_avg:33.14ms
+step:387/1480 train_time:12824ms step_avg:33.14ms
+step:388/1480 train_time:12859ms step_avg:33.14ms
+step:389/1480 train_time:12890ms step_avg:33.14ms
+step:390/1480 train_time:12926ms step_avg:33.14ms
+step:391/1480 train_time:12957ms step_avg:33.14ms
+step:392/1480 train_time:12992ms step_avg:33.14ms
+step:393/1480 train_time:13023ms step_avg:33.14ms
+step:394/1480 train_time:13058ms step_avg:33.14ms
+step:395/1480 train_time:13088ms step_avg:33.13ms
+step:396/1480 train_time:13125ms step_avg:33.14ms
+step:397/1480 train_time:13155ms step_avg:33.14ms
+step:398/1480 train_time:13191ms step_avg:33.14ms
+step:399/1480 train_time:13222ms step_avg:33.14ms
+step:400/1480 train_time:13257ms step_avg:33.14ms
+step:401/1480 train_time:13288ms step_avg:33.14ms
+step:402/1480 train_time:13324ms step_avg:33.14ms
+step:403/1480 train_time:13354ms step_avg:33.14ms
+step:404/1480 train_time:13390ms step_avg:33.14ms
+step:405/1480 train_time:13420ms step_avg:33.14ms
+step:406/1480 train_time:13456ms step_avg:33.14ms
+step:407/1480 train_time:13487ms step_avg:33.14ms
+step:408/1480 train_time:13526ms step_avg:33.15ms
+step:409/1480 train_time:13557ms step_avg:33.15ms
+step:410/1480 train_time:13594ms step_avg:33.16ms
+step:411/1480 train_time:13626ms step_avg:33.15ms
+step:412/1480 train_time:13664ms step_avg:33.16ms
+step:413/1480 train_time:13694ms step_avg:33.16ms
+step:414/1480 train_time:13732ms step_avg:33.17ms
+step:415/1480 train_time:13763ms step_avg:33.16ms
+step:416/1480 train_time:13799ms step_avg:33.17ms
+step:417/1480 train_time:13830ms step_avg:33.17ms
+step:418/1480 train_time:13867ms step_avg:33.17ms
+step:419/1480 train_time:13898ms step_avg:33.17ms
+step:420/1480 train_time:13935ms step_avg:33.18ms
+step:421/1480 train_time:13966ms step_avg:33.17ms
+step:422/1480 train_time:14004ms step_avg:33.18ms
+step:423/1480 train_time:14034ms step_avg:33.18ms
+step:424/1480 train_time:14071ms step_avg:33.19ms
+step:425/1480 train_time:14102ms step_avg:33.18ms
+step:426/1480 train_time:14138ms step_avg:33.19ms
+step:427/1480 train_time:14169ms step_avg:33.18ms
+step:428/1480 train_time:14206ms step_avg:33.19ms
+step:429/1480 train_time:14237ms step_avg:33.19ms
+step:430/1480 train_time:14273ms step_avg:33.19ms
+step:431/1480 train_time:14304ms step_avg:33.19ms
+step:432/1480 train_time:14340ms step_avg:33.19ms
+step:433/1480 train_time:14370ms step_avg:33.19ms
+step:434/1480 train_time:14407ms step_avg:33.20ms
+step:435/1480 train_time:14438ms step_avg:33.19ms
+step:436/1480 train_time:14474ms step_avg:33.20ms
+step:437/1480 train_time:14505ms step_avg:33.19ms
+step:438/1480 train_time:14541ms step_avg:33.20ms
+step:439/1480 train_time:14572ms step_avg:33.19ms
+step:440/1480 train_time:14608ms step_avg:33.20ms
+step:441/1480 train_time:14638ms step_avg:33.19ms
+step:442/1480 train_time:14674ms step_avg:33.20ms
+step:443/1480 train_time:14706ms step_avg:33.20ms
+step:444/1480 train_time:14742ms step_avg:33.20ms
+step:445/1480 train_time:14772ms step_avg:33.20ms
+step:446/1480 train_time:14809ms step_avg:33.20ms
+step:447/1480 train_time:14839ms step_avg:33.20ms
+step:448/1480 train_time:14874ms step_avg:33.20ms
+step:449/1480 train_time:14905ms step_avg:33.20ms
+step:450/1480 train_time:14941ms step_avg:33.20ms
+step:451/1480 train_time:14972ms step_avg:33.20ms
+step:452/1480 train_time:15009ms step_avg:33.20ms
+step:453/1480 train_time:15038ms step_avg:33.20ms
+step:454/1480 train_time:15075ms step_avg:33.20ms
+step:455/1480 train_time:15105ms step_avg:33.20ms
+step:456/1480 train_time:15141ms step_avg:33.20ms
+step:457/1480 train_time:15171ms step_avg:33.20ms
+step:458/1480 train_time:15209ms step_avg:33.21ms
+step:459/1480 train_time:15238ms step_avg:33.20ms
+step:460/1480 train_time:15274ms step_avg:33.21ms
+step:461/1480 train_time:15305ms step_avg:33.20ms
+step:462/1480 train_time:15341ms step_avg:33.21ms
+step:463/1480 train_time:15372ms step_avg:33.20ms
+step:464/1480 train_time:15408ms step_avg:33.21ms
+step:465/1480 train_time:15439ms step_avg:33.20ms
+step:466/1480 train_time:15475ms step_avg:33.21ms
+step:467/1480 train_time:15506ms step_avg:33.20ms
+step:468/1480 train_time:15542ms step_avg:33.21ms
+step:469/1480 train_time:15572ms step_avg:33.20ms
+step:470/1480 train_time:15609ms step_avg:33.21ms
+step:471/1480 train_time:15639ms step_avg:33.20ms
+step:472/1480 train_time:15674ms step_avg:33.21ms
+step:473/1480 train_time:15705ms step_avg:33.20ms
+step:474/1480 train_time:15742ms step_avg:33.21ms
+step:475/1480 train_time:15771ms step_avg:33.20ms
+step:476/1480 train_time:15808ms step_avg:33.21ms
+step:477/1480 train_time:15838ms step_avg:33.20ms
+step:478/1480 train_time:15873ms step_avg:33.21ms
+step:479/1480 train_time:15904ms step_avg:33.20ms
+step:480/1480 train_time:15940ms step_avg:33.21ms
+step:481/1480 train_time:15972ms step_avg:33.21ms
+step:482/1480 train_time:16034ms step_avg:33.27ms
+step:483/1480 train_time:16091ms step_avg:33.32ms
+step:484/1480 train_time:16155ms step_avg:33.38ms
+step:485/1480 train_time:16215ms step_avg:33.43ms
+step:486/1480 train_time:16278ms step_avg:33.49ms
+step:487/1480 train_time:16337ms step_avg:33.55ms
+step:488/1480 train_time:16403ms step_avg:33.61ms
+step:489/1480 train_time:16460ms step_avg:33.66ms
+step:490/1480 train_time:16523ms step_avg:33.72ms
+step:491/1480 train_time:16580ms step_avg:33.77ms
+step:492/1480 train_time:16643ms step_avg:33.83ms
+step:493/1480 train_time:16701ms step_avg:33.88ms
+step:494/1480 train_time:16766ms step_avg:33.94ms
+step:495/1480 train_time:16825ms step_avg:33.99ms
+step:496/1480 train_time:16889ms step_avg:34.05ms
+step:497/1480 train_time:16948ms step_avg:34.10ms
+step:498/1480 train_time:17013ms step_avg:34.16ms
+step:499/1480 train_time:17072ms step_avg:34.21ms
+step:500/1480 train_time:17137ms step_avg:34.27ms
+step:500/1480 val_loss:4.2048 train_time:17217ms step_avg:34.43ms
+step:501/1480 train_time:17236ms step_avg:34.40ms
+step:502/1480 train_time:17262ms step_avg:34.39ms
+step:503/1480 train_time:17321ms step_avg:34.44ms
+step:504/1480 train_time:17382ms step_avg:34.49ms
+step:505/1480 train_time:17439ms step_avg:34.53ms
+step:506/1480 train_time:17503ms step_avg:34.59ms
+step:507/1480 train_time:17560ms step_avg:34.64ms
+step:508/1480 train_time:17624ms step_avg:34.69ms
+step:509/1480 train_time:17683ms step_avg:34.74ms
+step:510/1480 train_time:17748ms step_avg:34.80ms
+step:511/1480 train_time:17808ms step_avg:34.85ms
+step:512/1480 train_time:17875ms step_avg:34.91ms
+step:513/1480 train_time:17933ms step_avg:34.96ms
+step:514/1480 train_time:17998ms step_avg:35.02ms
+step:515/1480 train_time:18058ms step_avg:35.06ms
+step:516/1480 train_time:18123ms step_avg:35.12ms
+step:517/1480 train_time:18180ms step_avg:35.16ms
+step:518/1480 train_time:18246ms step_avg:35.22ms
+step:519/1480 train_time:18306ms step_avg:35.27ms
+step:520/1480 train_time:18370ms step_avg:35.33ms
+step:521/1480 train_time:18428ms step_avg:35.37ms
+step:522/1480 train_time:18491ms step_avg:35.42ms
+step:523/1480 train_time:18549ms step_avg:35.47ms
+step:524/1480 train_time:18615ms step_avg:35.52ms
+step:525/1480 train_time:18673ms step_avg:35.57ms
+step:526/1480 train_time:18738ms step_avg:35.62ms
+step:527/1480 train_time:18797ms step_avg:35.67ms
+step:528/1480 train_time:18862ms step_avg:35.72ms
+step:529/1480 train_time:18921ms step_avg:35.77ms
+step:530/1480 train_time:18984ms step_avg:35.82ms
+step:531/1480 train_time:19042ms step_avg:35.86ms
+step:532/1480 train_time:19106ms step_avg:35.91ms
+step:533/1480 train_time:19167ms step_avg:35.96ms
+step:534/1480 train_time:19231ms step_avg:36.01ms
+step:535/1480 train_time:19289ms step_avg:36.05ms
+step:536/1480 train_time:19353ms step_avg:36.11ms
+step:537/1480 train_time:19411ms step_avg:36.15ms
+step:538/1480 train_time:19474ms step_avg:36.20ms
+step:539/1480 train_time:19532ms step_avg:36.24ms
+step:540/1480 train_time:19595ms step_avg:36.29ms
+step:541/1480 train_time:19652ms step_avg:36.33ms
+step:542/1480 train_time:19715ms step_avg:36.37ms
+step:543/1480 train_time:19773ms step_avg:36.41ms
+step:544/1480 train_time:19836ms step_avg:36.46ms
+step:545/1480 train_time:19894ms step_avg:36.50ms
+step:546/1480 train_time:19957ms step_avg:36.55ms
+step:547/1480 train_time:20016ms step_avg:36.59ms
+step:548/1480 train_time:20080ms step_avg:36.64ms
+step:549/1480 train_time:20138ms step_avg:36.68ms
+step:550/1480 train_time:20204ms step_avg:36.73ms
+step:551/1480 train_time:20265ms step_avg:36.78ms
+step:552/1480 train_time:20331ms step_avg:36.83ms
+step:553/1480 train_time:20390ms step_avg:36.87ms
+step:554/1480 train_time:20456ms step_avg:36.92ms
+step:555/1480 train_time:20516ms step_avg:36.97ms
+step:556/1480 train_time:20581ms step_avg:37.02ms
+step:557/1480 train_time:20641ms step_avg:37.06ms
+step:558/1480 train_time:20707ms step_avg:37.11ms
+step:559/1480 train_time:20767ms step_avg:37.15ms
+step:560/1480 train_time:20833ms step_avg:37.20ms
+step:561/1480 train_time:20892ms step_avg:37.24ms
+step:562/1480 train_time:20958ms step_avg:37.29ms
+step:563/1480 train_time:21017ms step_avg:37.33ms
+step:564/1480 train_time:21082ms step_avg:37.38ms
+step:565/1480 train_time:21142ms step_avg:37.42ms
+step:566/1480 train_time:21207ms step_avg:37.47ms
+step:567/1480 train_time:21267ms step_avg:37.51ms
+step:568/1480 train_time:21333ms step_avg:37.56ms
+step:569/1480 train_time:21391ms step_avg:37.59ms
+step:570/1480 train_time:21455ms step_avg:37.64ms
+step:571/1480 train_time:21514ms step_avg:37.68ms
+step:572/1480 train_time:21578ms step_avg:37.72ms
+step:573/1480 train_time:21636ms step_avg:37.76ms
+step:574/1480 train_time:21700ms step_avg:37.81ms
+step:575/1480 train_time:21761ms step_avg:37.84ms
+step:576/1480 train_time:21826ms step_avg:37.89ms
+step:577/1480 train_time:21884ms step_avg:37.93ms
+step:578/1480 train_time:21949ms step_avg:37.97ms
+step:579/1480 train_time:22010ms step_avg:38.01ms
+step:580/1480 train_time:22074ms step_avg:38.06ms
+step:581/1480 train_time:22132ms step_avg:38.09ms
+step:582/1480 train_time:22196ms step_avg:38.14ms
+step:583/1480 train_time:22254ms step_avg:38.17ms
+step:584/1480 train_time:22318ms step_avg:38.22ms
+step:585/1480 train_time:22378ms step_avg:38.25ms
+step:586/1480 train_time:22443ms step_avg:38.30ms
+step:587/1480 train_time:22502ms step_avg:38.33ms
+step:588/1480 train_time:22567ms step_avg:38.38ms
+step:589/1480 train_time:22625ms step_avg:38.41ms
+step:590/1480 train_time:22690ms step_avg:38.46ms
+step:591/1480 train_time:22750ms step_avg:38.49ms
+step:592/1480 train_time:22815ms step_avg:38.54ms
+step:593/1480 train_time:22872ms step_avg:38.57ms
+step:594/1480 train_time:22935ms step_avg:38.61ms
+step:595/1480 train_time:22993ms step_avg:38.64ms
+step:596/1480 train_time:23056ms step_avg:38.69ms
+step:597/1480 train_time:23114ms step_avg:38.72ms
+step:598/1480 train_time:23177ms step_avg:38.76ms
+step:599/1480 train_time:23233ms step_avg:38.79ms
+step:600/1480 train_time:23296ms step_avg:38.83ms
+step:601/1480 train_time:23353ms step_avg:38.86ms
+step:602/1480 train_time:23416ms step_avg:38.90ms
+step:603/1480 train_time:23472ms step_avg:38.93ms
+step:604/1480 train_time:23534ms step_avg:38.96ms
+step:605/1480 train_time:23593ms step_avg:39.00ms
+step:606/1480 train_time:23658ms step_avg:39.04ms
+step:607/1480 train_time:23716ms step_avg:39.07ms
+step:608/1480 train_time:23779ms step_avg:39.11ms
+step:609/1480 train_time:23837ms step_avg:39.14ms
+step:610/1480 train_time:23901ms step_avg:39.18ms
+step:611/1480 train_time:23959ms step_avg:39.21ms
+step:612/1480 train_time:24024ms step_avg:39.25ms
+step:613/1480 train_time:24083ms step_avg:39.29ms
+step:614/1480 train_time:24148ms step_avg:39.33ms
+step:615/1480 train_time:24208ms step_avg:39.36ms
+step:616/1480 train_time:24275ms step_avg:39.41ms
+step:617/1480 train_time:24333ms step_avg:39.44ms
+step:618/1480 train_time:24398ms step_avg:39.48ms
+step:619/1480 train_time:24458ms step_avg:39.51ms
+step:620/1480 train_time:24522ms step_avg:39.55ms
+step:621/1480 train_time:24580ms step_avg:39.58ms
+step:622/1480 train_time:24644ms step_avg:39.62ms
+step:623/1480 train_time:24703ms step_avg:39.65ms
+step:624/1480 train_time:24772ms step_avg:39.70ms
+step:625/1480 train_time:24831ms step_avg:39.73ms
+step:626/1480 train_time:24898ms step_avg:39.77ms
+step:627/1480 train_time:24957ms step_avg:39.80ms
+step:628/1480 train_time:25021ms step_avg:39.84ms
+step:629/1480 train_time:25079ms step_avg:39.87ms
+step:630/1480 train_time:25144ms step_avg:39.91ms
+step:631/1480 train_time:25203ms step_avg:39.94ms
+step:632/1480 train_time:25268ms step_avg:39.98ms
+step:633/1480 train_time:25326ms step_avg:40.01ms
+step:634/1480 train_time:25391ms step_avg:40.05ms
+step:635/1480 train_time:25449ms step_avg:40.08ms
+step:636/1480 train_time:25514ms step_avg:40.12ms
+step:637/1480 train_time:25572ms step_avg:40.14ms
+step:638/1480 train_time:25636ms step_avg:40.18ms
+step:639/1480 train_time:25694ms step_avg:40.21ms
+step:640/1480 train_time:25758ms step_avg:40.25ms
+step:641/1480 train_time:25816ms step_avg:40.28ms
+step:642/1480 train_time:25880ms step_avg:40.31ms
+step:643/1480 train_time:25938ms step_avg:40.34ms
+step:644/1480 train_time:26002ms step_avg:40.38ms
+step:645/1480 train_time:26060ms step_avg:40.40ms
+step:646/1480 train_time:26124ms step_avg:40.44ms
+step:647/1480 train_time:26183ms step_avg:40.47ms
+step:648/1480 train_time:26248ms step_avg:40.51ms
+step:649/1480 train_time:26309ms step_avg:40.54ms
+step:650/1480 train_time:26374ms step_avg:40.57ms
+step:651/1480 train_time:26432ms step_avg:40.60ms
+step:652/1480 train_time:26495ms step_avg:40.64ms
+step:653/1480 train_time:26553ms step_avg:40.66ms
+step:654/1480 train_time:26617ms step_avg:40.70ms
+step:655/1480 train_time:26674ms step_avg:40.72ms
+step:656/1480 train_time:26738ms step_avg:40.76ms
+step:657/1480 train_time:26794ms step_avg:40.78ms
+step:658/1480 train_time:26858ms step_avg:40.82ms
+step:659/1480 train_time:26914ms step_avg:40.84ms
+step:660/1480 train_time:26978ms step_avg:40.88ms
+step:661/1480 train_time:27034ms step_avg:40.90ms
+step:662/1480 train_time:27098ms step_avg:40.93ms
+step:663/1480 train_time:27156ms step_avg:40.96ms
+step:664/1480 train_time:27220ms step_avg:40.99ms
+step:665/1480 train_time:27277ms step_avg:41.02ms
+step:666/1480 train_time:27340ms step_avg:41.05ms
+step:667/1480 train_time:27398ms step_avg:41.08ms
+step:668/1480 train_time:27464ms step_avg:41.11ms
+step:669/1480 train_time:27523ms step_avg:41.14ms
+step:670/1480 train_time:27587ms step_avg:41.17ms
+step:671/1480 train_time:27646ms step_avg:41.20ms
+step:672/1480 train_time:27711ms step_avg:41.24ms
+step:673/1480 train_time:27769ms step_avg:41.26ms
+step:674/1480 train_time:27834ms step_avg:41.30ms
+step:675/1480 train_time:27893ms step_avg:41.32ms
+step:676/1480 train_time:27958ms step_avg:41.36ms
+step:677/1480 train_time:28016ms step_avg:41.38ms
+step:678/1480 train_time:28079ms step_avg:41.41ms
+step:679/1480 train_time:28137ms step_avg:41.44ms
+step:680/1480 train_time:28201ms step_avg:41.47ms
+step:681/1480 train_time:28260ms step_avg:41.50ms
+step:682/1480 train_time:28324ms step_avg:41.53ms
+step:683/1480 train_time:28383ms step_avg:41.56ms
+step:684/1480 train_time:28448ms step_avg:41.59ms
+step:685/1480 train_time:28509ms step_avg:41.62ms
+step:686/1480 train_time:28573ms step_avg:41.65ms
+step:687/1480 train_time:28630ms step_avg:41.67ms
+step:688/1480 train_time:28695ms step_avg:41.71ms
+step:689/1480 train_time:28753ms step_avg:41.73ms
+step:690/1480 train_time:28817ms step_avg:41.76ms
+step:691/1480 train_time:28874ms step_avg:41.79ms
+step:692/1480 train_time:28937ms step_avg:41.82ms
+step:693/1480 train_time:28995ms step_avg:41.84ms
+step:694/1480 train_time:29059ms step_avg:41.87ms
+step:695/1480 train_time:29116ms step_avg:41.89ms
+step:696/1480 train_time:29179ms step_avg:41.92ms
+step:697/1480 train_time:29236ms step_avg:41.94ms
+step:698/1480 train_time:29300ms step_avg:41.98ms
+step:699/1480 train_time:29360ms step_avg:42.00ms
+step:700/1480 train_time:29425ms step_avg:42.04ms
+step:701/1480 train_time:29485ms step_avg:42.06ms
+step:702/1480 train_time:29554ms step_avg:42.10ms
+step:703/1480 train_time:29617ms step_avg:42.13ms
+step:704/1480 train_time:29688ms step_avg:42.17ms
+step:705/1480 train_time:29751ms step_avg:42.20ms
+step:706/1480 train_time:29819ms step_avg:42.24ms
+step:707/1480 train_time:29882ms step_avg:42.27ms
+step:708/1480 train_time:29942ms step_avg:42.29ms
+step:709/1480 train_time:29996ms step_avg:42.31ms
+step:710/1480 train_time:30056ms step_avg:42.33ms
+step:711/1480 train_time:30114ms step_avg:42.35ms
+step:712/1480 train_time:30182ms step_avg:42.39ms
+step:713/1480 train_time:30242ms step_avg:42.42ms
+step:714/1480 train_time:30309ms step_avg:42.45ms
+step:715/1480 train_time:30370ms step_avg:42.47ms
+step:716/1480 train_time:30435ms step_avg:42.51ms
+step:717/1480 train_time:30494ms step_avg:42.53ms
+step:718/1480 train_time:30561ms step_avg:42.56ms
+step:719/1480 train_time:30621ms step_avg:42.59ms
+step:720/1480 train_time:30687ms step_avg:42.62ms
+step:721/1480 train_time:30743ms step_avg:42.64ms
+step:722/1480 train_time:30803ms step_avg:42.66ms
+step:723/1480 train_time:30858ms step_avg:42.68ms
+step:724/1480 train_time:30921ms step_avg:42.71ms
+step:725/1480 train_time:30976ms step_avg:42.73ms
+step:726/1480 train_time:31040ms step_avg:42.76ms
+step:727/1480 train_time:31099ms step_avg:42.78ms
+step:728/1480 train_time:31164ms step_avg:42.81ms
+step:729/1480 train_time:31220ms step_avg:42.83ms
+step:730/1480 train_time:31283ms step_avg:42.85ms
+step:731/1480 train_time:31341ms step_avg:42.87ms
+step:732/1480 train_time:31408ms step_avg:42.91ms
+step:733/1480 train_time:31470ms step_avg:42.93ms
+step:734/1480 train_time:31535ms step_avg:42.96ms
+step:735/1480 train_time:31593ms step_avg:42.98ms
+step:736/1480 train_time:31658ms step_avg:43.01ms
+step:737/1480 train_time:31717ms step_avg:43.03ms
+step:738/1480 train_time:31779ms step_avg:43.06ms
+step:739/1480 train_time:31837ms step_avg:43.08ms
+step:740/1480 train_time:31901ms step_avg:43.11ms
+step:741/1480 train_time:31957ms step_avg:43.13ms
+step:742/1480 train_time:32021ms step_avg:43.15ms
+step:743/1480 train_time:32078ms step_avg:43.17ms
+step:744/1480 train_time:32142ms step_avg:43.20ms
+step:745/1480 train_time:32199ms step_avg:43.22ms
+step:746/1480 train_time:32264ms step_avg:43.25ms
+step:747/1480 train_time:32321ms step_avg:43.27ms
+step:748/1480 train_time:32385ms step_avg:43.30ms
+step:749/1480 train_time:32444ms step_avg:43.32ms
+step:750/1480 train_time:32510ms step_avg:43.35ms
+step:750/1480 val_loss:3.8034 train_time:32587ms step_avg:43.45ms
+step:751/1480 train_time:32606ms step_avg:43.42ms
+step:752/1480 train_time:32633ms step_avg:43.39ms
+step:753/1480 train_time:32692ms step_avg:43.42ms
+step:754/1480 train_time:32758ms step_avg:43.45ms
+step:755/1480 train_time:32817ms step_avg:43.47ms
+step:756/1480 train_time:32880ms step_avg:43.49ms
+step:757/1480 train_time:32939ms step_avg:43.51ms
+step:758/1480 train_time:33003ms step_avg:43.54ms
+step:759/1480 train_time:33061ms step_avg:43.56ms
+step:760/1480 train_time:33126ms step_avg:43.59ms
+step:761/1480 train_time:33184ms step_avg:43.61ms
+step:762/1480 train_time:33248ms step_avg:43.63ms
+step:763/1480 train_time:33306ms step_avg:43.65ms
+step:764/1480 train_time:33370ms step_avg:43.68ms
+step:765/1480 train_time:33429ms step_avg:43.70ms
+step:766/1480 train_time:33493ms step_avg:43.72ms
+step:767/1480 train_time:33550ms step_avg:43.74ms
+step:768/1480 train_time:33613ms step_avg:43.77ms
+step:769/1480 train_time:33671ms step_avg:43.79ms
+step:770/1480 train_time:33734ms step_avg:43.81ms
+step:771/1480 train_time:33792ms step_avg:43.83ms
+step:772/1480 train_time:33856ms step_avg:43.86ms
+step:773/1480 train_time:33914ms step_avg:43.87ms
+step:774/1480 train_time:33978ms step_avg:43.90ms
+step:775/1480 train_time:34035ms step_avg:43.92ms
+step:776/1480 train_time:34099ms step_avg:43.94ms
+step:777/1480 train_time:34155ms step_avg:43.96ms
+step:778/1480 train_time:34220ms step_avg:43.98ms
+step:779/1480 train_time:34280ms step_avg:44.01ms
+step:780/1480 train_time:34345ms step_avg:44.03ms
+step:781/1480 train_time:34405ms step_avg:44.05ms
+step:782/1480 train_time:34473ms step_avg:44.08ms
+step:783/1480 train_time:34534ms step_avg:44.11ms
+step:784/1480 train_time:34602ms step_avg:44.13ms
+step:785/1480 train_time:34663ms step_avg:44.16ms
+step:786/1480 train_time:34730ms step_avg:44.19ms
+step:787/1480 train_time:34792ms step_avg:44.21ms
+step:788/1480 train_time:34859ms step_avg:44.24ms
+step:789/1480 train_time:34920ms step_avg:44.26ms
+step:790/1480 train_time:34987ms step_avg:44.29ms
+step:791/1480 train_time:35044ms step_avg:44.30ms
+step:792/1480 train_time:35103ms step_avg:44.32ms
+step:793/1480 train_time:35157ms step_avg:44.33ms
+step:794/1480 train_time:35221ms step_avg:44.36ms
+step:795/1480 train_time:35277ms step_avg:44.37ms
+step:796/1480 train_time:35341ms step_avg:44.40ms
+step:797/1480 train_time:35398ms step_avg:44.41ms
+step:798/1480 train_time:35462ms step_avg:44.44ms
+step:799/1480 train_time:35519ms step_avg:44.45ms
+step:800/1480 train_time:35583ms step_avg:44.48ms
+step:801/1480 train_time:35641ms step_avg:44.50ms
+step:802/1480 train_time:35706ms step_avg:44.52ms
+step:803/1480 train_time:35765ms step_avg:44.54ms
+step:804/1480 train_time:35831ms step_avg:44.57ms
+step:805/1480 train_time:35891ms step_avg:44.59ms
+step:806/1480 train_time:35956ms step_avg:44.61ms
+step:807/1480 train_time:36014ms step_avg:44.63ms
+step:808/1480 train_time:36078ms step_avg:44.65ms
+step:809/1480 train_time:36136ms step_avg:44.67ms
+step:810/1480 train_time:36199ms step_avg:44.69ms
+step:811/1480 train_time:36257ms step_avg:44.71ms
+step:812/1480 train_time:36321ms step_avg:44.73ms
+step:813/1480 train_time:36379ms step_avg:44.75ms
+step:814/1480 train_time:36444ms step_avg:44.77ms
+step:815/1480 train_time:36502ms step_avg:44.79ms
+step:816/1480 train_time:36566ms step_avg:44.81ms
+step:817/1480 train_time:36624ms step_avg:44.83ms
+step:818/1480 train_time:36688ms step_avg:44.85ms
+step:819/1480 train_time:36747ms step_avg:44.87ms
+step:820/1480 train_time:36810ms step_avg:44.89ms
+step:821/1480 train_time:36867ms step_avg:44.91ms
+step:822/1480 train_time:36932ms step_avg:44.93ms
+step:823/1480 train_time:36991ms step_avg:44.95ms
+step:824/1480 train_time:37054ms step_avg:44.97ms
+step:825/1480 train_time:37112ms step_avg:44.98ms
+step:826/1480 train_time:37176ms step_avg:45.01ms
+step:827/1480 train_time:37234ms step_avg:45.02ms
+step:828/1480 train_time:37299ms step_avg:45.05ms
+step:829/1480 train_time:37358ms step_avg:45.06ms
+step:830/1480 train_time:37422ms step_avg:45.09ms
+step:831/1480 train_time:37481ms step_avg:45.10ms
+step:832/1480 train_time:37546ms step_avg:45.13ms
+step:833/1480 train_time:37604ms step_avg:45.14ms
+step:834/1480 train_time:37670ms step_avg:45.17ms
+step:835/1480 train_time:37728ms step_avg:45.18ms
+step:836/1480 train_time:37794ms step_avg:45.21ms
+step:837/1480 train_time:37853ms step_avg:45.22ms
+step:838/1480 train_time:37918ms step_avg:45.25ms
+step:839/1480 train_time:37978ms step_avg:45.27ms
+step:840/1480 train_time:38043ms step_avg:45.29ms
+step:841/1480 train_time:38101ms step_avg:45.30ms
+step:842/1480 train_time:38165ms step_avg:45.33ms
+step:843/1480 train_time:38225ms step_avg:45.34ms
+step:844/1480 train_time:38292ms step_avg:45.37ms
+step:845/1480 train_time:38351ms step_avg:45.39ms
+step:846/1480 train_time:38415ms step_avg:45.41ms
+step:847/1480 train_time:38475ms step_avg:45.43ms
+step:848/1480 train_time:38540ms step_avg:45.45ms
+step:849/1480 train_time:38598ms step_avg:45.46ms
+step:850/1480 train_time:38661ms step_avg:45.48ms
+step:851/1480 train_time:38719ms step_avg:45.50ms
+step:852/1480 train_time:38783ms step_avg:45.52ms
+step:853/1480 train_time:38841ms step_avg:45.53ms
+step:854/1480 train_time:38905ms step_avg:45.56ms
+step:855/1480 train_time:38963ms step_avg:45.57ms
+step:856/1480 train_time:39026ms step_avg:45.59ms
+step:857/1480 train_time:39085ms step_avg:45.61ms
+step:858/1480 train_time:39151ms step_avg:45.63ms
+step:859/1480 train_time:39209ms step_avg:45.65ms
+step:860/1480 train_time:39273ms step_avg:45.67ms
+step:861/1480 train_time:39333ms step_avg:45.68ms
+step:862/1480 train_time:39402ms step_avg:45.71ms
+step:863/1480 train_time:39464ms step_avg:45.73ms
+step:864/1480 train_time:39534ms step_avg:45.76ms
+step:865/1480 train_time:39599ms step_avg:45.78ms
+step:866/1480 train_time:39667ms step_avg:45.80ms
+step:867/1480 train_time:39729ms step_avg:45.82ms
+step:868/1480 train_time:39789ms step_avg:45.84ms
+step:869/1480 train_time:39844ms step_avg:45.85ms
+step:870/1480 train_time:39903ms step_avg:45.87ms
+step:871/1480 train_time:39961ms step_avg:45.88ms
+step:872/1480 train_time:40026ms step_avg:45.90ms
+step:873/1480 train_time:40087ms step_avg:45.92ms
+step:874/1480 train_time:40152ms step_avg:45.94ms
+step:875/1480 train_time:40209ms step_avg:45.95ms
+step:876/1480 train_time:40274ms step_avg:45.97ms
+step:877/1480 train_time:40331ms step_avg:45.99ms
+step:878/1480 train_time:40397ms step_avg:46.01ms
+step:879/1480 train_time:40455ms step_avg:46.02ms
+step:880/1480 train_time:40521ms step_avg:46.05ms
+step:881/1480 train_time:40580ms step_avg:46.06ms
+step:882/1480 train_time:40645ms step_avg:46.08ms
+step:883/1480 train_time:40704ms step_avg:46.10ms
+step:884/1480 train_time:40768ms step_avg:46.12ms
+step:885/1480 train_time:40827ms step_avg:46.13ms
+step:886/1480 train_time:40893ms step_avg:46.15ms
+step:887/1480 train_time:40951ms step_avg:46.17ms
+step:888/1480 train_time:41016ms step_avg:46.19ms
+step:889/1480 train_time:41076ms step_avg:46.20ms
+step:890/1480 train_time:41142ms step_avg:46.23ms
+step:891/1480 train_time:41202ms step_avg:46.24ms
+step:892/1480 train_time:41266ms step_avg:46.26ms
+step:893/1480 train_time:41325ms step_avg:46.28ms
+step:894/1480 train_time:41389ms step_avg:46.30ms
+step:895/1480 train_time:41449ms step_avg:46.31ms
+step:896/1480 train_time:41514ms step_avg:46.33ms
+step:897/1480 train_time:41572ms step_avg:46.35ms
+step:898/1480 train_time:41637ms step_avg:46.37ms
+step:899/1480 train_time:41696ms step_avg:46.38ms
+step:900/1480 train_time:41760ms step_avg:46.40ms
+step:901/1480 train_time:41818ms step_avg:46.41ms
+step:902/1480 train_time:41882ms step_avg:46.43ms
+step:903/1480 train_time:41941ms step_avg:46.45ms
+step:904/1480 train_time:42005ms step_avg:46.47ms
+step:905/1480 train_time:42063ms step_avg:46.48ms
+step:906/1480 train_time:42128ms step_avg:46.50ms
+step:907/1480 train_time:42188ms step_avg:46.51ms
+step:908/1480 train_time:42252ms step_avg:46.53ms
+step:909/1480 train_time:42310ms step_avg:46.55ms
+step:910/1480 train_time:42376ms step_avg:46.57ms
+step:911/1480 train_time:42434ms step_avg:46.58ms
+step:912/1480 train_time:42499ms step_avg:46.60ms
+step:913/1480 train_time:42557ms step_avg:46.61ms
+step:914/1480 train_time:42621ms step_avg:46.63ms
+step:915/1480 train_time:42679ms step_avg:46.64ms
+step:916/1480 train_time:42744ms step_avg:46.66ms
+step:917/1480 train_time:42802ms step_avg:46.68ms
+step:918/1480 train_time:42867ms step_avg:46.70ms
+step:919/1480 train_time:42926ms step_avg:46.71ms
+step:920/1480 train_time:42991ms step_avg:46.73ms
+step:921/1480 train_time:43049ms step_avg:46.74ms
+step:922/1480 train_time:43114ms step_avg:46.76ms
+step:923/1480 train_time:43172ms step_avg:46.77ms
+step:924/1480 train_time:43236ms step_avg:46.79ms
+step:925/1480 train_time:43295ms step_avg:46.81ms
+step:926/1480 train_time:43359ms step_avg:46.82ms
+step:927/1480 train_time:43417ms step_avg:46.84ms
+step:928/1480 train_time:43481ms step_avg:46.85ms
+step:929/1480 train_time:43539ms step_avg:46.87ms
+step:930/1480 train_time:43603ms step_avg:46.89ms
+step:931/1480 train_time:43661ms step_avg:46.90ms
+step:932/1480 train_time:43724ms step_avg:46.91ms
+step:933/1480 train_time:43782ms step_avg:46.93ms
+step:934/1480 train_time:43846ms step_avg:46.94ms
+step:935/1480 train_time:43904ms step_avg:46.96ms
+step:936/1480 train_time:43967ms step_avg:46.97ms
+step:937/1480 train_time:44026ms step_avg:46.99ms
+step:938/1480 train_time:44089ms step_avg:47.00ms
+step:939/1480 train_time:44147ms step_avg:47.01ms
+step:940/1480 train_time:44211ms step_avg:47.03ms
+step:941/1480 train_time:44268ms step_avg:47.04ms
+step:942/1480 train_time:44331ms step_avg:47.06ms
+step:943/1480 train_time:44390ms step_avg:47.07ms
+step:944/1480 train_time:44454ms step_avg:47.09ms
+step:945/1480 train_time:44512ms step_avg:47.10ms
+step:946/1480 train_time:44577ms step_avg:47.12ms
+step:947/1480 train_time:44637ms step_avg:47.13ms
+step:948/1480 train_time:44701ms step_avg:47.15ms
+step:949/1480 train_time:44760ms step_avg:47.17ms
+step:950/1480 train_time:44825ms step_avg:47.18ms
+step:951/1480 train_time:44884ms step_avg:47.20ms
+step:952/1480 train_time:44948ms step_avg:47.21ms
+step:953/1480 train_time:45007ms step_avg:47.23ms
+step:954/1480 train_time:45072ms step_avg:47.24ms
+step:955/1480 train_time:45130ms step_avg:47.26ms
+step:956/1480 train_time:45195ms step_avg:47.28ms
+step:957/1480 train_time:45253ms step_avg:47.29ms
+step:958/1480 train_time:45316ms step_avg:47.30ms
+step:959/1480 train_time:45374ms step_avg:47.31ms
+step:960/1480 train_time:45439ms step_avg:47.33ms
+step:961/1480 train_time:45500ms step_avg:47.35ms
+step:962/1480 train_time:45590ms step_avg:47.39ms
+step:963/1480 train_time:45676ms step_avg:47.43ms
+step:964/1480 train_time:45769ms step_avg:47.48ms
+step:965/1480 train_time:45854ms step_avg:47.52ms
+step:966/1480 train_time:45948ms step_avg:47.56ms
+step:967/1480 train_time:46033ms step_avg:47.60ms
+step:968/1480 train_time:46125ms step_avg:47.65ms
+step:969/1480 train_time:46210ms step_avg:47.69ms
+step:970/1480 train_time:46302ms step_avg:47.73ms
+step:971/1480 train_time:46389ms step_avg:47.77ms
+step:972/1480 train_time:46479ms step_avg:47.82ms
+step:973/1480 train_time:46566ms step_avg:47.86ms
+step:974/1480 train_time:46657ms step_avg:47.90ms
+step:975/1480 train_time:46743ms step_avg:47.94ms
+step:976/1480 train_time:46834ms step_avg:47.99ms
+step:977/1480 train_time:46919ms step_avg:48.02ms
+step:978/1480 train_time:47010ms step_avg:48.07ms
+step:979/1480 train_time:47094ms step_avg:48.10ms
+step:980/1480 train_time:47188ms step_avg:48.15ms
+step:981/1480 train_time:47272ms step_avg:48.19ms
+step:982/1480 train_time:47364ms step_avg:48.23ms
+step:983/1480 train_time:47453ms step_avg:48.27ms
+step:984/1480 train_time:47546ms step_avg:48.32ms
+step:985/1480 train_time:47637ms step_avg:48.36ms
+step:986/1480 train_time:47731ms step_avg:48.41ms
+step:987/1480 train_time:47816ms step_avg:48.45ms
+step:988/1480 train_time:47908ms step_avg:48.49ms
+step:989/1480 train_time:47996ms step_avg:48.53ms
+step:990/1480 train_time:48088ms step_avg:48.57ms
+step:991/1480 train_time:48175ms step_avg:48.61ms
+step:992/1480 train_time:48273ms step_avg:48.66ms
+step:993/1480 train_time:48363ms step_avg:48.70ms
+step:994/1480 train_time:48459ms step_avg:48.75ms
+step:995/1480 train_time:48550ms step_avg:48.79ms
+step:996/1480 train_time:48646ms step_avg:48.84ms
+step:997/1480 train_time:48734ms step_avg:48.88ms
+step:998/1480 train_time:48831ms step_avg:48.93ms
+step:999/1480 train_time:48920ms step_avg:48.97ms
+step:1000/1480 train_time:49015ms step_avg:49.02ms
+step:1000/1480 val_loss:3.5100 train_time:49130ms step_avg:49.13ms
+step:1001/1480 train_time:49150ms step_avg:49.10ms
+step:1002/1480 train_time:49199ms step_avg:49.10ms
+step:1003/1480 train_time:49284ms step_avg:49.14ms
+step:1004/1480 train_time:49374ms step_avg:49.18ms
+step:1005/1480 train_time:49459ms step_avg:49.21ms
+step:1006/1480 train_time:49550ms step_avg:49.25ms
+step:1007/1480 train_time:49635ms step_avg:49.29ms
+step:1008/1480 train_time:49724ms step_avg:49.33ms
+step:1009/1480 train_time:49808ms step_avg:49.36ms
+step:1010/1480 train_time:49899ms step_avg:49.41ms
+step:1011/1480 train_time:49983ms step_avg:49.44ms
+step:1012/1480 train_time:50076ms step_avg:49.48ms
+step:1013/1480 train_time:50165ms step_avg:49.52ms
+step:1014/1480 train_time:50262ms step_avg:49.57ms
+step:1015/1480 train_time:50351ms step_avg:49.61ms
+step:1016/1480 train_time:50448ms step_avg:49.65ms
+step:1017/1480 train_time:50537ms step_avg:49.69ms
+step:1018/1480 train_time:50634ms step_avg:49.74ms
+step:1019/1480 train_time:50724ms step_avg:49.78ms
+step:1020/1480 train_time:50820ms step_avg:49.82ms
+step:1021/1480 train_time:50909ms step_avg:49.86ms
+step:1022/1480 train_time:51005ms step_avg:49.91ms
+step:1023/1480 train_time:51095ms step_avg:49.95ms
+step:1024/1480 train_time:51191ms step_avg:49.99ms
+step:1025/1480 train_time:51272ms step_avg:50.02ms
+step:1026/1480 train_time:51360ms step_avg:50.06ms
+step:1027/1480 train_time:51450ms step_avg:50.10ms
+step:1028/1480 train_time:51548ms step_avg:50.14ms
+step:1029/1480 train_time:51645ms step_avg:50.19ms
+step:1030/1480 train_time:51738ms step_avg:50.23ms
+step:1031/1480 train_time:51825ms step_avg:50.27ms
+step:1032/1480 train_time:51920ms step_avg:50.31ms
+step:1033/1480 train_time:52009ms step_avg:50.35ms
+step:1034/1480 train_time:52102ms step_avg:50.39ms
+step:1035/1480 train_time:52191ms step_avg:50.43ms
+step:1036/1480 train_time:52287ms step_avg:50.47ms
+step:1037/1480 train_time:52376ms step_avg:50.51ms
+step:1038/1480 train_time:52472ms step_avg:50.55ms
+step:1039/1480 train_time:52563ms step_avg:50.59ms
+step:1040/1480 train_time:52659ms step_avg:50.63ms
+step:1041/1480 train_time:52750ms step_avg:50.67ms
+step:1042/1480 train_time:52844ms step_avg:50.71ms
+step:1043/1480 train_time:52934ms step_avg:50.75ms
+step:1044/1480 train_time:53030ms step_avg:50.80ms
+step:1045/1480 train_time:53112ms step_avg:50.82ms
+step:1046/1480 train_time:53201ms step_avg:50.86ms
+step:1047/1480 train_time:53287ms step_avg:50.89ms
+step:1048/1480 train_time:53376ms step_avg:50.93ms
+step:1049/1480 train_time:53464ms step_avg:50.97ms
+step:1050/1480 train_time:53556ms step_avg:51.01ms
+step:1051/1480 train_time:53642ms step_avg:51.04ms
+step:1052/1480 train_time:53742ms step_avg:51.09ms
+step:1053/1480 train_time:53833ms step_avg:51.12ms
+step:1054/1480 train_time:53930ms step_avg:51.17ms
+step:1055/1480 train_time:54021ms step_avg:51.20ms
+step:1056/1480 train_time:54118ms step_avg:51.25ms
+step:1057/1480 train_time:54209ms step_avg:51.29ms
+step:1058/1480 train_time:54305ms step_avg:51.33ms
+step:1059/1480 train_time:54394ms step_avg:51.36ms
+step:1060/1480 train_time:54491ms step_avg:51.41ms
+step:1061/1480 train_time:54580ms step_avg:51.44ms
+step:1062/1480 train_time:54676ms step_avg:51.48ms
+step:1063/1480 train_time:54759ms step_avg:51.51ms
+step:1064/1480 train_time:54846ms step_avg:51.55ms
+step:1065/1480 train_time:54933ms step_avg:51.58ms
+step:1066/1480 train_time:55021ms step_avg:51.61ms
+step:1067/1480 train_time:55110ms step_avg:51.65ms
+step:1068/1480 train_time:55202ms step_avg:51.69ms
+step:1069/1480 train_time:55290ms step_avg:51.72ms
+step:1070/1480 train_time:55383ms step_avg:51.76ms
+step:1071/1480 train_time:55472ms step_avg:51.79ms
+step:1072/1480 train_time:55566ms step_avg:51.83ms
+step:1073/1480 train_time:55654ms step_avg:51.87ms
+step:1074/1480 train_time:55750ms step_avg:51.91ms
+step:1075/1480 train_time:55839ms step_avg:51.94ms
+step:1076/1480 train_time:55933ms step_avg:51.98ms
+step:1077/1480 train_time:56023ms step_avg:52.02ms
+step:1078/1480 train_time:56116ms step_avg:52.06ms
+step:1079/1480 train_time:56203ms step_avg:52.09ms
+step:1080/1480 train_time:56297ms step_avg:52.13ms
+step:1081/1480 train_time:56386ms step_avg:52.16ms
+step:1082/1480 train_time:56481ms step_avg:52.20ms
+step:1083/1480 train_time:56568ms step_avg:52.23ms
+step:1084/1480 train_time:56662ms step_avg:52.27ms
+step:1085/1480 train_time:56750ms step_avg:52.30ms
+step:1086/1480 train_time:56842ms step_avg:52.34ms
+step:1087/1480 train_time:56931ms step_avg:52.37ms
+step:1088/1480 train_time:57025ms step_avg:52.41ms
+step:1089/1480 train_time:57111ms step_avg:52.44ms
+step:1090/1480 train_time:57206ms step_avg:52.48ms
+step:1091/1480 train_time:57291ms step_avg:52.51ms
+step:1092/1480 train_time:57383ms step_avg:52.55ms
+step:1093/1480 train_time:57469ms step_avg:52.58ms
+step:1094/1480 train_time:57562ms step_avg:52.62ms
+step:1095/1480 train_time:57649ms step_avg:52.65ms
+step:1096/1480 train_time:57741ms step_avg:52.68ms
+step:1097/1480 train_time:57829ms step_avg:52.72ms
+step:1098/1480 train_time:57920ms step_avg:52.75ms
+step:1099/1480 train_time:58006ms step_avg:52.78ms
+step:1100/1480 train_time:58098ms step_avg:52.82ms
+step:1101/1480 train_time:58184ms step_avg:52.85ms
+step:1102/1480 train_time:58274ms step_avg:52.88ms
+step:1103/1480 train_time:58358ms step_avg:52.91ms
+step:1104/1480 train_time:58450ms step_avg:52.94ms
+step:1105/1480 train_time:58533ms step_avg:52.97ms
+step:1106/1480 train_time:58624ms step_avg:53.01ms
+step:1107/1480 train_time:58712ms step_avg:53.04ms
+step:1108/1480 train_time:58803ms step_avg:53.07ms
+step:1109/1480 train_time:58890ms step_avg:53.10ms
+step:1110/1480 train_time:58984ms step_avg:53.14ms
+step:1111/1480 train_time:59071ms step_avg:53.17ms
+step:1112/1480 train_time:59162ms step_avg:53.20ms
+step:1113/1480 train_time:59250ms step_avg:53.23ms
+step:1114/1480 train_time:59341ms step_avg:53.27ms
+step:1115/1480 train_time:59427ms step_avg:53.30ms
+step:1116/1480 train_time:59516ms step_avg:53.33ms
+step:1117/1480 train_time:59600ms step_avg:53.36ms
+step:1118/1480 train_time:59693ms step_avg:53.39ms
+step:1119/1480 train_time:59779ms step_avg:53.42ms
+step:1120/1480 train_time:59873ms step_avg:53.46ms
+step:1121/1480 train_time:59961ms step_avg:53.49ms
+step:1122/1480 train_time:60057ms step_avg:53.53ms
+step:1123/1480 train_time:60147ms step_avg:53.56ms
+step:1124/1480 train_time:60242ms step_avg:53.60ms
+step:1125/1480 train_time:60332ms step_avg:53.63ms
+step:1126/1480 train_time:60427ms step_avg:53.67ms
+step:1127/1480 train_time:60515ms step_avg:53.70ms
+step:1128/1480 train_time:60611ms step_avg:53.73ms
+step:1129/1480 train_time:60692ms step_avg:53.76ms
+step:1130/1480 train_time:60783ms step_avg:53.79ms
+step:1131/1480 train_time:60875ms step_avg:53.82ms
+step:1132/1480 train_time:60968ms step_avg:53.86ms
+step:1133/1480 train_time:61053ms step_avg:53.89ms
+step:1134/1480 train_time:61144ms step_avg:53.92ms
+step:1135/1480 train_time:61228ms step_avg:53.95ms
+step:1136/1480 train_time:61321ms step_avg:53.98ms
+step:1137/1480 train_time:61407ms step_avg:54.01ms
+step:1138/1480 train_time:61501ms step_avg:54.04ms
+step:1139/1480 train_time:61590ms step_avg:54.07ms
+step:1140/1480 train_time:61685ms step_avg:54.11ms
+step:1141/1480 train_time:61774ms step_avg:54.14ms
+step:1142/1480 train_time:61869ms step_avg:54.18ms
+step:1143/1480 train_time:61957ms step_avg:54.21ms
+step:1144/1480 train_time:62054ms step_avg:54.24ms
+step:1145/1480 train_time:62135ms step_avg:54.27ms
+step:1146/1480 train_time:62226ms step_avg:54.30ms
+step:1147/1480 train_time:62314ms step_avg:54.33ms
+step:1148/1480 train_time:62405ms step_avg:54.36ms
+step:1149/1480 train_time:62491ms step_avg:54.39ms
+step:1150/1480 train_time:62584ms step_avg:54.42ms
+step:1151/1480 train_time:62676ms step_avg:54.45ms
+step:1152/1480 train_time:62770ms step_avg:54.49ms
+step:1153/1480 train_time:62856ms step_avg:54.51ms
+step:1154/1480 train_time:62956ms step_avg:54.55ms
+step:1155/1480 train_time:63047ms step_avg:54.59ms
+step:1156/1480 train_time:63142ms step_avg:54.62ms
+step:1157/1480 train_time:63232ms step_avg:54.65ms
+step:1158/1480 train_time:63328ms step_avg:54.69ms
+step:1159/1480 train_time:63417ms step_avg:54.72ms
+step:1160/1480 train_time:63513ms step_avg:54.75ms
+step:1161/1480 train_time:63602ms step_avg:54.78ms
+step:1162/1480 train_time:63697ms step_avg:54.82ms
+step:1163/1480 train_time:63787ms step_avg:54.85ms
+step:1164/1480 train_time:63881ms step_avg:54.88ms
+step:1165/1480 train_time:63970ms step_avg:54.91ms
+step:1166/1480 train_time:64062ms step_avg:54.94ms
+step:1167/1480 train_time:64151ms step_avg:54.97ms
+step:1168/1480 train_time:64245ms step_avg:55.00ms
+step:1169/1480 train_time:64333ms step_avg:55.03ms
+step:1170/1480 train_time:64426ms step_avg:55.07ms
+step:1171/1480 train_time:64513ms step_avg:55.09ms
+step:1172/1480 train_time:64607ms step_avg:55.13ms
+step:1173/1480 train_time:64694ms step_avg:55.15ms
+step:1174/1480 train_time:64789ms step_avg:55.19ms
+step:1175/1480 train_time:64875ms step_avg:55.21ms
+step:1176/1480 train_time:64968ms step_avg:55.24ms
+step:1177/1480 train_time:65054ms step_avg:55.27ms
+step:1178/1480 train_time:65149ms step_avg:55.30ms
+step:1179/1480 train_time:65235ms step_avg:55.33ms
+step:1180/1480 train_time:65328ms step_avg:55.36ms
+step:1181/1480 train_time:65411ms step_avg:55.39ms
+step:1182/1480 train_time:65507ms step_avg:55.42ms
+step:1183/1480 train_time:65597ms step_avg:55.45ms
+step:1184/1480 train_time:65688ms step_avg:55.48ms
+step:1185/1480 train_time:65774ms step_avg:55.51ms
+step:1186/1480 train_time:65867ms step_avg:55.54ms
+step:1187/1480 train_time:65953ms step_avg:55.56ms
+step:1188/1480 train_time:66044ms step_avg:55.59ms
+step:1189/1480 train_time:66132ms step_avg:55.62ms
+step:1190/1480 train_time:66228ms step_avg:55.65ms
+step:1191/1480 train_time:66315ms step_avg:55.68ms
+step:1192/1480 train_time:66409ms step_avg:55.71ms
+step:1193/1480 train_time:66497ms step_avg:55.74ms
+step:1194/1480 train_time:66590ms step_avg:55.77ms
+step:1195/1480 train_time:66676ms step_avg:55.80ms
+step:1196/1480 train_time:66769ms step_avg:55.83ms
+step:1197/1480 train_time:66855ms step_avg:55.85ms
+step:1198/1480 train_time:66949ms step_avg:55.88ms
+step:1199/1480 train_time:67035ms step_avg:55.91ms
+step:1200/1480 train_time:67129ms step_avg:55.94ms
+step:1201/1480 train_time:67214ms step_avg:55.97ms
+step:1202/1480 train_time:67308ms step_avg:56.00ms
+step:1203/1480 train_time:67395ms step_avg:56.02ms
+step:1204/1480 train_time:67486ms step_avg:56.05ms
+step:1205/1480 train_time:67571ms step_avg:56.08ms
+step:1206/1480 train_time:67662ms step_avg:56.10ms
+step:1207/1480 train_time:67747ms step_avg:56.13ms
+step:1208/1480 train_time:67840ms step_avg:56.16ms
+step:1209/1480 train_time:67927ms step_avg:56.18ms
+step:1210/1480 train_time:68020ms step_avg:56.21ms
+step:1211/1480 train_time:68105ms step_avg:56.24ms
+step:1212/1480 train_time:68196ms step_avg:56.27ms
+step:1213/1480 train_time:68282ms step_avg:56.29ms
+step:1214/1480 train_time:68374ms step_avg:56.32ms
+step:1215/1480 train_time:68462ms step_avg:56.35ms
+step:1216/1480 train_time:68559ms step_avg:56.38ms
+step:1217/1480 train_time:68650ms step_avg:56.41ms
+step:1218/1480 train_time:68748ms step_avg:56.44ms
+step:1219/1480 train_time:68839ms step_avg:56.47ms
+step:1220/1480 train_time:68937ms step_avg:56.51ms
+step:1221/1480 train_time:69029ms step_avg:56.54ms
+step:1222/1480 train_time:69125ms step_avg:56.57ms
+step:1223/1480 train_time:69217ms step_avg:56.60ms
+step:1224/1480 train_time:69304ms step_avg:56.62ms
+step:1225/1480 train_time:69386ms step_avg:56.64ms
+step:1226/1480 train_time:69478ms step_avg:56.67ms
+step:1227/1480 train_time:69563ms step_avg:56.69ms
+step:1228/1480 train_time:69656ms step_avg:56.72ms
+step:1229/1480 train_time:69740ms step_avg:56.75ms
+step:1230/1480 train_time:69832ms step_avg:56.77ms
+step:1231/1480 train_time:69916ms step_avg:56.80ms
+step:1232/1480 train_time:70007ms step_avg:56.82ms
+step:1233/1480 train_time:70094ms step_avg:56.85ms
+step:1234/1480 train_time:70189ms step_avg:56.88ms
+step:1235/1480 train_time:70273ms step_avg:56.90ms
+step:1236/1480 train_time:70364ms step_avg:56.93ms
+step:1237/1480 train_time:70450ms step_avg:56.95ms
+step:1238/1480 train_time:70541ms step_avg:56.98ms
+step:1239/1480 train_time:70626ms step_avg:57.00ms
+step:1240/1480 train_time:70721ms step_avg:57.03ms
+step:1241/1480 train_time:70809ms step_avg:57.06ms
+step:1242/1480 train_time:70902ms step_avg:57.09ms
+step:1243/1480 train_time:70993ms step_avg:57.11ms
+step:1244/1480 train_time:71091ms step_avg:57.15ms
+step:1245/1480 train_time:71182ms step_avg:57.17ms
+step:1246/1480 train_time:71278ms step_avg:57.21ms
+step:1247/1480 train_time:71369ms step_avg:57.23ms
+step:1248/1480 train_time:71466ms step_avg:57.26ms
+step:1249/1480 train_time:71548ms step_avg:57.28ms
+step:1250/1480 train_time:71637ms step_avg:57.31ms
+step:1250/1480 val_loss:3.3687 train_time:71753ms step_avg:57.40ms
+step:1251/1480 train_time:71773ms step_avg:57.37ms
+step:1252/1480 train_time:71821ms step_avg:57.37ms
+step:1253/1480 train_time:71909ms step_avg:57.39ms
+step:1254/1480 train_time:72002ms step_avg:57.42ms
+step:1255/1480 train_time:72087ms step_avg:57.44ms
+step:1256/1480 train_time:72180ms step_avg:57.47ms
+step:1257/1480 train_time:72268ms step_avg:57.49ms
+step:1258/1480 train_time:72359ms step_avg:57.52ms
+step:1259/1480 train_time:72445ms step_avg:57.54ms
+step:1260/1480 train_time:72535ms step_avg:57.57ms
+step:1261/1480 train_time:72620ms step_avg:57.59ms
+step:1262/1480 train_time:72711ms step_avg:57.62ms
+step:1263/1480 train_time:72795ms step_avg:57.64ms
+step:1264/1480 train_time:72886ms step_avg:57.66ms
+step:1265/1480 train_time:72973ms step_avg:57.69ms
+step:1266/1480 train_time:73069ms step_avg:57.72ms
+step:1267/1480 train_time:73158ms step_avg:57.74ms
+step:1268/1480 train_time:73256ms step_avg:57.77ms
+step:1269/1480 train_time:73347ms step_avg:57.80ms
+step:1270/1480 train_time:73443ms step_avg:57.83ms
+step:1271/1480 train_time:73534ms step_avg:57.86ms
+step:1272/1480 train_time:73630ms step_avg:57.89ms
+step:1273/1480 train_time:73712ms step_avg:57.90ms
+step:1274/1480 train_time:73800ms step_avg:57.93ms
+step:1275/1480 train_time:73890ms step_avg:57.95ms
+step:1276/1480 train_time:73983ms step_avg:57.98ms
+step:1277/1480 train_time:74076ms step_avg:58.01ms
+step:1278/1480 train_time:74168ms step_avg:58.03ms
+step:1279/1480 train_time:74254ms step_avg:58.06ms
+step:1280/1480 train_time:74347ms step_avg:58.08ms
+step:1281/1480 train_time:74433ms step_avg:58.11ms
+step:1282/1480 train_time:74526ms step_avg:58.13ms
+step:1283/1480 train_time:74616ms step_avg:58.16ms
+step:1284/1480 train_time:74712ms step_avg:58.19ms
+step:1285/1480 train_time:74800ms step_avg:58.21ms
+step:1286/1480 train_time:74896ms step_avg:58.24ms
+step:1287/1480 train_time:74984ms step_avg:58.26ms
+step:1288/1480 train_time:75080ms step_avg:58.29ms
+step:1289/1480 train_time:75169ms step_avg:58.32ms
+step:1290/1480 train_time:75264ms step_avg:58.34ms
+step:1291/1480 train_time:75345ms step_avg:58.36ms
+step:1292/1480 train_time:75437ms step_avg:58.39ms
+step:1293/1480 train_time:75528ms step_avg:58.41ms
+step:1294/1480 train_time:75618ms step_avg:58.44ms
+step:1295/1480 train_time:75704ms step_avg:58.46ms
+step:1296/1480 train_time:75797ms step_avg:58.48ms
+step:1297/1480 train_time:75883ms step_avg:58.51ms
+step:1298/1480 train_time:75977ms step_avg:58.53ms
+step:1299/1480 train_time:76065ms step_avg:58.56ms
+step:1300/1480 train_time:76159ms step_avg:58.58ms
+step:1301/1480 train_time:76247ms step_avg:58.61ms
+step:1302/1480 train_time:76340ms step_avg:58.63ms
+step:1303/1480 train_time:76428ms step_avg:58.66ms
+step:1304/1480 train_time:76524ms step_avg:58.68ms
+step:1305/1480 train_time:76613ms step_avg:58.71ms
+step:1306/1480 train_time:76707ms step_avg:58.73ms
+step:1307/1480 train_time:76795ms step_avg:58.76ms
+step:1308/1480 train_time:76889ms step_avg:58.78ms
+step:1309/1480 train_time:76977ms step_avg:58.81ms
+step:1310/1480 train_time:77073ms step_avg:58.83ms
+step:1311/1480 train_time:77159ms step_avg:58.86ms
+step:1312/1480 train_time:77254ms step_avg:58.88ms
+step:1313/1480 train_time:77341ms step_avg:58.90ms
+step:1314/1480 train_time:77436ms step_avg:58.93ms
+step:1315/1480 train_time:77522ms step_avg:58.95ms
+step:1316/1480 train_time:77616ms step_avg:58.98ms
+step:1317/1480 train_time:77703ms step_avg:59.00ms
+step:1318/1480 train_time:77796ms step_avg:59.03ms
+step:1319/1480 train_time:77882ms step_avg:59.05ms
+step:1320/1480 train_time:77976ms step_avg:59.07ms
+step:1321/1480 train_time:78062ms step_avg:59.09ms
+step:1322/1480 train_time:78155ms step_avg:59.12ms
+step:1323/1480 train_time:78241ms step_avg:59.14ms
+step:1324/1480 train_time:78335ms step_avg:59.17ms
+step:1325/1480 train_time:78421ms step_avg:59.19ms
+step:1326/1480 train_time:78515ms step_avg:59.21ms
+step:1327/1480 train_time:78600ms step_avg:59.23ms
+step:1328/1480 train_time:78694ms step_avg:59.26ms
+step:1329/1480 train_time:78779ms step_avg:59.28ms
+step:1330/1480 train_time:78871ms step_avg:59.30ms
+step:1331/1480 train_time:78953ms step_avg:59.32ms
+step:1332/1480 train_time:79042ms step_avg:59.34ms
+step:1333/1480 train_time:79132ms step_avg:59.36ms
+step:1334/1480 train_time:79224ms step_avg:59.39ms
+step:1335/1480 train_time:79311ms step_avg:59.41ms
+step:1336/1480 train_time:79403ms step_avg:59.43ms
+step:1337/1480 train_time:79490ms step_avg:59.45ms
+step:1338/1480 train_time:79582ms step_avg:59.48ms
+step:1339/1480 train_time:79668ms step_avg:59.50ms
+step:1340/1480 train_time:79759ms step_avg:59.52ms
+step:1341/1480 train_time:79845ms step_avg:59.54ms
+step:1342/1480 train_time:79937ms step_avg:59.57ms
+step:1343/1480 train_time:80024ms step_avg:59.59ms
+step:1344/1480 train_time:80116ms step_avg:59.61ms
+step:1345/1480 train_time:80202ms step_avg:59.63ms
+step:1346/1480 train_time:80294ms step_avg:59.65ms
+step:1347/1480 train_time:80379ms step_avg:59.67ms
+step:1348/1480 train_time:80473ms step_avg:59.70ms
+step:1349/1480 train_time:80558ms step_avg:59.72ms
+step:1350/1480 train_time:80652ms step_avg:59.74ms
+step:1351/1480 train_time:80737ms step_avg:59.76ms
+step:1352/1480 train_time:80828ms step_avg:59.78ms
+step:1353/1480 train_time:80914ms step_avg:59.80ms
+step:1354/1480 train_time:81005ms step_avg:59.83ms
+step:1355/1480 train_time:81090ms step_avg:59.85ms
+step:1356/1480 train_time:81182ms step_avg:59.87ms
+step:1357/1480 train_time:81271ms step_avg:59.89ms
+step:1358/1480 train_time:81363ms step_avg:59.91ms
+step:1359/1480 train_time:81450ms step_avg:59.93ms
+step:1360/1480 train_time:81542ms step_avg:59.96ms
+step:1361/1480 train_time:81627ms step_avg:59.98ms
+step:1362/1480 train_time:81718ms step_avg:60.00ms
+step:1363/1480 train_time:81802ms step_avg:60.02ms
+step:1364/1480 train_time:81897ms step_avg:60.04ms
+step:1365/1480 train_time:81988ms step_avg:60.06ms
+step:1366/1480 train_time:82082ms step_avg:60.09ms
+step:1367/1480 train_time:82171ms step_avg:60.11ms
+step:1368/1480 train_time:82266ms step_avg:60.14ms
+step:1369/1480 train_time:82354ms step_avg:60.16ms
+step:1370/1480 train_time:82449ms step_avg:60.18ms
+step:1371/1480 train_time:82538ms step_avg:60.20ms
+step:1372/1480 train_time:82634ms step_avg:60.23ms
+step:1373/1480 train_time:82721ms step_avg:60.25ms
+step:1374/1480 train_time:82816ms step_avg:60.27ms
+step:1375/1480 train_time:82904ms step_avg:60.29ms
+step:1376/1480 train_time:82998ms step_avg:60.32ms
+step:1377/1480 train_time:83087ms step_avg:60.34ms
+step:1378/1480 train_time:83180ms step_avg:60.36ms
+step:1379/1480 train_time:83269ms step_avg:60.38ms
+step:1380/1480 train_time:83362ms step_avg:60.41ms
+step:1381/1480 train_time:83449ms step_avg:60.43ms
+step:1382/1480 train_time:83543ms step_avg:60.45ms
+step:1383/1480 train_time:83631ms step_avg:60.47ms
+step:1384/1480 train_time:83724ms step_avg:60.49ms
+step:1385/1480 train_time:83811ms step_avg:60.51ms
+step:1386/1480 train_time:83904ms step_avg:60.54ms
+step:1387/1480 train_time:83990ms step_avg:60.56ms
+step:1388/1480 train_time:84083ms step_avg:60.58ms
+step:1389/1480 train_time:84170ms step_avg:60.60ms
+step:1390/1480 train_time:84263ms step_avg:60.62ms
+step:1391/1480 train_time:84350ms step_avg:60.64ms
+step:1392/1480 train_time:84443ms step_avg:60.66ms
+step:1393/1480 train_time:84530ms step_avg:60.68ms
+step:1394/1480 train_time:84623ms step_avg:60.71ms
+step:1395/1480 train_time:84710ms step_avg:60.72ms
+step:1396/1480 train_time:84803ms step_avg:60.75ms
+step:1397/1480 train_time:84889ms step_avg:60.76ms
+step:1398/1480 train_time:84980ms step_avg:60.79ms
+step:1399/1480 train_time:85071ms step_avg:60.81ms
+step:1400/1480 train_time:85162ms step_avg:60.83ms
+step:1401/1480 train_time:85249ms step_avg:60.85ms
+step:1402/1480 train_time:85341ms step_avg:60.87ms
+step:1403/1480 train_time:85426ms step_avg:60.89ms
+step:1404/1480 train_time:85519ms step_avg:60.91ms
+step:1405/1480 train_time:85607ms step_avg:60.93ms
+step:1406/1480 train_time:85699ms step_avg:60.95ms
+step:1407/1480 train_time:85785ms step_avg:60.97ms
+step:1408/1480 train_time:85877ms step_avg:60.99ms
+step:1409/1480 train_time:85963ms step_avg:61.01ms
+step:1410/1480 train_time:86056ms step_avg:61.03ms
+step:1411/1480 train_time:86142ms step_avg:61.05ms
+step:1412/1480 train_time:86234ms step_avg:61.07ms
+step:1413/1480 train_time:86318ms step_avg:61.09ms
+step:1414/1480 train_time:86411ms step_avg:61.11ms
+step:1415/1480 train_time:86499ms step_avg:61.13ms
+step:1416/1480 train_time:86595ms step_avg:61.15ms
+step:1417/1480 train_time:86683ms step_avg:61.17ms
+step:1418/1480 train_time:86778ms step_avg:61.20ms
+step:1419/1480 train_time:86866ms step_avg:61.22ms
+step:1420/1480 train_time:86961ms step_avg:61.24ms
+step:1421/1480 train_time:87049ms step_avg:61.26ms
+step:1422/1480 train_time:87143ms step_avg:61.28ms
+step:1423/1480 train_time:87231ms step_avg:61.30ms
+step:1424/1480 train_time:87324ms step_avg:61.32ms
+step:1425/1480 train_time:87412ms step_avg:61.34ms
+step:1426/1480 train_time:87506ms step_avg:61.36ms
+step:1427/1480 train_time:87593ms step_avg:61.38ms
+step:1428/1480 train_time:87688ms step_avg:61.41ms
+step:1429/1480 train_time:87775ms step_avg:61.42ms
+step:1430/1480 train_time:87870ms step_avg:61.45ms
+step:1431/1480 train_time:87958ms step_avg:61.47ms
+step:1432/1480 train_time:88052ms step_avg:61.49ms
+step:1433/1480 train_time:88139ms step_avg:61.51ms
+step:1434/1480 train_time:88233ms step_avg:61.53ms
+step:1435/1480 train_time:88320ms step_avg:61.55ms
+step:1436/1480 train_time:88415ms step_avg:61.57ms
+step:1437/1480 train_time:88501ms step_avg:61.59ms
+step:1438/1480 train_time:88596ms step_avg:61.61ms
+step:1439/1480 train_time:88682ms step_avg:61.63ms
+step:1440/1480 train_time:88776ms step_avg:61.65ms
+step:1441/1480 train_time:88864ms step_avg:61.67ms
+step:1442/1480 train_time:88960ms step_avg:61.69ms
+step:1443/1480 train_time:89048ms step_avg:61.71ms
+step:1444/1480 train_time:89139ms step_avg:61.73ms
+step:1445/1480 train_time:89224ms step_avg:61.75ms
+step:1446/1480 train_time:89314ms step_avg:61.77ms
+step:1447/1480 train_time:89397ms step_avg:61.78ms
+step:1448/1480 train_time:89489ms step_avg:61.80ms
+step:1449/1480 train_time:89576ms step_avg:61.82ms
+step:1450/1480 train_time:89670ms step_avg:61.84ms
+step:1451/1480 train_time:89759ms step_avg:61.86ms
+step:1452/1480 train_time:89852ms step_avg:61.88ms
+step:1453/1480 train_time:89939ms step_avg:61.90ms
+step:1454/1480 train_time:90034ms step_avg:61.92ms
+step:1455/1480 train_time:90120ms step_avg:61.94ms
+step:1456/1480 train_time:90214ms step_avg:61.96ms
+step:1457/1480 train_time:90301ms step_avg:61.98ms
+step:1458/1480 train_time:90394ms step_avg:62.00ms
+step:1459/1480 train_time:90480ms step_avg:62.02ms
+step:1460/1480 train_time:90575ms step_avg:62.04ms
+step:1461/1480 train_time:90661ms step_avg:62.05ms
+step:1462/1480 train_time:90753ms step_avg:62.07ms
+step:1463/1480 train_time:90837ms step_avg:62.09ms
+step:1464/1480 train_time:90928ms step_avg:62.11ms
+step:1465/1480 train_time:91012ms step_avg:62.12ms
+step:1466/1480 train_time:91104ms step_avg:62.14ms
+step:1467/1480 train_time:91192ms step_avg:62.16ms
+step:1468/1480 train_time:91285ms step_avg:62.18ms
+step:1469/1480 train_time:91373ms step_avg:62.20ms
+step:1470/1480 train_time:91467ms step_avg:62.22ms
+step:1471/1480 train_time:91553ms step_avg:62.24ms
+step:1472/1480 train_time:91645ms step_avg:62.26ms
+step:1473/1480 train_time:91731ms step_avg:62.28ms
+step:1474/1480 train_time:91824ms step_avg:62.30ms
+step:1475/1480 train_time:91912ms step_avg:62.31ms
+step:1476/1480 train_time:92005ms step_avg:62.33ms
+step:1477/1480 train_time:92091ms step_avg:62.35ms
+step:1478/1480 train_time:92180ms step_avg:62.37ms
+step:1479/1480 train_time:92267ms step_avg:62.38ms
+step:1480/1480 train_time:92361ms step_avg:62.41ms
+step:1480/1480 val_loss:3.2792 train_time:92475ms step_avg:62.48ms
+peak memory allocated: 31308 MiB reserved: 47522 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk5-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk5-1480.txt
@@ -1,0 +1,4463 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # QK bank: per-head-pair Muon groups for Q, K weights
+        # Each pair of adjacent heads gets its own independent polar express orthogonalization
+        self._num_attn_layers = num_attn_layers
+        num_qk_groups = num_attn_layers * 2 * (num_heads // 2)  # 10 * 2 * 3 = 60
+        self._num_qk_groups = num_qk_groups
+        num_qk_padded = next_multiple_of_n(num_qk_groups, n=world_size)  # 64
+        self.qk_bank = nn.Parameter(torch.empty(num_qk_padded, head_dim * 2, model_dim))
+        self.qk_bank.reshape = (num_qk_padded, head_dim * 2, model_dim)
+
+        # VO bank: per-layer Muon groups for V and O weights
+        num_vo_real = num_attn_layers * 2  # 20
+        num_vo_padded = next_multiple_of_n(num_vo_real, n=world_size)  # 24
+        self.vo_bank = nn.Parameter(torch.empty(num_vo_padded, hdim, hdim))
+        self.vo_bank.reshape = (num_vo_padded, hdim, hdim)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.qk_bank[:num_qk_groups].uniform_(-bound, bound)
+            self.qk_bank[num_qk_groups:].zero_()
+            self.vo_bank[:num_vo_real].uniform_(-bound, bound)
+            self.vo_bank[num_vo_real:].zero_()
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from qk_bank/vo_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        qk_all = self.qk_bank[:self._num_qk_groups].view(self._num_attn_layers, -1, self.qk_bank.shape[-1])
+        vo_flat = self.vo_bank[:self._num_attn_layers * 2].view(self._num_attn_layers, 2, *self.vo_bank.shape[1:]).flatten(1, 2)
+        attn_weights = torch.cat([qk_all, vo_flat], dim=1).unbind(0)
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            attn_idx = i - (i > 6) if i != 6 else None
+            qkvo_w = attn_weights[attn_idx] if attn_idx is not None else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "qk_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "vo_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "qk_bank", "vo_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.qk_bank.data = model.qk_bank.data.bfloat16()
+model.vo_bank.data = model.vo_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:07:20 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   38C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   38C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   38C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   65C    P0            150W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          253336      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          253337      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          253338      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          253339      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          253340      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          253341      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          253342      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          253343      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8293 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:77ms step_avg:77.25ms
+step:2/1480 train_time:104ms step_avg:51.79ms
+step:3/1480 train_time:125ms step_avg:41.68ms
+step:4/1480 train_time:148ms step_avg:36.98ms
+step:5/1480 train_time:169ms step_avg:33.73ms
+step:6/1480 train_time:203ms step_avg:33.82ms
+step:7/1480 train_time:232ms step_avg:33.10ms
+step:8/1480 train_time:266ms step_avg:33.24ms
+step:9/1480 train_time:295ms step_avg:32.77ms
+step:10/1480 train_time:329ms step_avg:32.90ms
+step:11/1480 train_time:358ms step_avg:32.54ms
+step:12/1480 train_time:392ms step_avg:32.68ms
+step:13/1480 train_time:421ms step_avg:32.40ms
+step:14/1480 train_time:456ms step_avg:32.56ms
+step:15/1480 train_time:485ms step_avg:32.31ms
+step:16/1480 train_time:520ms step_avg:32.47ms
+step:17/1480 train_time:548ms step_avg:32.26ms
+step:18/1480 train_time:583ms step_avg:32.41ms
+step:19/1480 train_time:612ms step_avg:32.24ms
+step:20/1480 train_time:647ms step_avg:32.33ms
+step:21/1480 train_time:676ms step_avg:32.21ms
+step:22/1480 train_time:711ms step_avg:32.31ms
+step:23/1480 train_time:740ms step_avg:32.19ms
+step:24/1480 train_time:775ms step_avg:32.27ms
+step:25/1480 train_time:804ms step_avg:32.15ms
+step:26/1480 train_time:839ms step_avg:32.27ms
+step:27/1480 train_time:868ms step_avg:32.14ms
+step:28/1480 train_time:903ms step_avg:32.24ms
+step:29/1480 train_time:932ms step_avg:32.14ms
+step:30/1480 train_time:968ms step_avg:32.25ms
+step:31/1480 train_time:999ms step_avg:32.22ms
+step:32/1480 train_time:1034ms step_avg:32.32ms
+step:33/1480 train_time:1064ms step_avg:32.25ms
+step:34/1480 train_time:1100ms step_avg:32.35ms
+step:35/1480 train_time:1129ms step_avg:32.25ms
+step:36/1480 train_time:1164ms step_avg:32.34ms
+step:37/1480 train_time:1194ms step_avg:32.26ms
+step:38/1480 train_time:1228ms step_avg:32.32ms
+step:39/1480 train_time:1258ms step_avg:32.25ms
+step:40/1480 train_time:1292ms step_avg:32.30ms
+step:41/1480 train_time:1322ms step_avg:32.24ms
+step:42/1480 train_time:1357ms step_avg:32.30ms
+step:43/1480 train_time:1386ms step_avg:32.23ms
+step:44/1480 train_time:1421ms step_avg:32.30ms
+step:45/1480 train_time:1450ms step_avg:32.22ms
+step:46/1480 train_time:1485ms step_avg:32.28ms
+step:47/1480 train_time:1515ms step_avg:32.23ms
+step:48/1480 train_time:1550ms step_avg:32.28ms
+step:49/1480 train_time:1580ms step_avg:32.25ms
+step:50/1480 train_time:1615ms step_avg:32.31ms
+step:51/1480 train_time:1645ms step_avg:32.26ms
+step:52/1480 train_time:1681ms step_avg:32.33ms
+step:53/1480 train_time:1711ms step_avg:32.28ms
+step:54/1480 train_time:1746ms step_avg:32.34ms
+step:55/1480 train_time:1776ms step_avg:32.30ms
+step:56/1480 train_time:1811ms step_avg:32.35ms
+step:57/1480 train_time:1841ms step_avg:32.31ms
+step:58/1480 train_time:1877ms step_avg:32.36ms
+step:59/1480 train_time:1906ms step_avg:32.31ms
+step:60/1480 train_time:1942ms step_avg:32.37ms
+step:61/1480 train_time:1971ms step_avg:32.32ms
+step:62/1480 train_time:2006ms step_avg:32.36ms
+step:63/1480 train_time:2036ms step_avg:32.32ms
+step:64/1480 train_time:2071ms step_avg:32.37ms
+step:65/1480 train_time:2102ms step_avg:32.33ms
+step:66/1480 train_time:2137ms step_avg:32.38ms
+step:67/1480 train_time:2166ms step_avg:32.33ms
+step:68/1480 train_time:2201ms step_avg:32.37ms
+step:69/1480 train_time:2231ms step_avg:32.33ms
+step:70/1480 train_time:2266ms step_avg:32.37ms
+step:71/1480 train_time:2296ms step_avg:32.34ms
+step:72/1480 train_time:2331ms step_avg:32.38ms
+step:73/1480 train_time:2362ms step_avg:32.36ms
+step:74/1480 train_time:2399ms step_avg:32.41ms
+step:75/1480 train_time:2429ms step_avg:32.38ms
+step:76/1480 train_time:2465ms step_avg:32.44ms
+step:77/1480 train_time:2496ms step_avg:32.42ms
+step:78/1480 train_time:2532ms step_avg:32.46ms
+step:79/1480 train_time:2563ms step_avg:32.44ms
+step:80/1480 train_time:2599ms step_avg:32.49ms
+step:81/1480 train_time:2629ms step_avg:32.46ms
+step:82/1480 train_time:2666ms step_avg:32.51ms
+step:83/1480 train_time:2696ms step_avg:32.48ms
+step:84/1480 train_time:2732ms step_avg:32.52ms
+step:85/1480 train_time:2762ms step_avg:32.50ms
+step:86/1480 train_time:2798ms step_avg:32.54ms
+step:87/1480 train_time:2828ms step_avg:32.51ms
+step:88/1480 train_time:2865ms step_avg:32.55ms
+step:89/1480 train_time:2895ms step_avg:32.53ms
+step:90/1480 train_time:2931ms step_avg:32.56ms
+step:91/1480 train_time:2961ms step_avg:32.54ms
+step:92/1480 train_time:2997ms step_avg:32.58ms
+step:93/1480 train_time:3027ms step_avg:32.55ms
+step:94/1480 train_time:3063ms step_avg:32.59ms
+step:95/1480 train_time:3094ms step_avg:32.56ms
+step:96/1480 train_time:3129ms step_avg:32.60ms
+step:97/1480 train_time:3160ms step_avg:32.58ms
+step:98/1480 train_time:3196ms step_avg:32.61ms
+step:99/1480 train_time:3226ms step_avg:32.58ms
+step:100/1480 train_time:3262ms step_avg:32.62ms
+step:101/1480 train_time:3293ms step_avg:32.60ms
+step:102/1480 train_time:3329ms step_avg:32.63ms
+step:103/1480 train_time:3360ms step_avg:32.62ms
+step:104/1480 train_time:3395ms step_avg:32.65ms
+step:105/1480 train_time:3426ms step_avg:32.62ms
+step:106/1480 train_time:3462ms step_avg:32.66ms
+step:107/1480 train_time:3492ms step_avg:32.64ms
+step:108/1480 train_time:3528ms step_avg:32.67ms
+step:109/1480 train_time:3559ms step_avg:32.65ms
+step:110/1480 train_time:3594ms step_avg:32.67ms
+step:111/1480 train_time:3624ms step_avg:32.65ms
+step:112/1480 train_time:3661ms step_avg:32.69ms
+step:113/1480 train_time:3691ms step_avg:32.66ms
+step:114/1480 train_time:3727ms step_avg:32.69ms
+step:115/1480 train_time:3757ms step_avg:32.67ms
+step:116/1480 train_time:3791ms step_avg:32.68ms
+step:117/1480 train_time:3820ms step_avg:32.65ms
+step:118/1480 train_time:3856ms step_avg:32.68ms
+step:119/1480 train_time:3885ms step_avg:32.65ms
+step:120/1480 train_time:3920ms step_avg:32.67ms
+step:121/1480 train_time:3951ms step_avg:32.65ms
+step:122/1480 train_time:3989ms step_avg:32.70ms
+step:123/1480 train_time:4022ms step_avg:32.70ms
+step:124/1480 train_time:4061ms step_avg:32.75ms
+step:125/1480 train_time:4094ms step_avg:32.75ms
+step:126/1480 train_time:4131ms step_avg:32.79ms
+step:127/1480 train_time:4162ms step_avg:32.77ms
+step:128/1480 train_time:4196ms step_avg:32.78ms
+step:129/1480 train_time:4225ms step_avg:32.75ms
+step:130/1480 train_time:4260ms step_avg:32.77ms
+step:131/1480 train_time:4288ms step_avg:32.74ms
+step:132/1480 train_time:4325ms step_avg:32.76ms
+step:133/1480 train_time:4355ms step_avg:32.75ms
+step:134/1480 train_time:4391ms step_avg:32.77ms
+step:135/1480 train_time:4421ms step_avg:32.75ms
+step:136/1480 train_time:4456ms step_avg:32.77ms
+step:137/1480 train_time:4486ms step_avg:32.75ms
+step:138/1480 train_time:4522ms step_avg:32.77ms
+step:139/1480 train_time:4552ms step_avg:32.75ms
+step:140/1480 train_time:4587ms step_avg:32.76ms
+step:141/1480 train_time:4617ms step_avg:32.74ms
+step:142/1480 train_time:4652ms step_avg:32.76ms
+step:143/1480 train_time:4682ms step_avg:32.74ms
+step:144/1480 train_time:4718ms step_avg:32.77ms
+step:145/1480 train_time:4748ms step_avg:32.74ms
+step:146/1480 train_time:4784ms step_avg:32.77ms
+step:147/1480 train_time:4814ms step_avg:32.75ms
+step:148/1480 train_time:4849ms step_avg:32.76ms
+step:149/1480 train_time:4880ms step_avg:32.75ms
+step:150/1480 train_time:4915ms step_avg:32.77ms
+step:151/1480 train_time:4945ms step_avg:32.75ms
+step:152/1480 train_time:4981ms step_avg:32.77ms
+step:153/1480 train_time:5011ms step_avg:32.75ms
+step:154/1480 train_time:5047ms step_avg:32.77ms
+step:155/1480 train_time:5077ms step_avg:32.75ms
+step:156/1480 train_time:5112ms step_avg:32.77ms
+step:157/1480 train_time:5142ms step_avg:32.75ms
+step:158/1480 train_time:5178ms step_avg:32.77ms
+step:159/1480 train_time:5208ms step_avg:32.76ms
+step:160/1480 train_time:5245ms step_avg:32.78ms
+step:161/1480 train_time:5275ms step_avg:32.76ms
+step:162/1480 train_time:5311ms step_avg:32.78ms
+step:163/1480 train_time:5341ms step_avg:32.77ms
+step:164/1480 train_time:5377ms step_avg:32.79ms
+step:165/1480 train_time:5407ms step_avg:32.77ms
+step:166/1480 train_time:5444ms step_avg:32.79ms
+step:167/1480 train_time:5474ms step_avg:32.78ms
+step:168/1480 train_time:5510ms step_avg:32.80ms
+step:169/1480 train_time:5541ms step_avg:32.78ms
+step:170/1480 train_time:5576ms step_avg:32.80ms
+step:171/1480 train_time:5607ms step_avg:32.79ms
+step:172/1480 train_time:5643ms step_avg:32.81ms
+step:173/1480 train_time:5673ms step_avg:32.79ms
+step:174/1480 train_time:5709ms step_avg:32.81ms
+step:175/1480 train_time:5740ms step_avg:32.80ms
+step:176/1480 train_time:5775ms step_avg:32.82ms
+step:177/1480 train_time:5805ms step_avg:32.80ms
+step:178/1480 train_time:5842ms step_avg:32.82ms
+step:179/1480 train_time:5872ms step_avg:32.80ms
+step:180/1480 train_time:5907ms step_avg:32.82ms
+step:181/1480 train_time:5938ms step_avg:32.81ms
+step:182/1480 train_time:5973ms step_avg:32.82ms
+step:183/1480 train_time:6004ms step_avg:32.81ms
+step:184/1480 train_time:6040ms step_avg:32.83ms
+step:185/1480 train_time:6070ms step_avg:32.81ms
+step:186/1480 train_time:6106ms step_avg:32.83ms
+step:187/1480 train_time:6136ms step_avg:32.82ms
+step:188/1480 train_time:6172ms step_avg:32.83ms
+step:189/1480 train_time:6202ms step_avg:32.81ms
+step:190/1480 train_time:6238ms step_avg:32.83ms
+step:191/1480 train_time:6268ms step_avg:32.81ms
+step:192/1480 train_time:6304ms step_avg:32.83ms
+step:193/1480 train_time:6334ms step_avg:32.82ms
+step:194/1480 train_time:6369ms step_avg:32.83ms
+step:195/1480 train_time:6400ms step_avg:32.82ms
+step:196/1480 train_time:6435ms step_avg:32.83ms
+step:197/1480 train_time:6465ms step_avg:32.82ms
+step:198/1480 train_time:6501ms step_avg:32.84ms
+step:199/1480 train_time:6532ms step_avg:32.82ms
+step:200/1480 train_time:6567ms step_avg:32.84ms
+step:201/1480 train_time:6598ms step_avg:32.82ms
+step:202/1480 train_time:6633ms step_avg:32.84ms
+step:203/1480 train_time:6663ms step_avg:32.83ms
+step:204/1480 train_time:6700ms step_avg:32.84ms
+step:205/1480 train_time:6729ms step_avg:32.83ms
+step:206/1480 train_time:6765ms step_avg:32.84ms
+step:207/1480 train_time:6796ms step_avg:32.83ms
+step:208/1480 train_time:6831ms step_avg:32.84ms
+step:209/1480 train_time:6862ms step_avg:32.83ms
+step:210/1480 train_time:6898ms step_avg:32.85ms
+step:211/1480 train_time:6928ms step_avg:32.83ms
+step:212/1480 train_time:6964ms step_avg:32.85ms
+step:213/1480 train_time:6995ms step_avg:32.84ms
+step:214/1480 train_time:7030ms step_avg:32.85ms
+step:215/1480 train_time:7060ms step_avg:32.84ms
+step:216/1480 train_time:7096ms step_avg:32.85ms
+step:217/1480 train_time:7126ms step_avg:32.84ms
+step:218/1480 train_time:7162ms step_avg:32.86ms
+step:219/1480 train_time:7193ms step_avg:32.84ms
+step:220/1480 train_time:7228ms step_avg:32.86ms
+step:221/1480 train_time:7259ms step_avg:32.85ms
+step:222/1480 train_time:7294ms step_avg:32.86ms
+step:223/1480 train_time:7324ms step_avg:32.85ms
+step:224/1480 train_time:7361ms step_avg:32.86ms
+step:225/1480 train_time:7391ms step_avg:32.85ms
+step:226/1480 train_time:7427ms step_avg:32.86ms
+step:227/1480 train_time:7458ms step_avg:32.86ms
+step:228/1480 train_time:7493ms step_avg:32.87ms
+step:229/1480 train_time:7524ms step_avg:32.85ms
+step:230/1480 train_time:7560ms step_avg:32.87ms
+step:231/1480 train_time:7590ms step_avg:32.86ms
+step:232/1480 train_time:7626ms step_avg:32.87ms
+step:233/1480 train_time:7658ms step_avg:32.87ms
+step:234/1480 train_time:7693ms step_avg:32.88ms
+step:235/1480 train_time:7724ms step_avg:32.87ms
+step:236/1480 train_time:7762ms step_avg:32.89ms
+step:237/1480 train_time:7793ms step_avg:32.88ms
+step:238/1480 train_time:7830ms step_avg:32.90ms
+step:239/1480 train_time:7861ms step_avg:32.89ms
+step:240/1480 train_time:7898ms step_avg:32.91ms
+step:241/1480 train_time:7929ms step_avg:32.90ms
+step:242/1480 train_time:7966ms step_avg:32.92ms
+step:243/1480 train_time:7997ms step_avg:32.91ms
+step:244/1480 train_time:8033ms step_avg:32.92ms
+step:245/1480 train_time:8065ms step_avg:32.92ms
+step:246/1480 train_time:8101ms step_avg:32.93ms
+step:247/1480 train_time:8132ms step_avg:32.92ms
+step:248/1480 train_time:8168ms step_avg:32.94ms
+step:249/1480 train_time:8200ms step_avg:32.93ms
+step:250/1480 train_time:8236ms step_avg:32.94ms
+step:250/1480 val_loss:4.5163 train_time:8281ms step_avg:33.12ms
+step:251/1480 train_time:8297ms step_avg:33.06ms
+step:252/1480 train_time:8316ms step_avg:33.00ms
+step:253/1480 train_time:8335ms step_avg:32.94ms
+step:254/1480 train_time:8370ms step_avg:32.95ms
+step:255/1480 train_time:8399ms step_avg:32.94ms
+step:256/1480 train_time:8435ms step_avg:32.95ms
+step:257/1480 train_time:8466ms step_avg:32.94ms
+step:258/1480 train_time:8501ms step_avg:32.95ms
+step:259/1480 train_time:8531ms step_avg:32.94ms
+step:260/1480 train_time:8568ms step_avg:32.95ms
+step:261/1480 train_time:8597ms step_avg:32.94ms
+step:262/1480 train_time:8633ms step_avg:32.95ms
+step:263/1480 train_time:8664ms step_avg:32.94ms
+step:264/1480 train_time:8699ms step_avg:32.95ms
+step:265/1480 train_time:8729ms step_avg:32.94ms
+step:266/1480 train_time:8765ms step_avg:32.95ms
+step:267/1480 train_time:8795ms step_avg:32.94ms
+step:268/1480 train_time:8831ms step_avg:32.95ms
+step:269/1480 train_time:8861ms step_avg:32.94ms
+step:270/1480 train_time:8896ms step_avg:32.95ms
+step:271/1480 train_time:8927ms step_avg:32.94ms
+step:272/1480 train_time:8962ms step_avg:32.95ms
+step:273/1480 train_time:8992ms step_avg:32.94ms
+step:274/1480 train_time:9028ms step_avg:32.95ms
+step:275/1480 train_time:9058ms step_avg:32.94ms
+step:276/1480 train_time:9094ms step_avg:32.95ms
+step:277/1480 train_time:9125ms step_avg:32.94ms
+step:278/1480 train_time:9160ms step_avg:32.95ms
+step:279/1480 train_time:9190ms step_avg:32.94ms
+step:280/1480 train_time:9226ms step_avg:32.95ms
+step:281/1480 train_time:9256ms step_avg:32.94ms
+step:282/1480 train_time:9292ms step_avg:32.95ms
+step:283/1480 train_time:9322ms step_avg:32.94ms
+step:284/1480 train_time:9357ms step_avg:32.95ms
+step:285/1480 train_time:9388ms step_avg:32.94ms
+step:286/1480 train_time:9424ms step_avg:32.95ms
+step:287/1480 train_time:9454ms step_avg:32.94ms
+step:288/1480 train_time:9490ms step_avg:32.95ms
+step:289/1480 train_time:9520ms step_avg:32.94ms
+step:290/1480 train_time:9556ms step_avg:32.95ms
+step:291/1480 train_time:9588ms step_avg:32.95ms
+step:292/1480 train_time:9624ms step_avg:32.96ms
+step:293/1480 train_time:9655ms step_avg:32.95ms
+step:294/1480 train_time:9692ms step_avg:32.97ms
+step:295/1480 train_time:9724ms step_avg:32.96ms
+step:296/1480 train_time:9760ms step_avg:32.97ms
+step:297/1480 train_time:9792ms step_avg:32.97ms
+step:298/1480 train_time:9828ms step_avg:32.98ms
+step:299/1480 train_time:9859ms step_avg:32.97ms
+step:300/1480 train_time:9896ms step_avg:32.99ms
+step:301/1480 train_time:9927ms step_avg:32.98ms
+step:302/1480 train_time:9963ms step_avg:32.99ms
+step:303/1480 train_time:9994ms step_avg:32.99ms
+step:304/1480 train_time:10031ms step_avg:33.00ms
+step:305/1480 train_time:10062ms step_avg:32.99ms
+step:306/1480 train_time:10099ms step_avg:33.00ms
+step:307/1480 train_time:10130ms step_avg:33.00ms
+step:308/1480 train_time:10168ms step_avg:33.01ms
+step:309/1480 train_time:10198ms step_avg:33.00ms
+step:310/1480 train_time:10235ms step_avg:33.01ms
+step:311/1480 train_time:10266ms step_avg:33.01ms
+step:312/1480 train_time:10302ms step_avg:33.02ms
+step:313/1480 train_time:10333ms step_avg:33.01ms
+step:314/1480 train_time:10370ms step_avg:33.03ms
+step:315/1480 train_time:10400ms step_avg:33.02ms
+step:316/1480 train_time:10437ms step_avg:33.03ms
+step:317/1480 train_time:10468ms step_avg:33.02ms
+step:318/1480 train_time:10504ms step_avg:33.03ms
+step:319/1480 train_time:10534ms step_avg:33.02ms
+step:320/1480 train_time:10571ms step_avg:33.04ms
+step:321/1480 train_time:10602ms step_avg:33.03ms
+step:322/1480 train_time:10637ms step_avg:33.04ms
+step:323/1480 train_time:10669ms step_avg:33.03ms
+step:324/1480 train_time:10705ms step_avg:33.04ms
+step:325/1480 train_time:10735ms step_avg:33.03ms
+step:326/1480 train_time:10772ms step_avg:33.04ms
+step:327/1480 train_time:10802ms step_avg:33.03ms
+step:328/1480 train_time:10838ms step_avg:33.04ms
+step:329/1480 train_time:10869ms step_avg:33.04ms
+step:330/1480 train_time:10905ms step_avg:33.05ms
+step:331/1480 train_time:10935ms step_avg:33.04ms
+step:332/1480 train_time:10972ms step_avg:33.05ms
+step:333/1480 train_time:11002ms step_avg:33.04ms
+step:334/1480 train_time:11038ms step_avg:33.05ms
+step:335/1480 train_time:11068ms step_avg:33.04ms
+step:336/1480 train_time:11104ms step_avg:33.05ms
+step:337/1480 train_time:11134ms step_avg:33.04ms
+step:338/1480 train_time:11171ms step_avg:33.05ms
+step:339/1480 train_time:11201ms step_avg:33.04ms
+step:340/1480 train_time:11237ms step_avg:33.05ms
+step:341/1480 train_time:11268ms step_avg:33.04ms
+step:342/1480 train_time:11303ms step_avg:33.05ms
+step:343/1480 train_time:11334ms step_avg:33.04ms
+step:344/1480 train_time:11370ms step_avg:33.05ms
+step:345/1480 train_time:11400ms step_avg:33.04ms
+step:346/1480 train_time:11436ms step_avg:33.05ms
+step:347/1480 train_time:11467ms step_avg:33.05ms
+step:348/1480 train_time:11503ms step_avg:33.05ms
+step:349/1480 train_time:11533ms step_avg:33.05ms
+step:350/1480 train_time:11569ms step_avg:33.05ms
+step:351/1480 train_time:11599ms step_avg:33.05ms
+step:352/1480 train_time:11635ms step_avg:33.05ms
+step:353/1480 train_time:11666ms step_avg:33.05ms
+step:354/1480 train_time:11701ms step_avg:33.05ms
+step:355/1480 train_time:11731ms step_avg:33.05ms
+step:356/1480 train_time:11768ms step_avg:33.05ms
+step:357/1480 train_time:11798ms step_avg:33.05ms
+step:358/1480 train_time:11833ms step_avg:33.05ms
+step:359/1480 train_time:11864ms step_avg:33.05ms
+step:360/1480 train_time:11899ms step_avg:33.05ms
+step:361/1480 train_time:11930ms step_avg:33.05ms
+step:362/1480 train_time:11966ms step_avg:33.05ms
+step:363/1480 train_time:11996ms step_avg:33.05ms
+step:364/1480 train_time:12032ms step_avg:33.05ms
+step:365/1480 train_time:12062ms step_avg:33.05ms
+step:366/1480 train_time:12097ms step_avg:33.05ms
+step:367/1480 train_time:12128ms step_avg:33.05ms
+step:368/1480 train_time:12163ms step_avg:33.05ms
+step:369/1480 train_time:12193ms step_avg:33.04ms
+step:370/1480 train_time:12229ms step_avg:33.05ms
+step:371/1480 train_time:12259ms step_avg:33.04ms
+step:372/1480 train_time:12295ms step_avg:33.05ms
+step:373/1480 train_time:12326ms step_avg:33.05ms
+step:374/1480 train_time:12361ms step_avg:33.05ms
+step:375/1480 train_time:12392ms step_avg:33.04ms
+step:376/1480 train_time:12427ms step_avg:33.05ms
+step:377/1480 train_time:12457ms step_avg:33.04ms
+step:378/1480 train_time:12493ms step_avg:33.05ms
+step:379/1480 train_time:12524ms step_avg:33.04ms
+step:380/1480 train_time:12559ms step_avg:33.05ms
+step:381/1480 train_time:12590ms step_avg:33.04ms
+step:382/1480 train_time:12627ms step_avg:33.05ms
+step:383/1480 train_time:12659ms step_avg:33.05ms
+step:384/1480 train_time:12697ms step_avg:33.07ms
+step:385/1480 train_time:12730ms step_avg:33.07ms
+step:386/1480 train_time:12769ms step_avg:33.08ms
+step:387/1480 train_time:12801ms step_avg:33.08ms
+step:388/1480 train_time:12839ms step_avg:33.09ms
+step:389/1480 train_time:12872ms step_avg:33.09ms
+step:390/1480 train_time:12910ms step_avg:33.10ms
+step:391/1480 train_time:12943ms step_avg:33.10ms
+step:392/1480 train_time:12979ms step_avg:33.11ms
+step:393/1480 train_time:13011ms step_avg:33.11ms
+step:394/1480 train_time:13049ms step_avg:33.12ms
+step:395/1480 train_time:13080ms step_avg:33.11ms
+step:396/1480 train_time:13117ms step_avg:33.12ms
+step:397/1480 train_time:13149ms step_avg:33.12ms
+step:398/1480 train_time:13186ms step_avg:33.13ms
+step:399/1480 train_time:13217ms step_avg:33.13ms
+step:400/1480 train_time:13252ms step_avg:33.13ms
+step:401/1480 train_time:13281ms step_avg:33.12ms
+step:402/1480 train_time:13314ms step_avg:33.12ms
+step:403/1480 train_time:13343ms step_avg:33.11ms
+step:404/1480 train_time:13378ms step_avg:33.11ms
+step:405/1480 train_time:13408ms step_avg:33.11ms
+step:406/1480 train_time:13444ms step_avg:33.11ms
+step:407/1480 train_time:13475ms step_avg:33.11ms
+step:408/1480 train_time:13512ms step_avg:33.12ms
+step:409/1480 train_time:13543ms step_avg:33.11ms
+step:410/1480 train_time:13580ms step_avg:33.12ms
+step:411/1480 train_time:13611ms step_avg:33.12ms
+step:412/1480 train_time:13649ms step_avg:33.13ms
+step:413/1480 train_time:13680ms step_avg:33.12ms
+step:414/1480 train_time:13716ms step_avg:33.13ms
+step:415/1480 train_time:13748ms step_avg:33.13ms
+step:416/1480 train_time:13784ms step_avg:33.13ms
+step:417/1480 train_time:13815ms step_avg:33.13ms
+step:418/1480 train_time:13852ms step_avg:33.14ms
+step:419/1480 train_time:13883ms step_avg:33.13ms
+step:420/1480 train_time:13919ms step_avg:33.14ms
+step:421/1480 train_time:13950ms step_avg:33.14ms
+step:422/1480 train_time:13987ms step_avg:33.15ms
+step:423/1480 train_time:14019ms step_avg:33.14ms
+step:424/1480 train_time:14056ms step_avg:33.15ms
+step:425/1480 train_time:14086ms step_avg:33.14ms
+step:426/1480 train_time:14122ms step_avg:33.15ms
+step:427/1480 train_time:14153ms step_avg:33.15ms
+step:428/1480 train_time:14190ms step_avg:33.15ms
+step:429/1480 train_time:14221ms step_avg:33.15ms
+step:430/1480 train_time:14257ms step_avg:33.15ms
+step:431/1480 train_time:14288ms step_avg:33.15ms
+step:432/1480 train_time:14324ms step_avg:33.16ms
+step:433/1480 train_time:14355ms step_avg:33.15ms
+step:434/1480 train_time:14391ms step_avg:33.16ms
+step:435/1480 train_time:14422ms step_avg:33.15ms
+step:436/1480 train_time:14458ms step_avg:33.16ms
+step:437/1480 train_time:14489ms step_avg:33.16ms
+step:438/1480 train_time:14525ms step_avg:33.16ms
+step:439/1480 train_time:14555ms step_avg:33.16ms
+step:440/1480 train_time:14592ms step_avg:33.16ms
+step:441/1480 train_time:14623ms step_avg:33.16ms
+step:442/1480 train_time:14659ms step_avg:33.16ms
+step:443/1480 train_time:14690ms step_avg:33.16ms
+step:444/1480 train_time:14726ms step_avg:33.17ms
+step:445/1480 train_time:14756ms step_avg:33.16ms
+step:446/1480 train_time:14792ms step_avg:33.17ms
+step:447/1480 train_time:14823ms step_avg:33.16ms
+step:448/1480 train_time:14859ms step_avg:33.17ms
+step:449/1480 train_time:14889ms step_avg:33.16ms
+step:450/1480 train_time:14925ms step_avg:33.17ms
+step:451/1480 train_time:14955ms step_avg:33.16ms
+step:452/1480 train_time:14992ms step_avg:33.17ms
+step:453/1480 train_time:15022ms step_avg:33.16ms
+step:454/1480 train_time:15058ms step_avg:33.17ms
+step:455/1480 train_time:15089ms step_avg:33.16ms
+step:456/1480 train_time:15125ms step_avg:33.17ms
+step:457/1480 train_time:15155ms step_avg:33.16ms
+step:458/1480 train_time:15192ms step_avg:33.17ms
+step:459/1480 train_time:15222ms step_avg:33.16ms
+step:460/1480 train_time:15258ms step_avg:33.17ms
+step:461/1480 train_time:15288ms step_avg:33.16ms
+step:462/1480 train_time:15324ms step_avg:33.17ms
+step:463/1480 train_time:15355ms step_avg:33.16ms
+step:464/1480 train_time:15392ms step_avg:33.17ms
+step:465/1480 train_time:15422ms step_avg:33.17ms
+step:466/1480 train_time:15458ms step_avg:33.17ms
+step:467/1480 train_time:15489ms step_avg:33.17ms
+step:468/1480 train_time:15525ms step_avg:33.17ms
+step:469/1480 train_time:15555ms step_avg:33.17ms
+step:470/1480 train_time:15592ms step_avg:33.17ms
+step:471/1480 train_time:15622ms step_avg:33.17ms
+step:472/1480 train_time:15658ms step_avg:33.17ms
+step:473/1480 train_time:15689ms step_avg:33.17ms
+step:474/1480 train_time:15725ms step_avg:33.17ms
+step:475/1480 train_time:15755ms step_avg:33.17ms
+step:476/1480 train_time:15791ms step_avg:33.17ms
+step:477/1480 train_time:15821ms step_avg:33.17ms
+step:478/1480 train_time:15857ms step_avg:33.17ms
+step:479/1480 train_time:15888ms step_avg:33.17ms
+step:480/1480 train_time:15924ms step_avg:33.17ms
+step:481/1480 train_time:15956ms step_avg:33.17ms
+step:482/1480 train_time:16018ms step_avg:33.23ms
+step:483/1480 train_time:16075ms step_avg:33.28ms
+step:484/1480 train_time:16139ms step_avg:33.35ms
+step:485/1480 train_time:16200ms step_avg:33.40ms
+step:486/1480 train_time:16267ms step_avg:33.47ms
+step:487/1480 train_time:16324ms step_avg:33.52ms
+step:488/1480 train_time:16388ms step_avg:33.58ms
+step:489/1480 train_time:16446ms step_avg:33.63ms
+step:490/1480 train_time:16510ms step_avg:33.69ms
+step:491/1480 train_time:16569ms step_avg:33.75ms
+step:492/1480 train_time:16635ms step_avg:33.81ms
+step:493/1480 train_time:16695ms step_avg:33.86ms
+step:494/1480 train_time:16759ms step_avg:33.93ms
+step:495/1480 train_time:16818ms step_avg:33.98ms
+step:496/1480 train_time:16882ms step_avg:34.04ms
+step:497/1480 train_time:16940ms step_avg:34.08ms
+step:498/1480 train_time:17005ms step_avg:34.15ms
+step:499/1480 train_time:17063ms step_avg:34.19ms
+step:500/1480 train_time:17127ms step_avg:34.25ms
+step:500/1480 val_loss:4.2010 train_time:17204ms step_avg:34.41ms
+step:501/1480 train_time:17223ms step_avg:34.38ms
+step:502/1480 train_time:17250ms step_avg:34.36ms
+step:503/1480 train_time:17306ms step_avg:34.41ms
+step:504/1480 train_time:17369ms step_avg:34.46ms
+step:505/1480 train_time:17426ms step_avg:34.51ms
+step:506/1480 train_time:17488ms step_avg:34.56ms
+step:507/1480 train_time:17545ms step_avg:34.61ms
+step:508/1480 train_time:17608ms step_avg:34.66ms
+step:509/1480 train_time:17664ms step_avg:34.70ms
+step:510/1480 train_time:17728ms step_avg:34.76ms
+step:511/1480 train_time:17784ms step_avg:34.80ms
+step:512/1480 train_time:17846ms step_avg:34.86ms
+step:513/1480 train_time:17904ms step_avg:34.90ms
+step:514/1480 train_time:17968ms step_avg:34.96ms
+step:515/1480 train_time:18026ms step_avg:35.00ms
+step:516/1480 train_time:18090ms step_avg:35.06ms
+step:517/1480 train_time:18148ms step_avg:35.10ms
+step:518/1480 train_time:18212ms step_avg:35.16ms
+step:519/1480 train_time:18271ms step_avg:35.20ms
+step:520/1480 train_time:18337ms step_avg:35.26ms
+step:521/1480 train_time:18395ms step_avg:35.31ms
+step:522/1480 train_time:18461ms step_avg:35.37ms
+step:523/1480 train_time:18520ms step_avg:35.41ms
+step:524/1480 train_time:18585ms step_avg:35.47ms
+step:525/1480 train_time:18645ms step_avg:35.51ms
+step:526/1480 train_time:18709ms step_avg:35.57ms
+step:527/1480 train_time:18769ms step_avg:35.62ms
+step:528/1480 train_time:18835ms step_avg:35.67ms
+step:529/1480 train_time:18894ms step_avg:35.72ms
+step:530/1480 train_time:18959ms step_avg:35.77ms
+step:531/1480 train_time:19017ms step_avg:35.81ms
+step:532/1480 train_time:19082ms step_avg:35.87ms
+step:533/1480 train_time:19141ms step_avg:35.91ms
+step:534/1480 train_time:19206ms step_avg:35.97ms
+step:535/1480 train_time:19265ms step_avg:36.01ms
+step:536/1480 train_time:19331ms step_avg:36.07ms
+step:537/1480 train_time:19389ms step_avg:36.11ms
+step:538/1480 train_time:19452ms step_avg:36.16ms
+step:539/1480 train_time:19510ms step_avg:36.20ms
+step:540/1480 train_time:19573ms step_avg:36.25ms
+step:541/1480 train_time:19631ms step_avg:36.29ms
+step:542/1480 train_time:19695ms step_avg:36.34ms
+step:543/1480 train_time:19752ms step_avg:36.38ms
+step:544/1480 train_time:19816ms step_avg:36.43ms
+step:545/1480 train_time:19874ms step_avg:36.47ms
+step:546/1480 train_time:19939ms step_avg:36.52ms
+step:547/1480 train_time:19997ms step_avg:36.56ms
+step:548/1480 train_time:20063ms step_avg:36.61ms
+step:549/1480 train_time:20126ms step_avg:36.66ms
+step:550/1480 train_time:20192ms step_avg:36.71ms
+step:551/1480 train_time:20252ms step_avg:36.76ms
+step:552/1480 train_time:20319ms step_avg:36.81ms
+step:553/1480 train_time:20378ms step_avg:36.85ms
+step:554/1480 train_time:20443ms step_avg:36.90ms
+step:555/1480 train_time:20502ms step_avg:36.94ms
+step:556/1480 train_time:20567ms step_avg:36.99ms
+step:557/1480 train_time:20627ms step_avg:37.03ms
+step:558/1480 train_time:20693ms step_avg:37.08ms
+step:559/1480 train_time:20752ms step_avg:37.12ms
+step:560/1480 train_time:20818ms step_avg:37.17ms
+step:561/1480 train_time:20877ms step_avg:37.21ms
+step:562/1480 train_time:20941ms step_avg:37.26ms
+step:563/1480 train_time:21000ms step_avg:37.30ms
+step:564/1480 train_time:21065ms step_avg:37.35ms
+step:565/1480 train_time:21124ms step_avg:37.39ms
+step:566/1480 train_time:21188ms step_avg:37.44ms
+step:567/1480 train_time:21247ms step_avg:37.47ms
+step:568/1480 train_time:21312ms step_avg:37.52ms
+step:569/1480 train_time:21372ms step_avg:37.56ms
+step:570/1480 train_time:21437ms step_avg:37.61ms
+step:571/1480 train_time:21495ms step_avg:37.65ms
+step:572/1480 train_time:21561ms step_avg:37.69ms
+step:573/1480 train_time:21619ms step_avg:37.73ms
+step:574/1480 train_time:21684ms step_avg:37.78ms
+step:575/1480 train_time:21744ms step_avg:37.82ms
+step:576/1480 train_time:21809ms step_avg:37.86ms
+step:577/1480 train_time:21868ms step_avg:37.90ms
+step:578/1480 train_time:21932ms step_avg:37.94ms
+step:579/1480 train_time:21990ms step_avg:37.98ms
+step:580/1480 train_time:22054ms step_avg:38.02ms
+step:581/1480 train_time:22113ms step_avg:38.06ms
+step:582/1480 train_time:22177ms step_avg:38.10ms
+step:583/1480 train_time:22234ms step_avg:38.14ms
+step:584/1480 train_time:22298ms step_avg:38.18ms
+step:585/1480 train_time:22356ms step_avg:38.21ms
+step:586/1480 train_time:22420ms step_avg:38.26ms
+step:587/1480 train_time:22478ms step_avg:38.29ms
+step:588/1480 train_time:22541ms step_avg:38.34ms
+step:589/1480 train_time:22599ms step_avg:38.37ms
+step:590/1480 train_time:22662ms step_avg:38.41ms
+step:591/1480 train_time:22720ms step_avg:38.44ms
+step:592/1480 train_time:22784ms step_avg:38.49ms
+step:593/1480 train_time:22841ms step_avg:38.52ms
+step:594/1480 train_time:22905ms step_avg:38.56ms
+step:595/1480 train_time:22962ms step_avg:38.59ms
+step:596/1480 train_time:23027ms step_avg:38.64ms
+step:597/1480 train_time:23084ms step_avg:38.67ms
+step:598/1480 train_time:23147ms step_avg:38.71ms
+step:599/1480 train_time:23203ms step_avg:38.74ms
+step:600/1480 train_time:23267ms step_avg:38.78ms
+step:601/1480 train_time:23325ms step_avg:38.81ms
+step:602/1480 train_time:23390ms step_avg:38.85ms
+step:603/1480 train_time:23450ms step_avg:38.89ms
+step:604/1480 train_time:23515ms step_avg:38.93ms
+step:605/1480 train_time:23573ms step_avg:38.96ms
+step:606/1480 train_time:23636ms step_avg:39.00ms
+step:607/1480 train_time:23695ms step_avg:39.04ms
+step:608/1480 train_time:23760ms step_avg:39.08ms
+step:609/1480 train_time:23818ms step_avg:39.11ms
+step:610/1480 train_time:23883ms step_avg:39.15ms
+step:611/1480 train_time:23941ms step_avg:39.18ms
+step:612/1480 train_time:24006ms step_avg:39.23ms
+step:613/1480 train_time:24065ms step_avg:39.26ms
+step:614/1480 train_time:24131ms step_avg:39.30ms
+step:615/1480 train_time:24189ms step_avg:39.33ms
+step:616/1480 train_time:24253ms step_avg:39.37ms
+step:617/1480 train_time:24311ms step_avg:39.40ms
+step:618/1480 train_time:24375ms step_avg:39.44ms
+step:619/1480 train_time:24432ms step_avg:39.47ms
+step:620/1480 train_time:24496ms step_avg:39.51ms
+step:621/1480 train_time:24554ms step_avg:39.54ms
+step:622/1480 train_time:24617ms step_avg:39.58ms
+step:623/1480 train_time:24675ms step_avg:39.61ms
+step:624/1480 train_time:24739ms step_avg:39.65ms
+step:625/1480 train_time:24796ms step_avg:39.67ms
+step:626/1480 train_time:24860ms step_avg:39.71ms
+step:627/1480 train_time:24917ms step_avg:39.74ms
+step:628/1480 train_time:24983ms step_avg:39.78ms
+step:629/1480 train_time:25044ms step_avg:39.82ms
+step:630/1480 train_time:25111ms step_avg:39.86ms
+step:631/1480 train_time:25171ms step_avg:39.89ms
+step:632/1480 train_time:25238ms step_avg:39.93ms
+step:633/1480 train_time:25297ms step_avg:39.96ms
+step:634/1480 train_time:25364ms step_avg:40.01ms
+step:635/1480 train_time:25424ms step_avg:40.04ms
+step:636/1480 train_time:25488ms step_avg:40.08ms
+step:637/1480 train_time:25548ms step_avg:40.11ms
+step:638/1480 train_time:25614ms step_avg:40.15ms
+step:639/1480 train_time:25675ms step_avg:40.18ms
+step:640/1480 train_time:25740ms step_avg:40.22ms
+step:641/1480 train_time:25798ms step_avg:40.25ms
+step:642/1480 train_time:25863ms step_avg:40.29ms
+step:643/1480 train_time:25923ms step_avg:40.32ms
+step:644/1480 train_time:25988ms step_avg:40.35ms
+step:645/1480 train_time:26047ms step_avg:40.38ms
+step:646/1480 train_time:26111ms step_avg:40.42ms
+step:647/1480 train_time:26171ms step_avg:40.45ms
+step:648/1480 train_time:26236ms step_avg:40.49ms
+step:649/1480 train_time:26294ms step_avg:40.51ms
+step:650/1480 train_time:26359ms step_avg:40.55ms
+step:651/1480 train_time:26415ms step_avg:40.58ms
+step:652/1480 train_time:26475ms step_avg:40.61ms
+step:653/1480 train_time:26529ms step_avg:40.63ms
+step:654/1480 train_time:26593ms step_avg:40.66ms
+step:655/1480 train_time:26650ms step_avg:40.69ms
+step:656/1480 train_time:26712ms step_avg:40.72ms
+step:657/1480 train_time:26769ms step_avg:40.74ms
+step:658/1480 train_time:26832ms step_avg:40.78ms
+step:659/1480 train_time:26890ms step_avg:40.80ms
+step:660/1480 train_time:26953ms step_avg:40.84ms
+step:661/1480 train_time:27013ms step_avg:40.87ms
+step:662/1480 train_time:27082ms step_avg:40.91ms
+step:663/1480 train_time:27145ms step_avg:40.94ms
+step:664/1480 train_time:27212ms step_avg:40.98ms
+step:665/1480 train_time:27274ms step_avg:41.01ms
+step:666/1480 train_time:27341ms step_avg:41.05ms
+step:667/1480 train_time:27401ms step_avg:41.08ms
+step:668/1480 train_time:27467ms step_avg:41.12ms
+step:669/1480 train_time:27529ms step_avg:41.15ms
+step:670/1480 train_time:27596ms step_avg:41.19ms
+step:671/1480 train_time:27652ms step_avg:41.21ms
+step:672/1480 train_time:27711ms step_avg:41.24ms
+step:673/1480 train_time:27766ms step_avg:41.26ms
+step:674/1480 train_time:27829ms step_avg:41.29ms
+step:675/1480 train_time:27885ms step_avg:41.31ms
+step:676/1480 train_time:27948ms step_avg:41.34ms
+step:677/1480 train_time:28003ms step_avg:41.36ms
+step:678/1480 train_time:28069ms step_avg:41.40ms
+step:679/1480 train_time:28129ms step_avg:41.43ms
+step:680/1480 train_time:28193ms step_avg:41.46ms
+step:681/1480 train_time:28251ms step_avg:41.49ms
+step:682/1480 train_time:28315ms step_avg:41.52ms
+step:683/1480 train_time:28374ms step_avg:41.54ms
+step:684/1480 train_time:28438ms step_avg:41.58ms
+step:685/1480 train_time:28494ms step_avg:41.60ms
+step:686/1480 train_time:28558ms step_avg:41.63ms
+step:687/1480 train_time:28615ms step_avg:41.65ms
+step:688/1480 train_time:28679ms step_avg:41.69ms
+step:689/1480 train_time:28737ms step_avg:41.71ms
+step:690/1480 train_time:28801ms step_avg:41.74ms
+step:691/1480 train_time:28860ms step_avg:41.77ms
+step:692/1480 train_time:28926ms step_avg:41.80ms
+step:693/1480 train_time:28986ms step_avg:41.83ms
+step:694/1480 train_time:29050ms step_avg:41.86ms
+step:695/1480 train_time:29109ms step_avg:41.88ms
+step:696/1480 train_time:29175ms step_avg:41.92ms
+step:697/1480 train_time:29233ms step_avg:41.94ms
+step:698/1480 train_time:29297ms step_avg:41.97ms
+step:699/1480 train_time:29355ms step_avg:42.00ms
+step:700/1480 train_time:29419ms step_avg:42.03ms
+step:701/1480 train_time:29480ms step_avg:42.05ms
+step:702/1480 train_time:29550ms step_avg:42.09ms
+step:703/1480 train_time:29617ms step_avg:42.13ms
+step:704/1480 train_time:29687ms step_avg:42.17ms
+step:705/1480 train_time:29740ms step_avg:42.18ms
+step:706/1480 train_time:29799ms step_avg:42.21ms
+step:707/1480 train_time:29859ms step_avg:42.23ms
+step:708/1480 train_time:29924ms step_avg:42.27ms
+step:709/1480 train_time:29983ms step_avg:42.29ms
+step:710/1480 train_time:30048ms step_avg:42.32ms
+step:711/1480 train_time:30108ms step_avg:42.35ms
+step:712/1480 train_time:30172ms step_avg:42.38ms
+step:713/1480 train_time:30233ms step_avg:42.40ms
+step:714/1480 train_time:30297ms step_avg:42.43ms
+step:715/1480 train_time:30356ms step_avg:42.46ms
+step:716/1480 train_time:30422ms step_avg:42.49ms
+step:717/1480 train_time:30482ms step_avg:42.51ms
+step:718/1480 train_time:30544ms step_avg:42.54ms
+step:719/1480 train_time:30602ms step_avg:42.56ms
+step:720/1480 train_time:30666ms step_avg:42.59ms
+step:721/1480 train_time:30724ms step_avg:42.61ms
+step:722/1480 train_time:30788ms step_avg:42.64ms
+step:723/1480 train_time:30846ms step_avg:42.66ms
+step:724/1480 train_time:30909ms step_avg:42.69ms
+step:725/1480 train_time:30968ms step_avg:42.71ms
+step:726/1480 train_time:31035ms step_avg:42.75ms
+step:727/1480 train_time:31095ms step_avg:42.77ms
+step:728/1480 train_time:31160ms step_avg:42.80ms
+step:729/1480 train_time:31218ms step_avg:42.82ms
+step:730/1480 train_time:31284ms step_avg:42.85ms
+step:731/1480 train_time:31344ms step_avg:42.88ms
+step:732/1480 train_time:31409ms step_avg:42.91ms
+step:733/1480 train_time:31468ms step_avg:42.93ms
+step:734/1480 train_time:31532ms step_avg:42.96ms
+step:735/1480 train_time:31591ms step_avg:42.98ms
+step:736/1480 train_time:31658ms step_avg:43.01ms
+step:737/1480 train_time:31717ms step_avg:43.03ms
+step:738/1480 train_time:31781ms step_avg:43.06ms
+step:739/1480 train_time:31839ms step_avg:43.08ms
+step:740/1480 train_time:31903ms step_avg:43.11ms
+step:741/1480 train_time:31961ms step_avg:43.13ms
+step:742/1480 train_time:32024ms step_avg:43.16ms
+step:743/1480 train_time:32083ms step_avg:43.18ms
+step:744/1480 train_time:32148ms step_avg:43.21ms
+step:745/1480 train_time:32205ms step_avg:43.23ms
+step:746/1480 train_time:32270ms step_avg:43.26ms
+step:747/1480 train_time:32331ms step_avg:43.28ms
+step:748/1480 train_time:32396ms step_avg:43.31ms
+step:749/1480 train_time:32454ms step_avg:43.33ms
+step:750/1480 train_time:32519ms step_avg:43.36ms
+step:750/1480 val_loss:3.7973 train_time:32597ms step_avg:43.46ms
+step:751/1480 train_time:32614ms step_avg:43.43ms
+step:752/1480 train_time:32643ms step_avg:43.41ms
+step:753/1480 train_time:32711ms step_avg:43.44ms
+step:754/1480 train_time:32776ms step_avg:43.47ms
+step:755/1480 train_time:32836ms step_avg:43.49ms
+step:756/1480 train_time:32900ms step_avg:43.52ms
+step:757/1480 train_time:32958ms step_avg:43.54ms
+step:758/1480 train_time:33022ms step_avg:43.56ms
+step:759/1480 train_time:33079ms step_avg:43.58ms
+step:760/1480 train_time:33143ms step_avg:43.61ms
+step:761/1480 train_time:33201ms step_avg:43.63ms
+step:762/1480 train_time:33263ms step_avg:43.65ms
+step:763/1480 train_time:33320ms step_avg:43.67ms
+step:764/1480 train_time:33383ms step_avg:43.70ms
+step:765/1480 train_time:33441ms step_avg:43.71ms
+step:766/1480 train_time:33505ms step_avg:43.74ms
+step:767/1480 train_time:33569ms step_avg:43.77ms
+step:768/1480 train_time:33642ms step_avg:43.80ms
+step:769/1480 train_time:33705ms step_avg:43.83ms
+step:770/1480 train_time:33775ms step_avg:43.86ms
+step:771/1480 train_time:33839ms step_avg:43.89ms
+step:772/1480 train_time:33910ms step_avg:43.92ms
+step:773/1480 train_time:33971ms step_avg:43.95ms
+step:774/1480 train_time:34030ms step_avg:43.97ms
+step:775/1480 train_time:34084ms step_avg:43.98ms
+step:776/1480 train_time:34145ms step_avg:44.00ms
+step:777/1480 train_time:34206ms step_avg:44.02ms
+step:778/1480 train_time:34272ms step_avg:44.05ms
+step:779/1480 train_time:34334ms step_avg:44.07ms
+step:780/1480 train_time:34399ms step_avg:44.10ms
+step:781/1480 train_time:34457ms step_avg:44.12ms
+step:782/1480 train_time:34520ms step_avg:44.14ms
+step:783/1480 train_time:34578ms step_avg:44.16ms
+step:784/1480 train_time:34643ms step_avg:44.19ms
+step:785/1480 train_time:34700ms step_avg:44.20ms
+step:786/1480 train_time:34765ms step_avg:44.23ms
+step:787/1480 train_time:34822ms step_avg:44.25ms
+step:788/1480 train_time:34888ms step_avg:44.27ms
+step:789/1480 train_time:34947ms step_avg:44.29ms
+step:790/1480 train_time:35012ms step_avg:44.32ms
+step:791/1480 train_time:35073ms step_avg:44.34ms
+step:792/1480 train_time:35140ms step_avg:44.37ms
+step:793/1480 train_time:35200ms step_avg:44.39ms
+step:794/1480 train_time:35266ms step_avg:44.42ms
+step:795/1480 train_time:35326ms step_avg:44.44ms
+step:796/1480 train_time:35393ms step_avg:44.46ms
+step:797/1480 train_time:35453ms step_avg:44.48ms
+step:798/1480 train_time:35520ms step_avg:44.51ms
+step:799/1480 train_time:35580ms step_avg:44.53ms
+step:800/1480 train_time:35647ms step_avg:44.56ms
+step:801/1480 train_time:35706ms step_avg:44.58ms
+step:802/1480 train_time:35772ms step_avg:44.60ms
+step:803/1480 train_time:35830ms step_avg:44.62ms
+step:804/1480 train_time:35891ms step_avg:44.64ms
+step:805/1480 train_time:35945ms step_avg:44.65ms
+step:806/1480 train_time:36010ms step_avg:44.68ms
+step:807/1480 train_time:36068ms step_avg:44.69ms
+step:808/1480 train_time:36132ms step_avg:44.72ms
+step:809/1480 train_time:36192ms step_avg:44.74ms
+step:810/1480 train_time:36256ms step_avg:44.76ms
+step:811/1480 train_time:36315ms step_avg:44.78ms
+step:812/1480 train_time:36380ms step_avg:44.80ms
+step:813/1480 train_time:36440ms step_avg:44.82ms
+step:814/1480 train_time:36505ms step_avg:44.85ms
+step:815/1480 train_time:36562ms step_avg:44.86ms
+step:816/1480 train_time:36627ms step_avg:44.89ms
+step:817/1480 train_time:36688ms step_avg:44.91ms
+step:818/1480 train_time:36753ms step_avg:44.93ms
+step:819/1480 train_time:36811ms step_avg:44.95ms
+step:820/1480 train_time:36873ms step_avg:44.97ms
+step:821/1480 train_time:36931ms step_avg:44.98ms
+step:822/1480 train_time:36994ms step_avg:45.01ms
+step:823/1480 train_time:37051ms step_avg:45.02ms
+step:824/1480 train_time:37114ms step_avg:45.04ms
+step:825/1480 train_time:37171ms step_avg:45.06ms
+step:826/1480 train_time:37234ms step_avg:45.08ms
+step:827/1480 train_time:37292ms step_avg:45.09ms
+step:828/1480 train_time:37356ms step_avg:45.12ms
+step:829/1480 train_time:37413ms step_avg:45.13ms
+step:830/1480 train_time:37477ms step_avg:45.15ms
+step:831/1480 train_time:37537ms step_avg:45.17ms
+step:832/1480 train_time:37601ms step_avg:45.19ms
+step:833/1480 train_time:37659ms step_avg:45.21ms
+step:834/1480 train_time:37723ms step_avg:45.23ms
+step:835/1480 train_time:37781ms step_avg:45.25ms
+step:836/1480 train_time:37846ms step_avg:45.27ms
+step:837/1480 train_time:37905ms step_avg:45.29ms
+step:838/1480 train_time:37971ms step_avg:45.31ms
+step:839/1480 train_time:38032ms step_avg:45.33ms
+step:840/1480 train_time:38096ms step_avg:45.35ms
+step:841/1480 train_time:38154ms step_avg:45.37ms
+step:842/1480 train_time:38219ms step_avg:45.39ms
+step:843/1480 train_time:38280ms step_avg:45.41ms
+step:844/1480 train_time:38345ms step_avg:45.43ms
+step:845/1480 train_time:38403ms step_avg:45.45ms
+step:846/1480 train_time:38466ms step_avg:45.47ms
+step:847/1480 train_time:38524ms step_avg:45.48ms
+step:848/1480 train_time:38588ms step_avg:45.50ms
+step:849/1480 train_time:38647ms step_avg:45.52ms
+step:850/1480 train_time:38709ms step_avg:45.54ms
+step:851/1480 train_time:38766ms step_avg:45.55ms
+step:852/1480 train_time:38830ms step_avg:45.58ms
+step:853/1480 train_time:38888ms step_avg:45.59ms
+step:854/1480 train_time:38951ms step_avg:45.61ms
+step:855/1480 train_time:39009ms step_avg:45.62ms
+step:856/1480 train_time:39072ms step_avg:45.65ms
+step:857/1480 train_time:39131ms step_avg:45.66ms
+step:858/1480 train_time:39194ms step_avg:45.68ms
+step:859/1480 train_time:39252ms step_avg:45.69ms
+step:860/1480 train_time:39315ms step_avg:45.72ms
+step:861/1480 train_time:39375ms step_avg:45.73ms
+step:862/1480 train_time:39441ms step_avg:45.75ms
+step:863/1480 train_time:39500ms step_avg:45.77ms
+step:864/1480 train_time:39569ms step_avg:45.80ms
+step:865/1480 train_time:39632ms step_avg:45.82ms
+step:866/1480 train_time:39701ms step_avg:45.84ms
+step:867/1480 train_time:39763ms step_avg:45.86ms
+step:868/1480 train_time:39832ms step_avg:45.89ms
+step:869/1480 train_time:39895ms step_avg:45.91ms
+step:870/1480 train_time:39955ms step_avg:45.93ms
+step:871/1480 train_time:40009ms step_avg:45.93ms
+step:872/1480 train_time:40069ms step_avg:45.95ms
+step:873/1480 train_time:40130ms step_avg:45.97ms
+step:874/1480 train_time:40197ms step_avg:45.99ms
+step:875/1480 train_time:40257ms step_avg:46.01ms
+step:876/1480 train_time:40322ms step_avg:46.03ms
+step:877/1480 train_time:40381ms step_avg:46.04ms
+step:878/1480 train_time:40446ms step_avg:46.07ms
+step:879/1480 train_time:40505ms step_avg:46.08ms
+step:880/1480 train_time:40570ms step_avg:46.10ms
+step:881/1480 train_time:40628ms step_avg:46.12ms
+step:882/1480 train_time:40693ms step_avg:46.14ms
+step:883/1480 train_time:40752ms step_avg:46.15ms
+step:884/1480 train_time:40817ms step_avg:46.17ms
+step:885/1480 train_time:40876ms step_avg:46.19ms
+step:886/1480 train_time:40942ms step_avg:46.21ms
+step:887/1480 train_time:41000ms step_avg:46.22ms
+step:888/1480 train_time:41064ms step_avg:46.24ms
+step:889/1480 train_time:41122ms step_avg:46.26ms
+step:890/1480 train_time:41187ms step_avg:46.28ms
+step:891/1480 train_time:41246ms step_avg:46.29ms
+step:892/1480 train_time:41310ms step_avg:46.31ms
+step:893/1480 train_time:41368ms step_avg:46.32ms
+step:894/1480 train_time:41432ms step_avg:46.34ms
+step:895/1480 train_time:41491ms step_avg:46.36ms
+step:896/1480 train_time:41555ms step_avg:46.38ms
+step:897/1480 train_time:41614ms step_avg:46.39ms
+step:898/1480 train_time:41678ms step_avg:46.41ms
+step:899/1480 train_time:41738ms step_avg:46.43ms
+step:900/1480 train_time:41803ms step_avg:46.45ms
+step:901/1480 train_time:41861ms step_avg:46.46ms
+step:902/1480 train_time:41925ms step_avg:46.48ms
+step:903/1480 train_time:41983ms step_avg:46.49ms
+step:904/1480 train_time:42048ms step_avg:46.51ms
+step:905/1480 train_time:42106ms step_avg:46.53ms
+step:906/1480 train_time:42169ms step_avg:46.54ms
+step:907/1480 train_time:42227ms step_avg:46.56ms
+step:908/1480 train_time:42292ms step_avg:46.58ms
+step:909/1480 train_time:42350ms step_avg:46.59ms
+step:910/1480 train_time:42415ms step_avg:46.61ms
+step:911/1480 train_time:42473ms step_avg:46.62ms
+step:912/1480 train_time:42538ms step_avg:46.64ms
+step:913/1480 train_time:42597ms step_avg:46.66ms
+step:914/1480 train_time:42660ms step_avg:46.67ms
+step:915/1480 train_time:42719ms step_avg:46.69ms
+step:916/1480 train_time:42784ms step_avg:46.71ms
+step:917/1480 train_time:42843ms step_avg:46.72ms
+step:918/1480 train_time:42906ms step_avg:46.74ms
+step:919/1480 train_time:42964ms step_avg:46.75ms
+step:920/1480 train_time:43027ms step_avg:46.77ms
+step:921/1480 train_time:43085ms step_avg:46.78ms
+step:922/1480 train_time:43149ms step_avg:46.80ms
+step:923/1480 train_time:43206ms step_avg:46.81ms
+step:924/1480 train_time:43269ms step_avg:46.83ms
+step:925/1480 train_time:43328ms step_avg:46.84ms
+step:926/1480 train_time:43391ms step_avg:46.86ms
+step:927/1480 train_time:43449ms step_avg:46.87ms
+step:928/1480 train_time:43512ms step_avg:46.89ms
+step:929/1480 train_time:43570ms step_avg:46.90ms
+step:930/1480 train_time:43633ms step_avg:46.92ms
+step:931/1480 train_time:43690ms step_avg:46.93ms
+step:932/1480 train_time:43753ms step_avg:46.95ms
+step:933/1480 train_time:43812ms step_avg:46.96ms
+step:934/1480 train_time:43876ms step_avg:46.98ms
+step:935/1480 train_time:43935ms step_avg:46.99ms
+step:936/1480 train_time:44001ms step_avg:47.01ms
+step:937/1480 train_time:44058ms step_avg:47.02ms
+step:938/1480 train_time:44121ms step_avg:47.04ms
+step:939/1480 train_time:44178ms step_avg:47.05ms
+step:940/1480 train_time:44242ms step_avg:47.07ms
+step:941/1480 train_time:44299ms step_avg:47.08ms
+step:942/1480 train_time:44364ms step_avg:47.10ms
+step:943/1480 train_time:44424ms step_avg:47.11ms
+step:944/1480 train_time:44496ms step_avg:47.14ms
+step:945/1480 train_time:44561ms step_avg:47.15ms
+step:946/1480 train_time:44631ms step_avg:47.18ms
+step:947/1480 train_time:44695ms step_avg:47.20ms
+step:948/1480 train_time:44765ms step_avg:47.22ms
+step:949/1480 train_time:44826ms step_avg:47.24ms
+step:950/1480 train_time:44885ms step_avg:47.25ms
+step:951/1480 train_time:44941ms step_avg:47.26ms
+step:952/1480 train_time:45000ms step_avg:47.27ms
+step:953/1480 train_time:45059ms step_avg:47.28ms
+step:954/1480 train_time:45123ms step_avg:47.30ms
+step:955/1480 train_time:45180ms step_avg:47.31ms
+step:956/1480 train_time:45245ms step_avg:47.33ms
+step:957/1480 train_time:45304ms step_avg:47.34ms
+step:958/1480 train_time:45369ms step_avg:47.36ms
+step:959/1480 train_time:45429ms step_avg:47.37ms
+step:960/1480 train_time:45495ms step_avg:47.39ms
+step:961/1480 train_time:45557ms step_avg:47.41ms
+step:962/1480 train_time:45648ms step_avg:47.45ms
+step:963/1480 train_time:45736ms step_avg:47.49ms
+step:964/1480 train_time:45828ms step_avg:47.54ms
+step:965/1480 train_time:45914ms step_avg:47.58ms
+step:966/1480 train_time:46005ms step_avg:47.62ms
+step:967/1480 train_time:46090ms step_avg:47.66ms
+step:968/1480 train_time:46182ms step_avg:47.71ms
+step:969/1480 train_time:46268ms step_avg:47.75ms
+step:970/1480 train_time:46358ms step_avg:47.79ms
+step:971/1480 train_time:46442ms step_avg:47.83ms
+step:972/1480 train_time:46532ms step_avg:47.87ms
+step:973/1480 train_time:46619ms step_avg:47.91ms
+step:974/1480 train_time:46712ms step_avg:47.96ms
+step:975/1480 train_time:46801ms step_avg:48.00ms
+step:976/1480 train_time:46897ms step_avg:48.05ms
+step:977/1480 train_time:46982ms step_avg:48.09ms
+step:978/1480 train_time:47077ms step_avg:48.14ms
+step:979/1480 train_time:47165ms step_avg:48.18ms
+step:980/1480 train_time:47260ms step_avg:48.22ms
+step:981/1480 train_time:47346ms step_avg:48.26ms
+step:982/1480 train_time:47442ms step_avg:48.31ms
+step:983/1480 train_time:47529ms step_avg:48.35ms
+step:984/1480 train_time:47623ms step_avg:48.40ms
+step:985/1480 train_time:47711ms step_avg:48.44ms
+step:986/1480 train_time:47804ms step_avg:48.48ms
+step:987/1480 train_time:47893ms step_avg:48.52ms
+step:988/1480 train_time:47986ms step_avg:48.57ms
+step:989/1480 train_time:48074ms step_avg:48.61ms
+step:990/1480 train_time:48167ms step_avg:48.65ms
+step:991/1480 train_time:48254ms step_avg:48.69ms
+step:992/1480 train_time:48348ms step_avg:48.74ms
+step:993/1480 train_time:48435ms step_avg:48.78ms
+step:994/1480 train_time:48527ms step_avg:48.82ms
+step:995/1480 train_time:48616ms step_avg:48.86ms
+step:996/1480 train_time:48708ms step_avg:48.90ms
+step:997/1480 train_time:48795ms step_avg:48.94ms
+step:998/1480 train_time:48887ms step_avg:48.99ms
+step:999/1480 train_time:48974ms step_avg:49.02ms
+step:1000/1480 train_time:49066ms step_avg:49.07ms
+step:1000/1480 val_loss:3.5101 train_time:49176ms step_avg:49.18ms
+step:1001/1480 train_time:49194ms step_avg:49.14ms
+step:1002/1480 train_time:49245ms step_avg:49.15ms
+step:1003/1480 train_time:49332ms step_avg:49.18ms
+step:1004/1480 train_time:49422ms step_avg:49.23ms
+step:1005/1480 train_time:49511ms step_avg:49.26ms
+step:1006/1480 train_time:49604ms step_avg:49.31ms
+step:1007/1480 train_time:49694ms step_avg:49.35ms
+step:1008/1480 train_time:49789ms step_avg:49.39ms
+step:1009/1480 train_time:49877ms step_avg:49.43ms
+step:1010/1480 train_time:49973ms step_avg:49.48ms
+step:1011/1480 train_time:50063ms step_avg:49.52ms
+step:1012/1480 train_time:50158ms step_avg:49.56ms
+step:1013/1480 train_time:50247ms step_avg:49.60ms
+step:1014/1480 train_time:50341ms step_avg:49.65ms
+step:1015/1480 train_time:50430ms step_avg:49.68ms
+step:1016/1480 train_time:50525ms step_avg:49.73ms
+step:1017/1480 train_time:50612ms step_avg:49.77ms
+step:1018/1480 train_time:50706ms step_avg:49.81ms
+step:1019/1480 train_time:50792ms step_avg:49.85ms
+step:1020/1480 train_time:50887ms step_avg:49.89ms
+step:1021/1480 train_time:50974ms step_avg:49.93ms
+step:1022/1480 train_time:51069ms step_avg:49.97ms
+step:1023/1480 train_time:51155ms step_avg:50.01ms
+step:1024/1480 train_time:51253ms step_avg:50.05ms
+step:1025/1480 train_time:51339ms step_avg:50.09ms
+step:1026/1480 train_time:51433ms step_avg:50.13ms
+step:1027/1480 train_time:51520ms step_avg:50.17ms
+step:1028/1480 train_time:51614ms step_avg:50.21ms
+step:1029/1480 train_time:51699ms step_avg:50.24ms
+step:1030/1480 train_time:51793ms step_avg:50.28ms
+step:1031/1480 train_time:51879ms step_avg:50.32ms
+step:1032/1480 train_time:51973ms step_avg:50.36ms
+step:1033/1480 train_time:52058ms step_avg:50.40ms
+step:1034/1480 train_time:52151ms step_avg:50.44ms
+step:1035/1480 train_time:52235ms step_avg:50.47ms
+step:1036/1480 train_time:52328ms step_avg:50.51ms
+step:1037/1480 train_time:52413ms step_avg:50.54ms
+step:1038/1480 train_time:52503ms step_avg:50.58ms
+step:1039/1480 train_time:52589ms step_avg:50.61ms
+step:1040/1480 train_time:52680ms step_avg:50.65ms
+step:1041/1480 train_time:52768ms step_avg:50.69ms
+step:1042/1480 train_time:52863ms step_avg:50.73ms
+step:1043/1480 train_time:52950ms step_avg:50.77ms
+step:1044/1480 train_time:53043ms step_avg:50.81ms
+step:1045/1480 train_time:53130ms step_avg:50.84ms
+step:1046/1480 train_time:53223ms step_avg:50.88ms
+step:1047/1480 train_time:53307ms step_avg:50.91ms
+step:1048/1480 train_time:53401ms step_avg:50.95ms
+step:1049/1480 train_time:53489ms step_avg:50.99ms
+step:1050/1480 train_time:53584ms step_avg:51.03ms
+step:1051/1480 train_time:53675ms step_avg:51.07ms
+step:1052/1480 train_time:53769ms step_avg:51.11ms
+step:1053/1480 train_time:53856ms step_avg:51.15ms
+step:1054/1480 train_time:53948ms step_avg:51.18ms
+step:1055/1480 train_time:54039ms step_avg:51.22ms
+step:1056/1480 train_time:54138ms step_avg:51.27ms
+step:1057/1480 train_time:54227ms step_avg:51.30ms
+step:1058/1480 train_time:54321ms step_avg:51.34ms
+step:1059/1480 train_time:54410ms step_avg:51.38ms
+step:1060/1480 train_time:54504ms step_avg:51.42ms
+step:1061/1480 train_time:54594ms step_avg:51.46ms
+step:1062/1480 train_time:54690ms step_avg:51.50ms
+step:1063/1480 train_time:54780ms step_avg:51.53ms
+step:1064/1480 train_time:54875ms step_avg:51.57ms
+step:1065/1480 train_time:54963ms step_avg:51.61ms
+step:1066/1480 train_time:55058ms step_avg:51.65ms
+step:1067/1480 train_time:55140ms step_avg:51.68ms
+step:1068/1480 train_time:55228ms step_avg:51.71ms
+step:1069/1480 train_time:55318ms step_avg:51.75ms
+step:1070/1480 train_time:55414ms step_avg:51.79ms
+step:1071/1480 train_time:55500ms step_avg:51.82ms
+step:1072/1480 train_time:55593ms step_avg:51.86ms
+step:1073/1480 train_time:55678ms step_avg:51.89ms
+step:1074/1480 train_time:55771ms step_avg:51.93ms
+step:1075/1480 train_time:55856ms step_avg:51.96ms
+step:1076/1480 train_time:55950ms step_avg:52.00ms
+step:1077/1480 train_time:56037ms step_avg:52.03ms
+step:1078/1480 train_time:56129ms step_avg:52.07ms
+step:1079/1480 train_time:56214ms step_avg:52.10ms
+step:1080/1480 train_time:56305ms step_avg:52.13ms
+step:1081/1480 train_time:56390ms step_avg:52.17ms
+step:1082/1480 train_time:56481ms step_avg:52.20ms
+step:1083/1480 train_time:56575ms step_avg:52.24ms
+step:1084/1480 train_time:56683ms step_avg:52.29ms
+step:1085/1480 train_time:56771ms step_avg:52.32ms
+step:1086/1480 train_time:56859ms step_avg:52.36ms
+step:1087/1480 train_time:56946ms step_avg:52.39ms
+step:1088/1480 train_time:57037ms step_avg:52.42ms
+step:1089/1480 train_time:57126ms step_avg:52.46ms
+step:1090/1480 train_time:57217ms step_avg:52.49ms
+step:1091/1480 train_time:57307ms step_avg:52.53ms
+step:1092/1480 train_time:57400ms step_avg:52.56ms
+step:1093/1480 train_time:57489ms step_avg:52.60ms
+step:1094/1480 train_time:57584ms step_avg:52.64ms
+step:1095/1480 train_time:57672ms step_avg:52.67ms
+step:1096/1480 train_time:57768ms step_avg:52.71ms
+step:1097/1480 train_time:57857ms step_avg:52.74ms
+step:1098/1480 train_time:57951ms step_avg:52.78ms
+step:1099/1480 train_time:58041ms step_avg:52.81ms
+step:1100/1480 train_time:58135ms step_avg:52.85ms
+step:1101/1480 train_time:58224ms step_avg:52.88ms
+step:1102/1480 train_time:58319ms step_avg:52.92ms
+step:1103/1480 train_time:58407ms step_avg:52.95ms
+step:1104/1480 train_time:58502ms step_avg:52.99ms
+step:1105/1480 train_time:58590ms step_avg:53.02ms
+step:1106/1480 train_time:58685ms step_avg:53.06ms
+step:1107/1480 train_time:58771ms step_avg:53.09ms
+step:1108/1480 train_time:58866ms step_avg:53.13ms
+step:1109/1480 train_time:58953ms step_avg:53.16ms
+step:1110/1480 train_time:59047ms step_avg:53.20ms
+step:1111/1480 train_time:59135ms step_avg:53.23ms
+step:1112/1480 train_time:59229ms step_avg:53.26ms
+step:1113/1480 train_time:59315ms step_avg:53.29ms
+step:1114/1480 train_time:59410ms step_avg:53.33ms
+step:1115/1480 train_time:59496ms step_avg:53.36ms
+step:1116/1480 train_time:59591ms step_avg:53.40ms
+step:1117/1480 train_time:59678ms step_avg:53.43ms
+step:1118/1480 train_time:59770ms step_avg:53.46ms
+step:1119/1480 train_time:59857ms step_avg:53.49ms
+step:1120/1480 train_time:59951ms step_avg:53.53ms
+step:1121/1480 train_time:60036ms step_avg:53.56ms
+step:1122/1480 train_time:60128ms step_avg:53.59ms
+step:1123/1480 train_time:60214ms step_avg:53.62ms
+step:1124/1480 train_time:60305ms step_avg:53.65ms
+step:1125/1480 train_time:60391ms step_avg:53.68ms
+step:1126/1480 train_time:60481ms step_avg:53.71ms
+step:1127/1480 train_time:60567ms step_avg:53.74ms
+step:1128/1480 train_time:60659ms step_avg:53.78ms
+step:1129/1480 train_time:60749ms step_avg:53.81ms
+step:1130/1480 train_time:60842ms step_avg:53.84ms
+step:1131/1480 train_time:60932ms step_avg:53.87ms
+step:1132/1480 train_time:61024ms step_avg:53.91ms
+step:1133/1480 train_time:61112ms step_avg:53.94ms
+step:1134/1480 train_time:61207ms step_avg:53.97ms
+step:1135/1480 train_time:61295ms step_avg:54.00ms
+step:1136/1480 train_time:61389ms step_avg:54.04ms
+step:1137/1480 train_time:61477ms step_avg:54.07ms
+step:1138/1480 train_time:61570ms step_avg:54.10ms
+step:1139/1480 train_time:61658ms step_avg:54.13ms
+step:1140/1480 train_time:61753ms step_avg:54.17ms
+step:1141/1480 train_time:61840ms step_avg:54.20ms
+step:1142/1480 train_time:61934ms step_avg:54.23ms
+step:1143/1480 train_time:62021ms step_avg:54.26ms
+step:1144/1480 train_time:62114ms step_avg:54.30ms
+step:1145/1480 train_time:62200ms step_avg:54.32ms
+step:1146/1480 train_time:62294ms step_avg:54.36ms
+step:1147/1480 train_time:62380ms step_avg:54.39ms
+step:1148/1480 train_time:62472ms step_avg:54.42ms
+step:1149/1480 train_time:62559ms step_avg:54.45ms
+step:1150/1480 train_time:62653ms step_avg:54.48ms
+step:1151/1480 train_time:62738ms step_avg:54.51ms
+step:1152/1480 train_time:62832ms step_avg:54.54ms
+step:1153/1480 train_time:62918ms step_avg:54.57ms
+step:1154/1480 train_time:63012ms step_avg:54.60ms
+step:1155/1480 train_time:63097ms step_avg:54.63ms
+step:1156/1480 train_time:63192ms step_avg:54.66ms
+step:1157/1480 train_time:63280ms step_avg:54.69ms
+step:1158/1480 train_time:63375ms step_avg:54.73ms
+step:1159/1480 train_time:63463ms step_avg:54.76ms
+step:1160/1480 train_time:63558ms step_avg:54.79ms
+step:1161/1480 train_time:63645ms step_avg:54.82ms
+step:1162/1480 train_time:63739ms step_avg:54.85ms
+step:1163/1480 train_time:63829ms step_avg:54.88ms
+step:1164/1480 train_time:63922ms step_avg:54.92ms
+step:1165/1480 train_time:64009ms step_avg:54.94ms
+step:1166/1480 train_time:64102ms step_avg:54.98ms
+step:1167/1480 train_time:64190ms step_avg:55.00ms
+step:1168/1480 train_time:64283ms step_avg:55.04ms
+step:1169/1480 train_time:64365ms step_avg:55.06ms
+step:1170/1480 train_time:64458ms step_avg:55.09ms
+step:1171/1480 train_time:64545ms step_avg:55.12ms
+step:1172/1480 train_time:64642ms step_avg:55.15ms
+step:1173/1480 train_time:64736ms step_avg:55.19ms
+step:1174/1480 train_time:64828ms step_avg:55.22ms
+step:1175/1480 train_time:64916ms step_avg:55.25ms
+step:1176/1480 train_time:65008ms step_avg:55.28ms
+step:1177/1480 train_time:65096ms step_avg:55.31ms
+step:1178/1480 train_time:65190ms step_avg:55.34ms
+step:1179/1480 train_time:65277ms step_avg:55.37ms
+step:1180/1480 train_time:65370ms step_avg:55.40ms
+step:1181/1480 train_time:65457ms step_avg:55.42ms
+step:1182/1480 train_time:65550ms step_avg:55.46ms
+step:1183/1480 train_time:65636ms step_avg:55.48ms
+step:1184/1480 train_time:65730ms step_avg:55.52ms
+step:1185/1480 train_time:65816ms step_avg:55.54ms
+step:1186/1480 train_time:65911ms step_avg:55.57ms
+step:1187/1480 train_time:65997ms step_avg:55.60ms
+step:1188/1480 train_time:66091ms step_avg:55.63ms
+step:1189/1480 train_time:66177ms step_avg:55.66ms
+step:1190/1480 train_time:66271ms step_avg:55.69ms
+step:1191/1480 train_time:66358ms step_avg:55.72ms
+step:1192/1480 train_time:66451ms step_avg:55.75ms
+step:1193/1480 train_time:66535ms step_avg:55.77ms
+step:1194/1480 train_time:66627ms step_avg:55.80ms
+step:1195/1480 train_time:66711ms step_avg:55.82ms
+step:1196/1480 train_time:66802ms step_avg:55.85ms
+step:1197/1480 train_time:66890ms step_avg:55.88ms
+step:1198/1480 train_time:66985ms step_avg:55.91ms
+step:1199/1480 train_time:67073ms step_avg:55.94ms
+step:1200/1480 train_time:67169ms step_avg:55.97ms
+step:1201/1480 train_time:67256ms step_avg:56.00ms
+step:1202/1480 train_time:67352ms step_avg:56.03ms
+step:1203/1480 train_time:67439ms step_avg:56.06ms
+step:1204/1480 train_time:67534ms step_avg:56.09ms
+step:1205/1480 train_time:67622ms step_avg:56.12ms
+step:1206/1480 train_time:67716ms step_avg:56.15ms
+step:1207/1480 train_time:67803ms step_avg:56.18ms
+step:1208/1480 train_time:67899ms step_avg:56.21ms
+step:1209/1480 train_time:67987ms step_avg:56.23ms
+step:1210/1480 train_time:68082ms step_avg:56.27ms
+step:1211/1480 train_time:68169ms step_avg:56.29ms
+step:1212/1480 train_time:68262ms step_avg:56.32ms
+step:1213/1480 train_time:68349ms step_avg:56.35ms
+step:1214/1480 train_time:68442ms step_avg:56.38ms
+step:1215/1480 train_time:68529ms step_avg:56.40ms
+step:1216/1480 train_time:68622ms step_avg:56.43ms
+step:1217/1480 train_time:68709ms step_avg:56.46ms
+step:1218/1480 train_time:68802ms step_avg:56.49ms
+step:1219/1480 train_time:68891ms step_avg:56.51ms
+step:1220/1480 train_time:68984ms step_avg:56.54ms
+step:1221/1480 train_time:69071ms step_avg:56.57ms
+step:1222/1480 train_time:69165ms step_avg:56.60ms
+step:1223/1480 train_time:69251ms step_avg:56.62ms
+step:1224/1480 train_time:69344ms step_avg:56.65ms
+step:1225/1480 train_time:69430ms step_avg:56.68ms
+step:1226/1480 train_time:69523ms step_avg:56.71ms
+step:1227/1480 train_time:69609ms step_avg:56.73ms
+step:1228/1480 train_time:69702ms step_avg:56.76ms
+step:1229/1480 train_time:69788ms step_avg:56.78ms
+step:1230/1480 train_time:69881ms step_avg:56.81ms
+step:1231/1480 train_time:69966ms step_avg:56.84ms
+step:1232/1480 train_time:70058ms step_avg:56.87ms
+step:1233/1480 train_time:70145ms step_avg:56.89ms
+step:1234/1480 train_time:70238ms step_avg:56.92ms
+step:1235/1480 train_time:70324ms step_avg:56.94ms
+step:1236/1480 train_time:70416ms step_avg:56.97ms
+step:1237/1480 train_time:70503ms step_avg:56.99ms
+step:1238/1480 train_time:70595ms step_avg:57.02ms
+step:1239/1480 train_time:70680ms step_avg:57.05ms
+step:1240/1480 train_time:70774ms step_avg:57.08ms
+step:1241/1480 train_time:70859ms step_avg:57.10ms
+step:1242/1480 train_time:70950ms step_avg:57.13ms
+step:1243/1480 train_time:71034ms step_avg:57.15ms
+step:1244/1480 train_time:71124ms step_avg:57.17ms
+step:1245/1480 train_time:71212ms step_avg:57.20ms
+step:1246/1480 train_time:71304ms step_avg:57.23ms
+step:1247/1480 train_time:71390ms step_avg:57.25ms
+step:1248/1480 train_time:71482ms step_avg:57.28ms
+step:1249/1480 train_time:71568ms step_avg:57.30ms
+step:1250/1480 train_time:71661ms step_avg:57.33ms
+step:1250/1480 val_loss:3.3669 train_time:71772ms step_avg:57.42ms
+step:1251/1480 train_time:71791ms step_avg:57.39ms
+step:1252/1480 train_time:71841ms step_avg:57.38ms
+step:1253/1480 train_time:71929ms step_avg:57.41ms
+step:1254/1480 train_time:72021ms step_avg:57.43ms
+step:1255/1480 train_time:72107ms step_avg:57.46ms
+step:1256/1480 train_time:72199ms step_avg:57.48ms
+step:1257/1480 train_time:72284ms step_avg:57.50ms
+step:1258/1480 train_time:72377ms step_avg:57.53ms
+step:1259/1480 train_time:72462ms step_avg:57.56ms
+step:1260/1480 train_time:72554ms step_avg:57.58ms
+step:1261/1480 train_time:72643ms step_avg:57.61ms
+step:1262/1480 train_time:72734ms step_avg:57.63ms
+step:1263/1480 train_time:72822ms step_avg:57.66ms
+step:1264/1480 train_time:72914ms step_avg:57.69ms
+step:1265/1480 train_time:73001ms step_avg:57.71ms
+step:1266/1480 train_time:73093ms step_avg:57.74ms
+step:1267/1480 train_time:73183ms step_avg:57.76ms
+step:1268/1480 train_time:73278ms step_avg:57.79ms
+step:1269/1480 train_time:73368ms step_avg:57.82ms
+step:1270/1480 train_time:73464ms step_avg:57.85ms
+step:1271/1480 train_time:73554ms step_avg:57.87ms
+step:1272/1480 train_time:73649ms step_avg:57.90ms
+step:1273/1480 train_time:73732ms step_avg:57.92ms
+step:1274/1480 train_time:73822ms step_avg:57.94ms
+step:1275/1480 train_time:73910ms step_avg:57.97ms
+step:1276/1480 train_time:74005ms step_avg:58.00ms
+step:1277/1480 train_time:74090ms step_avg:58.02ms
+step:1278/1480 train_time:74186ms step_avg:58.05ms
+step:1279/1480 train_time:74270ms step_avg:58.07ms
+step:1280/1480 train_time:74362ms step_avg:58.10ms
+step:1281/1480 train_time:74447ms step_avg:58.12ms
+step:1282/1480 train_time:74539ms step_avg:58.14ms
+step:1283/1480 train_time:74624ms step_avg:58.16ms
+step:1284/1480 train_time:74718ms step_avg:58.19ms
+step:1285/1480 train_time:74804ms step_avg:58.21ms
+step:1286/1480 train_time:74895ms step_avg:58.24ms
+step:1287/1480 train_time:74981ms step_avg:58.26ms
+step:1288/1480 train_time:75074ms step_avg:58.29ms
+step:1289/1480 train_time:75171ms step_avg:58.32ms
+step:1290/1480 train_time:75280ms step_avg:58.36ms
+step:1291/1480 train_time:75369ms step_avg:58.38ms
+step:1292/1480 train_time:75453ms step_avg:58.40ms
+step:1293/1480 train_time:75539ms step_avg:58.42ms
+step:1294/1480 train_time:75631ms step_avg:58.45ms
+step:1295/1480 train_time:75719ms step_avg:58.47ms
+step:1296/1480 train_time:75810ms step_avg:58.49ms
+step:1297/1480 train_time:75899ms step_avg:58.52ms
+step:1298/1480 train_time:75993ms step_avg:58.55ms
+step:1299/1480 train_time:76081ms step_avg:58.57ms
+step:1300/1480 train_time:76176ms step_avg:58.60ms
+step:1301/1480 train_time:76263ms step_avg:58.62ms
+step:1302/1480 train_time:76357ms step_avg:58.65ms
+step:1303/1480 train_time:76444ms step_avg:58.67ms
+step:1304/1480 train_time:76538ms step_avg:58.69ms
+step:1305/1480 train_time:76624ms step_avg:58.72ms
+step:1306/1480 train_time:76718ms step_avg:58.74ms
+step:1307/1480 train_time:76806ms step_avg:58.77ms
+step:1308/1480 train_time:76900ms step_avg:58.79ms
+step:1309/1480 train_time:76986ms step_avg:58.81ms
+step:1310/1480 train_time:77077ms step_avg:58.84ms
+step:1311/1480 train_time:77162ms step_avg:58.86ms
+step:1312/1480 train_time:77252ms step_avg:58.88ms
+step:1313/1480 train_time:77337ms step_avg:58.90ms
+step:1314/1480 train_time:77431ms step_avg:58.93ms
+step:1315/1480 train_time:77521ms step_avg:58.95ms
+step:1316/1480 train_time:77616ms step_avg:58.98ms
+step:1317/1480 train_time:77704ms step_avg:59.00ms
+step:1318/1480 train_time:77798ms step_avg:59.03ms
+step:1319/1480 train_time:77888ms step_avg:59.05ms
+step:1320/1480 train_time:77982ms step_avg:59.08ms
+step:1321/1480 train_time:78072ms step_avg:59.10ms
+step:1322/1480 train_time:78167ms step_avg:59.13ms
+step:1323/1480 train_time:78249ms step_avg:59.14ms
+step:1324/1480 train_time:78338ms step_avg:59.17ms
+step:1325/1480 train_time:78424ms step_avg:59.19ms
+step:1326/1480 train_time:78516ms step_avg:59.21ms
+step:1327/1480 train_time:78604ms step_avg:59.23ms
+step:1328/1480 train_time:78695ms step_avg:59.26ms
+step:1329/1480 train_time:78783ms step_avg:59.28ms
+step:1330/1480 train_time:78874ms step_avg:59.30ms
+step:1331/1480 train_time:78961ms step_avg:59.32ms
+step:1332/1480 train_time:79056ms step_avg:59.35ms
+step:1333/1480 train_time:79145ms step_avg:59.37ms
+step:1334/1480 train_time:79238ms step_avg:59.40ms
+step:1335/1480 train_time:79328ms step_avg:59.42ms
+step:1336/1480 train_time:79426ms step_avg:59.45ms
+step:1337/1480 train_time:79516ms step_avg:59.47ms
+step:1338/1480 train_time:79613ms step_avg:59.50ms
+step:1339/1480 train_time:79702ms step_avg:59.52ms
+step:1340/1480 train_time:79797ms step_avg:59.55ms
+step:1341/1480 train_time:79879ms step_avg:59.57ms
+step:1342/1480 train_time:79972ms step_avg:59.59ms
+step:1343/1480 train_time:80060ms step_avg:59.61ms
+step:1344/1480 train_time:80152ms step_avg:59.64ms
+step:1345/1480 train_time:80244ms step_avg:59.66ms
+step:1346/1480 train_time:80335ms step_avg:59.68ms
+step:1347/1480 train_time:80420ms step_avg:59.70ms
+step:1348/1480 train_time:80513ms step_avg:59.73ms
+step:1349/1480 train_time:80599ms step_avg:59.75ms
+step:1350/1480 train_time:80692ms step_avg:59.77ms
+step:1351/1480 train_time:80780ms step_avg:59.79ms
+step:1352/1480 train_time:80876ms step_avg:59.82ms
+step:1353/1480 train_time:80969ms step_avg:59.84ms
+step:1354/1480 train_time:81067ms step_avg:59.87ms
+step:1355/1480 train_time:81160ms step_avg:59.90ms
+step:1356/1480 train_time:81259ms step_avg:59.93ms
+step:1357/1480 train_time:81350ms step_avg:59.95ms
+step:1358/1480 train_time:81449ms step_avg:59.98ms
+step:1359/1480 train_time:81531ms step_avg:59.99ms
+step:1360/1480 train_time:81616ms step_avg:60.01ms
+step:1361/1480 train_time:81702ms step_avg:60.03ms
+step:1362/1480 train_time:81796ms step_avg:60.06ms
+step:1363/1480 train_time:81887ms step_avg:60.08ms
+step:1364/1480 train_time:81982ms step_avg:60.10ms
+step:1365/1480 train_time:82066ms step_avg:60.12ms
+step:1366/1480 train_time:82156ms step_avg:60.14ms
+step:1367/1480 train_time:82246ms step_avg:60.17ms
+step:1368/1480 train_time:82339ms step_avg:60.19ms
+step:1369/1480 train_time:82427ms step_avg:60.21ms
+step:1370/1480 train_time:82521ms step_avg:60.23ms
+step:1371/1480 train_time:82607ms step_avg:60.25ms
+step:1372/1480 train_time:82701ms step_avg:60.28ms
+step:1373/1480 train_time:82786ms step_avg:60.30ms
+step:1374/1480 train_time:82879ms step_avg:60.32ms
+step:1375/1480 train_time:82963ms step_avg:60.34ms
+step:1376/1480 train_time:83055ms step_avg:60.36ms
+step:1377/1480 train_time:83142ms step_avg:60.38ms
+step:1378/1480 train_time:83232ms step_avg:60.40ms
+step:1379/1480 train_time:83317ms step_avg:60.42ms
+step:1380/1480 train_time:83407ms step_avg:60.44ms
+step:1381/1480 train_time:83491ms step_avg:60.46ms
+step:1382/1480 train_time:83584ms step_avg:60.48ms
+step:1383/1480 train_time:83670ms step_avg:60.50ms
+step:1384/1480 train_time:83763ms step_avg:60.52ms
+step:1385/1480 train_time:83850ms step_avg:60.54ms
+step:1386/1480 train_time:83944ms step_avg:60.57ms
+step:1387/1480 train_time:84031ms step_avg:60.58ms
+step:1388/1480 train_time:84125ms step_avg:60.61ms
+step:1389/1480 train_time:84214ms step_avg:60.63ms
+step:1390/1480 train_time:84306ms step_avg:60.65ms
+step:1391/1480 train_time:84391ms step_avg:60.67ms
+step:1392/1480 train_time:84484ms step_avg:60.69ms
+step:1393/1480 train_time:84570ms step_avg:60.71ms
+step:1394/1480 train_time:84669ms step_avg:60.74ms
+step:1395/1480 train_time:84757ms step_avg:60.76ms
+step:1396/1480 train_time:84852ms step_avg:60.78ms
+step:1397/1480 train_time:84940ms step_avg:60.80ms
+step:1398/1480 train_time:85034ms step_avg:60.83ms
+step:1399/1480 train_time:85121ms step_avg:60.84ms
+step:1400/1480 train_time:85214ms step_avg:60.87ms
+step:1401/1480 train_time:85300ms step_avg:60.88ms
+step:1402/1480 train_time:85394ms step_avg:60.91ms
+step:1403/1480 train_time:85480ms step_avg:60.93ms
+step:1404/1480 train_time:85574ms step_avg:60.95ms
+step:1405/1480 train_time:85661ms step_avg:60.97ms
+step:1406/1480 train_time:85755ms step_avg:60.99ms
+step:1407/1480 train_time:85842ms step_avg:61.01ms
+step:1408/1480 train_time:85934ms step_avg:61.03ms
+step:1409/1480 train_time:86022ms step_avg:61.05ms
+step:1410/1480 train_time:86115ms step_avg:61.07ms
+step:1411/1480 train_time:86202ms step_avg:61.09ms
+step:1412/1480 train_time:86295ms step_avg:61.12ms
+step:1413/1480 train_time:86382ms step_avg:61.13ms
+step:1414/1480 train_time:86473ms step_avg:61.15ms
+step:1415/1480 train_time:86557ms step_avg:61.17ms
+step:1416/1480 train_time:86648ms step_avg:61.19ms
+step:1417/1480 train_time:86733ms step_avg:61.21ms
+step:1418/1480 train_time:86826ms step_avg:61.23ms
+step:1419/1480 train_time:86912ms step_avg:61.25ms
+step:1420/1480 train_time:87005ms step_avg:61.27ms
+step:1421/1480 train_time:87088ms step_avg:61.29ms
+step:1422/1480 train_time:87178ms step_avg:61.31ms
+step:1423/1480 train_time:87264ms step_avg:61.32ms
+step:1424/1480 train_time:87356ms step_avg:61.35ms
+step:1425/1480 train_time:87442ms step_avg:61.36ms
+step:1426/1480 train_time:87534ms step_avg:61.38ms
+step:1427/1480 train_time:87623ms step_avg:61.40ms
+step:1428/1480 train_time:87716ms step_avg:61.43ms
+step:1429/1480 train_time:87800ms step_avg:61.44ms
+step:1430/1480 train_time:87890ms step_avg:61.46ms
+step:1431/1480 train_time:87979ms step_avg:61.48ms
+step:1432/1480 train_time:88074ms step_avg:61.50ms
+step:1433/1480 train_time:88163ms step_avg:61.52ms
+step:1434/1480 train_time:88257ms step_avg:61.55ms
+step:1435/1480 train_time:88346ms step_avg:61.56ms
+step:1436/1480 train_time:88440ms step_avg:61.59ms
+step:1437/1480 train_time:88529ms step_avg:61.61ms
+step:1438/1480 train_time:88625ms step_avg:61.63ms
+step:1439/1480 train_time:88714ms step_avg:61.65ms
+step:1440/1480 train_time:88809ms step_avg:61.67ms
+step:1441/1480 train_time:88901ms step_avg:61.69ms
+step:1442/1480 train_time:88999ms step_avg:61.72ms
+step:1443/1480 train_time:89087ms step_avg:61.74ms
+step:1444/1480 train_time:89183ms step_avg:61.76ms
+step:1445/1480 train_time:89269ms step_avg:61.78ms
+step:1446/1480 train_time:89365ms step_avg:61.80ms
+step:1447/1480 train_time:89453ms step_avg:61.82ms
+step:1448/1480 train_time:89549ms step_avg:61.84ms
+step:1449/1480 train_time:89637ms step_avg:61.86ms
+step:1450/1480 train_time:89732ms step_avg:61.88ms
+step:1451/1480 train_time:89822ms step_avg:61.90ms
+step:1452/1480 train_time:89915ms step_avg:61.92ms
+step:1453/1480 train_time:90001ms step_avg:61.94ms
+step:1454/1480 train_time:90095ms step_avg:61.96ms
+step:1455/1480 train_time:90182ms step_avg:61.98ms
+step:1456/1480 train_time:90275ms step_avg:62.00ms
+step:1457/1480 train_time:90364ms step_avg:62.02ms
+step:1458/1480 train_time:90457ms step_avg:62.04ms
+step:1459/1480 train_time:90544ms step_avg:62.06ms
+step:1460/1480 train_time:90637ms step_avg:62.08ms
+step:1461/1480 train_time:90724ms step_avg:62.10ms
+step:1462/1480 train_time:90818ms step_avg:62.12ms
+step:1463/1480 train_time:90903ms step_avg:62.13ms
+step:1464/1480 train_time:90995ms step_avg:62.16ms
+step:1465/1480 train_time:91079ms step_avg:62.17ms
+step:1466/1480 train_time:91170ms step_avg:62.19ms
+step:1467/1480 train_time:91255ms step_avg:62.21ms
+step:1468/1480 train_time:91350ms step_avg:62.23ms
+step:1469/1480 train_time:91439ms step_avg:62.25ms
+step:1470/1480 train_time:91535ms step_avg:62.27ms
+step:1471/1480 train_time:91624ms step_avg:62.29ms
+step:1472/1480 train_time:91720ms step_avg:62.31ms
+step:1473/1480 train_time:91808ms step_avg:62.33ms
+step:1474/1480 train_time:91904ms step_avg:62.35ms
+step:1475/1480 train_time:91993ms step_avg:62.37ms
+step:1476/1480 train_time:92089ms step_avg:62.39ms
+step:1477/1480 train_time:92171ms step_avg:62.40ms
+step:1478/1480 train_time:92267ms step_avg:62.43ms
+step:1479/1480 train_time:92355ms step_avg:62.44ms
+step:1480/1480 train_time:92448ms step_avg:62.47ms
+step:1480/1480 val_loss:3.2785 train_time:92557ms step_avg:62.54ms
+peak memory allocated: 31345 MiB reserved: 47242 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk6-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk6-1480.txt
@@ -1,0 +1,4463 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # QK bank: per-head-pair Muon groups for Q, K weights
+        # Each pair of adjacent heads gets its own independent polar express orthogonalization
+        self._num_attn_layers = num_attn_layers
+        num_qk_groups = num_attn_layers * 2 * (num_heads // 2)  # 10 * 2 * 3 = 60
+        self._num_qk_groups = num_qk_groups
+        num_qk_padded = next_multiple_of_n(num_qk_groups, n=world_size)  # 64
+        self.qk_bank = nn.Parameter(torch.empty(num_qk_padded, head_dim * 2, model_dim))
+        self.qk_bank.reshape = (num_qk_padded, head_dim * 2, model_dim)
+
+        # VO bank: per-layer Muon groups for V and O weights
+        num_vo_real = num_attn_layers * 2  # 20
+        num_vo_padded = next_multiple_of_n(num_vo_real, n=world_size)  # 24
+        self.vo_bank = nn.Parameter(torch.empty(num_vo_padded, hdim, hdim))
+        self.vo_bank.reshape = (num_vo_padded, hdim, hdim)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.qk_bank[:num_qk_groups].uniform_(-bound, bound)
+            self.qk_bank[num_qk_groups:].zero_()
+            self.vo_bank[:num_vo_real].uniform_(-bound, bound)
+            self.vo_bank[num_vo_real:].zero_()
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from qk_bank/vo_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        qk_all = self.qk_bank[:self._num_qk_groups].view(self._num_attn_layers, -1, self.qk_bank.shape[-1])
+        vo_flat = self.vo_bank[:self._num_attn_layers * 2].view(self._num_attn_layers, 2, *self.vo_bank.shape[1:]).flatten(1, 2)
+        attn_weights = torch.cat([qk_all, vo_flat], dim=1).unbind(0)
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            attn_idx = i - (i > 6) if i != 6 else None
+            qkvo_w = attn_weights[attn_idx] if attn_idx is not None else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "qk_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "vo_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "qk_bank", "vo_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.qk_bank.data = model.qk_bank.data.bfloat16()
+model.vo_bank.data = model.vo_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:10:52 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   40C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   35C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   39C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   66C    P0            151W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          270642      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          270643      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          270644      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          270645      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          270646      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          270647      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          270648      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          270649      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8309 train_time:0ms step_avg:0.03ms
+step:1/1480 train_time:86ms step_avg:86.20ms
+step:2/1480 train_time:108ms step_avg:54.17ms
+step:3/1480 train_time:127ms step_avg:42.18ms
+step:4/1480 train_time:154ms step_avg:38.50ms
+step:5/1480 train_time:182ms step_avg:36.42ms
+step:6/1480 train_time:217ms step_avg:36.19ms
+step:7/1480 train_time:245ms step_avg:35.03ms
+step:8/1480 train_time:281ms step_avg:35.09ms
+step:9/1480 train_time:308ms step_avg:34.23ms
+step:10/1480 train_time:343ms step_avg:34.26ms
+step:11/1480 train_time:371ms step_avg:33.76ms
+step:12/1480 train_time:406ms step_avg:33.84ms
+step:13/1480 train_time:435ms step_avg:33.44ms
+step:14/1480 train_time:470ms step_avg:33.55ms
+step:15/1480 train_time:498ms step_avg:33.23ms
+step:16/1480 train_time:533ms step_avg:33.30ms
+step:17/1480 train_time:562ms step_avg:33.08ms
+step:18/1480 train_time:597ms step_avg:33.16ms
+step:19/1480 train_time:627ms step_avg:33.03ms
+step:20/1480 train_time:664ms step_avg:33.21ms
+step:21/1480 train_time:694ms step_avg:33.06ms
+step:22/1480 train_time:731ms step_avg:33.22ms
+step:23/1480 train_time:761ms step_avg:33.11ms
+step:24/1480 train_time:797ms step_avg:33.21ms
+step:25/1480 train_time:828ms step_avg:33.10ms
+step:26/1480 train_time:864ms step_avg:33.22ms
+step:27/1480 train_time:894ms step_avg:33.10ms
+step:28/1480 train_time:930ms step_avg:33.21ms
+step:29/1480 train_time:960ms step_avg:33.10ms
+step:30/1480 train_time:995ms step_avg:33.17ms
+step:31/1480 train_time:1025ms step_avg:33.05ms
+step:32/1480 train_time:1058ms step_avg:33.08ms
+step:33/1480 train_time:1087ms step_avg:32.95ms
+step:34/1480 train_time:1122ms step_avg:32.99ms
+step:35/1480 train_time:1151ms step_avg:32.87ms
+step:36/1480 train_time:1186ms step_avg:32.94ms
+step:37/1480 train_time:1215ms step_avg:32.83ms
+step:38/1480 train_time:1250ms step_avg:32.90ms
+step:39/1480 train_time:1279ms step_avg:32.80ms
+step:40/1480 train_time:1314ms step_avg:32.85ms
+step:41/1480 train_time:1344ms step_avg:32.77ms
+step:42/1480 train_time:1378ms step_avg:32.81ms
+step:43/1480 train_time:1408ms step_avg:32.74ms
+step:44/1480 train_time:1443ms step_avg:32.80ms
+step:45/1480 train_time:1472ms step_avg:32.71ms
+step:46/1480 train_time:1507ms step_avg:32.77ms
+step:47/1480 train_time:1537ms step_avg:32.69ms
+step:48/1480 train_time:1572ms step_avg:32.75ms
+step:49/1480 train_time:1602ms step_avg:32.68ms
+step:50/1480 train_time:1636ms step_avg:32.73ms
+step:51/1480 train_time:1666ms step_avg:32.68ms
+step:52/1480 train_time:1701ms step_avg:32.72ms
+step:53/1480 train_time:1731ms step_avg:32.66ms
+step:54/1480 train_time:1767ms step_avg:32.73ms
+step:55/1480 train_time:1796ms step_avg:32.66ms
+step:56/1480 train_time:1835ms step_avg:32.76ms
+step:57/1480 train_time:1868ms step_avg:32.78ms
+step:58/1480 train_time:1907ms step_avg:32.88ms
+step:59/1480 train_time:1939ms step_avg:32.86ms
+step:60/1480 train_time:1976ms step_avg:32.94ms
+step:61/1480 train_time:2009ms step_avg:32.93ms
+step:62/1480 train_time:2044ms step_avg:32.97ms
+step:63/1480 train_time:2073ms step_avg:32.90ms
+step:64/1480 train_time:2107ms step_avg:32.92ms
+step:65/1480 train_time:2136ms step_avg:32.86ms
+step:66/1480 train_time:2171ms step_avg:32.89ms
+step:67/1480 train_time:2200ms step_avg:32.83ms
+step:68/1480 train_time:2234ms step_avg:32.85ms
+step:69/1480 train_time:2265ms step_avg:32.82ms
+step:70/1480 train_time:2299ms step_avg:32.85ms
+step:71/1480 train_time:2329ms step_avg:32.81ms
+step:72/1480 train_time:2365ms step_avg:32.85ms
+step:73/1480 train_time:2395ms step_avg:32.80ms
+step:74/1480 train_time:2430ms step_avg:32.84ms
+step:75/1480 train_time:2461ms step_avg:32.81ms
+step:76/1480 train_time:2496ms step_avg:32.84ms
+step:77/1480 train_time:2527ms step_avg:32.81ms
+step:78/1480 train_time:2562ms step_avg:32.84ms
+step:79/1480 train_time:2592ms step_avg:32.81ms
+step:80/1480 train_time:2628ms step_avg:32.85ms
+step:81/1480 train_time:2657ms step_avg:32.81ms
+step:82/1480 train_time:2693ms step_avg:32.84ms
+step:83/1480 train_time:2724ms step_avg:32.81ms
+step:84/1480 train_time:2758ms step_avg:32.84ms
+step:85/1480 train_time:2789ms step_avg:32.81ms
+step:86/1480 train_time:2825ms step_avg:32.85ms
+step:87/1480 train_time:2854ms step_avg:32.81ms
+step:88/1480 train_time:2891ms step_avg:32.85ms
+step:89/1480 train_time:2920ms step_avg:32.81ms
+step:90/1480 train_time:2955ms step_avg:32.84ms
+step:91/1480 train_time:2986ms step_avg:32.81ms
+step:92/1480 train_time:3021ms step_avg:32.84ms
+step:93/1480 train_time:3051ms step_avg:32.81ms
+step:94/1480 train_time:3088ms step_avg:32.85ms
+step:95/1480 train_time:3118ms step_avg:32.82ms
+step:96/1480 train_time:3154ms step_avg:32.85ms
+step:97/1480 train_time:3185ms step_avg:32.83ms
+step:98/1480 train_time:3220ms step_avg:32.86ms
+step:99/1480 train_time:3251ms step_avg:32.84ms
+step:100/1480 train_time:3287ms step_avg:32.87ms
+step:101/1480 train_time:3317ms step_avg:32.85ms
+step:102/1480 train_time:3353ms step_avg:32.88ms
+step:103/1480 train_time:3384ms step_avg:32.86ms
+step:104/1480 train_time:3420ms step_avg:32.88ms
+step:105/1480 train_time:3450ms step_avg:32.86ms
+step:106/1480 train_time:3486ms step_avg:32.89ms
+step:107/1480 train_time:3516ms step_avg:32.86ms
+step:108/1480 train_time:3552ms step_avg:32.89ms
+step:109/1480 train_time:3583ms step_avg:32.87ms
+step:110/1480 train_time:3619ms step_avg:32.90ms
+step:111/1480 train_time:3649ms step_avg:32.88ms
+step:112/1480 train_time:3685ms step_avg:32.91ms
+step:113/1480 train_time:3715ms step_avg:32.88ms
+step:114/1480 train_time:3751ms step_avg:32.90ms
+step:115/1480 train_time:3781ms step_avg:32.88ms
+step:116/1480 train_time:3817ms step_avg:32.90ms
+step:117/1480 train_time:3847ms step_avg:32.88ms
+step:118/1480 train_time:3883ms step_avg:32.91ms
+step:119/1480 train_time:3913ms step_avg:32.88ms
+step:120/1480 train_time:3949ms step_avg:32.91ms
+step:121/1480 train_time:3979ms step_avg:32.88ms
+step:122/1480 train_time:4014ms step_avg:32.90ms
+step:123/1480 train_time:4045ms step_avg:32.88ms
+step:124/1480 train_time:4080ms step_avg:32.90ms
+step:125/1480 train_time:4110ms step_avg:32.88ms
+step:126/1480 train_time:4146ms step_avg:32.90ms
+step:127/1480 train_time:4176ms step_avg:32.88ms
+step:128/1480 train_time:4212ms step_avg:32.91ms
+step:129/1480 train_time:4242ms step_avg:32.88ms
+step:130/1480 train_time:4278ms step_avg:32.91ms
+step:131/1480 train_time:4308ms step_avg:32.89ms
+step:132/1480 train_time:4345ms step_avg:32.92ms
+step:133/1480 train_time:4376ms step_avg:32.90ms
+step:134/1480 train_time:4413ms step_avg:32.93ms
+step:135/1480 train_time:4444ms step_avg:32.92ms
+step:136/1480 train_time:4480ms step_avg:32.94ms
+step:137/1480 train_time:4511ms step_avg:32.93ms
+step:138/1480 train_time:4548ms step_avg:32.96ms
+step:139/1480 train_time:4579ms step_avg:32.94ms
+step:140/1480 train_time:4615ms step_avg:32.96ms
+step:141/1480 train_time:4646ms step_avg:32.95ms
+step:142/1480 train_time:4682ms step_avg:32.97ms
+step:143/1480 train_time:4713ms step_avg:32.95ms
+step:144/1480 train_time:4750ms step_avg:32.98ms
+step:145/1480 train_time:4780ms step_avg:32.96ms
+step:146/1480 train_time:4815ms step_avg:32.98ms
+step:147/1480 train_time:4846ms step_avg:32.97ms
+step:148/1480 train_time:4883ms step_avg:32.99ms
+step:149/1480 train_time:4913ms step_avg:32.97ms
+step:150/1480 train_time:4950ms step_avg:33.00ms
+step:151/1480 train_time:4980ms step_avg:32.98ms
+step:152/1480 train_time:5016ms step_avg:33.00ms
+step:153/1480 train_time:5047ms step_avg:32.99ms
+step:154/1480 train_time:5084ms step_avg:33.01ms
+step:155/1480 train_time:5114ms step_avg:32.99ms
+step:156/1480 train_time:5150ms step_avg:33.01ms
+step:157/1480 train_time:5181ms step_avg:33.00ms
+step:158/1480 train_time:5216ms step_avg:33.01ms
+step:159/1480 train_time:5247ms step_avg:33.00ms
+step:160/1480 train_time:5283ms step_avg:33.02ms
+step:161/1480 train_time:5313ms step_avg:33.00ms
+step:162/1480 train_time:5349ms step_avg:33.02ms
+step:163/1480 train_time:5379ms step_avg:33.00ms
+step:164/1480 train_time:5415ms step_avg:33.02ms
+step:165/1480 train_time:5446ms step_avg:33.01ms
+step:166/1480 train_time:5482ms step_avg:33.02ms
+step:167/1480 train_time:5512ms step_avg:33.01ms
+step:168/1480 train_time:5548ms step_avg:33.03ms
+step:169/1480 train_time:5579ms step_avg:33.01ms
+step:170/1480 train_time:5614ms step_avg:33.03ms
+step:171/1480 train_time:5646ms step_avg:33.02ms
+step:172/1480 train_time:5681ms step_avg:33.03ms
+step:173/1480 train_time:5711ms step_avg:33.01ms
+step:174/1480 train_time:5748ms step_avg:33.03ms
+step:175/1480 train_time:5778ms step_avg:33.02ms
+step:176/1480 train_time:5814ms step_avg:33.03ms
+step:177/1480 train_time:5845ms step_avg:33.02ms
+step:178/1480 train_time:5881ms step_avg:33.04ms
+step:179/1480 train_time:5911ms step_avg:33.02ms
+step:180/1480 train_time:5947ms step_avg:33.04ms
+step:181/1480 train_time:5977ms step_avg:33.02ms
+step:182/1480 train_time:6013ms step_avg:33.04ms
+step:183/1480 train_time:6043ms step_avg:33.02ms
+step:184/1480 train_time:6079ms step_avg:33.04ms
+step:185/1480 train_time:6109ms step_avg:33.02ms
+step:186/1480 train_time:6146ms step_avg:33.04ms
+step:187/1480 train_time:6175ms step_avg:33.02ms
+step:188/1480 train_time:6211ms step_avg:33.04ms
+step:189/1480 train_time:6242ms step_avg:33.02ms
+step:190/1480 train_time:6277ms step_avg:33.04ms
+step:191/1480 train_time:6308ms step_avg:33.02ms
+step:192/1480 train_time:6344ms step_avg:33.04ms
+step:193/1480 train_time:6373ms step_avg:33.02ms
+step:194/1480 train_time:6409ms step_avg:33.04ms
+step:195/1480 train_time:6439ms step_avg:33.02ms
+step:196/1480 train_time:6475ms step_avg:33.03ms
+step:197/1480 train_time:6505ms step_avg:33.02ms
+step:198/1480 train_time:6540ms step_avg:33.03ms
+step:199/1480 train_time:6570ms step_avg:33.02ms
+step:200/1480 train_time:6607ms step_avg:33.03ms
+step:201/1480 train_time:6636ms step_avg:33.02ms
+step:202/1480 train_time:6672ms step_avg:33.03ms
+step:203/1480 train_time:6703ms step_avg:33.02ms
+step:204/1480 train_time:6738ms step_avg:33.03ms
+step:205/1480 train_time:6768ms step_avg:33.02ms
+step:206/1480 train_time:6804ms step_avg:33.03ms
+step:207/1480 train_time:6834ms step_avg:33.01ms
+step:208/1480 train_time:6870ms step_avg:33.03ms
+step:209/1480 train_time:6900ms step_avg:33.02ms
+step:210/1480 train_time:6936ms step_avg:33.03ms
+step:211/1480 train_time:6967ms step_avg:33.02ms
+step:212/1480 train_time:7002ms step_avg:33.03ms
+step:213/1480 train_time:7032ms step_avg:33.01ms
+step:214/1480 train_time:7068ms step_avg:33.03ms
+step:215/1480 train_time:7099ms step_avg:33.02ms
+step:216/1480 train_time:7134ms step_avg:33.03ms
+step:217/1480 train_time:7165ms step_avg:33.02ms
+step:218/1480 train_time:7200ms step_avg:33.03ms
+step:219/1480 train_time:7230ms step_avg:33.01ms
+step:220/1480 train_time:7267ms step_avg:33.03ms
+step:221/1480 train_time:7296ms step_avg:33.02ms
+step:222/1480 train_time:7332ms step_avg:33.03ms
+step:223/1480 train_time:7363ms step_avg:33.02ms
+step:224/1480 train_time:7398ms step_avg:33.03ms
+step:225/1480 train_time:7428ms step_avg:33.01ms
+step:226/1480 train_time:7464ms step_avg:33.03ms
+step:227/1480 train_time:7495ms step_avg:33.02ms
+step:228/1480 train_time:7531ms step_avg:33.03ms
+step:229/1480 train_time:7561ms step_avg:33.02ms
+step:230/1480 train_time:7598ms step_avg:33.03ms
+step:231/1480 train_time:7629ms step_avg:33.02ms
+step:232/1480 train_time:7666ms step_avg:33.04ms
+step:233/1480 train_time:7697ms step_avg:33.04ms
+step:234/1480 train_time:7734ms step_avg:33.05ms
+step:235/1480 train_time:7765ms step_avg:33.04ms
+step:236/1480 train_time:7801ms step_avg:33.05ms
+step:237/1480 train_time:7831ms step_avg:33.04ms
+step:238/1480 train_time:7869ms step_avg:33.06ms
+step:239/1480 train_time:7900ms step_avg:33.05ms
+step:240/1480 train_time:7936ms step_avg:33.06ms
+step:241/1480 train_time:7967ms step_avg:33.06ms
+step:242/1480 train_time:8003ms step_avg:33.07ms
+step:243/1480 train_time:8034ms step_avg:33.06ms
+step:244/1480 train_time:8071ms step_avg:33.08ms
+step:245/1480 train_time:8102ms step_avg:33.07ms
+step:246/1480 train_time:8138ms step_avg:33.08ms
+step:247/1480 train_time:8252ms step_avg:33.41ms
+step:248/1480 train_time:8270ms step_avg:33.35ms
+step:249/1480 train_time:8287ms step_avg:33.28ms
+step:250/1480 train_time:8321ms step_avg:33.29ms
+step:250/1480 val_loss:4.4842 train_time:8365ms step_avg:33.46ms
+step:251/1480 train_time:8382ms step_avg:33.40ms
+step:252/1480 train_time:8401ms step_avg:33.34ms
+step:253/1480 train_time:8420ms step_avg:33.28ms
+step:254/1480 train_time:8456ms step_avg:33.29ms
+step:255/1480 train_time:8488ms step_avg:33.29ms
+step:256/1480 train_time:8526ms step_avg:33.30ms
+step:257/1480 train_time:8557ms step_avg:33.30ms
+step:258/1480 train_time:8594ms step_avg:33.31ms
+step:259/1480 train_time:8627ms step_avg:33.31ms
+step:260/1480 train_time:8665ms step_avg:33.33ms
+step:261/1480 train_time:8695ms step_avg:33.31ms
+step:262/1480 train_time:8734ms step_avg:33.33ms
+step:263/1480 train_time:8764ms step_avg:33.32ms
+step:264/1480 train_time:8801ms step_avg:33.34ms
+step:265/1480 train_time:8832ms step_avg:33.33ms
+step:266/1480 train_time:8870ms step_avg:33.35ms
+step:267/1480 train_time:8901ms step_avg:33.34ms
+step:268/1480 train_time:8938ms step_avg:33.35ms
+step:269/1480 train_time:8970ms step_avg:33.34ms
+step:270/1480 train_time:9007ms step_avg:33.36ms
+step:271/1480 train_time:9038ms step_avg:33.35ms
+step:272/1480 train_time:9073ms step_avg:33.36ms
+step:273/1480 train_time:9103ms step_avg:33.34ms
+step:274/1480 train_time:9137ms step_avg:33.35ms
+step:275/1480 train_time:9166ms step_avg:33.33ms
+step:276/1480 train_time:9200ms step_avg:33.33ms
+step:277/1480 train_time:9229ms step_avg:33.32ms
+step:278/1480 train_time:9266ms step_avg:33.33ms
+step:279/1480 train_time:9297ms step_avg:33.32ms
+step:280/1480 train_time:9334ms step_avg:33.34ms
+step:281/1480 train_time:9366ms step_avg:33.33ms
+step:282/1480 train_time:9403ms step_avg:33.34ms
+step:283/1480 train_time:9434ms step_avg:33.34ms
+step:284/1480 train_time:9471ms step_avg:33.35ms
+step:285/1480 train_time:9503ms step_avg:33.34ms
+step:286/1480 train_time:9539ms step_avg:33.35ms
+step:287/1480 train_time:9571ms step_avg:33.35ms
+step:288/1480 train_time:9608ms step_avg:33.36ms
+step:289/1480 train_time:9640ms step_avg:33.36ms
+step:290/1480 train_time:9676ms step_avg:33.37ms
+step:291/1480 train_time:9708ms step_avg:33.36ms
+step:292/1480 train_time:9744ms step_avg:33.37ms
+step:293/1480 train_time:9775ms step_avg:33.36ms
+step:294/1480 train_time:9812ms step_avg:33.37ms
+step:295/1480 train_time:9843ms step_avg:33.37ms
+step:296/1480 train_time:9879ms step_avg:33.37ms
+step:297/1480 train_time:9910ms step_avg:33.37ms
+step:298/1480 train_time:9947ms step_avg:33.38ms
+step:299/1480 train_time:9978ms step_avg:33.37ms
+step:300/1480 train_time:10014ms step_avg:33.38ms
+step:301/1480 train_time:10046ms step_avg:33.37ms
+step:302/1480 train_time:10082ms step_avg:33.38ms
+step:303/1480 train_time:10112ms step_avg:33.37ms
+step:304/1480 train_time:10149ms step_avg:33.39ms
+step:305/1480 train_time:10180ms step_avg:33.38ms
+step:306/1480 train_time:10216ms step_avg:33.39ms
+step:307/1480 train_time:10247ms step_avg:33.38ms
+step:308/1480 train_time:10283ms step_avg:33.39ms
+step:309/1480 train_time:10314ms step_avg:33.38ms
+step:310/1480 train_time:10351ms step_avg:33.39ms
+step:311/1480 train_time:10381ms step_avg:33.38ms
+step:312/1480 train_time:10417ms step_avg:33.39ms
+step:313/1480 train_time:10448ms step_avg:33.38ms
+step:314/1480 train_time:10484ms step_avg:33.39ms
+step:315/1480 train_time:10515ms step_avg:33.38ms
+step:316/1480 train_time:10551ms step_avg:33.39ms
+step:317/1480 train_time:10582ms step_avg:33.38ms
+step:318/1480 train_time:10618ms step_avg:33.39ms
+step:319/1480 train_time:10648ms step_avg:33.38ms
+step:320/1480 train_time:10685ms step_avg:33.39ms
+step:321/1480 train_time:10715ms step_avg:33.38ms
+step:322/1480 train_time:10751ms step_avg:33.39ms
+step:323/1480 train_time:10782ms step_avg:33.38ms
+step:324/1480 train_time:10817ms step_avg:33.39ms
+step:325/1480 train_time:10848ms step_avg:33.38ms
+step:326/1480 train_time:10884ms step_avg:33.39ms
+step:327/1480 train_time:10914ms step_avg:33.38ms
+step:328/1480 train_time:10950ms step_avg:33.38ms
+step:329/1480 train_time:10980ms step_avg:33.38ms
+step:330/1480 train_time:11016ms step_avg:33.38ms
+step:331/1480 train_time:11047ms step_avg:33.38ms
+step:332/1480 train_time:11083ms step_avg:33.38ms
+step:333/1480 train_time:11113ms step_avg:33.37ms
+step:334/1480 train_time:11149ms step_avg:33.38ms
+step:335/1480 train_time:11180ms step_avg:33.37ms
+step:336/1480 train_time:11215ms step_avg:33.38ms
+step:337/1480 train_time:11247ms step_avg:33.37ms
+step:338/1480 train_time:11282ms step_avg:33.38ms
+step:339/1480 train_time:11313ms step_avg:33.37ms
+step:340/1480 train_time:11349ms step_avg:33.38ms
+step:341/1480 train_time:11379ms step_avg:33.37ms
+step:342/1480 train_time:11415ms step_avg:33.38ms
+step:343/1480 train_time:11446ms step_avg:33.37ms
+step:344/1480 train_time:11482ms step_avg:33.38ms
+step:345/1480 train_time:11512ms step_avg:33.37ms
+step:346/1480 train_time:11549ms step_avg:33.38ms
+step:347/1480 train_time:11579ms step_avg:33.37ms
+step:348/1480 train_time:11615ms step_avg:33.38ms
+step:349/1480 train_time:11646ms step_avg:33.37ms
+step:350/1480 train_time:11682ms step_avg:33.38ms
+step:351/1480 train_time:11712ms step_avg:33.37ms
+step:352/1480 train_time:11748ms step_avg:33.38ms
+step:353/1480 train_time:11778ms step_avg:33.37ms
+step:354/1480 train_time:11814ms step_avg:33.37ms
+step:355/1480 train_time:11845ms step_avg:33.37ms
+step:356/1480 train_time:11881ms step_avg:33.37ms
+step:357/1480 train_time:11912ms step_avg:33.37ms
+step:358/1480 train_time:11948ms step_avg:33.37ms
+step:359/1480 train_time:11978ms step_avg:33.36ms
+step:360/1480 train_time:12014ms step_avg:33.37ms
+step:361/1480 train_time:12044ms step_avg:33.36ms
+step:362/1480 train_time:12080ms step_avg:33.37ms
+step:363/1480 train_time:12110ms step_avg:33.36ms
+step:364/1480 train_time:12147ms step_avg:33.37ms
+step:365/1480 train_time:12177ms step_avg:33.36ms
+step:366/1480 train_time:12212ms step_avg:33.37ms
+step:367/1480 train_time:12243ms step_avg:33.36ms
+step:368/1480 train_time:12278ms step_avg:33.37ms
+step:369/1480 train_time:12309ms step_avg:33.36ms
+step:370/1480 train_time:12345ms step_avg:33.36ms
+step:371/1480 train_time:12375ms step_avg:33.35ms
+step:372/1480 train_time:12411ms step_avg:33.36ms
+step:373/1480 train_time:12441ms step_avg:33.36ms
+step:374/1480 train_time:12477ms step_avg:33.36ms
+step:375/1480 train_time:12508ms step_avg:33.35ms
+step:376/1480 train_time:12544ms step_avg:33.36ms
+step:377/1480 train_time:12573ms step_avg:33.35ms
+step:378/1480 train_time:12610ms step_avg:33.36ms
+step:379/1480 train_time:12640ms step_avg:33.35ms
+step:380/1480 train_time:12675ms step_avg:33.36ms
+step:381/1480 train_time:12706ms step_avg:33.35ms
+step:382/1480 train_time:12742ms step_avg:33.36ms
+step:383/1480 train_time:12772ms step_avg:33.35ms
+step:384/1480 train_time:12809ms step_avg:33.36ms
+step:385/1480 train_time:12839ms step_avg:33.35ms
+step:386/1480 train_time:12875ms step_avg:33.35ms
+step:387/1480 train_time:12906ms step_avg:33.35ms
+step:388/1480 train_time:12941ms step_avg:33.35ms
+step:389/1480 train_time:12971ms step_avg:33.35ms
+step:390/1480 train_time:13008ms step_avg:33.35ms
+step:391/1480 train_time:13038ms step_avg:33.35ms
+step:392/1480 train_time:13074ms step_avg:33.35ms
+step:393/1480 train_time:13105ms step_avg:33.35ms
+step:394/1480 train_time:13140ms step_avg:33.35ms
+step:395/1480 train_time:13171ms step_avg:33.34ms
+step:396/1480 train_time:13207ms step_avg:33.35ms
+step:397/1480 train_time:13238ms step_avg:33.34ms
+step:398/1480 train_time:13274ms step_avg:33.35ms
+step:399/1480 train_time:13304ms step_avg:33.34ms
+step:400/1480 train_time:13340ms step_avg:33.35ms
+step:401/1480 train_time:13370ms step_avg:33.34ms
+step:402/1480 train_time:13406ms step_avg:33.35ms
+step:403/1480 train_time:13437ms step_avg:33.34ms
+step:404/1480 train_time:13472ms step_avg:33.35ms
+step:405/1480 train_time:13503ms step_avg:33.34ms
+step:406/1480 train_time:13539ms step_avg:33.35ms
+step:407/1480 train_time:13569ms step_avg:33.34ms
+step:408/1480 train_time:13605ms step_avg:33.35ms
+step:409/1480 train_time:13636ms step_avg:33.34ms
+step:410/1480 train_time:13672ms step_avg:33.35ms
+step:411/1480 train_time:13703ms step_avg:33.34ms
+step:412/1480 train_time:13739ms step_avg:33.35ms
+step:413/1480 train_time:13771ms step_avg:33.34ms
+step:414/1480 train_time:13811ms step_avg:33.36ms
+step:415/1480 train_time:13842ms step_avg:33.35ms
+step:416/1480 train_time:13879ms step_avg:33.36ms
+step:417/1480 train_time:13911ms step_avg:33.36ms
+step:418/1480 train_time:13950ms step_avg:33.37ms
+step:419/1480 train_time:13982ms step_avg:33.37ms
+step:420/1480 train_time:14019ms step_avg:33.38ms
+step:421/1480 train_time:14051ms step_avg:33.38ms
+step:422/1480 train_time:14089ms step_avg:33.39ms
+step:423/1480 train_time:14121ms step_avg:33.38ms
+step:424/1480 train_time:14158ms step_avg:33.39ms
+step:425/1480 train_time:14190ms step_avg:33.39ms
+step:426/1480 train_time:14228ms step_avg:33.40ms
+step:427/1480 train_time:14260ms step_avg:33.40ms
+step:428/1480 train_time:14298ms step_avg:33.41ms
+step:429/1480 train_time:14330ms step_avg:33.40ms
+step:430/1480 train_time:14367ms step_avg:33.41ms
+step:431/1480 train_time:14396ms step_avg:33.40ms
+step:432/1480 train_time:14431ms step_avg:33.40ms
+step:433/1480 train_time:14460ms step_avg:33.39ms
+step:434/1480 train_time:14495ms step_avg:33.40ms
+step:435/1480 train_time:14524ms step_avg:33.39ms
+step:436/1480 train_time:14562ms step_avg:33.40ms
+step:437/1480 train_time:14593ms step_avg:33.39ms
+step:438/1480 train_time:14630ms step_avg:33.40ms
+step:439/1480 train_time:14660ms step_avg:33.39ms
+step:440/1480 train_time:14696ms step_avg:33.40ms
+step:441/1480 train_time:14727ms step_avg:33.40ms
+step:442/1480 train_time:14764ms step_avg:33.40ms
+step:443/1480 train_time:14794ms step_avg:33.40ms
+step:444/1480 train_time:14831ms step_avg:33.40ms
+step:445/1480 train_time:14861ms step_avg:33.40ms
+step:446/1480 train_time:14897ms step_avg:33.40ms
+step:447/1480 train_time:14928ms step_avg:33.40ms
+step:448/1480 train_time:14965ms step_avg:33.40ms
+step:449/1480 train_time:14996ms step_avg:33.40ms
+step:450/1480 train_time:15032ms step_avg:33.40ms
+step:451/1480 train_time:15063ms step_avg:33.40ms
+step:452/1480 train_time:15098ms step_avg:33.40ms
+step:453/1480 train_time:15129ms step_avg:33.40ms
+step:454/1480 train_time:15166ms step_avg:33.41ms
+step:455/1480 train_time:15196ms step_avg:33.40ms
+step:456/1480 train_time:15233ms step_avg:33.41ms
+step:457/1480 train_time:15264ms step_avg:33.40ms
+step:458/1480 train_time:15300ms step_avg:33.41ms
+step:459/1480 train_time:15331ms step_avg:33.40ms
+step:460/1480 train_time:15368ms step_avg:33.41ms
+step:461/1480 train_time:15398ms step_avg:33.40ms
+step:462/1480 train_time:15434ms step_avg:33.41ms
+step:463/1480 train_time:15465ms step_avg:33.40ms
+step:464/1480 train_time:15501ms step_avg:33.41ms
+step:465/1480 train_time:15531ms step_avg:33.40ms
+step:466/1480 train_time:15568ms step_avg:33.41ms
+step:467/1480 train_time:15599ms step_avg:33.40ms
+step:468/1480 train_time:15635ms step_avg:33.41ms
+step:469/1480 train_time:15666ms step_avg:33.40ms
+step:470/1480 train_time:15702ms step_avg:33.41ms
+step:471/1480 train_time:15733ms step_avg:33.40ms
+step:472/1480 train_time:15769ms step_avg:33.41ms
+step:473/1480 train_time:15800ms step_avg:33.40ms
+step:474/1480 train_time:15836ms step_avg:33.41ms
+step:475/1480 train_time:15867ms step_avg:33.40ms
+step:476/1480 train_time:15903ms step_avg:33.41ms
+step:477/1480 train_time:15933ms step_avg:33.40ms
+step:478/1480 train_time:15970ms step_avg:33.41ms
+step:479/1480 train_time:16000ms step_avg:33.40ms
+step:480/1480 train_time:16035ms step_avg:33.41ms
+step:481/1480 train_time:16068ms step_avg:33.41ms
+step:482/1480 train_time:16129ms step_avg:33.46ms
+step:483/1480 train_time:16188ms step_avg:33.51ms
+step:484/1480 train_time:16252ms step_avg:33.58ms
+step:485/1480 train_time:16312ms step_avg:33.63ms
+step:486/1480 train_time:16380ms step_avg:33.70ms
+step:487/1480 train_time:16439ms step_avg:33.76ms
+step:488/1480 train_time:16504ms step_avg:33.82ms
+step:489/1480 train_time:16563ms step_avg:33.87ms
+step:490/1480 train_time:16628ms step_avg:33.93ms
+step:491/1480 train_time:16687ms step_avg:33.99ms
+step:492/1480 train_time:16752ms step_avg:34.05ms
+step:493/1480 train_time:16811ms step_avg:34.10ms
+step:494/1480 train_time:16876ms step_avg:34.16ms
+step:495/1480 train_time:16936ms step_avg:34.21ms
+step:496/1480 train_time:17001ms step_avg:34.28ms
+step:497/1480 train_time:17059ms step_avg:34.32ms
+step:498/1480 train_time:17125ms step_avg:34.39ms
+step:499/1480 train_time:17184ms step_avg:34.44ms
+step:500/1480 train_time:17248ms step_avg:34.50ms
+step:500/1480 val_loss:4.1919 train_time:17325ms step_avg:34.65ms
+step:501/1480 train_time:17342ms step_avg:34.62ms
+step:502/1480 train_time:17371ms step_avg:34.60ms
+step:503/1480 train_time:17430ms step_avg:34.65ms
+step:504/1480 train_time:17494ms step_avg:34.71ms
+step:505/1480 train_time:17554ms step_avg:34.76ms
+step:506/1480 train_time:17618ms step_avg:34.82ms
+step:507/1480 train_time:17677ms step_avg:34.87ms
+step:508/1480 train_time:17743ms step_avg:34.93ms
+step:509/1480 train_time:17802ms step_avg:34.97ms
+step:510/1480 train_time:17868ms step_avg:35.04ms
+step:511/1480 train_time:17927ms step_avg:35.08ms
+step:512/1480 train_time:17990ms step_avg:35.14ms
+step:513/1480 train_time:18048ms step_avg:35.18ms
+step:514/1480 train_time:18112ms step_avg:35.24ms
+step:515/1480 train_time:18170ms step_avg:35.28ms
+step:516/1480 train_time:18235ms step_avg:35.34ms
+step:517/1480 train_time:18293ms step_avg:35.38ms
+step:518/1480 train_time:18360ms step_avg:35.44ms
+step:519/1480 train_time:18418ms step_avg:35.49ms
+step:520/1480 train_time:18482ms step_avg:35.54ms
+step:521/1480 train_time:18540ms step_avg:35.59ms
+step:522/1480 train_time:18605ms step_avg:35.64ms
+step:523/1480 train_time:18663ms step_avg:35.68ms
+step:524/1480 train_time:18727ms step_avg:35.74ms
+step:525/1480 train_time:18787ms step_avg:35.78ms
+step:526/1480 train_time:18852ms step_avg:35.84ms
+step:527/1480 train_time:18911ms step_avg:35.88ms
+step:528/1480 train_time:18975ms step_avg:35.94ms
+step:529/1480 train_time:19032ms step_avg:35.98ms
+step:530/1480 train_time:19096ms step_avg:36.03ms
+step:531/1480 train_time:19155ms step_avg:36.07ms
+step:532/1480 train_time:19218ms step_avg:36.12ms
+step:533/1480 train_time:19276ms step_avg:36.17ms
+step:534/1480 train_time:19339ms step_avg:36.22ms
+step:535/1480 train_time:19398ms step_avg:36.26ms
+step:536/1480 train_time:19462ms step_avg:36.31ms
+step:537/1480 train_time:19520ms step_avg:36.35ms
+step:538/1480 train_time:19585ms step_avg:36.40ms
+step:539/1480 train_time:19643ms step_avg:36.44ms
+step:540/1480 train_time:19708ms step_avg:36.50ms
+step:541/1480 train_time:19767ms step_avg:36.54ms
+step:542/1480 train_time:19831ms step_avg:36.59ms
+step:543/1480 train_time:19890ms step_avg:36.63ms
+step:544/1480 train_time:19956ms step_avg:36.68ms
+step:545/1480 train_time:20014ms step_avg:36.72ms
+step:546/1480 train_time:20080ms step_avg:36.78ms
+step:547/1480 train_time:20139ms step_avg:36.82ms
+step:548/1480 train_time:20204ms step_avg:36.87ms
+step:549/1480 train_time:20262ms step_avg:36.91ms
+step:550/1480 train_time:20326ms step_avg:36.96ms
+step:551/1480 train_time:20384ms step_avg:37.00ms
+step:552/1480 train_time:20449ms step_avg:37.04ms
+step:553/1480 train_time:20508ms step_avg:37.08ms
+step:554/1480 train_time:20573ms step_avg:37.13ms
+step:555/1480 train_time:20631ms step_avg:37.17ms
+step:556/1480 train_time:20696ms step_avg:37.22ms
+step:557/1480 train_time:20756ms step_avg:37.26ms
+step:558/1480 train_time:20820ms step_avg:37.31ms
+step:559/1480 train_time:20879ms step_avg:37.35ms
+step:560/1480 train_time:20944ms step_avg:37.40ms
+step:561/1480 train_time:21002ms step_avg:37.44ms
+step:562/1480 train_time:21067ms step_avg:37.49ms
+step:563/1480 train_time:21125ms step_avg:37.52ms
+step:564/1480 train_time:21190ms step_avg:37.57ms
+step:565/1480 train_time:21248ms step_avg:37.61ms
+step:566/1480 train_time:21313ms step_avg:37.66ms
+step:567/1480 train_time:21371ms step_avg:37.69ms
+step:568/1480 train_time:21436ms step_avg:37.74ms
+step:569/1480 train_time:21496ms step_avg:37.78ms
+step:570/1480 train_time:21560ms step_avg:37.82ms
+step:571/1480 train_time:21618ms step_avg:37.86ms
+step:572/1480 train_time:21683ms step_avg:37.91ms
+step:573/1480 train_time:21741ms step_avg:37.94ms
+step:574/1480 train_time:21805ms step_avg:37.99ms
+step:575/1480 train_time:21864ms step_avg:38.03ms
+step:576/1480 train_time:21930ms step_avg:38.07ms
+step:577/1480 train_time:21990ms step_avg:38.11ms
+step:578/1480 train_time:22057ms step_avg:38.16ms
+step:579/1480 train_time:22116ms step_avg:38.20ms
+step:580/1480 train_time:22181ms step_avg:38.24ms
+step:581/1480 train_time:22239ms step_avg:38.28ms
+step:582/1480 train_time:22304ms step_avg:38.32ms
+step:583/1480 train_time:22362ms step_avg:38.36ms
+step:584/1480 train_time:22425ms step_avg:38.40ms
+step:585/1480 train_time:22483ms step_avg:38.43ms
+step:586/1480 train_time:22546ms step_avg:38.47ms
+step:587/1480 train_time:22604ms step_avg:38.51ms
+step:588/1480 train_time:22667ms step_avg:38.55ms
+step:589/1480 train_time:22725ms step_avg:38.58ms
+step:590/1480 train_time:22789ms step_avg:38.62ms
+step:591/1480 train_time:22847ms step_avg:38.66ms
+step:592/1480 train_time:22911ms step_avg:38.70ms
+step:593/1480 train_time:22969ms step_avg:38.73ms
+step:594/1480 train_time:23033ms step_avg:38.78ms
+step:595/1480 train_time:23093ms step_avg:38.81ms
+step:596/1480 train_time:23158ms step_avg:38.86ms
+step:597/1480 train_time:23217ms step_avg:38.89ms
+step:598/1480 train_time:23283ms step_avg:38.93ms
+step:599/1480 train_time:23341ms step_avg:38.97ms
+step:600/1480 train_time:23404ms step_avg:39.01ms
+step:601/1480 train_time:23462ms step_avg:39.04ms
+step:602/1480 train_time:23525ms step_avg:39.08ms
+step:603/1480 train_time:23583ms step_avg:39.11ms
+step:604/1480 train_time:23647ms step_avg:39.15ms
+step:605/1480 train_time:23705ms step_avg:39.18ms
+step:606/1480 train_time:23769ms step_avg:39.22ms
+step:607/1480 train_time:23828ms step_avg:39.25ms
+step:608/1480 train_time:23892ms step_avg:39.30ms
+step:609/1480 train_time:23950ms step_avg:39.33ms
+step:610/1480 train_time:24013ms step_avg:39.37ms
+step:611/1480 train_time:24072ms step_avg:39.40ms
+step:612/1480 train_time:24135ms step_avg:39.44ms
+step:613/1480 train_time:24194ms step_avg:39.47ms
+step:614/1480 train_time:24260ms step_avg:39.51ms
+step:615/1480 train_time:24318ms step_avg:39.54ms
+step:616/1480 train_time:24382ms step_avg:39.58ms
+step:617/1480 train_time:24439ms step_avg:39.61ms
+step:618/1480 train_time:24503ms step_avg:39.65ms
+step:619/1480 train_time:24561ms step_avg:39.68ms
+step:620/1480 train_time:24624ms step_avg:39.72ms
+step:621/1480 train_time:24684ms step_avg:39.75ms
+step:622/1480 train_time:24755ms step_avg:39.80ms
+step:623/1480 train_time:24821ms step_avg:39.84ms
+step:624/1480 train_time:24892ms step_avg:39.89ms
+step:625/1480 train_time:24946ms step_avg:39.91ms
+step:626/1480 train_time:25007ms step_avg:39.95ms
+step:627/1480 train_time:25066ms step_avg:39.98ms
+step:628/1480 train_time:25130ms step_avg:40.02ms
+step:629/1480 train_time:25186ms step_avg:40.04ms
+step:630/1480 train_time:25251ms step_avg:40.08ms
+step:631/1480 train_time:25308ms step_avg:40.11ms
+step:632/1480 train_time:25371ms step_avg:40.14ms
+step:633/1480 train_time:25429ms step_avg:40.17ms
+step:634/1480 train_time:25493ms step_avg:40.21ms
+step:635/1480 train_time:25552ms step_avg:40.24ms
+step:636/1480 train_time:25616ms step_avg:40.28ms
+step:637/1480 train_time:25676ms step_avg:40.31ms
+step:638/1480 train_time:25741ms step_avg:40.35ms
+step:639/1480 train_time:25801ms step_avg:40.38ms
+step:640/1480 train_time:25866ms step_avg:40.42ms
+step:641/1480 train_time:25924ms step_avg:40.44ms
+step:642/1480 train_time:25989ms step_avg:40.48ms
+step:643/1480 train_time:26049ms step_avg:40.51ms
+step:644/1480 train_time:26114ms step_avg:40.55ms
+step:645/1480 train_time:26173ms step_avg:40.58ms
+step:646/1480 train_time:26238ms step_avg:40.62ms
+step:647/1480 train_time:26296ms step_avg:40.64ms
+step:648/1480 train_time:26360ms step_avg:40.68ms
+step:649/1480 train_time:26418ms step_avg:40.71ms
+step:650/1480 train_time:26484ms step_avg:40.74ms
+step:651/1480 train_time:26542ms step_avg:40.77ms
+step:652/1480 train_time:26607ms step_avg:40.81ms
+step:653/1480 train_time:26665ms step_avg:40.84ms
+step:654/1480 train_time:26729ms step_avg:40.87ms
+step:655/1480 train_time:26790ms step_avg:40.90ms
+step:656/1480 train_time:26856ms step_avg:40.94ms
+step:657/1480 train_time:26916ms step_avg:40.97ms
+step:658/1480 train_time:26981ms step_avg:41.00ms
+step:659/1480 train_time:27041ms step_avg:41.03ms
+step:660/1480 train_time:27107ms step_avg:41.07ms
+step:661/1480 train_time:27164ms step_avg:41.10ms
+step:662/1480 train_time:27228ms step_avg:41.13ms
+step:663/1480 train_time:27285ms step_avg:41.15ms
+step:664/1480 train_time:27349ms step_avg:41.19ms
+step:665/1480 train_time:27408ms step_avg:41.22ms
+step:666/1480 train_time:27475ms step_avg:41.25ms
+step:667/1480 train_time:27535ms step_avg:41.28ms
+step:668/1480 train_time:27601ms step_avg:41.32ms
+step:669/1480 train_time:27662ms step_avg:41.35ms
+step:670/1480 train_time:27727ms step_avg:41.38ms
+step:671/1480 train_time:27786ms step_avg:41.41ms
+step:672/1480 train_time:27851ms step_avg:41.44ms
+step:673/1480 train_time:27910ms step_avg:41.47ms
+step:674/1480 train_time:27975ms step_avg:41.51ms
+step:675/1480 train_time:28034ms step_avg:41.53ms
+step:676/1480 train_time:28098ms step_avg:41.57ms
+step:677/1480 train_time:28157ms step_avg:41.59ms
+step:678/1480 train_time:28222ms step_avg:41.63ms
+step:679/1480 train_time:28281ms step_avg:41.65ms
+step:680/1480 train_time:28345ms step_avg:41.68ms
+step:681/1480 train_time:28404ms step_avg:41.71ms
+step:682/1480 train_time:28467ms step_avg:41.74ms
+step:683/1480 train_time:28526ms step_avg:41.77ms
+step:684/1480 train_time:28590ms step_avg:41.80ms
+step:685/1480 train_time:28648ms step_avg:41.82ms
+step:686/1480 train_time:28712ms step_avg:41.85ms
+step:687/1480 train_time:28771ms step_avg:41.88ms
+step:688/1480 train_time:28837ms step_avg:41.91ms
+step:689/1480 train_time:28899ms step_avg:41.94ms
+step:690/1480 train_time:28965ms step_avg:41.98ms
+step:691/1480 train_time:29024ms step_avg:42.00ms
+step:692/1480 train_time:29092ms step_avg:42.04ms
+step:693/1480 train_time:29151ms step_avg:42.07ms
+step:694/1480 train_time:29218ms step_avg:42.10ms
+step:695/1480 train_time:29277ms step_avg:42.12ms
+step:696/1480 train_time:29343ms step_avg:42.16ms
+step:697/1480 train_time:29402ms step_avg:42.18ms
+step:698/1480 train_time:29468ms step_avg:42.22ms
+step:699/1480 train_time:29528ms step_avg:42.24ms
+step:700/1480 train_time:29593ms step_avg:42.28ms
+step:701/1480 train_time:29652ms step_avg:42.30ms
+step:702/1480 train_time:29718ms step_avg:42.33ms
+step:703/1480 train_time:29777ms step_avg:42.36ms
+step:704/1480 train_time:29843ms step_avg:42.39ms
+step:705/1480 train_time:29902ms step_avg:42.41ms
+step:706/1480 train_time:29967ms step_avg:42.45ms
+step:707/1480 train_time:30023ms step_avg:42.47ms
+step:708/1480 train_time:30084ms step_avg:42.49ms
+step:709/1480 train_time:30141ms step_avg:42.51ms
+step:710/1480 train_time:30203ms step_avg:42.54ms
+step:711/1480 train_time:30263ms step_avg:42.56ms
+step:712/1480 train_time:30329ms step_avg:42.60ms
+step:713/1480 train_time:30390ms step_avg:42.62ms
+step:714/1480 train_time:30453ms step_avg:42.65ms
+step:715/1480 train_time:30511ms step_avg:42.67ms
+step:716/1480 train_time:30574ms step_avg:42.70ms
+step:717/1480 train_time:30633ms step_avg:42.72ms
+step:718/1480 train_time:30697ms step_avg:42.75ms
+step:719/1480 train_time:30756ms step_avg:42.78ms
+step:720/1480 train_time:30819ms step_avg:42.80ms
+step:721/1480 train_time:30877ms step_avg:42.83ms
+step:722/1480 train_time:30942ms step_avg:42.86ms
+step:723/1480 train_time:31001ms step_avg:42.88ms
+step:724/1480 train_time:31065ms step_avg:42.91ms
+step:725/1480 train_time:31123ms step_avg:42.93ms
+step:726/1480 train_time:31188ms step_avg:42.96ms
+step:727/1480 train_time:31247ms step_avg:42.98ms
+step:728/1480 train_time:31312ms step_avg:43.01ms
+step:729/1480 train_time:31370ms step_avg:43.03ms
+step:730/1480 train_time:31436ms step_avg:43.06ms
+step:731/1480 train_time:31497ms step_avg:43.09ms
+step:732/1480 train_time:31562ms step_avg:43.12ms
+step:733/1480 train_time:31619ms step_avg:43.14ms
+step:734/1480 train_time:31683ms step_avg:43.17ms
+step:735/1480 train_time:31740ms step_avg:43.18ms
+step:736/1480 train_time:31803ms step_avg:43.21ms
+step:737/1480 train_time:31861ms step_avg:43.23ms
+step:738/1480 train_time:31924ms step_avg:43.26ms
+step:739/1480 train_time:31983ms step_avg:43.28ms
+step:740/1480 train_time:32048ms step_avg:43.31ms
+step:741/1480 train_time:32108ms step_avg:43.33ms
+step:742/1480 train_time:32172ms step_avg:43.36ms
+step:743/1480 train_time:32232ms step_avg:43.38ms
+step:744/1480 train_time:32299ms step_avg:43.41ms
+step:745/1480 train_time:32357ms step_avg:43.43ms
+step:746/1480 train_time:32422ms step_avg:43.46ms
+step:747/1480 train_time:32482ms step_avg:43.48ms
+step:748/1480 train_time:32548ms step_avg:43.51ms
+step:749/1480 train_time:32608ms step_avg:43.54ms
+step:750/1480 train_time:32672ms step_avg:43.56ms
+step:750/1480 val_loss:3.8003 train_time:32752ms step_avg:43.67ms
+step:751/1480 train_time:32770ms step_avg:43.63ms
+step:752/1480 train_time:32798ms step_avg:43.61ms
+step:753/1480 train_time:32856ms step_avg:43.63ms
+step:754/1480 train_time:32921ms step_avg:43.66ms
+step:755/1480 train_time:32983ms step_avg:43.69ms
+step:756/1480 train_time:33050ms step_avg:43.72ms
+step:757/1480 train_time:33112ms step_avg:43.74ms
+step:758/1480 train_time:33179ms step_avg:43.77ms
+step:759/1480 train_time:33240ms step_avg:43.79ms
+step:760/1480 train_time:33308ms step_avg:43.83ms
+step:761/1480 train_time:33368ms step_avg:43.85ms
+step:762/1480 train_time:33434ms step_avg:43.88ms
+step:763/1480 train_time:33494ms step_avg:43.90ms
+step:764/1480 train_time:33561ms step_avg:43.93ms
+step:765/1480 train_time:33620ms step_avg:43.95ms
+step:766/1480 train_time:33686ms step_avg:43.98ms
+step:767/1480 train_time:33745ms step_avg:44.00ms
+step:768/1480 train_time:33811ms step_avg:44.02ms
+step:769/1480 train_time:33870ms step_avg:44.04ms
+step:770/1480 train_time:33936ms step_avg:44.07ms
+step:771/1480 train_time:33996ms step_avg:44.09ms
+step:772/1480 train_time:34062ms step_avg:44.12ms
+step:773/1480 train_time:34121ms step_avg:44.14ms
+step:774/1480 train_time:34186ms step_avg:44.17ms
+step:775/1480 train_time:34242ms step_avg:44.18ms
+step:776/1480 train_time:34302ms step_avg:44.20ms
+step:777/1480 train_time:34359ms step_avg:44.22ms
+step:778/1480 train_time:34425ms step_avg:44.25ms
+step:779/1480 train_time:34484ms step_avg:44.27ms
+step:780/1480 train_time:34548ms step_avg:44.29ms
+step:781/1480 train_time:34605ms step_avg:44.31ms
+step:782/1480 train_time:34668ms step_avg:44.33ms
+step:783/1480 train_time:34727ms step_avg:44.35ms
+step:784/1480 train_time:34791ms step_avg:44.38ms
+step:785/1480 train_time:34849ms step_avg:44.39ms
+step:786/1480 train_time:34915ms step_avg:44.42ms
+step:787/1480 train_time:34975ms step_avg:44.44ms
+step:788/1480 train_time:35039ms step_avg:44.47ms
+step:789/1480 train_time:35097ms step_avg:44.48ms
+step:790/1480 train_time:35160ms step_avg:44.51ms
+step:791/1480 train_time:35217ms step_avg:44.52ms
+step:792/1480 train_time:35280ms step_avg:44.55ms
+step:793/1480 train_time:35337ms step_avg:44.56ms
+step:794/1480 train_time:35401ms step_avg:44.59ms
+step:795/1480 train_time:35462ms step_avg:44.61ms
+step:796/1480 train_time:35533ms step_avg:44.64ms
+step:797/1480 train_time:35598ms step_avg:44.66ms
+step:798/1480 train_time:35668ms step_avg:44.70ms
+step:799/1480 train_time:35731ms step_avg:44.72ms
+step:800/1480 train_time:35802ms step_avg:44.75ms
+step:801/1480 train_time:35864ms step_avg:44.77ms
+step:802/1480 train_time:35924ms step_avg:44.79ms
+step:803/1480 train_time:35977ms step_avg:44.80ms
+step:804/1480 train_time:36037ms step_avg:44.82ms
+step:805/1480 train_time:36093ms step_avg:44.84ms
+step:806/1480 train_time:36159ms step_avg:44.86ms
+step:807/1480 train_time:36223ms step_avg:44.89ms
+step:808/1480 train_time:36295ms step_avg:44.92ms
+step:809/1480 train_time:36357ms step_avg:44.94ms
+step:810/1480 train_time:36424ms step_avg:44.97ms
+step:811/1480 train_time:36483ms step_avg:44.98ms
+step:812/1480 train_time:36548ms step_avg:45.01ms
+step:813/1480 train_time:36609ms step_avg:45.03ms
+step:814/1480 train_time:36674ms step_avg:45.05ms
+step:815/1480 train_time:36734ms step_avg:45.07ms
+step:816/1480 train_time:36801ms step_avg:45.10ms
+step:817/1480 train_time:36860ms step_avg:45.12ms
+step:818/1480 train_time:36926ms step_avg:45.14ms
+step:819/1480 train_time:36987ms step_avg:45.16ms
+step:820/1480 train_time:37053ms step_avg:45.19ms
+step:821/1480 train_time:37112ms step_avg:45.20ms
+step:822/1480 train_time:37178ms step_avg:45.23ms
+step:823/1480 train_time:37238ms step_avg:45.25ms
+step:824/1480 train_time:37304ms step_avg:45.27ms
+step:825/1480 train_time:37364ms step_avg:45.29ms
+step:826/1480 train_time:37428ms step_avg:45.31ms
+step:827/1480 train_time:37488ms step_avg:45.33ms
+step:828/1480 train_time:37553ms step_avg:45.35ms
+step:829/1480 train_time:37613ms step_avg:45.37ms
+step:830/1480 train_time:37677ms step_avg:45.39ms
+step:831/1480 train_time:37738ms step_avg:45.41ms
+step:832/1480 train_time:37804ms step_avg:45.44ms
+step:833/1480 train_time:37861ms step_avg:45.45ms
+step:834/1480 train_time:37925ms step_avg:45.47ms
+step:835/1480 train_time:37983ms step_avg:45.49ms
+step:836/1480 train_time:38047ms step_avg:45.51ms
+step:837/1480 train_time:38106ms step_avg:45.53ms
+step:838/1480 train_time:38171ms step_avg:45.55ms
+step:839/1480 train_time:38229ms step_avg:45.56ms
+step:840/1480 train_time:38293ms step_avg:45.59ms
+step:841/1480 train_time:38352ms step_avg:45.60ms
+step:842/1480 train_time:38416ms step_avg:45.62ms
+step:843/1480 train_time:38474ms step_avg:45.64ms
+step:844/1480 train_time:38540ms step_avg:45.66ms
+step:845/1480 train_time:38600ms step_avg:45.68ms
+step:846/1480 train_time:38664ms step_avg:45.70ms
+step:847/1480 train_time:38721ms step_avg:45.72ms
+step:848/1480 train_time:38785ms step_avg:45.74ms
+step:849/1480 train_time:38843ms step_avg:45.75ms
+step:850/1480 train_time:38907ms step_avg:45.77ms
+step:851/1480 train_time:38965ms step_avg:45.79ms
+step:852/1480 train_time:39028ms step_avg:45.81ms
+step:853/1480 train_time:39087ms step_avg:45.82ms
+step:854/1480 train_time:39153ms step_avg:45.85ms
+step:855/1480 train_time:39210ms step_avg:45.86ms
+step:856/1480 train_time:39274ms step_avg:45.88ms
+step:857/1480 train_time:39333ms step_avg:45.90ms
+step:858/1480 train_time:39400ms step_avg:45.92ms
+step:859/1480 train_time:39458ms step_avg:45.93ms
+step:860/1480 train_time:39522ms step_avg:45.96ms
+step:861/1480 train_time:39579ms step_avg:45.97ms
+step:862/1480 train_time:39644ms step_avg:45.99ms
+step:863/1480 train_time:39702ms step_avg:46.01ms
+step:864/1480 train_time:39767ms step_avg:46.03ms
+step:865/1480 train_time:39827ms step_avg:46.04ms
+step:866/1480 train_time:39893ms step_avg:46.07ms
+step:867/1480 train_time:39954ms step_avg:46.08ms
+step:868/1480 train_time:40020ms step_avg:46.11ms
+step:869/1480 train_time:40079ms step_avg:46.12ms
+step:870/1480 train_time:40148ms step_avg:46.15ms
+step:871/1480 train_time:40210ms step_avg:46.17ms
+step:872/1480 train_time:40276ms step_avg:46.19ms
+step:873/1480 train_time:40336ms step_avg:46.20ms
+step:874/1480 train_time:40403ms step_avg:46.23ms
+step:875/1480 train_time:40462ms step_avg:46.24ms
+step:876/1480 train_time:40527ms step_avg:46.26ms
+step:877/1480 train_time:40588ms step_avg:46.28ms
+step:878/1480 train_time:40655ms step_avg:46.30ms
+step:879/1480 train_time:40714ms step_avg:46.32ms
+step:880/1480 train_time:40781ms step_avg:46.34ms
+step:881/1480 train_time:40841ms step_avg:46.36ms
+step:882/1480 train_time:40907ms step_avg:46.38ms
+step:883/1480 train_time:40965ms step_avg:46.39ms
+step:884/1480 train_time:41031ms step_avg:46.41ms
+step:885/1480 train_time:41092ms step_avg:46.43ms
+step:886/1480 train_time:41157ms step_avg:46.45ms
+step:887/1480 train_time:41213ms step_avg:46.46ms
+step:888/1480 train_time:41274ms step_avg:46.48ms
+step:889/1480 train_time:41329ms step_avg:46.49ms
+step:890/1480 train_time:41393ms step_avg:46.51ms
+step:891/1480 train_time:41453ms step_avg:46.52ms
+step:892/1480 train_time:41518ms step_avg:46.54ms
+step:893/1480 train_time:41579ms step_avg:46.56ms
+step:894/1480 train_time:41644ms step_avg:46.58ms
+step:895/1480 train_time:41702ms step_avg:46.59ms
+step:896/1480 train_time:41769ms step_avg:46.62ms
+step:897/1480 train_time:41826ms step_avg:46.63ms
+step:898/1480 train_time:41890ms step_avg:46.65ms
+step:899/1480 train_time:41948ms step_avg:46.66ms
+step:900/1480 train_time:42011ms step_avg:46.68ms
+step:901/1480 train_time:42070ms step_avg:46.69ms
+step:902/1480 train_time:42135ms step_avg:46.71ms
+step:903/1480 train_time:42195ms step_avg:46.73ms
+step:904/1480 train_time:42262ms step_avg:46.75ms
+step:905/1480 train_time:42320ms step_avg:46.76ms
+step:906/1480 train_time:42385ms step_avg:46.78ms
+step:907/1480 train_time:42443ms step_avg:46.79ms
+step:908/1480 train_time:42507ms step_avg:46.81ms
+step:909/1480 train_time:42566ms step_avg:46.83ms
+step:910/1480 train_time:42632ms step_avg:46.85ms
+step:911/1480 train_time:42692ms step_avg:46.86ms
+step:912/1480 train_time:42756ms step_avg:46.88ms
+step:913/1480 train_time:42815ms step_avg:46.89ms
+step:914/1480 train_time:42882ms step_avg:46.92ms
+step:915/1480 train_time:42939ms step_avg:46.93ms
+step:916/1480 train_time:43003ms step_avg:46.95ms
+step:917/1480 train_time:43062ms step_avg:46.96ms
+step:918/1480 train_time:43126ms step_avg:46.98ms
+step:919/1480 train_time:43185ms step_avg:46.99ms
+step:920/1480 train_time:43252ms step_avg:47.01ms
+step:921/1480 train_time:43314ms step_avg:47.03ms
+step:922/1480 train_time:43381ms step_avg:47.05ms
+step:923/1480 train_time:43442ms step_avg:47.07ms
+step:924/1480 train_time:43509ms step_avg:47.09ms
+step:925/1480 train_time:43569ms step_avg:47.10ms
+step:926/1480 train_time:43635ms step_avg:47.12ms
+step:927/1480 train_time:43697ms step_avg:47.14ms
+step:928/1480 train_time:43763ms step_avg:47.16ms
+step:929/1480 train_time:43822ms step_avg:47.17ms
+step:930/1480 train_time:43889ms step_avg:47.19ms
+step:931/1480 train_time:43951ms step_avg:47.21ms
+step:932/1480 train_time:44017ms step_avg:47.23ms
+step:933/1480 train_time:44073ms step_avg:47.24ms
+step:934/1480 train_time:44133ms step_avg:47.25ms
+step:935/1480 train_time:44188ms step_avg:47.26ms
+step:936/1480 train_time:44251ms step_avg:47.28ms
+step:937/1480 train_time:44307ms step_avg:47.29ms
+step:938/1480 train_time:44368ms step_avg:47.30ms
+step:939/1480 train_time:44426ms step_avg:47.31ms
+step:940/1480 train_time:44490ms step_avg:47.33ms
+step:941/1480 train_time:44551ms step_avg:47.34ms
+step:942/1480 train_time:44617ms step_avg:47.36ms
+step:943/1480 train_time:44677ms step_avg:47.38ms
+step:944/1480 train_time:44747ms step_avg:47.40ms
+step:945/1480 train_time:44811ms step_avg:47.42ms
+step:946/1480 train_time:44881ms step_avg:47.44ms
+step:947/1480 train_time:44945ms step_avg:47.46ms
+step:948/1480 train_time:45014ms step_avg:47.48ms
+step:949/1480 train_time:45077ms step_avg:47.50ms
+step:950/1480 train_time:45137ms step_avg:47.51ms
+step:951/1480 train_time:45192ms step_avg:47.52ms
+step:952/1480 train_time:45251ms step_avg:47.53ms
+step:953/1480 train_time:45309ms step_avg:47.54ms
+step:954/1480 train_time:45375ms step_avg:47.56ms
+step:955/1480 train_time:45436ms step_avg:47.58ms
+step:956/1480 train_time:45500ms step_avg:47.59ms
+step:957/1480 train_time:45559ms step_avg:47.61ms
+step:958/1480 train_time:45623ms step_avg:47.62ms
+step:959/1480 train_time:45682ms step_avg:47.64ms
+step:960/1480 train_time:45748ms step_avg:47.65ms
+step:961/1480 train_time:45809ms step_avg:47.67ms
+step:962/1480 train_time:45899ms step_avg:47.71ms
+step:963/1480 train_time:45985ms step_avg:47.75ms
+step:964/1480 train_time:46078ms step_avg:47.80ms
+step:965/1480 train_time:46163ms step_avg:47.84ms
+step:966/1480 train_time:46257ms step_avg:47.88ms
+step:967/1480 train_time:46344ms step_avg:47.93ms
+step:968/1480 train_time:46441ms step_avg:47.98ms
+step:969/1480 train_time:46529ms step_avg:48.02ms
+step:970/1480 train_time:46624ms step_avg:48.07ms
+step:971/1480 train_time:46714ms step_avg:48.11ms
+step:972/1480 train_time:46809ms step_avg:48.16ms
+step:973/1480 train_time:46899ms step_avg:48.20ms
+step:974/1480 train_time:46993ms step_avg:48.25ms
+step:975/1480 train_time:47084ms step_avg:48.29ms
+step:976/1480 train_time:47178ms step_avg:48.34ms
+step:977/1480 train_time:47265ms step_avg:48.38ms
+step:978/1480 train_time:47361ms step_avg:48.43ms
+step:979/1480 train_time:47449ms step_avg:48.47ms
+step:980/1480 train_time:47544ms step_avg:48.51ms
+step:981/1480 train_time:47630ms step_avg:48.55ms
+step:982/1480 train_time:47725ms step_avg:48.60ms
+step:983/1480 train_time:47811ms step_avg:48.64ms
+step:984/1480 train_time:47905ms step_avg:48.68ms
+step:985/1480 train_time:47993ms step_avg:48.72ms
+step:986/1480 train_time:48086ms step_avg:48.77ms
+step:987/1480 train_time:48174ms step_avg:48.81ms
+step:988/1480 train_time:48267ms step_avg:48.85ms
+step:989/1480 train_time:48354ms step_avg:48.89ms
+step:990/1480 train_time:48447ms step_avg:48.94ms
+step:991/1480 train_time:48534ms step_avg:48.97ms
+step:992/1480 train_time:48627ms step_avg:49.02ms
+step:993/1480 train_time:48714ms step_avg:49.06ms
+step:994/1480 train_time:48807ms step_avg:49.10ms
+step:995/1480 train_time:48893ms step_avg:49.14ms
+step:996/1480 train_time:48987ms step_avg:49.18ms
+step:997/1480 train_time:49074ms step_avg:49.22ms
+step:998/1480 train_time:49166ms step_avg:49.26ms
+step:999/1480 train_time:49253ms step_avg:49.30ms
+step:1000/1480 train_time:49346ms step_avg:49.35ms
+step:1000/1480 val_loss:3.5096 train_time:49456ms step_avg:49.46ms
+step:1001/1480 train_time:49474ms step_avg:49.42ms
+step:1002/1480 train_time:49524ms step_avg:49.43ms
+step:1003/1480 train_time:49614ms step_avg:49.47ms
+step:1004/1480 train_time:49707ms step_avg:49.51ms
+step:1005/1480 train_time:49794ms step_avg:49.55ms
+step:1006/1480 train_time:49887ms step_avg:49.59ms
+step:1007/1480 train_time:49975ms step_avg:49.63ms
+step:1008/1480 train_time:50068ms step_avg:49.67ms
+step:1009/1480 train_time:50155ms step_avg:49.71ms
+step:1010/1480 train_time:50247ms step_avg:49.75ms
+step:1011/1480 train_time:50332ms step_avg:49.78ms
+step:1012/1480 train_time:50424ms step_avg:49.83ms
+step:1013/1480 train_time:50509ms step_avg:49.86ms
+step:1014/1480 train_time:50601ms step_avg:49.90ms
+step:1015/1480 train_time:50688ms step_avg:49.94ms
+step:1016/1480 train_time:50782ms step_avg:49.98ms
+step:1017/1480 train_time:50869ms step_avg:50.02ms
+step:1018/1480 train_time:50960ms step_avg:50.06ms
+step:1019/1480 train_time:51045ms step_avg:50.09ms
+step:1020/1480 train_time:51137ms step_avg:50.13ms
+step:1021/1480 train_time:51224ms step_avg:50.17ms
+step:1022/1480 train_time:51318ms step_avg:50.21ms
+step:1023/1480 train_time:51403ms step_avg:50.25ms
+step:1024/1480 train_time:51497ms step_avg:50.29ms
+step:1025/1480 train_time:51583ms step_avg:50.33ms
+step:1026/1480 train_time:51680ms step_avg:50.37ms
+step:1027/1480 train_time:51770ms step_avg:50.41ms
+step:1028/1480 train_time:51865ms step_avg:50.45ms
+step:1029/1480 train_time:51954ms step_avg:50.49ms
+step:1030/1480 train_time:52050ms step_avg:50.53ms
+step:1031/1480 train_time:52139ms step_avg:50.57ms
+step:1032/1480 train_time:52235ms step_avg:50.62ms
+step:1033/1480 train_time:52325ms step_avg:50.65ms
+step:1034/1480 train_time:52421ms step_avg:50.70ms
+step:1035/1480 train_time:52509ms step_avg:50.73ms
+step:1036/1480 train_time:52604ms step_avg:50.78ms
+step:1037/1480 train_time:52693ms step_avg:50.81ms
+step:1038/1480 train_time:52786ms step_avg:50.85ms
+step:1039/1480 train_time:52874ms step_avg:50.89ms
+step:1040/1480 train_time:52968ms step_avg:50.93ms
+step:1041/1480 train_time:53055ms step_avg:50.97ms
+step:1042/1480 train_time:53148ms step_avg:51.01ms
+step:1043/1480 train_time:53236ms step_avg:51.04ms
+step:1044/1480 train_time:53328ms step_avg:51.08ms
+step:1045/1480 train_time:53414ms step_avg:51.11ms
+step:1046/1480 train_time:53508ms step_avg:51.16ms
+step:1047/1480 train_time:53595ms step_avg:51.19ms
+step:1048/1480 train_time:53689ms step_avg:51.23ms
+step:1049/1480 train_time:53776ms step_avg:51.26ms
+step:1050/1480 train_time:53870ms step_avg:51.30ms
+step:1051/1480 train_time:53956ms step_avg:51.34ms
+step:1052/1480 train_time:54049ms step_avg:51.38ms
+step:1053/1480 train_time:54135ms step_avg:51.41ms
+step:1054/1480 train_time:54228ms step_avg:51.45ms
+step:1055/1480 train_time:54314ms step_avg:51.48ms
+step:1056/1480 train_time:54406ms step_avg:51.52ms
+step:1057/1480 train_time:54493ms step_avg:51.55ms
+step:1058/1480 train_time:54586ms step_avg:51.59ms
+step:1059/1480 train_time:54673ms step_avg:51.63ms
+step:1060/1480 train_time:54766ms step_avg:51.67ms
+step:1061/1480 train_time:54851ms step_avg:51.70ms
+step:1062/1480 train_time:54942ms step_avg:51.73ms
+step:1063/1480 train_time:55028ms step_avg:51.77ms
+step:1064/1480 train_time:55122ms step_avg:51.81ms
+step:1065/1480 train_time:55207ms step_avg:51.84ms
+step:1066/1480 train_time:55300ms step_avg:51.88ms
+step:1067/1480 train_time:55386ms step_avg:51.91ms
+step:1068/1480 train_time:55480ms step_avg:51.95ms
+step:1069/1480 train_time:55566ms step_avg:51.98ms
+step:1070/1480 train_time:55659ms step_avg:52.02ms
+step:1071/1480 train_time:55746ms step_avg:52.05ms
+step:1072/1480 train_time:55841ms step_avg:52.09ms
+step:1073/1480 train_time:55927ms step_avg:52.12ms
+step:1074/1480 train_time:56020ms step_avg:52.16ms
+step:1075/1480 train_time:56106ms step_avg:52.19ms
+step:1076/1480 train_time:56198ms step_avg:52.23ms
+step:1077/1480 train_time:56284ms step_avg:52.26ms
+step:1078/1480 train_time:56378ms step_avg:52.30ms
+step:1079/1480 train_time:56465ms step_avg:52.33ms
+step:1080/1480 train_time:56561ms step_avg:52.37ms
+step:1081/1480 train_time:56649ms step_avg:52.40ms
+step:1082/1480 train_time:56744ms step_avg:52.44ms
+step:1083/1480 train_time:56832ms step_avg:52.48ms
+step:1084/1480 train_time:56926ms step_avg:52.51ms
+step:1085/1480 train_time:57013ms step_avg:52.55ms
+step:1086/1480 train_time:57107ms step_avg:52.58ms
+step:1087/1480 train_time:57195ms step_avg:52.62ms
+step:1088/1480 train_time:57289ms step_avg:52.65ms
+step:1089/1480 train_time:57376ms step_avg:52.69ms
+step:1090/1480 train_time:57469ms step_avg:52.72ms
+step:1091/1480 train_time:57557ms step_avg:52.76ms
+step:1092/1480 train_time:57649ms step_avg:52.79ms
+step:1093/1480 train_time:57737ms step_avg:52.82ms
+step:1094/1480 train_time:57831ms step_avg:52.86ms
+step:1095/1480 train_time:57917ms step_avg:52.89ms
+step:1096/1480 train_time:58011ms step_avg:52.93ms
+step:1097/1480 train_time:58097ms step_avg:52.96ms
+step:1098/1480 train_time:58190ms step_avg:53.00ms
+step:1099/1480 train_time:58277ms step_avg:53.03ms
+step:1100/1480 train_time:58369ms step_avg:53.06ms
+step:1101/1480 train_time:58457ms step_avg:53.09ms
+step:1102/1480 train_time:58549ms step_avg:53.13ms
+step:1103/1480 train_time:58635ms step_avg:53.16ms
+step:1104/1480 train_time:58729ms step_avg:53.20ms
+step:1105/1480 train_time:58814ms step_avg:53.23ms
+step:1106/1480 train_time:58907ms step_avg:53.26ms
+step:1107/1480 train_time:58992ms step_avg:53.29ms
+step:1108/1480 train_time:59085ms step_avg:53.33ms
+step:1109/1480 train_time:59172ms step_avg:53.36ms
+step:1110/1480 train_time:59264ms step_avg:53.39ms
+step:1111/1480 train_time:59351ms step_avg:53.42ms
+step:1112/1480 train_time:59443ms step_avg:53.46ms
+step:1113/1480 train_time:59531ms step_avg:53.49ms
+step:1114/1480 train_time:59625ms step_avg:53.52ms
+step:1115/1480 train_time:59710ms step_avg:53.55ms
+step:1116/1480 train_time:59803ms step_avg:53.59ms
+step:1117/1480 train_time:59890ms step_avg:53.62ms
+step:1118/1480 train_time:59983ms step_avg:53.65ms
+step:1119/1480 train_time:60068ms step_avg:53.68ms
+step:1120/1480 train_time:60162ms step_avg:53.72ms
+step:1121/1480 train_time:60248ms step_avg:53.74ms
+step:1122/1480 train_time:60340ms step_avg:53.78ms
+step:1123/1480 train_time:60426ms step_avg:53.81ms
+step:1124/1480 train_time:60519ms step_avg:53.84ms
+step:1125/1480 train_time:60605ms step_avg:53.87ms
+step:1126/1480 train_time:60698ms step_avg:53.91ms
+step:1127/1480 train_time:60784ms step_avg:53.93ms
+step:1128/1480 train_time:60880ms step_avg:53.97ms
+step:1129/1480 train_time:60968ms step_avg:54.00ms
+step:1130/1480 train_time:61061ms step_avg:54.04ms
+step:1131/1480 train_time:61150ms step_avg:54.07ms
+step:1132/1480 train_time:61244ms step_avg:54.10ms
+step:1133/1480 train_time:61331ms step_avg:54.13ms
+step:1134/1480 train_time:61425ms step_avg:54.17ms
+step:1135/1480 train_time:61512ms step_avg:54.20ms
+step:1136/1480 train_time:61606ms step_avg:54.23ms
+step:1137/1480 train_time:61693ms step_avg:54.26ms
+step:1138/1480 train_time:61788ms step_avg:54.30ms
+step:1139/1480 train_time:61875ms step_avg:54.32ms
+step:1140/1480 train_time:61968ms step_avg:54.36ms
+step:1141/1480 train_time:62052ms step_avg:54.38ms
+step:1142/1480 train_time:62145ms step_avg:54.42ms
+step:1143/1480 train_time:62233ms step_avg:54.45ms
+step:1144/1480 train_time:62330ms step_avg:54.48ms
+step:1145/1480 train_time:62426ms step_avg:54.52ms
+step:1146/1480 train_time:62521ms step_avg:54.56ms
+step:1147/1480 train_time:62608ms step_avg:54.58ms
+step:1148/1480 train_time:62703ms step_avg:54.62ms
+step:1149/1480 train_time:62789ms step_avg:54.65ms
+step:1150/1480 train_time:62884ms step_avg:54.68ms
+step:1151/1480 train_time:62970ms step_avg:54.71ms
+step:1152/1480 train_time:63063ms step_avg:54.74ms
+step:1153/1480 train_time:63150ms step_avg:54.77ms
+step:1154/1480 train_time:63244ms step_avg:54.80ms
+step:1155/1480 train_time:63330ms step_avg:54.83ms
+step:1156/1480 train_time:63422ms step_avg:54.86ms
+step:1157/1480 train_time:63505ms step_avg:54.89ms
+step:1158/1480 train_time:63598ms step_avg:54.92ms
+step:1159/1480 train_time:63683ms step_avg:54.95ms
+step:1160/1480 train_time:63780ms step_avg:54.98ms
+step:1161/1480 train_time:63868ms step_avg:55.01ms
+step:1162/1480 train_time:63963ms step_avg:55.05ms
+step:1163/1480 train_time:64054ms step_avg:55.08ms
+step:1164/1480 train_time:64148ms step_avg:55.11ms
+step:1165/1480 train_time:64238ms step_avg:55.14ms
+step:1166/1480 train_time:64332ms step_avg:55.17ms
+step:1167/1480 train_time:64421ms step_avg:55.20ms
+step:1168/1480 train_time:64516ms step_avg:55.24ms
+step:1169/1480 train_time:64604ms step_avg:55.26ms
+step:1170/1480 train_time:64700ms step_avg:55.30ms
+step:1171/1480 train_time:64787ms step_avg:55.33ms
+step:1172/1480 train_time:64881ms step_avg:55.36ms
+step:1173/1480 train_time:64969ms step_avg:55.39ms
+step:1174/1480 train_time:65064ms step_avg:55.42ms
+step:1175/1480 train_time:65151ms step_avg:55.45ms
+step:1176/1480 train_time:65244ms step_avg:55.48ms
+step:1177/1480 train_time:65331ms step_avg:55.51ms
+step:1178/1480 train_time:65424ms step_avg:55.54ms
+step:1179/1480 train_time:65510ms step_avg:55.56ms
+step:1180/1480 train_time:65603ms step_avg:55.60ms
+step:1181/1480 train_time:65690ms step_avg:55.62ms
+step:1182/1480 train_time:65782ms step_avg:55.65ms
+step:1183/1480 train_time:65870ms step_avg:55.68ms
+step:1184/1480 train_time:65963ms step_avg:55.71ms
+step:1185/1480 train_time:66051ms step_avg:55.74ms
+step:1186/1480 train_time:66144ms step_avg:55.77ms
+step:1187/1480 train_time:66231ms step_avg:55.80ms
+step:1188/1480 train_time:66324ms step_avg:55.83ms
+step:1189/1480 train_time:66410ms step_avg:55.85ms
+step:1190/1480 train_time:66502ms step_avg:55.88ms
+step:1191/1480 train_time:66590ms step_avg:55.91ms
+step:1192/1480 train_time:66683ms step_avg:55.94ms
+step:1193/1480 train_time:66769ms step_avg:55.97ms
+step:1194/1480 train_time:66863ms step_avg:56.00ms
+step:1195/1480 train_time:66948ms step_avg:56.02ms
+step:1196/1480 train_time:67041ms step_avg:56.05ms
+step:1197/1480 train_time:67127ms step_avg:56.08ms
+step:1198/1480 train_time:67220ms step_avg:56.11ms
+step:1199/1480 train_time:67306ms step_avg:56.13ms
+step:1200/1480 train_time:67399ms step_avg:56.17ms
+step:1201/1480 train_time:67485ms step_avg:56.19ms
+step:1202/1480 train_time:67579ms step_avg:56.22ms
+step:1203/1480 train_time:67665ms step_avg:56.25ms
+step:1204/1480 train_time:67759ms step_avg:56.28ms
+step:1205/1480 train_time:67843ms step_avg:56.30ms
+step:1206/1480 train_time:67935ms step_avg:56.33ms
+step:1207/1480 train_time:68019ms step_avg:56.35ms
+step:1208/1480 train_time:68112ms step_avg:56.38ms
+step:1209/1480 train_time:68198ms step_avg:56.41ms
+step:1210/1480 train_time:68290ms step_avg:56.44ms
+step:1211/1480 train_time:68375ms step_avg:56.46ms
+step:1212/1480 train_time:68467ms step_avg:56.49ms
+step:1213/1480 train_time:68552ms step_avg:56.51ms
+step:1214/1480 train_time:68641ms step_avg:56.54ms
+step:1215/1480 train_time:68726ms step_avg:56.56ms
+step:1216/1480 train_time:68820ms step_avg:56.60ms
+step:1217/1480 train_time:68909ms step_avg:56.62ms
+step:1218/1480 train_time:69004ms step_avg:56.65ms
+step:1219/1480 train_time:69094ms step_avg:56.68ms
+step:1220/1480 train_time:69190ms step_avg:56.71ms
+step:1221/1480 train_time:69280ms step_avg:56.74ms
+step:1222/1480 train_time:69375ms step_avg:56.77ms
+step:1223/1480 train_time:69465ms step_avg:56.80ms
+step:1224/1480 train_time:69561ms step_avg:56.83ms
+step:1225/1480 train_time:69642ms step_avg:56.85ms
+step:1226/1480 train_time:69733ms step_avg:56.88ms
+step:1227/1480 train_time:69821ms step_avg:56.90ms
+step:1228/1480 train_time:69918ms step_avg:56.94ms
+step:1229/1480 train_time:70007ms step_avg:56.96ms
+step:1230/1480 train_time:70103ms step_avg:56.99ms
+step:1231/1480 train_time:70189ms step_avg:57.02ms
+step:1232/1480 train_time:70280ms step_avg:57.05ms
+step:1233/1480 train_time:70367ms step_avg:57.07ms
+step:1234/1480 train_time:70460ms step_avg:57.10ms
+step:1235/1480 train_time:70543ms step_avg:57.12ms
+step:1236/1480 train_time:70635ms step_avg:57.15ms
+step:1237/1480 train_time:70720ms step_avg:57.17ms
+step:1238/1480 train_time:70810ms step_avg:57.20ms
+step:1239/1480 train_time:70895ms step_avg:57.22ms
+step:1240/1480 train_time:70985ms step_avg:57.25ms
+step:1241/1480 train_time:71072ms step_avg:57.27ms
+step:1242/1480 train_time:71165ms step_avg:57.30ms
+step:1243/1480 train_time:71254ms step_avg:57.32ms
+step:1244/1480 train_time:71347ms step_avg:57.35ms
+step:1245/1480 train_time:71436ms step_avg:57.38ms
+step:1246/1480 train_time:71527ms step_avg:57.41ms
+step:1247/1480 train_time:71613ms step_avg:57.43ms
+step:1248/1480 train_time:71705ms step_avg:57.46ms
+step:1249/1480 train_time:71793ms step_avg:57.48ms
+step:1250/1480 train_time:71886ms step_avg:57.51ms
+step:1250/1480 val_loss:3.3674 train_time:72000ms step_avg:57.60ms
+step:1251/1480 train_time:72018ms step_avg:57.57ms
+step:1252/1480 train_time:72069ms step_avg:57.56ms
+step:1253/1480 train_time:72157ms step_avg:57.59ms
+step:1254/1480 train_time:72250ms step_avg:57.62ms
+step:1255/1480 train_time:72337ms step_avg:57.64ms
+step:1256/1480 train_time:72428ms step_avg:57.67ms
+step:1257/1480 train_time:72513ms step_avg:57.69ms
+step:1258/1480 train_time:72604ms step_avg:57.71ms
+step:1259/1480 train_time:72689ms step_avg:57.74ms
+step:1260/1480 train_time:72781ms step_avg:57.76ms
+step:1261/1480 train_time:72866ms step_avg:57.78ms
+step:1262/1480 train_time:72957ms step_avg:57.81ms
+step:1263/1480 train_time:73040ms step_avg:57.83ms
+step:1264/1480 train_time:73130ms step_avg:57.86ms
+step:1265/1480 train_time:73217ms step_avg:57.88ms
+step:1266/1480 train_time:73310ms step_avg:57.91ms
+step:1267/1480 train_time:73398ms step_avg:57.93ms
+step:1268/1480 train_time:73492ms step_avg:57.96ms
+step:1269/1480 train_time:73579ms step_avg:57.98ms
+step:1270/1480 train_time:73673ms step_avg:58.01ms
+step:1271/1480 train_time:73761ms step_avg:58.03ms
+step:1272/1480 train_time:73856ms step_avg:58.06ms
+step:1273/1480 train_time:73944ms step_avg:58.09ms
+step:1274/1480 train_time:74038ms step_avg:58.11ms
+step:1275/1480 train_time:74124ms step_avg:58.14ms
+step:1276/1480 train_time:74219ms step_avg:58.17ms
+step:1277/1480 train_time:74306ms step_avg:58.19ms
+step:1278/1480 train_time:74398ms step_avg:58.21ms
+step:1279/1480 train_time:74484ms step_avg:58.24ms
+step:1280/1480 train_time:74576ms step_avg:58.26ms
+step:1281/1480 train_time:74662ms step_avg:58.28ms
+step:1282/1480 train_time:74756ms step_avg:58.31ms
+step:1283/1480 train_time:74841ms step_avg:58.33ms
+step:1284/1480 train_time:74933ms step_avg:58.36ms
+step:1285/1480 train_time:75018ms step_avg:58.38ms
+step:1286/1480 train_time:75109ms step_avg:58.40ms
+step:1287/1480 train_time:75193ms step_avg:58.43ms
+step:1288/1480 train_time:75284ms step_avg:58.45ms
+step:1289/1480 train_time:75368ms step_avg:58.47ms
+step:1290/1480 train_time:75462ms step_avg:58.50ms
+step:1291/1480 train_time:75549ms step_avg:58.52ms
+step:1292/1480 train_time:75641ms step_avg:58.55ms
+step:1293/1480 train_time:75727ms step_avg:58.57ms
+step:1294/1480 train_time:75821ms step_avg:58.59ms
+step:1295/1480 train_time:75908ms step_avg:58.62ms
+step:1296/1480 train_time:76001ms step_avg:58.64ms
+step:1297/1480 train_time:76088ms step_avg:58.66ms
+step:1298/1480 train_time:76186ms step_avg:58.69ms
+step:1299/1480 train_time:76281ms step_avg:58.72ms
+step:1300/1480 train_time:76381ms step_avg:58.75ms
+step:1301/1480 train_time:76474ms step_avg:58.78ms
+step:1302/1480 train_time:76571ms step_avg:58.81ms
+step:1303/1480 train_time:76650ms step_avg:58.83ms
+step:1304/1480 train_time:76739ms step_avg:58.85ms
+step:1305/1480 train_time:76823ms step_avg:58.87ms
+step:1306/1480 train_time:76916ms step_avg:58.89ms
+step:1307/1480 train_time:77003ms step_avg:58.92ms
+step:1308/1480 train_time:77097ms step_avg:58.94ms
+step:1309/1480 train_time:77184ms step_avg:58.96ms
+step:1310/1480 train_time:77281ms step_avg:58.99ms
+step:1311/1480 train_time:77367ms step_avg:59.01ms
+step:1312/1480 train_time:77459ms step_avg:59.04ms
+step:1313/1480 train_time:77544ms step_avg:59.06ms
+step:1314/1480 train_time:77636ms step_avg:59.08ms
+step:1315/1480 train_time:77720ms step_avg:59.10ms
+step:1316/1480 train_time:77814ms step_avg:59.13ms
+step:1317/1480 train_time:77903ms step_avg:59.15ms
+step:1318/1480 train_time:77998ms step_avg:59.18ms
+step:1319/1480 train_time:78088ms step_avg:59.20ms
+step:1320/1480 train_time:78183ms step_avg:59.23ms
+step:1321/1480 train_time:78272ms step_avg:59.25ms
+step:1322/1480 train_time:78368ms step_avg:59.28ms
+step:1323/1480 train_time:78457ms step_avg:59.30ms
+step:1324/1480 train_time:78551ms step_avg:59.33ms
+step:1325/1480 train_time:78638ms step_avg:59.35ms
+step:1326/1480 train_time:78732ms step_avg:59.38ms
+step:1327/1480 train_time:78820ms step_avg:59.40ms
+step:1328/1480 train_time:78915ms step_avg:59.42ms
+step:1329/1480 train_time:79002ms step_avg:59.44ms
+step:1330/1480 train_time:79097ms step_avg:59.47ms
+step:1331/1480 train_time:79185ms step_avg:59.49ms
+step:1332/1480 train_time:79280ms step_avg:59.52ms
+step:1333/1480 train_time:79368ms step_avg:59.54ms
+step:1334/1480 train_time:79462ms step_avg:59.57ms
+step:1335/1480 train_time:79551ms step_avg:59.59ms
+step:1336/1480 train_time:79646ms step_avg:59.62ms
+step:1337/1480 train_time:79733ms step_avg:59.64ms
+step:1338/1480 train_time:79827ms step_avg:59.66ms
+step:1339/1480 train_time:79915ms step_avg:59.68ms
+step:1340/1480 train_time:80008ms step_avg:59.71ms
+step:1341/1480 train_time:80095ms step_avg:59.73ms
+step:1342/1480 train_time:80187ms step_avg:59.75ms
+step:1343/1480 train_time:80275ms step_avg:59.77ms
+step:1344/1480 train_time:80367ms step_avg:59.80ms
+step:1345/1480 train_time:80456ms step_avg:59.82ms
+step:1346/1480 train_time:80548ms step_avg:59.84ms
+step:1347/1480 train_time:80635ms step_avg:59.86ms
+step:1348/1480 train_time:80727ms step_avg:59.89ms
+step:1349/1480 train_time:80813ms step_avg:59.91ms
+step:1350/1480 train_time:80905ms step_avg:59.93ms
+step:1351/1480 train_time:80990ms step_avg:59.95ms
+step:1352/1480 train_time:81082ms step_avg:59.97ms
+step:1353/1480 train_time:81168ms step_avg:59.99ms
+step:1354/1480 train_time:81259ms step_avg:60.01ms
+step:1355/1480 train_time:81344ms step_avg:60.03ms
+step:1356/1480 train_time:81435ms step_avg:60.06ms
+step:1357/1480 train_time:81520ms step_avg:60.07ms
+step:1358/1480 train_time:81611ms step_avg:60.10ms
+step:1359/1480 train_time:81701ms step_avg:60.12ms
+step:1360/1480 train_time:81794ms step_avg:60.14ms
+step:1361/1480 train_time:81880ms step_avg:60.16ms
+step:1362/1480 train_time:81970ms step_avg:60.18ms
+step:1363/1480 train_time:82057ms step_avg:60.20ms
+step:1364/1480 train_time:82147ms step_avg:60.23ms
+step:1365/1480 train_time:82234ms step_avg:60.24ms
+step:1366/1480 train_time:82328ms step_avg:60.27ms
+step:1367/1480 train_time:82419ms step_avg:60.29ms
+step:1368/1480 train_time:82513ms step_avg:60.32ms
+step:1369/1480 train_time:82604ms step_avg:60.34ms
+step:1370/1480 train_time:82701ms step_avg:60.37ms
+step:1371/1480 train_time:82792ms step_avg:60.39ms
+step:1372/1480 train_time:82890ms step_avg:60.42ms
+step:1373/1480 train_time:82981ms step_avg:60.44ms
+step:1374/1480 train_time:83077ms step_avg:60.46ms
+step:1375/1480 train_time:83158ms step_avg:60.48ms
+step:1376/1480 train_time:83254ms step_avg:60.50ms
+step:1377/1480 train_time:83342ms step_avg:60.52ms
+step:1378/1480 train_time:83432ms step_avg:60.55ms
+step:1379/1480 train_time:83520ms step_avg:60.57ms
+step:1380/1480 train_time:83614ms step_avg:60.59ms
+step:1381/1480 train_time:83703ms step_avg:60.61ms
+step:1382/1480 train_time:83796ms step_avg:60.63ms
+step:1383/1480 train_time:83884ms step_avg:60.65ms
+step:1384/1480 train_time:83983ms step_avg:60.68ms
+step:1385/1480 train_time:84077ms step_avg:60.71ms
+step:1386/1480 train_time:84176ms step_avg:60.73ms
+step:1387/1480 train_time:84269ms step_avg:60.76ms
+step:1388/1480 train_time:84368ms step_avg:60.78ms
+step:1389/1480 train_time:84461ms step_avg:60.81ms
+step:1390/1480 train_time:84554ms step_avg:60.83ms
+step:1391/1480 train_time:84632ms step_avg:60.84ms
+step:1392/1480 train_time:84724ms step_avg:60.86ms
+step:1393/1480 train_time:84813ms step_avg:60.88ms
+step:1394/1480 train_time:84903ms step_avg:60.91ms
+step:1395/1480 train_time:84989ms step_avg:60.92ms
+step:1396/1480 train_time:85084ms step_avg:60.95ms
+step:1397/1480 train_time:85170ms step_avg:60.97ms
+step:1398/1480 train_time:85262ms step_avg:60.99ms
+step:1399/1480 train_time:85349ms step_avg:61.01ms
+step:1400/1480 train_time:85441ms step_avg:61.03ms
+step:1401/1480 train_time:85525ms step_avg:61.05ms
+step:1402/1480 train_time:85625ms step_avg:61.07ms
+step:1403/1480 train_time:85716ms step_avg:61.09ms
+step:1404/1480 train_time:85811ms step_avg:61.12ms
+step:1405/1480 train_time:85900ms step_avg:61.14ms
+step:1406/1480 train_time:85995ms step_avg:61.16ms
+step:1407/1480 train_time:86084ms step_avg:61.18ms
+step:1408/1480 train_time:86179ms step_avg:61.21ms
+step:1409/1480 train_time:86269ms step_avg:61.23ms
+step:1410/1480 train_time:86364ms step_avg:61.25ms
+step:1411/1480 train_time:86453ms step_avg:61.27ms
+step:1412/1480 train_time:86548ms step_avg:61.29ms
+step:1413/1480 train_time:86630ms step_avg:61.31ms
+step:1414/1480 train_time:86720ms step_avg:61.33ms
+step:1415/1480 train_time:86807ms step_avg:61.35ms
+step:1416/1480 train_time:86899ms step_avg:61.37ms
+step:1417/1480 train_time:86984ms step_avg:61.39ms
+step:1418/1480 train_time:87078ms step_avg:61.41ms
+step:1419/1480 train_time:87165ms step_avg:61.43ms
+step:1420/1480 train_time:87258ms step_avg:61.45ms
+step:1421/1480 train_time:87346ms step_avg:61.47ms
+step:1422/1480 train_time:87441ms step_avg:61.49ms
+step:1423/1480 train_time:87529ms step_avg:61.51ms
+step:1424/1480 train_time:87625ms step_avg:61.53ms
+step:1425/1480 train_time:87713ms step_avg:61.55ms
+step:1426/1480 train_time:87806ms step_avg:61.58ms
+step:1427/1480 train_time:87891ms step_avg:61.59ms
+step:1428/1480 train_time:87984ms step_avg:61.61ms
+step:1429/1480 train_time:88071ms step_avg:61.63ms
+step:1430/1480 train_time:88162ms step_avg:61.65ms
+step:1431/1480 train_time:88251ms step_avg:61.67ms
+step:1432/1480 train_time:88342ms step_avg:61.69ms
+step:1433/1480 train_time:88427ms step_avg:61.71ms
+step:1434/1480 train_time:88519ms step_avg:61.73ms
+step:1435/1480 train_time:88603ms step_avg:61.74ms
+step:1436/1480 train_time:88696ms step_avg:61.77ms
+step:1437/1480 train_time:88784ms step_avg:61.78ms
+step:1438/1480 train_time:88881ms step_avg:61.81ms
+step:1439/1480 train_time:88970ms step_avg:61.83ms
+step:1440/1480 train_time:89065ms step_avg:61.85ms
+step:1441/1480 train_time:89158ms step_avg:61.87ms
+step:1442/1480 train_time:89256ms step_avg:61.90ms
+step:1443/1480 train_time:89345ms step_avg:61.92ms
+step:1444/1480 train_time:89442ms step_avg:61.94ms
+step:1445/1480 train_time:89531ms step_avg:61.96ms
+step:1446/1480 train_time:89627ms step_avg:61.98ms
+step:1447/1480 train_time:89716ms step_avg:62.00ms
+step:1448/1480 train_time:89812ms step_avg:62.02ms
+step:1449/1480 train_time:89899ms step_avg:62.04ms
+step:1450/1480 train_time:89995ms step_avg:62.07ms
+step:1451/1480 train_time:90083ms step_avg:62.08ms
+step:1452/1480 train_time:90179ms step_avg:62.11ms
+step:1453/1480 train_time:90266ms step_avg:62.12ms
+step:1454/1480 train_time:90361ms step_avg:62.15ms
+step:1455/1480 train_time:90451ms step_avg:62.17ms
+step:1456/1480 train_time:90545ms step_avg:62.19ms
+step:1457/1480 train_time:90633ms step_avg:62.20ms
+step:1458/1480 train_time:90727ms step_avg:62.23ms
+step:1459/1480 train_time:90815ms step_avg:62.24ms
+step:1460/1480 train_time:90909ms step_avg:62.27ms
+step:1461/1480 train_time:90995ms step_avg:62.28ms
+step:1462/1480 train_time:91089ms step_avg:62.30ms
+step:1463/1480 train_time:91176ms step_avg:62.32ms
+step:1464/1480 train_time:91268ms step_avg:62.34ms
+step:1465/1480 train_time:91357ms step_avg:62.36ms
+step:1466/1480 train_time:91449ms step_avg:62.38ms
+step:1467/1480 train_time:91536ms step_avg:62.40ms
+step:1468/1480 train_time:91629ms step_avg:62.42ms
+step:1469/1480 train_time:91716ms step_avg:62.43ms
+step:1470/1480 train_time:91809ms step_avg:62.45ms
+step:1471/1480 train_time:91894ms step_avg:62.47ms
+step:1472/1480 train_time:91985ms step_avg:62.49ms
+step:1473/1480 train_time:92070ms step_avg:62.51ms
+step:1474/1480 train_time:92164ms step_avg:62.53ms
+step:1475/1480 train_time:92255ms step_avg:62.55ms
+step:1476/1480 train_time:92350ms step_avg:62.57ms
+step:1477/1480 train_time:92440ms step_avg:62.59ms
+step:1478/1480 train_time:92536ms step_avg:62.61ms
+step:1479/1480 train_time:92623ms step_avg:62.63ms
+step:1480/1480 train_time:92720ms step_avg:62.65ms
+step:1480/1480 val_loss:3.2786 train_time:92834ms step_avg:62.73ms
+peak memory allocated: 31308 MiB reserved: 47022 MiB

--- a/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk7-1480.txt
+++ b/records/track_1_short/2026-04-08_PairedHeadMuon/logs/split_qk7-1480.txt
@@ -1,0 +1,4463 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # QK bank: per-head-pair Muon groups for Q, K weights
+        # Each pair of adjacent heads gets its own independent polar express orthogonalization
+        self._num_attn_layers = num_attn_layers
+        num_qk_groups = num_attn_layers * 2 * (num_heads // 2)  # 10 * 2 * 3 = 60
+        self._num_qk_groups = num_qk_groups
+        num_qk_padded = next_multiple_of_n(num_qk_groups, n=world_size)  # 64
+        self.qk_bank = nn.Parameter(torch.empty(num_qk_padded, head_dim * 2, model_dim))
+        self.qk_bank.reshape = (num_qk_padded, head_dim * 2, model_dim)
+
+        # VO bank: per-layer Muon groups for V and O weights
+        num_vo_real = num_attn_layers * 2  # 20
+        num_vo_padded = next_multiple_of_n(num_vo_real, n=world_size)  # 24
+        self.vo_bank = nn.Parameter(torch.empty(num_vo_padded, hdim, hdim))
+        self.vo_bank.reshape = (num_vo_padded, hdim, hdim)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.qk_bank[:num_qk_groups].uniform_(-bound, bound)
+            self.qk_bank[num_qk_groups:].zero_()
+            self.vo_bank[:num_vo_real].uniform_(-bound, bound)
+            self.vo_bank[num_vo_real:].zero_()
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from qk_bank/vo_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        qk_all = self.qk_bank[:self._num_qk_groups].view(self._num_attn_layers, -1, self.qk_bank.shape[-1])
+        vo_flat = self.vo_bank[:self._num_attn_layers * 2].view(self._num_attn_layers, 2, *self.vo_bank.shape[1:]).flatten(1, 2)
+        attn_weights = torch.cat([qk_all, vo_flat], dim=1).unbind(0)
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            attn_idx = i - (i > 6) if i != 6 else None
+            qkvo_w = attn_weights[attn_idx] if attn_idx is not None else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "qk_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "vo_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "qk_bank", "vo_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.qk_bank.data = model.qk_bank.data.bfloat16()
+model.vo_bank.data = model.vo_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.10.0+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Wed Apr  8 16:40:17 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   34C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   39C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   66C    P0            151W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          423273      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          423274      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          423275      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          423276      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          423277      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          423278      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          423279      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          423280      C   ...ded-nanogpt/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 478, 479, 480, 481, 958, 959, 960, 961, 1438, 1439, 1440, 1441] for warmup
+Resetting Model
+step:0/1480 val_loss:10.8293 train_time:0ms step_avg:0.04ms
+step:1/1480 train_time:91ms step_avg:90.93ms
+step:2/1480 train_time:117ms step_avg:58.52ms
+step:3/1480 train_time:139ms step_avg:46.26ms
+step:4/1480 train_time:163ms step_avg:40.76ms
+step:5/1480 train_time:184ms step_avg:36.81ms
+step:6/1480 train_time:219ms step_avg:36.56ms
+step:7/1480 train_time:247ms step_avg:35.32ms
+step:8/1480 train_time:282ms step_avg:35.20ms
+step:9/1480 train_time:311ms step_avg:34.54ms
+step:10/1480 train_time:345ms step_avg:34.54ms
+step:11/1480 train_time:374ms step_avg:34.04ms
+step:12/1480 train_time:409ms step_avg:34.08ms
+step:13/1480 train_time:438ms step_avg:33.69ms
+step:14/1480 train_time:472ms step_avg:33.69ms
+step:15/1480 train_time:501ms step_avg:33.38ms
+step:16/1480 train_time:536ms step_avg:33.47ms
+step:17/1480 train_time:565ms step_avg:33.23ms
+step:18/1480 train_time:600ms step_avg:33.33ms
+step:19/1480 train_time:630ms step_avg:33.14ms
+step:20/1480 train_time:664ms step_avg:33.22ms
+step:21/1480 train_time:694ms step_avg:33.07ms
+step:22/1480 train_time:729ms step_avg:33.15ms
+step:23/1480 train_time:759ms step_avg:32.98ms
+step:24/1480 train_time:793ms step_avg:33.05ms
+step:25/1480 train_time:822ms step_avg:32.89ms
+step:26/1480 train_time:857ms step_avg:32.98ms
+step:27/1480 train_time:887ms step_avg:32.84ms
+step:28/1480 train_time:921ms step_avg:32.91ms
+step:29/1480 train_time:951ms step_avg:32.81ms
+step:30/1480 train_time:986ms step_avg:32.87ms
+step:31/1480 train_time:1016ms step_avg:32.79ms
+step:32/1480 train_time:1052ms step_avg:32.87ms
+step:33/1480 train_time:1082ms step_avg:32.77ms
+step:34/1480 train_time:1117ms step_avg:32.84ms
+step:35/1480 train_time:1146ms step_avg:32.75ms
+step:36/1480 train_time:1182ms step_avg:32.83ms
+step:37/1480 train_time:1212ms step_avg:32.76ms
+step:38/1480 train_time:1247ms step_avg:32.83ms
+step:39/1480 train_time:1277ms step_avg:32.76ms
+step:40/1480 train_time:1314ms step_avg:32.84ms
+step:41/1480 train_time:1343ms step_avg:32.76ms
+step:42/1480 train_time:1379ms step_avg:32.83ms
+step:43/1480 train_time:1409ms step_avg:32.77ms
+step:44/1480 train_time:1444ms step_avg:32.82ms
+step:45/1480 train_time:1474ms step_avg:32.76ms
+step:46/1480 train_time:1510ms step_avg:32.83ms
+step:47/1480 train_time:1540ms step_avg:32.76ms
+step:48/1480 train_time:1575ms step_avg:32.82ms
+step:49/1480 train_time:1605ms step_avg:32.75ms
+step:50/1480 train_time:1640ms step_avg:32.80ms
+step:51/1480 train_time:1670ms step_avg:32.75ms
+step:52/1480 train_time:1706ms step_avg:32.80ms
+step:53/1480 train_time:1736ms step_avg:32.75ms
+step:54/1480 train_time:1771ms step_avg:32.80ms
+step:55/1480 train_time:1801ms step_avg:32.74ms
+step:56/1480 train_time:1836ms step_avg:32.78ms
+step:57/1480 train_time:1865ms step_avg:32.73ms
+step:58/1480 train_time:1900ms step_avg:32.77ms
+step:59/1480 train_time:1931ms step_avg:32.72ms
+step:60/1480 train_time:1966ms step_avg:32.77ms
+step:61/1480 train_time:1996ms step_avg:32.73ms
+step:62/1480 train_time:2031ms step_avg:32.76ms
+step:63/1480 train_time:2061ms step_avg:32.71ms
+step:64/1480 train_time:2095ms step_avg:32.74ms
+step:65/1480 train_time:2125ms step_avg:32.70ms
+step:66/1480 train_time:2161ms step_avg:32.74ms
+step:67/1480 train_time:2190ms step_avg:32.69ms
+step:68/1480 train_time:2225ms step_avg:32.73ms
+step:69/1480 train_time:2256ms step_avg:32.69ms
+step:70/1480 train_time:2291ms step_avg:32.72ms
+step:71/1480 train_time:2320ms step_avg:32.68ms
+step:72/1480 train_time:2355ms step_avg:32.71ms
+step:73/1480 train_time:2385ms step_avg:32.68ms
+step:74/1480 train_time:2421ms step_avg:32.72ms
+step:75/1480 train_time:2452ms step_avg:32.70ms
+step:76/1480 train_time:2488ms step_avg:32.74ms
+step:77/1480 train_time:2518ms step_avg:32.70ms
+step:78/1480 train_time:2554ms step_avg:32.74ms
+step:79/1480 train_time:2585ms step_avg:32.72ms
+step:80/1480 train_time:2621ms step_avg:32.76ms
+step:81/1480 train_time:2652ms step_avg:32.73ms
+step:82/1480 train_time:2688ms step_avg:32.77ms
+step:83/1480 train_time:2718ms step_avg:32.75ms
+step:84/1480 train_time:2754ms step_avg:32.78ms
+step:85/1480 train_time:2784ms step_avg:32.76ms
+step:86/1480 train_time:2821ms step_avg:32.80ms
+step:87/1480 train_time:2851ms step_avg:32.77ms
+step:88/1480 train_time:2886ms step_avg:32.80ms
+step:89/1480 train_time:2917ms step_avg:32.78ms
+step:90/1480 train_time:2953ms step_avg:32.81ms
+step:91/1480 train_time:2983ms step_avg:32.78ms
+step:92/1480 train_time:3019ms step_avg:32.82ms
+step:93/1480 train_time:3050ms step_avg:32.80ms
+step:94/1480 train_time:3086ms step_avg:32.83ms
+step:95/1480 train_time:3117ms step_avg:32.81ms
+step:96/1480 train_time:3153ms step_avg:32.84ms
+step:97/1480 train_time:3183ms step_avg:32.81ms
+step:98/1480 train_time:3219ms step_avg:32.85ms
+step:99/1480 train_time:3250ms step_avg:32.82ms
+step:100/1480 train_time:3285ms step_avg:32.85ms
+step:101/1480 train_time:3316ms step_avg:32.83ms
+step:102/1480 train_time:3352ms step_avg:32.86ms
+step:103/1480 train_time:3382ms step_avg:32.83ms
+step:104/1480 train_time:3418ms step_avg:32.87ms
+step:105/1480 train_time:3448ms step_avg:32.84ms
+step:106/1480 train_time:3484ms step_avg:32.87ms
+step:107/1480 train_time:3514ms step_avg:32.85ms
+step:108/1480 train_time:3550ms step_avg:32.87ms
+step:109/1480 train_time:3581ms step_avg:32.85ms
+step:110/1480 train_time:3616ms step_avg:32.88ms
+step:111/1480 train_time:3647ms step_avg:32.85ms
+step:112/1480 train_time:3682ms step_avg:32.88ms
+step:113/1480 train_time:3713ms step_avg:32.86ms
+step:114/1480 train_time:3748ms step_avg:32.88ms
+step:115/1480 train_time:3779ms step_avg:32.86ms
+step:116/1480 train_time:3814ms step_avg:32.88ms
+step:117/1480 train_time:3844ms step_avg:32.86ms
+step:118/1480 train_time:3880ms step_avg:32.88ms
+step:119/1480 train_time:3910ms step_avg:32.86ms
+step:120/1480 train_time:3946ms step_avg:32.88ms
+step:121/1480 train_time:3976ms step_avg:32.86ms
+step:122/1480 train_time:4011ms step_avg:32.88ms
+step:123/1480 train_time:4041ms step_avg:32.85ms
+step:124/1480 train_time:4076ms step_avg:32.87ms
+step:125/1480 train_time:4106ms step_avg:32.85ms
+step:126/1480 train_time:4142ms step_avg:32.87ms
+step:127/1480 train_time:4172ms step_avg:32.85ms
+step:128/1480 train_time:4208ms step_avg:32.87ms
+step:129/1480 train_time:4238ms step_avg:32.85ms
+step:130/1480 train_time:4273ms step_avg:32.87ms
+step:131/1480 train_time:4303ms step_avg:32.85ms
+step:132/1480 train_time:4338ms step_avg:32.86ms
+step:133/1480 train_time:4368ms step_avg:32.84ms
+step:134/1480 train_time:4404ms step_avg:32.86ms
+step:135/1480 train_time:4436ms step_avg:32.86ms
+step:136/1480 train_time:4473ms step_avg:32.89ms
+step:137/1480 train_time:4505ms step_avg:32.88ms
+step:138/1480 train_time:4542ms step_avg:32.91ms
+step:139/1480 train_time:4575ms step_avg:32.91ms
+step:140/1480 train_time:4613ms step_avg:32.95ms
+step:141/1480 train_time:4644ms step_avg:32.93ms
+step:142/1480 train_time:4681ms step_avg:32.96ms
+step:143/1480 train_time:4713ms step_avg:32.96ms
+step:144/1480 train_time:4750ms step_avg:32.99ms
+step:145/1480 train_time:4782ms step_avg:32.98ms
+step:146/1480 train_time:4819ms step_avg:33.01ms
+step:147/1480 train_time:4848ms step_avg:32.98ms
+step:148/1480 train_time:4883ms step_avg:32.99ms
+step:149/1480 train_time:4912ms step_avg:32.96ms
+step:150/1480 train_time:4946ms step_avg:32.97ms
+step:151/1480 train_time:4975ms step_avg:32.95ms
+step:152/1480 train_time:5009ms step_avg:32.96ms
+step:153/1480 train_time:5040ms step_avg:32.94ms
+step:154/1480 train_time:5075ms step_avg:32.95ms
+step:155/1480 train_time:5104ms step_avg:32.93ms
+step:156/1480 train_time:5140ms step_avg:32.95ms
+step:157/1480 train_time:5170ms step_avg:32.93ms
+step:158/1480 train_time:5205ms step_avg:32.94ms
+step:159/1480 train_time:5235ms step_avg:32.92ms
+step:160/1480 train_time:5270ms step_avg:32.94ms
+step:161/1480 train_time:5301ms step_avg:32.92ms
+step:162/1480 train_time:5336ms step_avg:32.94ms
+step:163/1480 train_time:5365ms step_avg:32.92ms
+step:164/1480 train_time:5402ms step_avg:32.94ms
+step:165/1480 train_time:5432ms step_avg:32.92ms
+step:166/1480 train_time:5468ms step_avg:32.94ms
+step:167/1480 train_time:5499ms step_avg:32.93ms
+step:168/1480 train_time:5534ms step_avg:32.94ms
+step:169/1480 train_time:5565ms step_avg:32.93ms
+step:170/1480 train_time:5602ms step_avg:32.95ms
+step:171/1480 train_time:5632ms step_avg:32.94ms
+step:172/1480 train_time:5669ms step_avg:32.96ms
+step:173/1480 train_time:5701ms step_avg:32.95ms
+step:174/1480 train_time:5738ms step_avg:32.98ms
+step:175/1480 train_time:5771ms step_avg:32.98ms
+step:176/1480 train_time:5808ms step_avg:33.00ms
+step:177/1480 train_time:5840ms step_avg:32.99ms
+step:178/1480 train_time:5878ms step_avg:33.02ms
+step:179/1480 train_time:5910ms step_avg:33.02ms
+step:180/1480 train_time:5947ms step_avg:33.04ms
+step:181/1480 train_time:5979ms step_avg:33.04ms
+step:182/1480 train_time:6017ms step_avg:33.06ms
+step:183/1480 train_time:6049ms step_avg:33.05ms
+step:184/1480 train_time:6084ms step_avg:33.06ms
+step:185/1480 train_time:6113ms step_avg:33.04ms
+step:186/1480 train_time:6147ms step_avg:33.05ms
+step:187/1480 train_time:6176ms step_avg:33.03ms
+step:188/1480 train_time:6211ms step_avg:33.04ms
+step:189/1480 train_time:6242ms step_avg:33.03ms
+step:190/1480 train_time:6281ms step_avg:33.06ms
+step:191/1480 train_time:6314ms step_avg:33.06ms
+step:192/1480 train_time:6353ms step_avg:33.09ms
+step:193/1480 train_time:6386ms step_avg:33.09ms
+step:194/1480 train_time:6424ms step_avg:33.11ms
+step:195/1480 train_time:6455ms step_avg:33.10ms
+step:196/1480 train_time:6490ms step_avg:33.11ms
+step:197/1480 train_time:6519ms step_avg:33.09ms
+step:198/1480 train_time:6553ms step_avg:33.09ms
+step:199/1480 train_time:6583ms step_avg:33.08ms
+step:200/1480 train_time:6620ms step_avg:33.10ms
+step:201/1480 train_time:6650ms step_avg:33.09ms
+step:202/1480 train_time:6689ms step_avg:33.11ms
+step:203/1480 train_time:6719ms step_avg:33.10ms
+step:204/1480 train_time:6755ms step_avg:33.11ms
+step:205/1480 train_time:6786ms step_avg:33.10ms
+step:206/1480 train_time:6822ms step_avg:33.12ms
+step:207/1480 train_time:6853ms step_avg:33.11ms
+step:208/1480 train_time:6889ms step_avg:33.12ms
+step:209/1480 train_time:6919ms step_avg:33.11ms
+step:210/1480 train_time:6955ms step_avg:33.12ms
+step:211/1480 train_time:6986ms step_avg:33.11ms
+step:212/1480 train_time:7022ms step_avg:33.12ms
+step:213/1480 train_time:7053ms step_avg:33.11ms
+step:214/1480 train_time:7089ms step_avg:33.12ms
+step:215/1480 train_time:7119ms step_avg:33.11ms
+step:216/1480 train_time:7155ms step_avg:33.13ms
+step:217/1480 train_time:7186ms step_avg:33.11ms
+step:218/1480 train_time:7222ms step_avg:33.13ms
+step:219/1480 train_time:7253ms step_avg:33.12ms
+step:220/1480 train_time:7289ms step_avg:33.13ms
+step:221/1480 train_time:7320ms step_avg:33.12ms
+step:222/1480 train_time:7356ms step_avg:33.13ms
+step:223/1480 train_time:7386ms step_avg:33.12ms
+step:224/1480 train_time:7422ms step_avg:33.14ms
+step:225/1480 train_time:7454ms step_avg:33.13ms
+step:226/1480 train_time:7490ms step_avg:33.14ms
+step:227/1480 train_time:7520ms step_avg:33.13ms
+step:228/1480 train_time:7556ms step_avg:33.14ms
+step:229/1480 train_time:7587ms step_avg:33.13ms
+step:230/1480 train_time:7623ms step_avg:33.14ms
+step:231/1480 train_time:7653ms step_avg:33.13ms
+step:232/1480 train_time:7689ms step_avg:33.14ms
+step:233/1480 train_time:7719ms step_avg:33.13ms
+step:234/1480 train_time:7755ms step_avg:33.14ms
+step:235/1480 train_time:7786ms step_avg:33.13ms
+step:236/1480 train_time:7822ms step_avg:33.14ms
+step:237/1480 train_time:7853ms step_avg:33.13ms
+step:238/1480 train_time:7888ms step_avg:33.14ms
+step:239/1480 train_time:7919ms step_avg:33.13ms
+step:240/1480 train_time:7954ms step_avg:33.14ms
+step:241/1480 train_time:7985ms step_avg:33.13ms
+step:242/1480 train_time:8020ms step_avg:33.14ms
+step:243/1480 train_time:8051ms step_avg:33.13ms
+step:244/1480 train_time:8087ms step_avg:33.14ms
+step:245/1480 train_time:8117ms step_avg:33.13ms
+step:246/1480 train_time:8153ms step_avg:33.14ms
+step:247/1480 train_time:8184ms step_avg:33.13ms
+step:248/1480 train_time:8220ms step_avg:33.14ms
+step:249/1480 train_time:8250ms step_avg:33.13ms
+step:250/1480 train_time:8286ms step_avg:33.14ms
+step:250/1480 val_loss:4.5035 train_time:8330ms step_avg:33.32ms
+step:251/1480 train_time:8347ms step_avg:33.25ms
+step:252/1480 train_time:8365ms step_avg:33.19ms
+step:253/1480 train_time:8384ms step_avg:33.14ms
+step:254/1480 train_time:8419ms step_avg:33.15ms
+step:255/1480 train_time:8451ms step_avg:33.14ms
+step:256/1480 train_time:8488ms step_avg:33.16ms
+step:257/1480 train_time:8520ms step_avg:33.15ms
+step:258/1480 train_time:8557ms step_avg:33.17ms
+step:259/1480 train_time:8588ms step_avg:33.16ms
+step:260/1480 train_time:8625ms step_avg:33.17ms
+step:261/1480 train_time:8657ms step_avg:33.17ms
+step:262/1480 train_time:8694ms step_avg:33.18ms
+step:263/1480 train_time:8725ms step_avg:33.18ms
+step:264/1480 train_time:8763ms step_avg:33.19ms
+step:265/1480 train_time:8794ms step_avg:33.18ms
+step:266/1480 train_time:8830ms step_avg:33.20ms
+step:267/1480 train_time:8862ms step_avg:33.19ms
+step:268/1480 train_time:8900ms step_avg:33.21ms
+step:269/1480 train_time:8931ms step_avg:33.20ms
+step:270/1480 train_time:8968ms step_avg:33.21ms
+step:271/1480 train_time:8999ms step_avg:33.21ms
+step:272/1480 train_time:9036ms step_avg:33.22ms
+step:273/1480 train_time:9067ms step_avg:33.21ms
+step:274/1480 train_time:9104ms step_avg:33.23ms
+step:275/1480 train_time:9135ms step_avg:33.22ms
+step:276/1480 train_time:9172ms step_avg:33.23ms
+step:277/1480 train_time:9204ms step_avg:33.23ms
+step:278/1480 train_time:9241ms step_avg:33.24ms
+step:279/1480 train_time:9272ms step_avg:33.23ms
+step:280/1480 train_time:9309ms step_avg:33.25ms
+step:281/1480 train_time:9340ms step_avg:33.24ms
+step:282/1480 train_time:9377ms step_avg:33.25ms
+step:283/1480 train_time:9408ms step_avg:33.24ms
+step:284/1480 train_time:9445ms step_avg:33.26ms
+step:285/1480 train_time:9476ms step_avg:33.25ms
+step:286/1480 train_time:9513ms step_avg:33.26ms
+step:287/1480 train_time:9544ms step_avg:33.26ms
+step:288/1480 train_time:9582ms step_avg:33.27ms
+step:289/1480 train_time:9613ms step_avg:33.26ms
+step:290/1480 train_time:9650ms step_avg:33.28ms
+step:291/1480 train_time:9681ms step_avg:33.27ms
+step:292/1480 train_time:9718ms step_avg:33.28ms
+step:293/1480 train_time:9748ms step_avg:33.27ms
+step:294/1480 train_time:9785ms step_avg:33.28ms
+step:295/1480 train_time:9816ms step_avg:33.27ms
+step:296/1480 train_time:9852ms step_avg:33.28ms
+step:297/1480 train_time:9883ms step_avg:33.28ms
+step:298/1480 train_time:9919ms step_avg:33.29ms
+step:299/1480 train_time:9950ms step_avg:33.28ms
+step:300/1480 train_time:9987ms step_avg:33.29ms
+step:301/1480 train_time:10017ms step_avg:33.28ms
+step:302/1480 train_time:10054ms step_avg:33.29ms
+step:303/1480 train_time:10085ms step_avg:33.28ms
+step:304/1480 train_time:10121ms step_avg:33.29ms
+step:305/1480 train_time:10151ms step_avg:33.28ms
+step:306/1480 train_time:10188ms step_avg:33.29ms
+step:307/1480 train_time:10218ms step_avg:33.28ms
+step:308/1480 train_time:10254ms step_avg:33.29ms
+step:309/1480 train_time:10285ms step_avg:33.28ms
+step:310/1480 train_time:10321ms step_avg:33.29ms
+step:311/1480 train_time:10351ms step_avg:33.28ms
+step:312/1480 train_time:10388ms step_avg:33.29ms
+step:313/1480 train_time:10418ms step_avg:33.28ms
+step:314/1480 train_time:10454ms step_avg:33.29ms
+step:315/1480 train_time:10485ms step_avg:33.29ms
+step:316/1480 train_time:10521ms step_avg:33.29ms
+step:317/1480 train_time:10551ms step_avg:33.29ms
+step:318/1480 train_time:10588ms step_avg:33.30ms
+step:319/1480 train_time:10619ms step_avg:33.29ms
+step:320/1480 train_time:10654ms step_avg:33.30ms
+step:321/1480 train_time:10685ms step_avg:33.29ms
+step:322/1480 train_time:10721ms step_avg:33.30ms
+step:323/1480 train_time:10752ms step_avg:33.29ms
+step:324/1480 train_time:10788ms step_avg:33.30ms
+step:325/1480 train_time:10818ms step_avg:33.29ms
+step:326/1480 train_time:10853ms step_avg:33.29ms
+step:327/1480 train_time:10882ms step_avg:33.28ms
+step:328/1480 train_time:10917ms step_avg:33.28ms
+step:329/1480 train_time:10948ms step_avg:33.28ms
+step:330/1480 train_time:10984ms step_avg:33.29ms
+step:331/1480 train_time:11015ms step_avg:33.28ms
+step:332/1480 train_time:11054ms step_avg:33.30ms
+step:333/1480 train_time:11086ms step_avg:33.29ms
+step:334/1480 train_time:11127ms step_avg:33.31ms
+step:335/1480 train_time:11157ms step_avg:33.31ms
+step:336/1480 train_time:11197ms step_avg:33.33ms
+step:337/1480 train_time:11232ms step_avg:33.33ms
+step:338/1480 train_time:11268ms step_avg:33.34ms
+step:339/1480 train_time:11298ms step_avg:33.33ms
+step:340/1480 train_time:11335ms step_avg:33.34ms
+step:341/1480 train_time:11365ms step_avg:33.33ms
+step:342/1480 train_time:11401ms step_avg:33.34ms
+step:343/1480 train_time:11431ms step_avg:33.33ms
+step:344/1480 train_time:11467ms step_avg:33.33ms
+step:345/1480 train_time:11497ms step_avg:33.32ms
+step:346/1480 train_time:11533ms step_avg:33.33ms
+step:347/1480 train_time:11564ms step_avg:33.32ms
+step:348/1480 train_time:11600ms step_avg:33.33ms
+step:349/1480 train_time:11629ms step_avg:33.32ms
+step:350/1480 train_time:11665ms step_avg:33.33ms
+step:351/1480 train_time:11695ms step_avg:33.32ms
+step:352/1480 train_time:11731ms step_avg:33.33ms
+step:353/1480 train_time:11762ms step_avg:33.32ms
+step:354/1480 train_time:11798ms step_avg:33.33ms
+step:355/1480 train_time:11828ms step_avg:33.32ms
+step:356/1480 train_time:11863ms step_avg:33.32ms
+step:357/1480 train_time:11893ms step_avg:33.31ms
+step:358/1480 train_time:11929ms step_avg:33.32ms
+step:359/1480 train_time:11959ms step_avg:33.31ms
+step:360/1480 train_time:11995ms step_avg:33.32ms
+step:361/1480 train_time:12025ms step_avg:33.31ms
+step:362/1480 train_time:12064ms step_avg:33.33ms
+step:363/1480 train_time:12097ms step_avg:33.32ms
+step:364/1480 train_time:12135ms step_avg:33.34ms
+step:365/1480 train_time:12167ms step_avg:33.33ms
+step:366/1480 train_time:12204ms step_avg:33.34ms
+step:367/1480 train_time:12236ms step_avg:33.34ms
+step:368/1480 train_time:12274ms step_avg:33.35ms
+step:369/1480 train_time:12306ms step_avg:33.35ms
+step:370/1480 train_time:12344ms step_avg:33.36ms
+step:371/1480 train_time:12377ms step_avg:33.36ms
+step:372/1480 train_time:12416ms step_avg:33.38ms
+step:373/1480 train_time:12448ms step_avg:33.37ms
+step:374/1480 train_time:12482ms step_avg:33.37ms
+step:375/1480 train_time:12511ms step_avg:33.36ms
+step:376/1480 train_time:12546ms step_avg:33.37ms
+step:377/1480 train_time:12574ms step_avg:33.35ms
+step:378/1480 train_time:12609ms step_avg:33.36ms
+step:379/1480 train_time:12639ms step_avg:33.35ms
+step:380/1480 train_time:12675ms step_avg:33.35ms
+step:381/1480 train_time:12706ms step_avg:33.35ms
+step:382/1480 train_time:12742ms step_avg:33.36ms
+step:383/1480 train_time:12773ms step_avg:33.35ms
+step:384/1480 train_time:12809ms step_avg:33.36ms
+step:385/1480 train_time:12841ms step_avg:33.35ms
+step:386/1480 train_time:12877ms step_avg:33.36ms
+step:387/1480 train_time:12908ms step_avg:33.35ms
+step:388/1480 train_time:12945ms step_avg:33.36ms
+step:389/1480 train_time:12975ms step_avg:33.36ms
+step:390/1480 train_time:13012ms step_avg:33.36ms
+step:391/1480 train_time:13043ms step_avg:33.36ms
+step:392/1480 train_time:13079ms step_avg:33.37ms
+step:393/1480 train_time:13110ms step_avg:33.36ms
+step:394/1480 train_time:13147ms step_avg:33.37ms
+step:395/1480 train_time:13178ms step_avg:33.36ms
+step:396/1480 train_time:13214ms step_avg:33.37ms
+step:397/1480 train_time:13245ms step_avg:33.36ms
+step:398/1480 train_time:13282ms step_avg:33.37ms
+step:399/1480 train_time:13312ms step_avg:33.36ms
+step:400/1480 train_time:13349ms step_avg:33.37ms
+step:401/1480 train_time:13380ms step_avg:33.37ms
+step:402/1480 train_time:13416ms step_avg:33.37ms
+step:403/1480 train_time:13447ms step_avg:33.37ms
+step:404/1480 train_time:13483ms step_avg:33.37ms
+step:405/1480 train_time:13514ms step_avg:33.37ms
+step:406/1480 train_time:13551ms step_avg:33.38ms
+step:407/1480 train_time:13582ms step_avg:33.37ms
+step:408/1480 train_time:13618ms step_avg:33.38ms
+step:409/1480 train_time:13648ms step_avg:33.37ms
+step:410/1480 train_time:13685ms step_avg:33.38ms
+step:411/1480 train_time:13716ms step_avg:33.37ms
+step:412/1480 train_time:13752ms step_avg:33.38ms
+step:413/1480 train_time:13783ms step_avg:33.37ms
+step:414/1480 train_time:13819ms step_avg:33.38ms
+step:415/1480 train_time:13849ms step_avg:33.37ms
+step:416/1480 train_time:13885ms step_avg:33.38ms
+step:417/1480 train_time:13916ms step_avg:33.37ms
+step:418/1480 train_time:13953ms step_avg:33.38ms
+step:419/1480 train_time:13983ms step_avg:33.37ms
+step:420/1480 train_time:14019ms step_avg:33.38ms
+step:421/1480 train_time:14049ms step_avg:33.37ms
+step:422/1480 train_time:14085ms step_avg:33.38ms
+step:423/1480 train_time:14116ms step_avg:33.37ms
+step:424/1480 train_time:14152ms step_avg:33.38ms
+step:425/1480 train_time:14182ms step_avg:33.37ms
+step:426/1480 train_time:14218ms step_avg:33.38ms
+step:427/1480 train_time:14248ms step_avg:33.37ms
+step:428/1480 train_time:14284ms step_avg:33.37ms
+step:429/1480 train_time:14315ms step_avg:33.37ms
+step:430/1480 train_time:14352ms step_avg:33.38ms
+step:431/1480 train_time:14384ms step_avg:33.37ms
+step:432/1480 train_time:14421ms step_avg:33.38ms
+step:433/1480 train_time:14452ms step_avg:33.38ms
+step:434/1480 train_time:14488ms step_avg:33.38ms
+step:435/1480 train_time:14520ms step_avg:33.38ms
+step:436/1480 train_time:14556ms step_avg:33.39ms
+step:437/1480 train_time:14587ms step_avg:33.38ms
+step:438/1480 train_time:14624ms step_avg:33.39ms
+step:439/1480 train_time:14656ms step_avg:33.38ms
+step:440/1480 train_time:14693ms step_avg:33.39ms
+step:441/1480 train_time:14724ms step_avg:33.39ms
+step:442/1480 train_time:14761ms step_avg:33.40ms
+step:443/1480 train_time:14792ms step_avg:33.39ms
+step:444/1480 train_time:14829ms step_avg:33.40ms
+step:445/1480 train_time:14860ms step_avg:33.39ms
+step:446/1480 train_time:14897ms step_avg:33.40ms
+step:447/1480 train_time:14928ms step_avg:33.39ms
+step:448/1480 train_time:14965ms step_avg:33.40ms
+step:449/1480 train_time:14995ms step_avg:33.40ms
+step:450/1480 train_time:15032ms step_avg:33.40ms
+step:451/1480 train_time:15064ms step_avg:33.40ms
+step:452/1480 train_time:15100ms step_avg:33.41ms
+step:453/1480 train_time:15131ms step_avg:33.40ms
+step:454/1480 train_time:15168ms step_avg:33.41ms
+step:455/1480 train_time:15199ms step_avg:33.40ms
+step:456/1480 train_time:15236ms step_avg:33.41ms
+step:457/1480 train_time:15267ms step_avg:33.41ms
+step:458/1480 train_time:15304ms step_avg:33.41ms
+step:459/1480 train_time:15334ms step_avg:33.41ms
+step:460/1480 train_time:15371ms step_avg:33.41ms
+step:461/1480 train_time:15402ms step_avg:33.41ms
+step:462/1480 train_time:15439ms step_avg:33.42ms
+step:463/1480 train_time:15470ms step_avg:33.41ms
+step:464/1480 train_time:15506ms step_avg:33.42ms
+step:465/1480 train_time:15538ms step_avg:33.41ms
+step:466/1480 train_time:15574ms step_avg:33.42ms
+step:467/1480 train_time:15605ms step_avg:33.42ms
+step:468/1480 train_time:15642ms step_avg:33.42ms
+step:469/1480 train_time:15673ms step_avg:33.42ms
+step:470/1480 train_time:15710ms step_avg:33.42ms
+step:471/1480 train_time:15741ms step_avg:33.42ms
+step:472/1480 train_time:15777ms step_avg:33.43ms
+step:473/1480 train_time:15808ms step_avg:33.42ms
+step:474/1480 train_time:15844ms step_avg:33.43ms
+step:475/1480 train_time:15875ms step_avg:33.42ms
+step:476/1480 train_time:15912ms step_avg:33.43ms
+step:477/1480 train_time:15943ms step_avg:33.42ms
+step:478/1480 train_time:15980ms step_avg:33.43ms
+step:479/1480 train_time:16011ms step_avg:33.43ms
+step:480/1480 train_time:16048ms step_avg:33.43ms
+step:481/1480 train_time:16080ms step_avg:33.43ms
+step:482/1480 train_time:16142ms step_avg:33.49ms
+step:483/1480 train_time:16200ms step_avg:33.54ms
+step:484/1480 train_time:16264ms step_avg:33.60ms
+step:485/1480 train_time:16322ms step_avg:33.65ms
+step:486/1480 train_time:16386ms step_avg:33.72ms
+step:487/1480 train_time:16444ms step_avg:33.77ms
+step:488/1480 train_time:16509ms step_avg:33.83ms
+step:489/1480 train_time:16569ms step_avg:33.88ms
+step:490/1480 train_time:16631ms step_avg:33.94ms
+step:491/1480 train_time:16689ms step_avg:33.99ms
+step:492/1480 train_time:16752ms step_avg:34.05ms
+step:493/1480 train_time:16811ms step_avg:34.10ms
+step:494/1480 train_time:16873ms step_avg:34.16ms
+step:495/1480 train_time:16931ms step_avg:34.20ms
+step:496/1480 train_time:16995ms step_avg:34.26ms
+step:497/1480 train_time:17054ms step_avg:34.31ms
+step:498/1480 train_time:17121ms step_avg:34.38ms
+step:499/1480 train_time:17180ms step_avg:34.43ms
+step:500/1480 train_time:17245ms step_avg:34.49ms
+step:500/1480 val_loss:4.2235 train_time:17326ms step_avg:34.65ms
+step:501/1480 train_time:17343ms step_avg:34.62ms
+step:502/1480 train_time:17372ms step_avg:34.60ms
+step:503/1480 train_time:17433ms step_avg:34.66ms
+step:504/1480 train_time:17499ms step_avg:34.72ms
+step:505/1480 train_time:17556ms step_avg:34.76ms
+step:506/1480 train_time:17619ms step_avg:34.82ms
+step:507/1480 train_time:17676ms step_avg:34.86ms
+step:508/1480 train_time:17740ms step_avg:34.92ms
+step:509/1480 train_time:17797ms step_avg:34.96ms
+step:510/1480 train_time:17861ms step_avg:35.02ms
+step:511/1480 train_time:17918ms step_avg:35.06ms
+step:512/1480 train_time:17982ms step_avg:35.12ms
+step:513/1480 train_time:18041ms step_avg:35.17ms
+step:514/1480 train_time:18106ms step_avg:35.22ms
+step:515/1480 train_time:18163ms step_avg:35.27ms
+step:516/1480 train_time:18229ms step_avg:35.33ms
+step:517/1480 train_time:18288ms step_avg:35.37ms
+step:518/1480 train_time:18353ms step_avg:35.43ms
+step:519/1480 train_time:18412ms step_avg:35.48ms
+step:520/1480 train_time:18477ms step_avg:35.53ms
+step:521/1480 train_time:18536ms step_avg:35.58ms
+step:522/1480 train_time:18600ms step_avg:35.63ms
+step:523/1480 train_time:18657ms step_avg:35.67ms
+step:524/1480 train_time:18722ms step_avg:35.73ms
+step:525/1480 train_time:18781ms step_avg:35.77ms
+step:526/1480 train_time:18845ms step_avg:35.83ms
+step:527/1480 train_time:18903ms step_avg:35.87ms
+step:528/1480 train_time:18968ms step_avg:35.92ms
+step:529/1480 train_time:19027ms step_avg:35.97ms
+step:530/1480 train_time:19092ms step_avg:36.02ms
+step:531/1480 train_time:19151ms step_avg:36.07ms
+step:532/1480 train_time:19215ms step_avg:36.12ms
+step:533/1480 train_time:19272ms step_avg:36.16ms
+step:534/1480 train_time:19336ms step_avg:36.21ms
+step:535/1480 train_time:19393ms step_avg:36.25ms
+step:536/1480 train_time:19457ms step_avg:36.30ms
+step:537/1480 train_time:19516ms step_avg:36.34ms
+step:538/1480 train_time:19580ms step_avg:36.39ms
+step:539/1480 train_time:19639ms step_avg:36.44ms
+step:540/1480 train_time:19706ms step_avg:36.49ms
+step:541/1480 train_time:19765ms step_avg:36.53ms
+step:542/1480 train_time:19833ms step_avg:36.59ms
+step:543/1480 train_time:19895ms step_avg:36.64ms
+step:544/1480 train_time:19960ms step_avg:36.69ms
+step:545/1480 train_time:20020ms step_avg:36.73ms
+step:546/1480 train_time:20085ms step_avg:36.79ms
+step:547/1480 train_time:20145ms step_avg:36.83ms
+step:548/1480 train_time:20211ms step_avg:36.88ms
+step:549/1480 train_time:20272ms step_avg:36.93ms
+step:550/1480 train_time:20339ms step_avg:36.98ms
+step:551/1480 train_time:20398ms step_avg:37.02ms
+step:552/1480 train_time:20463ms step_avg:37.07ms
+step:553/1480 train_time:20522ms step_avg:37.11ms
+step:554/1480 train_time:20588ms step_avg:37.16ms
+step:555/1480 train_time:20648ms step_avg:37.20ms
+step:556/1480 train_time:20713ms step_avg:37.25ms
+step:557/1480 train_time:20773ms step_avg:37.29ms
+step:558/1480 train_time:20839ms step_avg:37.35ms
+step:559/1480 train_time:20895ms step_avg:37.38ms
+step:560/1480 train_time:20955ms step_avg:37.42ms
+step:561/1480 train_time:21012ms step_avg:37.45ms
+step:562/1480 train_time:21073ms step_avg:37.50ms
+step:563/1480 train_time:21131ms step_avg:37.53ms
+step:564/1480 train_time:21194ms step_avg:37.58ms
+step:565/1480 train_time:21250ms step_avg:37.61ms
+step:566/1480 train_time:21313ms step_avg:37.66ms
+step:567/1480 train_time:21370ms step_avg:37.69ms
+step:568/1480 train_time:21435ms step_avg:37.74ms
+step:569/1480 train_time:21495ms step_avg:37.78ms
+step:570/1480 train_time:21563ms step_avg:37.83ms
+step:571/1480 train_time:21625ms step_avg:37.87ms
+step:572/1480 train_time:21693ms step_avg:37.92ms
+step:573/1480 train_time:21755ms step_avg:37.97ms
+step:574/1480 train_time:21822ms step_avg:38.02ms
+step:575/1480 train_time:21883ms step_avg:38.06ms
+step:576/1480 train_time:21950ms step_avg:38.11ms
+step:577/1480 train_time:22012ms step_avg:38.15ms
+step:578/1480 train_time:22079ms step_avg:38.20ms
+step:579/1480 train_time:22136ms step_avg:38.23ms
+step:580/1480 train_time:22195ms step_avg:38.27ms
+step:581/1480 train_time:22249ms step_avg:38.29ms
+step:582/1480 train_time:22310ms step_avg:38.33ms
+step:583/1480 train_time:22367ms step_avg:38.37ms
+step:584/1480 train_time:22430ms step_avg:38.41ms
+step:585/1480 train_time:22487ms step_avg:38.44ms
+step:586/1480 train_time:22549ms step_avg:38.48ms
+step:587/1480 train_time:22607ms step_avg:38.51ms
+step:588/1480 train_time:22671ms step_avg:38.56ms
+step:589/1480 train_time:22730ms step_avg:38.59ms
+step:590/1480 train_time:22794ms step_avg:38.63ms
+step:591/1480 train_time:22852ms step_avg:38.67ms
+step:592/1480 train_time:22916ms step_avg:38.71ms
+step:593/1480 train_time:22974ms step_avg:38.74ms
+step:594/1480 train_time:23038ms step_avg:38.79ms
+step:595/1480 train_time:23096ms step_avg:38.82ms
+step:596/1480 train_time:23160ms step_avg:38.86ms
+step:597/1480 train_time:23218ms step_avg:38.89ms
+step:598/1480 train_time:23282ms step_avg:38.93ms
+step:599/1480 train_time:23340ms step_avg:38.97ms
+step:600/1480 train_time:23407ms step_avg:39.01ms
+step:601/1480 train_time:23465ms step_avg:39.04ms
+step:602/1480 train_time:23530ms step_avg:39.09ms
+step:603/1480 train_time:23592ms step_avg:39.12ms
+step:604/1480 train_time:23658ms step_avg:39.17ms
+step:605/1480 train_time:23716ms step_avg:39.20ms
+step:606/1480 train_time:23781ms step_avg:39.24ms
+step:607/1480 train_time:23839ms step_avg:39.27ms
+step:608/1480 train_time:23903ms step_avg:39.31ms
+step:609/1480 train_time:23961ms step_avg:39.34ms
+step:610/1480 train_time:24025ms step_avg:39.39ms
+step:611/1480 train_time:24084ms step_avg:39.42ms
+step:612/1480 train_time:24149ms step_avg:39.46ms
+step:613/1480 train_time:24208ms step_avg:39.49ms
+step:614/1480 train_time:24273ms step_avg:39.53ms
+step:615/1480 train_time:24333ms step_avg:39.57ms
+step:616/1480 train_time:24399ms step_avg:39.61ms
+step:617/1480 train_time:24458ms step_avg:39.64ms
+step:618/1480 train_time:24521ms step_avg:39.68ms
+step:619/1480 train_time:24579ms step_avg:39.71ms
+step:620/1480 train_time:24643ms step_avg:39.75ms
+step:621/1480 train_time:24702ms step_avg:39.78ms
+step:622/1480 train_time:24765ms step_avg:39.82ms
+step:623/1480 train_time:24823ms step_avg:39.84ms
+step:624/1480 train_time:24888ms step_avg:39.88ms
+step:625/1480 train_time:24947ms step_avg:39.91ms
+step:626/1480 train_time:25012ms step_avg:39.96ms
+step:627/1480 train_time:25071ms step_avg:39.99ms
+step:628/1480 train_time:25136ms step_avg:40.03ms
+step:629/1480 train_time:25194ms step_avg:40.05ms
+step:630/1480 train_time:25258ms step_avg:40.09ms
+step:631/1480 train_time:25316ms step_avg:40.12ms
+step:632/1480 train_time:25380ms step_avg:40.16ms
+step:633/1480 train_time:25438ms step_avg:40.19ms
+step:634/1480 train_time:25503ms step_avg:40.22ms
+step:635/1480 train_time:25560ms step_avg:40.25ms
+step:636/1480 train_time:25622ms step_avg:40.29ms
+step:637/1480 train_time:25678ms step_avg:40.31ms
+step:638/1480 train_time:25741ms step_avg:40.35ms
+step:639/1480 train_time:25804ms step_avg:40.38ms
+step:640/1480 train_time:25875ms step_avg:40.43ms
+step:641/1480 train_time:25940ms step_avg:40.47ms
+step:642/1480 train_time:26012ms step_avg:40.52ms
+step:643/1480 train_time:26078ms step_avg:40.56ms
+step:644/1480 train_time:26148ms step_avg:40.60ms
+step:645/1480 train_time:26210ms step_avg:40.64ms
+step:646/1480 train_time:26271ms step_avg:40.67ms
+step:647/1480 train_time:26325ms step_avg:40.69ms
+step:648/1480 train_time:26386ms step_avg:40.72ms
+step:649/1480 train_time:26440ms step_avg:40.74ms
+step:650/1480 train_time:26501ms step_avg:40.77ms
+step:651/1480 train_time:26556ms step_avg:40.79ms
+step:652/1480 train_time:26618ms step_avg:40.82ms
+step:653/1480 train_time:26677ms step_avg:40.85ms
+step:654/1480 train_time:26742ms step_avg:40.89ms
+step:655/1480 train_time:26799ms step_avg:40.91ms
+step:656/1480 train_time:26862ms step_avg:40.95ms
+step:657/1480 train_time:26919ms step_avg:40.97ms
+step:658/1480 train_time:26983ms step_avg:41.01ms
+step:659/1480 train_time:27040ms step_avg:41.03ms
+step:660/1480 train_time:27103ms step_avg:41.07ms
+step:661/1480 train_time:27159ms step_avg:41.09ms
+step:662/1480 train_time:27224ms step_avg:41.12ms
+step:663/1480 train_time:27284ms step_avg:41.15ms
+step:664/1480 train_time:27350ms step_avg:41.19ms
+step:665/1480 train_time:27409ms step_avg:41.22ms
+step:666/1480 train_time:27474ms step_avg:41.25ms
+step:667/1480 train_time:27534ms step_avg:41.28ms
+step:668/1480 train_time:27600ms step_avg:41.32ms
+step:669/1480 train_time:27657ms step_avg:41.34ms
+step:670/1480 train_time:27722ms step_avg:41.38ms
+step:671/1480 train_time:27779ms step_avg:41.40ms
+step:672/1480 train_time:27844ms step_avg:41.43ms
+step:673/1480 train_time:27904ms step_avg:41.46ms
+step:674/1480 train_time:27970ms step_avg:41.50ms
+step:675/1480 train_time:28031ms step_avg:41.53ms
+step:676/1480 train_time:28097ms step_avg:41.56ms
+step:677/1480 train_time:28155ms step_avg:41.59ms
+step:678/1480 train_time:28220ms step_avg:41.62ms
+step:679/1480 train_time:28278ms step_avg:41.65ms
+step:680/1480 train_time:28343ms step_avg:41.68ms
+step:681/1480 train_time:28401ms step_avg:41.71ms
+step:682/1480 train_time:28465ms step_avg:41.74ms
+step:683/1480 train_time:28524ms step_avg:41.76ms
+step:684/1480 train_time:28589ms step_avg:41.80ms
+step:685/1480 train_time:28648ms step_avg:41.82ms
+step:686/1480 train_time:28713ms step_avg:41.86ms
+step:687/1480 train_time:28772ms step_avg:41.88ms
+step:688/1480 train_time:28838ms step_avg:41.92ms
+step:689/1480 train_time:28897ms step_avg:41.94ms
+step:690/1480 train_time:28961ms step_avg:41.97ms
+step:691/1480 train_time:29019ms step_avg:42.00ms
+step:692/1480 train_time:29084ms step_avg:42.03ms
+step:693/1480 train_time:29145ms step_avg:42.06ms
+step:694/1480 train_time:29212ms step_avg:42.09ms
+step:695/1480 train_time:29274ms step_avg:42.12ms
+step:696/1480 train_time:29340ms step_avg:42.16ms
+step:697/1480 train_time:29399ms step_avg:42.18ms
+step:698/1480 train_time:29465ms step_avg:42.21ms
+step:699/1480 train_time:29524ms step_avg:42.24ms
+step:700/1480 train_time:29591ms step_avg:42.27ms
+step:701/1480 train_time:29653ms step_avg:42.30ms
+step:702/1480 train_time:29719ms step_avg:42.33ms
+step:703/1480 train_time:29778ms step_avg:42.36ms
+step:704/1480 train_time:29844ms step_avg:42.39ms
+step:705/1480 train_time:29900ms step_avg:42.41ms
+step:706/1480 train_time:29959ms step_avg:42.43ms
+step:707/1480 train_time:30015ms step_avg:42.45ms
+step:708/1480 train_time:30079ms step_avg:42.48ms
+step:709/1480 train_time:30135ms step_avg:42.50ms
+step:710/1480 train_time:30198ms step_avg:42.53ms
+step:711/1480 train_time:30256ms step_avg:42.55ms
+step:712/1480 train_time:30321ms step_avg:42.59ms
+step:713/1480 train_time:30381ms step_avg:42.61ms
+step:714/1480 train_time:30446ms step_avg:42.64ms
+step:715/1480 train_time:30505ms step_avg:42.66ms
+step:716/1480 train_time:30570ms step_avg:42.70ms
+step:717/1480 train_time:30629ms step_avg:42.72ms
+step:718/1480 train_time:30696ms step_avg:42.75ms
+step:719/1480 train_time:30754ms step_avg:42.77ms
+step:720/1480 train_time:30818ms step_avg:42.80ms
+step:721/1480 train_time:30876ms step_avg:42.82ms
+step:722/1480 train_time:30940ms step_avg:42.85ms
+step:723/1480 train_time:30997ms step_avg:42.87ms
+step:724/1480 train_time:31061ms step_avg:42.90ms
+step:725/1480 train_time:31118ms step_avg:42.92ms
+step:726/1480 train_time:31182ms step_avg:42.95ms
+step:727/1480 train_time:31240ms step_avg:42.97ms
+step:728/1480 train_time:31304ms step_avg:43.00ms
+step:729/1480 train_time:31361ms step_avg:43.02ms
+step:730/1480 train_time:31424ms step_avg:43.05ms
+step:731/1480 train_time:31482ms step_avg:43.07ms
+step:732/1480 train_time:31548ms step_avg:43.10ms
+step:733/1480 train_time:31610ms step_avg:43.12ms
+step:734/1480 train_time:31677ms step_avg:43.16ms
+step:735/1480 train_time:31737ms step_avg:43.18ms
+step:736/1480 train_time:31804ms step_avg:43.21ms
+step:737/1480 train_time:31863ms step_avg:43.23ms
+step:738/1480 train_time:31929ms step_avg:43.26ms
+step:739/1480 train_time:31990ms step_avg:43.29ms
+step:740/1480 train_time:32056ms step_avg:43.32ms
+step:741/1480 train_time:32115ms step_avg:43.34ms
+step:742/1480 train_time:32181ms step_avg:43.37ms
+step:743/1480 train_time:32241ms step_avg:43.39ms
+step:744/1480 train_time:32306ms step_avg:43.42ms
+step:745/1480 train_time:32365ms step_avg:43.44ms
+step:746/1480 train_time:32432ms step_avg:43.47ms
+step:747/1480 train_time:32493ms step_avg:43.50ms
+step:748/1480 train_time:32559ms step_avg:43.53ms
+step:749/1480 train_time:32617ms step_avg:43.55ms
+step:750/1480 train_time:32682ms step_avg:43.58ms
+step:750/1480 val_loss:3.8072 train_time:32761ms step_avg:43.68ms
+step:751/1480 train_time:32778ms step_avg:43.65ms
+step:752/1480 train_time:32807ms step_avg:43.63ms
+step:753/1480 train_time:32865ms step_avg:43.65ms
+step:754/1480 train_time:32931ms step_avg:43.67ms
+step:755/1480 train_time:32988ms step_avg:43.69ms
+step:756/1480 train_time:33053ms step_avg:43.72ms
+step:757/1480 train_time:33111ms step_avg:43.74ms
+step:758/1480 train_time:33174ms step_avg:43.77ms
+step:759/1480 train_time:33233ms step_avg:43.79ms
+step:760/1480 train_time:33298ms step_avg:43.81ms
+step:761/1480 train_time:33356ms step_avg:43.83ms
+step:762/1480 train_time:33420ms step_avg:43.86ms
+step:763/1480 train_time:33477ms step_avg:43.88ms
+step:764/1480 train_time:33541ms step_avg:43.90ms
+step:765/1480 train_time:33599ms step_avg:43.92ms
+step:766/1480 train_time:33662ms step_avg:43.95ms
+step:767/1480 train_time:33720ms step_avg:43.96ms
+step:768/1480 train_time:33783ms step_avg:43.99ms
+step:769/1480 train_time:33841ms step_avg:44.01ms
+step:770/1480 train_time:33904ms step_avg:44.03ms
+step:771/1480 train_time:33960ms step_avg:44.05ms
+step:772/1480 train_time:34024ms step_avg:44.07ms
+step:773/1480 train_time:34083ms step_avg:44.09ms
+step:774/1480 train_time:34148ms step_avg:44.12ms
+step:775/1480 train_time:34207ms step_avg:44.14ms
+step:776/1480 train_time:34274ms step_avg:44.17ms
+step:777/1480 train_time:34335ms step_avg:44.19ms
+step:778/1480 train_time:34401ms step_avg:44.22ms
+step:779/1480 train_time:34459ms step_avg:44.24ms
+step:780/1480 train_time:34525ms step_avg:44.26ms
+step:781/1480 train_time:34584ms step_avg:44.28ms
+step:782/1480 train_time:34649ms step_avg:44.31ms
+step:783/1480 train_time:34708ms step_avg:44.33ms
+step:784/1480 train_time:34774ms step_avg:44.35ms
+step:785/1480 train_time:34835ms step_avg:44.38ms
+step:786/1480 train_time:34901ms step_avg:44.40ms
+step:787/1480 train_time:34959ms step_avg:44.42ms
+step:788/1480 train_time:35024ms step_avg:44.45ms
+step:789/1480 train_time:35083ms step_avg:44.46ms
+step:790/1480 train_time:35147ms step_avg:44.49ms
+step:791/1480 train_time:35206ms step_avg:44.51ms
+step:792/1480 train_time:35271ms step_avg:44.53ms
+step:793/1480 train_time:35333ms step_avg:44.56ms
+step:794/1480 train_time:35398ms step_avg:44.58ms
+step:795/1480 train_time:35457ms step_avg:44.60ms
+step:796/1480 train_time:35521ms step_avg:44.62ms
+step:797/1480 train_time:35579ms step_avg:44.64ms
+step:798/1480 train_time:35644ms step_avg:44.67ms
+step:799/1480 train_time:35701ms step_avg:44.68ms
+step:800/1480 train_time:35765ms step_avg:44.71ms
+step:801/1480 train_time:35823ms step_avg:44.72ms
+step:802/1480 train_time:35886ms step_avg:44.75ms
+step:803/1480 train_time:35945ms step_avg:44.76ms
+step:804/1480 train_time:36009ms step_avg:44.79ms
+step:805/1480 train_time:36067ms step_avg:44.80ms
+step:806/1480 train_time:36132ms step_avg:44.83ms
+step:807/1480 train_time:36191ms step_avg:44.85ms
+step:808/1480 train_time:36256ms step_avg:44.87ms
+step:809/1480 train_time:36314ms step_avg:44.89ms
+step:810/1480 train_time:36379ms step_avg:44.91ms
+step:811/1480 train_time:36438ms step_avg:44.93ms
+step:812/1480 train_time:36502ms step_avg:44.95ms
+step:813/1480 train_time:36559ms step_avg:44.97ms
+step:814/1480 train_time:36623ms step_avg:44.99ms
+step:815/1480 train_time:36681ms step_avg:45.01ms
+step:816/1480 train_time:36745ms step_avg:45.03ms
+step:817/1480 train_time:36805ms step_avg:45.05ms
+step:818/1480 train_time:36869ms step_avg:45.07ms
+step:819/1480 train_time:36927ms step_avg:45.09ms
+step:820/1480 train_time:36992ms step_avg:45.11ms
+step:821/1480 train_time:37051ms step_avg:45.13ms
+step:822/1480 train_time:37118ms step_avg:45.16ms
+step:823/1480 train_time:37177ms step_avg:45.17ms
+step:824/1480 train_time:37241ms step_avg:45.20ms
+step:825/1480 train_time:37300ms step_avg:45.21ms
+step:826/1480 train_time:37362ms step_avg:45.23ms
+step:827/1480 train_time:37420ms step_avg:45.25ms
+step:828/1480 train_time:37484ms step_avg:45.27ms
+step:829/1480 train_time:37542ms step_avg:45.29ms
+step:830/1480 train_time:37606ms step_avg:45.31ms
+step:831/1480 train_time:37663ms step_avg:45.32ms
+step:832/1480 train_time:37726ms step_avg:45.34ms
+step:833/1480 train_time:37785ms step_avg:45.36ms
+step:834/1480 train_time:37849ms step_avg:45.38ms
+step:835/1480 train_time:37907ms step_avg:45.40ms
+step:836/1480 train_time:37973ms step_avg:45.42ms
+step:837/1480 train_time:38034ms step_avg:45.44ms
+step:838/1480 train_time:38100ms step_avg:45.47ms
+step:839/1480 train_time:38159ms step_avg:45.48ms
+step:840/1480 train_time:38225ms step_avg:45.51ms
+step:841/1480 train_time:38284ms step_avg:45.52ms
+step:842/1480 train_time:38350ms step_avg:45.55ms
+step:843/1480 train_time:38412ms step_avg:45.57ms
+step:844/1480 train_time:38479ms step_avg:45.59ms
+step:845/1480 train_time:38539ms step_avg:45.61ms
+step:846/1480 train_time:38604ms step_avg:45.63ms
+step:847/1480 train_time:38663ms step_avg:45.65ms
+step:848/1480 train_time:38727ms step_avg:45.67ms
+step:849/1480 train_time:38787ms step_avg:45.69ms
+step:850/1480 train_time:38853ms step_avg:45.71ms
+step:851/1480 train_time:38916ms step_avg:45.73ms
+step:852/1480 train_time:38983ms step_avg:45.75ms
+step:853/1480 train_time:39043ms step_avg:45.77ms
+step:854/1480 train_time:39107ms step_avg:45.79ms
+step:855/1480 train_time:39165ms step_avg:45.81ms
+step:856/1480 train_time:39230ms step_avg:45.83ms
+step:857/1480 train_time:39289ms step_avg:45.84ms
+step:858/1480 train_time:39352ms step_avg:45.87ms
+step:859/1480 train_time:39412ms step_avg:45.88ms
+step:860/1480 train_time:39477ms step_avg:45.90ms
+step:861/1480 train_time:39538ms step_avg:45.92ms
+step:862/1480 train_time:39602ms step_avg:45.94ms
+step:863/1480 train_time:39660ms step_avg:45.96ms
+step:864/1480 train_time:39724ms step_avg:45.98ms
+step:865/1480 train_time:39781ms step_avg:45.99ms
+step:866/1480 train_time:39845ms step_avg:46.01ms
+step:867/1480 train_time:39905ms step_avg:46.03ms
+step:868/1480 train_time:39969ms step_avg:46.05ms
+step:869/1480 train_time:40028ms step_avg:46.06ms
+step:870/1480 train_time:40092ms step_avg:46.08ms
+step:871/1480 train_time:40151ms step_avg:46.10ms
+step:872/1480 train_time:40215ms step_avg:46.12ms
+step:873/1480 train_time:40274ms step_avg:46.13ms
+step:874/1480 train_time:40338ms step_avg:46.15ms
+step:875/1480 train_time:40396ms step_avg:46.17ms
+step:876/1480 train_time:40460ms step_avg:46.19ms
+step:877/1480 train_time:40518ms step_avg:46.20ms
+step:878/1480 train_time:40582ms step_avg:46.22ms
+step:879/1480 train_time:40640ms step_avg:46.23ms
+step:880/1480 train_time:40704ms step_avg:46.25ms
+step:881/1480 train_time:40761ms step_avg:46.27ms
+step:882/1480 train_time:40824ms step_avg:46.29ms
+step:883/1480 train_time:40881ms step_avg:46.30ms
+step:884/1480 train_time:40945ms step_avg:46.32ms
+step:885/1480 train_time:41004ms step_avg:46.33ms
+step:886/1480 train_time:41067ms step_avg:46.35ms
+step:887/1480 train_time:41124ms step_avg:46.36ms
+step:888/1480 train_time:41188ms step_avg:46.38ms
+step:889/1480 train_time:41246ms step_avg:46.40ms
+step:890/1480 train_time:41311ms step_avg:46.42ms
+step:891/1480 train_time:41369ms step_avg:46.43ms
+step:892/1480 train_time:41433ms step_avg:46.45ms
+step:893/1480 train_time:41491ms step_avg:46.46ms
+step:894/1480 train_time:41554ms step_avg:46.48ms
+step:895/1480 train_time:41612ms step_avg:46.49ms
+step:896/1480 train_time:41675ms step_avg:46.51ms
+step:897/1480 train_time:41733ms step_avg:46.53ms
+step:898/1480 train_time:41798ms step_avg:46.55ms
+step:899/1480 train_time:41857ms step_avg:46.56ms
+step:900/1480 train_time:41921ms step_avg:46.58ms
+step:901/1480 train_time:41979ms step_avg:46.59ms
+step:902/1480 train_time:42043ms step_avg:46.61ms
+step:903/1480 train_time:42100ms step_avg:46.62ms
+step:904/1480 train_time:42163ms step_avg:46.64ms
+step:905/1480 train_time:42221ms step_avg:46.65ms
+step:906/1480 train_time:42286ms step_avg:46.67ms
+step:907/1480 train_time:42344ms step_avg:46.69ms
+step:908/1480 train_time:42408ms step_avg:46.71ms
+step:909/1480 train_time:42468ms step_avg:46.72ms
+step:910/1480 train_time:42535ms step_avg:46.74ms
+step:911/1480 train_time:42594ms step_avg:46.76ms
+step:912/1480 train_time:42657ms step_avg:46.77ms
+step:913/1480 train_time:42715ms step_avg:46.79ms
+step:914/1480 train_time:42778ms step_avg:46.80ms
+step:915/1480 train_time:42836ms step_avg:46.82ms
+step:916/1480 train_time:42899ms step_avg:46.83ms
+step:917/1480 train_time:42957ms step_avg:46.84ms
+step:918/1480 train_time:43021ms step_avg:46.86ms
+step:919/1480 train_time:43079ms step_avg:46.88ms
+step:920/1480 train_time:43144ms step_avg:46.90ms
+step:921/1480 train_time:43202ms step_avg:46.91ms
+step:922/1480 train_time:43266ms step_avg:46.93ms
+step:923/1480 train_time:43324ms step_avg:46.94ms
+step:924/1480 train_time:43388ms step_avg:46.96ms
+step:925/1480 train_time:43447ms step_avg:46.97ms
+step:926/1480 train_time:43512ms step_avg:46.99ms
+step:927/1480 train_time:43570ms step_avg:47.00ms
+step:928/1480 train_time:43635ms step_avg:47.02ms
+step:929/1480 train_time:43696ms step_avg:47.04ms
+step:930/1480 train_time:43761ms step_avg:47.05ms
+step:931/1480 train_time:43818ms step_avg:47.07ms
+step:932/1480 train_time:43880ms step_avg:47.08ms
+step:933/1480 train_time:43937ms step_avg:47.09ms
+step:934/1480 train_time:43999ms step_avg:47.11ms
+step:935/1480 train_time:44060ms step_avg:47.12ms
+step:936/1480 train_time:44129ms step_avg:47.15ms
+step:937/1480 train_time:44191ms step_avg:47.16ms
+step:938/1480 train_time:44258ms step_avg:47.18ms
+step:939/1480 train_time:44319ms step_avg:47.20ms
+step:940/1480 train_time:44387ms step_avg:47.22ms
+step:941/1480 train_time:44448ms step_avg:47.23ms
+step:942/1480 train_time:44515ms step_avg:47.26ms
+step:943/1480 train_time:44578ms step_avg:47.27ms
+step:944/1480 train_time:44645ms step_avg:47.29ms
+step:945/1480 train_time:44706ms step_avg:47.31ms
+step:946/1480 train_time:44772ms step_avg:47.33ms
+step:947/1480 train_time:44836ms step_avg:47.35ms
+step:948/1480 train_time:44903ms step_avg:47.37ms
+step:949/1480 train_time:44961ms step_avg:47.38ms
+step:950/1480 train_time:45028ms step_avg:47.40ms
+step:951/1480 train_time:45085ms step_avg:47.41ms
+step:952/1480 train_time:45143ms step_avg:47.42ms
+step:953/1480 train_time:45200ms step_avg:47.43ms
+step:954/1480 train_time:45266ms step_avg:47.45ms
+step:955/1480 train_time:45322ms step_avg:47.46ms
+step:956/1480 train_time:45385ms step_avg:47.47ms
+step:957/1480 train_time:45443ms step_avg:47.48ms
+step:958/1480 train_time:45506ms step_avg:47.50ms
+step:959/1480 train_time:45563ms step_avg:47.51ms
+step:960/1480 train_time:45627ms step_avg:47.53ms
+step:961/1480 train_time:45687ms step_avg:47.54ms
+step:962/1480 train_time:45779ms step_avg:47.59ms
+step:963/1480 train_time:45868ms step_avg:47.63ms
+step:964/1480 train_time:45963ms step_avg:47.68ms
+step:965/1480 train_time:46048ms step_avg:47.72ms
+step:966/1480 train_time:46140ms step_avg:47.76ms
+step:967/1480 train_time:46227ms step_avg:47.80ms
+step:968/1480 train_time:46319ms step_avg:47.85ms
+step:969/1480 train_time:46405ms step_avg:47.89ms
+step:970/1480 train_time:46498ms step_avg:47.94ms
+step:971/1480 train_time:46585ms step_avg:47.98ms
+step:972/1480 train_time:46677ms step_avg:48.02ms
+step:973/1480 train_time:46764ms step_avg:48.06ms
+step:974/1480 train_time:46855ms step_avg:48.11ms
+step:975/1480 train_time:46941ms step_avg:48.15ms
+step:976/1480 train_time:47037ms step_avg:48.19ms
+step:977/1480 train_time:47125ms step_avg:48.23ms
+step:978/1480 train_time:47219ms step_avg:48.28ms
+step:979/1480 train_time:47308ms step_avg:48.32ms
+step:980/1480 train_time:47403ms step_avg:48.37ms
+step:981/1480 train_time:47490ms step_avg:48.41ms
+step:982/1480 train_time:47587ms step_avg:48.46ms
+step:983/1480 train_time:47673ms step_avg:48.50ms
+step:984/1480 train_time:47768ms step_avg:48.54ms
+step:985/1480 train_time:47854ms step_avg:48.58ms
+step:986/1480 train_time:47950ms step_avg:48.63ms
+step:987/1480 train_time:48037ms step_avg:48.67ms
+step:988/1480 train_time:48131ms step_avg:48.72ms
+step:989/1480 train_time:48215ms step_avg:48.75ms
+step:990/1480 train_time:48307ms step_avg:48.80ms
+step:991/1480 train_time:48393ms step_avg:48.83ms
+step:992/1480 train_time:48485ms step_avg:48.88ms
+step:993/1480 train_time:48574ms step_avg:48.92ms
+step:994/1480 train_time:48666ms step_avg:48.96ms
+step:995/1480 train_time:48755ms step_avg:49.00ms
+step:996/1480 train_time:48850ms step_avg:49.05ms
+step:997/1480 train_time:48935ms step_avg:49.08ms
+step:998/1480 train_time:49031ms step_avg:49.13ms
+step:999/1480 train_time:49121ms step_avg:49.17ms
+step:1000/1480 train_time:49218ms step_avg:49.22ms
+step:1000/1480 val_loss:3.5102 train_time:49334ms step_avg:49.33ms
+step:1001/1480 train_time:49352ms step_avg:49.30ms
+step:1002/1480 train_time:49402ms step_avg:49.30ms
+step:1003/1480 train_time:49487ms step_avg:49.34ms
+step:1004/1480 train_time:49577ms step_avg:49.38ms
+step:1005/1480 train_time:49662ms step_avg:49.41ms
+step:1006/1480 train_time:49752ms step_avg:49.45ms
+step:1007/1480 train_time:49836ms step_avg:49.49ms
+step:1008/1480 train_time:49928ms step_avg:49.53ms
+step:1009/1480 train_time:50012ms step_avg:49.57ms
+step:1010/1480 train_time:50102ms step_avg:49.61ms
+step:1011/1480 train_time:50188ms step_avg:49.64ms
+step:1012/1480 train_time:50282ms step_avg:49.69ms
+step:1013/1480 train_time:50367ms step_avg:49.72ms
+step:1014/1480 train_time:50458ms step_avg:49.76ms
+step:1015/1480 train_time:50544ms step_avg:49.80ms
+step:1016/1480 train_time:50636ms step_avg:49.84ms
+step:1017/1480 train_time:50721ms step_avg:49.87ms
+step:1018/1480 train_time:50812ms step_avg:49.91ms
+step:1019/1480 train_time:50900ms step_avg:49.95ms
+step:1020/1480 train_time:50992ms step_avg:49.99ms
+step:1021/1480 train_time:51077ms step_avg:50.03ms
+step:1022/1480 train_time:51170ms step_avg:50.07ms
+step:1023/1480 train_time:51255ms step_avg:50.10ms
+step:1024/1480 train_time:51347ms step_avg:50.14ms
+step:1025/1480 train_time:51432ms step_avg:50.18ms
+step:1026/1480 train_time:51527ms step_avg:50.22ms
+step:1027/1480 train_time:51613ms step_avg:50.26ms
+step:1028/1480 train_time:51708ms step_avg:50.30ms
+step:1029/1480 train_time:51794ms step_avg:50.33ms
+step:1030/1480 train_time:51889ms step_avg:50.38ms
+step:1031/1480 train_time:51978ms step_avg:50.41ms
+step:1032/1480 train_time:52075ms step_avg:50.46ms
+step:1033/1480 train_time:52165ms step_avg:50.50ms
+step:1034/1480 train_time:52260ms step_avg:50.54ms
+step:1035/1480 train_time:52351ms step_avg:50.58ms
+step:1036/1480 train_time:52449ms step_avg:50.63ms
+step:1037/1480 train_time:52537ms step_avg:50.66ms
+step:1038/1480 train_time:52634ms step_avg:50.71ms
+step:1039/1480 train_time:52715ms step_avg:50.74ms
+step:1040/1480 train_time:52802ms step_avg:50.77ms
+step:1041/1480 train_time:52888ms step_avg:50.80ms
+step:1042/1480 train_time:52979ms step_avg:50.84ms
+step:1043/1480 train_time:53069ms step_avg:50.88ms
+step:1044/1480 train_time:53163ms step_avg:50.92ms
+step:1045/1480 train_time:53250ms step_avg:50.96ms
+step:1046/1480 train_time:53344ms step_avg:51.00ms
+step:1047/1480 train_time:53430ms step_avg:51.03ms
+step:1048/1480 train_time:53526ms step_avg:51.07ms
+step:1049/1480 train_time:53614ms step_avg:51.11ms
+step:1050/1480 train_time:53711ms step_avg:51.15ms
+step:1051/1480 train_time:53800ms step_avg:51.19ms
+step:1052/1480 train_time:53895ms step_avg:51.23ms
+step:1053/1480 train_time:53982ms step_avg:51.26ms
+step:1054/1480 train_time:54077ms step_avg:51.31ms
+step:1055/1480 train_time:54161ms step_avg:51.34ms
+step:1056/1480 train_time:54255ms step_avg:51.38ms
+step:1057/1480 train_time:54344ms step_avg:51.41ms
+step:1058/1480 train_time:54437ms step_avg:51.45ms
+step:1059/1480 train_time:54522ms step_avg:51.48ms
+step:1060/1480 train_time:54616ms step_avg:51.52ms
+step:1061/1480 train_time:54703ms step_avg:51.56ms
+step:1062/1480 train_time:54795ms step_avg:51.60ms
+step:1063/1480 train_time:54880ms step_avg:51.63ms
+step:1064/1480 train_time:54974ms step_avg:51.67ms
+step:1065/1480 train_time:55062ms step_avg:51.70ms
+step:1066/1480 train_time:55155ms step_avg:51.74ms
+step:1067/1480 train_time:55244ms step_avg:51.77ms
+step:1068/1480 train_time:55339ms step_avg:51.82ms
+step:1069/1480 train_time:55429ms step_avg:51.85ms
+step:1070/1480 train_time:55523ms step_avg:51.89ms
+step:1071/1480 train_time:55613ms step_avg:51.93ms
+step:1072/1480 train_time:55708ms step_avg:51.97ms
+step:1073/1480 train_time:55794ms step_avg:52.00ms
+step:1074/1480 train_time:55889ms step_avg:52.04ms
+step:1075/1480 train_time:55977ms step_avg:52.07ms
+step:1076/1480 train_time:56071ms step_avg:52.11ms
+step:1077/1480 train_time:56160ms step_avg:52.14ms
+step:1078/1480 train_time:56255ms step_avg:52.18ms
+step:1079/1480 train_time:56344ms step_avg:52.22ms
+step:1080/1480 train_time:56438ms step_avg:52.26ms
+step:1081/1480 train_time:56527ms step_avg:52.29ms
+step:1082/1480 train_time:56620ms step_avg:52.33ms
+step:1083/1480 train_time:56707ms step_avg:52.36ms
+step:1084/1480 train_time:56802ms step_avg:52.40ms
+step:1085/1480 train_time:56889ms step_avg:52.43ms
+step:1086/1480 train_time:56982ms step_avg:52.47ms
+step:1087/1480 train_time:57069ms step_avg:52.50ms
+step:1088/1480 train_time:57163ms step_avg:52.54ms
+step:1089/1480 train_time:57250ms step_avg:52.57ms
+step:1090/1480 train_time:57345ms step_avg:52.61ms
+step:1091/1480 train_time:57430ms step_avg:52.64ms
+step:1092/1480 train_time:57525ms step_avg:52.68ms
+step:1093/1480 train_time:57610ms step_avg:52.71ms
+step:1094/1480 train_time:57702ms step_avg:52.74ms
+step:1095/1480 train_time:57790ms step_avg:52.78ms
+step:1096/1480 train_time:57883ms step_avg:52.81ms
+step:1097/1480 train_time:57970ms step_avg:52.84ms
+step:1098/1480 train_time:58064ms step_avg:52.88ms
+step:1099/1480 train_time:58149ms step_avg:52.91ms
+step:1100/1480 train_time:58240ms step_avg:52.95ms
+step:1101/1480 train_time:58327ms step_avg:52.98ms
+step:1102/1480 train_time:58418ms step_avg:53.01ms
+step:1103/1480 train_time:58505ms step_avg:53.04ms
+step:1104/1480 train_time:58597ms step_avg:53.08ms
+step:1105/1480 train_time:58684ms step_avg:53.11ms
+step:1106/1480 train_time:58778ms step_avg:53.14ms
+step:1107/1480 train_time:58863ms step_avg:53.17ms
+step:1108/1480 train_time:58956ms step_avg:53.21ms
+step:1109/1480 train_time:59043ms step_avg:53.24ms
+step:1110/1480 train_time:59138ms step_avg:53.28ms
+step:1111/1480 train_time:59226ms step_avg:53.31ms
+step:1112/1480 train_time:59320ms step_avg:53.34ms
+step:1113/1480 train_time:59408ms step_avg:53.38ms
+step:1114/1480 train_time:59503ms step_avg:53.41ms
+step:1115/1480 train_time:59589ms step_avg:53.44ms
+step:1116/1480 train_time:59682ms step_avg:53.48ms
+step:1117/1480 train_time:59770ms step_avg:53.51ms
+step:1118/1480 train_time:59864ms step_avg:53.55ms
+step:1119/1480 train_time:59949ms step_avg:53.57ms
+step:1120/1480 train_time:60043ms step_avg:53.61ms
+step:1121/1480 train_time:60128ms step_avg:53.64ms
+step:1122/1480 train_time:60221ms step_avg:53.67ms
+step:1123/1480 train_time:60309ms step_avg:53.70ms
+step:1124/1480 train_time:60402ms step_avg:53.74ms
+step:1125/1480 train_time:60489ms step_avg:53.77ms
+step:1126/1480 train_time:60582ms step_avg:53.80ms
+step:1127/1480 train_time:60669ms step_avg:53.83ms
+step:1128/1480 train_time:60763ms step_avg:53.87ms
+step:1129/1480 train_time:60849ms step_avg:53.90ms
+step:1130/1480 train_time:60941ms step_avg:53.93ms
+step:1131/1480 train_time:61029ms step_avg:53.96ms
+step:1132/1480 train_time:61121ms step_avg:53.99ms
+step:1133/1480 train_time:61208ms step_avg:54.02ms
+step:1134/1480 train_time:61301ms step_avg:54.06ms
+step:1135/1480 train_time:61387ms step_avg:54.09ms
+step:1136/1480 train_time:61480ms step_avg:54.12ms
+step:1137/1480 train_time:61568ms step_avg:54.15ms
+step:1138/1480 train_time:61661ms step_avg:54.18ms
+step:1139/1480 train_time:61747ms step_avg:54.21ms
+step:1140/1480 train_time:61839ms step_avg:54.25ms
+step:1141/1480 train_time:61926ms step_avg:54.27ms
+step:1142/1480 train_time:62018ms step_avg:54.31ms
+step:1143/1480 train_time:62104ms step_avg:54.33ms
+step:1144/1480 train_time:62197ms step_avg:54.37ms
+step:1145/1480 train_time:62283ms step_avg:54.40ms
+step:1146/1480 train_time:62377ms step_avg:54.43ms
+step:1147/1480 train_time:62465ms step_avg:54.46ms
+step:1148/1480 train_time:62557ms step_avg:54.49ms
+step:1149/1480 train_time:62645ms step_avg:54.52ms
+step:1150/1480 train_time:62737ms step_avg:54.55ms
+step:1151/1480 train_time:62825ms step_avg:54.58ms
+step:1152/1480 train_time:62918ms step_avg:54.62ms
+step:1153/1480 train_time:63005ms step_avg:54.64ms
+step:1154/1480 train_time:63097ms step_avg:54.68ms
+step:1155/1480 train_time:63184ms step_avg:54.70ms
+step:1156/1480 train_time:63276ms step_avg:54.74ms
+step:1157/1480 train_time:63362ms step_avg:54.76ms
+step:1158/1480 train_time:63456ms step_avg:54.80ms
+step:1159/1480 train_time:63544ms step_avg:54.83ms
+step:1160/1480 train_time:63638ms step_avg:54.86ms
+step:1161/1480 train_time:63725ms step_avg:54.89ms
+step:1162/1480 train_time:63820ms step_avg:54.92ms
+step:1163/1480 train_time:63910ms step_avg:54.95ms
+step:1164/1480 train_time:64004ms step_avg:54.99ms
+step:1165/1480 train_time:64091ms step_avg:55.01ms
+step:1166/1480 train_time:64186ms step_avg:55.05ms
+step:1167/1480 train_time:64273ms step_avg:55.08ms
+step:1168/1480 train_time:64367ms step_avg:55.11ms
+step:1169/1480 train_time:64453ms step_avg:55.13ms
+step:1170/1480 train_time:64548ms step_avg:55.17ms
+step:1171/1480 train_time:64634ms step_avg:55.20ms
+step:1172/1480 train_time:64728ms step_avg:55.23ms
+step:1173/1480 train_time:64814ms step_avg:55.26ms
+step:1174/1480 train_time:64910ms step_avg:55.29ms
+step:1175/1480 train_time:64995ms step_avg:55.31ms
+step:1176/1480 train_time:65090ms step_avg:55.35ms
+step:1177/1480 train_time:65176ms step_avg:55.37ms
+step:1178/1480 train_time:65270ms step_avg:55.41ms
+step:1179/1480 train_time:65356ms step_avg:55.43ms
+step:1180/1480 train_time:65449ms step_avg:55.47ms
+step:1181/1480 train_time:65535ms step_avg:55.49ms
+step:1182/1480 train_time:65629ms step_avg:55.52ms
+step:1183/1480 train_time:65716ms step_avg:55.55ms
+step:1184/1480 train_time:65809ms step_avg:55.58ms
+step:1185/1480 train_time:65895ms step_avg:55.61ms
+step:1186/1480 train_time:65989ms step_avg:55.64ms
+step:1187/1480 train_time:66075ms step_avg:55.67ms
+step:1188/1480 train_time:66168ms step_avg:55.70ms
+step:1189/1480 train_time:66254ms step_avg:55.72ms
+step:1190/1480 train_time:66348ms step_avg:55.75ms
+step:1191/1480 train_time:66434ms step_avg:55.78ms
+step:1192/1480 train_time:66528ms step_avg:55.81ms
+step:1193/1480 train_time:66614ms step_avg:55.84ms
+step:1194/1480 train_time:66705ms step_avg:55.87ms
+step:1195/1480 train_time:66788ms step_avg:55.89ms
+step:1196/1480 train_time:66878ms step_avg:55.92ms
+step:1197/1480 train_time:66962ms step_avg:55.94ms
+step:1198/1480 train_time:67056ms step_avg:55.97ms
+step:1199/1480 train_time:67143ms step_avg:56.00ms
+step:1200/1480 train_time:67238ms step_avg:56.03ms
+step:1201/1480 train_time:67326ms step_avg:56.06ms
+step:1202/1480 train_time:67420ms step_avg:56.09ms
+step:1203/1480 train_time:67509ms step_avg:56.12ms
+step:1204/1480 train_time:67602ms step_avg:56.15ms
+step:1205/1480 train_time:67690ms step_avg:56.17ms
+step:1206/1480 train_time:67784ms step_avg:56.21ms
+step:1207/1480 train_time:67871ms step_avg:56.23ms
+step:1208/1480 train_time:67965ms step_avg:56.26ms
+step:1209/1480 train_time:68051ms step_avg:56.29ms
+step:1210/1480 train_time:68143ms step_avg:56.32ms
+step:1211/1480 train_time:68229ms step_avg:56.34ms
+step:1212/1480 train_time:68320ms step_avg:56.37ms
+step:1213/1480 train_time:68406ms step_avg:56.39ms
+step:1214/1480 train_time:68496ms step_avg:56.42ms
+step:1215/1480 train_time:68581ms step_avg:56.45ms
+step:1216/1480 train_time:68673ms step_avg:56.47ms
+step:1217/1480 train_time:68758ms step_avg:56.50ms
+step:1218/1480 train_time:68848ms step_avg:56.53ms
+step:1219/1480 train_time:68936ms step_avg:56.55ms
+step:1220/1480 train_time:69029ms step_avg:56.58ms
+step:1221/1480 train_time:69118ms step_avg:56.61ms
+step:1222/1480 train_time:69210ms step_avg:56.64ms
+step:1223/1480 train_time:69299ms step_avg:56.66ms
+step:1224/1480 train_time:69391ms step_avg:56.69ms
+step:1225/1480 train_time:69480ms step_avg:56.72ms
+step:1226/1480 train_time:69573ms step_avg:56.75ms
+step:1227/1480 train_time:69660ms step_avg:56.77ms
+step:1228/1480 train_time:69756ms step_avg:56.80ms
+step:1229/1480 train_time:69842ms step_avg:56.83ms
+step:1230/1480 train_time:69935ms step_avg:56.86ms
+step:1231/1480 train_time:70021ms step_avg:56.88ms
+step:1232/1480 train_time:70113ms step_avg:56.91ms
+step:1233/1480 train_time:70200ms step_avg:56.93ms
+step:1234/1480 train_time:70291ms step_avg:56.96ms
+step:1235/1480 train_time:70376ms step_avg:56.98ms
+step:1236/1480 train_time:70468ms step_avg:57.01ms
+step:1237/1480 train_time:70552ms step_avg:57.03ms
+step:1238/1480 train_time:70645ms step_avg:57.06ms
+step:1239/1480 train_time:70737ms step_avg:57.09ms
+step:1240/1480 train_time:70843ms step_avg:57.13ms
+step:1241/1480 train_time:70941ms step_avg:57.16ms
+step:1242/1480 train_time:71045ms step_avg:57.20ms
+step:1243/1480 train_time:71136ms step_avg:57.23ms
+step:1244/1480 train_time:71221ms step_avg:57.25ms
+step:1245/1480 train_time:71301ms step_avg:57.27ms
+step:1246/1480 train_time:71389ms step_avg:57.29ms
+step:1247/1480 train_time:71478ms step_avg:57.32ms
+step:1248/1480 train_time:71572ms step_avg:57.35ms
+step:1249/1480 train_time:71659ms step_avg:57.37ms
+step:1250/1480 train_time:71751ms step_avg:57.40ms
+step:1250/1480 val_loss:3.3684 train_time:71862ms step_avg:57.49ms
+step:1251/1480 train_time:71881ms step_avg:57.46ms
+step:1252/1480 train_time:71930ms step_avg:57.45ms
+step:1253/1480 train_time:72024ms step_avg:57.48ms
+step:1254/1480 train_time:72118ms step_avg:57.51ms
+step:1255/1480 train_time:72203ms step_avg:57.53ms
+step:1256/1480 train_time:72295ms step_avg:57.56ms
+step:1257/1480 train_time:72382ms step_avg:57.58ms
+step:1258/1480 train_time:72473ms step_avg:57.61ms
+step:1259/1480 train_time:72559ms step_avg:57.63ms
+step:1260/1480 train_time:72650ms step_avg:57.66ms
+step:1261/1480 train_time:72736ms step_avg:57.68ms
+step:1262/1480 train_time:72829ms step_avg:57.71ms
+step:1263/1480 train_time:72913ms step_avg:57.73ms
+step:1264/1480 train_time:73005ms step_avg:57.76ms
+step:1265/1480 train_time:73093ms step_avg:57.78ms
+step:1266/1480 train_time:73189ms step_avg:57.81ms
+step:1267/1480 train_time:73281ms step_avg:57.84ms
+step:1268/1480 train_time:73378ms step_avg:57.87ms
+step:1269/1480 train_time:73469ms step_avg:57.90ms
+step:1270/1480 train_time:73566ms step_avg:57.93ms
+step:1271/1480 train_time:73658ms step_avg:57.95ms
+step:1272/1480 train_time:73755ms step_avg:57.98ms
+step:1273/1480 train_time:73845ms step_avg:58.01ms
+step:1274/1480 train_time:73941ms step_avg:58.04ms
+step:1275/1480 train_time:74033ms step_avg:58.06ms
+step:1276/1480 train_time:74129ms step_avg:58.09ms
+step:1277/1480 train_time:74213ms step_avg:58.12ms
+step:1278/1480 train_time:74298ms step_avg:58.14ms
+step:1279/1480 train_time:74383ms step_avg:58.16ms
+step:1280/1480 train_time:74474ms step_avg:58.18ms
+step:1281/1480 train_time:74559ms step_avg:58.20ms
+step:1282/1480 train_time:74652ms step_avg:58.23ms
+step:1283/1480 train_time:74738ms step_avg:58.25ms
+step:1284/1480 train_time:74831ms step_avg:58.28ms
+step:1285/1480 train_time:74918ms step_avg:58.30ms
+step:1286/1480 train_time:75009ms step_avg:58.33ms
+step:1287/1480 train_time:75095ms step_avg:58.35ms
+step:1288/1480 train_time:75188ms step_avg:58.38ms
+step:1289/1480 train_time:75274ms step_avg:58.40ms
+step:1290/1480 train_time:75366ms step_avg:58.42ms
+step:1291/1480 train_time:75452ms step_avg:58.44ms
+step:1292/1480 train_time:75543ms step_avg:58.47ms
+step:1293/1480 train_time:75631ms step_avg:58.49ms
+step:1294/1480 train_time:75728ms step_avg:58.52ms
+step:1295/1480 train_time:75819ms step_avg:58.55ms
+step:1296/1480 train_time:75917ms step_avg:58.58ms
+step:1297/1480 train_time:76008ms step_avg:58.60ms
+step:1298/1480 train_time:76106ms step_avg:58.63ms
+step:1299/1480 train_time:76197ms step_avg:58.66ms
+step:1300/1480 train_time:76294ms step_avg:58.69ms
+step:1301/1480 train_time:76383ms step_avg:58.71ms
+step:1302/1480 train_time:76471ms step_avg:58.73ms
+step:1303/1480 train_time:76554ms step_avg:58.75ms
+step:1304/1480 train_time:76645ms step_avg:58.78ms
+step:1305/1480 train_time:76728ms step_avg:58.80ms
+step:1306/1480 train_time:76819ms step_avg:58.82ms
+step:1307/1480 train_time:76905ms step_avg:58.84ms
+step:1308/1480 train_time:76998ms step_avg:58.87ms
+step:1309/1480 train_time:77087ms step_avg:58.89ms
+step:1310/1480 train_time:77181ms step_avg:58.92ms
+step:1311/1480 train_time:77270ms step_avg:58.94ms
+step:1312/1480 train_time:77367ms step_avg:58.97ms
+step:1313/1480 train_time:77458ms step_avg:58.99ms
+step:1314/1480 train_time:77555ms step_avg:59.02ms
+step:1315/1480 train_time:77643ms step_avg:59.04ms
+step:1316/1480 train_time:77740ms step_avg:59.07ms
+step:1317/1480 train_time:77829ms step_avg:59.10ms
+step:1318/1480 train_time:77924ms step_avg:59.12ms
+step:1319/1480 train_time:78013ms step_avg:59.15ms
+step:1320/1480 train_time:78109ms step_avg:59.17ms
+step:1321/1480 train_time:78197ms step_avg:59.20ms
+step:1322/1480 train_time:78292ms step_avg:59.22ms
+step:1323/1480 train_time:78380ms step_avg:59.24ms
+step:1324/1480 train_time:78476ms step_avg:59.27ms
+step:1325/1480 train_time:78563ms step_avg:59.29ms
+step:1326/1480 train_time:78658ms step_avg:59.32ms
+step:1327/1480 train_time:78745ms step_avg:59.34ms
+step:1328/1480 train_time:78840ms step_avg:59.37ms
+step:1329/1480 train_time:78927ms step_avg:59.39ms
+step:1330/1480 train_time:79022ms step_avg:59.41ms
+step:1331/1480 train_time:79110ms step_avg:59.44ms
+step:1332/1480 train_time:79203ms step_avg:59.46ms
+step:1333/1480 train_time:79291ms step_avg:59.48ms
+step:1334/1480 train_time:79383ms step_avg:59.51ms
+step:1335/1480 train_time:79471ms step_avg:59.53ms
+step:1336/1480 train_time:79564ms step_avg:59.55ms
+step:1337/1480 train_time:79651ms step_avg:59.57ms
+step:1338/1480 train_time:79744ms step_avg:59.60ms
+step:1339/1480 train_time:79831ms step_avg:59.62ms
+step:1340/1480 train_time:79922ms step_avg:59.64ms
+step:1341/1480 train_time:80010ms step_avg:59.66ms
+step:1342/1480 train_time:80103ms step_avg:59.69ms
+step:1343/1480 train_time:80190ms step_avg:59.71ms
+step:1344/1480 train_time:80282ms step_avg:59.73ms
+step:1345/1480 train_time:80370ms step_avg:59.75ms
+step:1346/1480 train_time:80462ms step_avg:59.78ms
+step:1347/1480 train_time:80547ms step_avg:59.80ms
+step:1348/1480 train_time:80640ms step_avg:59.82ms
+step:1349/1480 train_time:80726ms step_avg:59.84ms
+step:1350/1480 train_time:80819ms step_avg:59.87ms
+step:1351/1480 train_time:80906ms step_avg:59.89ms
+step:1352/1480 train_time:80999ms step_avg:59.91ms
+step:1353/1480 train_time:81086ms step_avg:59.93ms
+step:1354/1480 train_time:81180ms step_avg:59.96ms
+step:1355/1480 train_time:81268ms step_avg:59.98ms
+step:1356/1480 train_time:81361ms step_avg:60.00ms
+step:1357/1480 train_time:81449ms step_avg:60.02ms
+step:1358/1480 train_time:81542ms step_avg:60.05ms
+step:1359/1480 train_time:81629ms step_avg:60.07ms
+step:1360/1480 train_time:81722ms step_avg:60.09ms
+step:1361/1480 train_time:81809ms step_avg:60.11ms
+step:1362/1480 train_time:81902ms step_avg:60.13ms
+step:1363/1480 train_time:81988ms step_avg:60.15ms
+step:1364/1480 train_time:82081ms step_avg:60.18ms
+step:1365/1480 train_time:82168ms step_avg:60.20ms
+step:1366/1480 train_time:82261ms step_avg:60.22ms
+step:1367/1480 train_time:82349ms step_avg:60.24ms
+step:1368/1480 train_time:82441ms step_avg:60.26ms
+step:1369/1480 train_time:82526ms step_avg:60.28ms
+step:1370/1480 train_time:82617ms step_avg:60.30ms
+step:1371/1480 train_time:82702ms step_avg:60.32ms
+step:1372/1480 train_time:82794ms step_avg:60.35ms
+step:1373/1480 train_time:82881ms step_avg:60.36ms
+step:1374/1480 train_time:82977ms step_avg:60.39ms
+step:1375/1480 train_time:83062ms step_avg:60.41ms
+step:1376/1480 train_time:83157ms step_avg:60.43ms
+step:1377/1480 train_time:83244ms step_avg:60.45ms
+step:1378/1480 train_time:83336ms step_avg:60.48ms
+step:1379/1480 train_time:83423ms step_avg:60.50ms
+step:1380/1480 train_time:83516ms step_avg:60.52ms
+step:1381/1480 train_time:83602ms step_avg:60.54ms
+step:1382/1480 train_time:83694ms step_avg:60.56ms
+step:1383/1480 train_time:83780ms step_avg:60.58ms
+step:1384/1480 train_time:83872ms step_avg:60.60ms
+step:1385/1480 train_time:83958ms step_avg:60.62ms
+step:1386/1480 train_time:84051ms step_avg:60.64ms
+step:1387/1480 train_time:84136ms step_avg:60.66ms
+step:1388/1480 train_time:84227ms step_avg:60.68ms
+step:1389/1480 train_time:84313ms step_avg:60.70ms
+step:1390/1480 train_time:84404ms step_avg:60.72ms
+step:1391/1480 train_time:84488ms step_avg:60.74ms
+step:1392/1480 train_time:84578ms step_avg:60.76ms
+step:1393/1480 train_time:84666ms step_avg:60.78ms
+step:1394/1480 train_time:84758ms step_avg:60.80ms
+step:1395/1480 train_time:84845ms step_avg:60.82ms
+step:1396/1480 train_time:84941ms step_avg:60.85ms
+step:1397/1480 train_time:85032ms step_avg:60.87ms
+step:1398/1480 train_time:85129ms step_avg:60.89ms
+step:1399/1480 train_time:85221ms step_avg:60.92ms
+step:1400/1480 train_time:85318ms step_avg:60.94ms
+step:1401/1480 train_time:85409ms step_avg:60.96ms
+step:1402/1480 train_time:85506ms step_avg:60.99ms
+step:1403/1480 train_time:85597ms step_avg:61.01ms
+step:1404/1480 train_time:85686ms step_avg:61.03ms
+step:1405/1480 train_time:85769ms step_avg:61.05ms
+step:1406/1480 train_time:85861ms step_avg:61.07ms
+step:1407/1480 train_time:85946ms step_avg:61.08ms
+step:1408/1480 train_time:86038ms step_avg:61.11ms
+step:1409/1480 train_time:86129ms step_avg:61.13ms
+step:1410/1480 train_time:86222ms step_avg:61.15ms
+step:1411/1480 train_time:86308ms step_avg:61.17ms
+step:1412/1480 train_time:86400ms step_avg:61.19ms
+step:1413/1480 train_time:86490ms step_avg:61.21ms
+step:1414/1480 train_time:86586ms step_avg:61.24ms
+step:1415/1480 train_time:86677ms step_avg:61.26ms
+step:1416/1480 train_time:86775ms step_avg:61.28ms
+step:1417/1480 train_time:86864ms step_avg:61.30ms
+step:1418/1480 train_time:86962ms step_avg:61.33ms
+step:1419/1480 train_time:87053ms step_avg:61.35ms
+step:1420/1480 train_time:87148ms step_avg:61.37ms
+step:1421/1480 train_time:87239ms step_avg:61.39ms
+step:1422/1480 train_time:87329ms step_avg:61.41ms
+step:1423/1480 train_time:87413ms step_avg:61.43ms
+step:1424/1480 train_time:87507ms step_avg:61.45ms
+step:1425/1480 train_time:87600ms step_avg:61.47ms
+step:1426/1480 train_time:87700ms step_avg:61.50ms
+step:1427/1480 train_time:87785ms step_avg:61.52ms
+step:1428/1480 train_time:87877ms step_avg:61.54ms
+step:1429/1480 train_time:87963ms step_avg:61.56ms
+step:1430/1480 train_time:88058ms step_avg:61.58ms
+step:1431/1480 train_time:88152ms step_avg:61.60ms
+step:1432/1480 train_time:88253ms step_avg:61.63ms
+step:1433/1480 train_time:88347ms step_avg:61.65ms
+step:1434/1480 train_time:88447ms step_avg:61.68ms
+step:1435/1480 train_time:88536ms step_avg:61.70ms
+step:1436/1480 train_time:88623ms step_avg:61.72ms
+step:1437/1480 train_time:88710ms step_avg:61.73ms
+step:1438/1480 train_time:88802ms step_avg:61.75ms
+step:1439/1480 train_time:88894ms step_avg:61.78ms
+step:1440/1480 train_time:88990ms step_avg:61.80ms
+step:1441/1480 train_time:89081ms step_avg:61.82ms
+step:1442/1480 train_time:89180ms step_avg:61.84ms
+step:1443/1480 train_time:89268ms step_avg:61.86ms
+step:1444/1480 train_time:89364ms step_avg:61.89ms
+step:1445/1480 train_time:89456ms step_avg:61.91ms
+step:1446/1480 train_time:89555ms step_avg:61.93ms
+step:1447/1480 train_time:89646ms step_avg:61.95ms
+step:1448/1480 train_time:89745ms step_avg:61.98ms
+step:1449/1480 train_time:89837ms step_avg:62.00ms
+step:1450/1480 train_time:89934ms step_avg:62.02ms
+step:1451/1480 train_time:90025ms step_avg:62.04ms
+step:1452/1480 train_time:90123ms step_avg:62.07ms
+step:1453/1480 train_time:90203ms step_avg:62.08ms
+step:1454/1480 train_time:90294ms step_avg:62.10ms
+step:1455/1480 train_time:90382ms step_avg:62.12ms
+step:1456/1480 train_time:90475ms step_avg:62.14ms
+step:1457/1480 train_time:90566ms step_avg:62.16ms
+step:1458/1480 train_time:90661ms step_avg:62.18ms
+step:1459/1480 train_time:90748ms step_avg:62.20ms
+step:1460/1480 train_time:90841ms step_avg:62.22ms
+step:1461/1480 train_time:90930ms step_avg:62.24ms
+step:1462/1480 train_time:91025ms step_avg:62.26ms
+step:1463/1480 train_time:91114ms step_avg:62.28ms
+step:1464/1480 train_time:91209ms step_avg:62.30ms
+step:1465/1480 train_time:91299ms step_avg:62.32ms
+step:1466/1480 train_time:91393ms step_avg:62.34ms
+step:1467/1480 train_time:91482ms step_avg:62.36ms
+step:1468/1480 train_time:91576ms step_avg:62.38ms
+step:1469/1480 train_time:91662ms step_avg:62.40ms
+step:1470/1480 train_time:91758ms step_avg:62.42ms
+step:1471/1480 train_time:91844ms step_avg:62.44ms
+step:1472/1480 train_time:91939ms step_avg:62.46ms
+step:1473/1480 train_time:92026ms step_avg:62.48ms
+step:1474/1480 train_time:92119ms step_avg:62.50ms
+step:1475/1480 train_time:92208ms step_avg:62.51ms
+step:1476/1480 train_time:92302ms step_avg:62.53ms
+step:1477/1480 train_time:92390ms step_avg:62.55ms
+step:1478/1480 train_time:92482ms step_avg:62.57ms
+step:1479/1480 train_time:92568ms step_avg:62.59ms
+step:1480/1480 train_time:92661ms step_avg:62.61ms
+step:1480/1480 val_loss:3.2791 train_time:92770ms step_avg:62.68ms
+peak memory allocated: 31345 MiB reserved: 47242 MiB

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -1180,12 +1180,20 @@ class GPT(nn.Module):
         hdim = num_heads * head_dim
         mlp_hdim = 4 * model_dim
 
-        # Attention bank: stores QKVO weights for all attention layers
-        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
-        # https://x.com/hi_tysam/status/1879699187107033311
-        # Simplified layout by @chrisjmccormick
-        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
-        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+        # QK bank: per-head-pair Muon groups for Q, K weights
+        # Each pair of adjacent heads gets its own independent polar express orthogonalization
+        self._num_attn_layers = num_attn_layers
+        num_qk_groups = num_attn_layers * 2 * (num_heads // 2)  # 10 * 2 * 3 = 60
+        self._num_qk_groups = num_qk_groups
+        num_qk_padded = next_multiple_of_n(num_qk_groups, n=world_size)  # 64
+        self.qk_bank = nn.Parameter(torch.empty(num_qk_padded, head_dim * 2, model_dim))
+        self.qk_bank.reshape = (num_qk_padded, head_dim * 2, model_dim)
+
+        # VO bank: per-layer Muon groups for V and O weights
+        num_vo_real = num_attn_layers * 2  # 20
+        num_vo_padded = next_multiple_of_n(num_vo_real, n=world_size)  # 24
+        self.vo_bank = nn.Parameter(torch.empty(num_vo_padded, hdim, hdim))
+        self.vo_bank.reshape = (num_vo_padded, hdim, hdim)
 
         # MLP bank: stores c_fc and c_proj for all MLP layers
         # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
@@ -1196,11 +1204,14 @@ class GPT(nn.Module):
         std = 0.5 * model_dim ** -0.5
         bound = (3 ** 0.5) * std
         with torch.no_grad():
-            self.attn_bank.uniform_(-bound, bound)
+            self.qk_bank[:num_qk_groups].uniform_(-bound, bound)
+            self.qk_bank[num_qk_groups:].zero_()
+            self.vo_bank[:num_vo_real].uniform_(-bound, bound)
+            self.vo_bank[num_vo_real:].zero_()
             self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
             self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
 
-        # Attention modules (no learned params -- weights come from attn_bank)
+        # Attention modules (no learned params -- weights come from qk_bank/vo_bank)
         self.paired_head_layers = [0, 2, 5, 9]
         self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
         self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
@@ -1276,7 +1287,9 @@ class GPT(nn.Module):
         ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
         assert len(attn_gates) == self.num_layers
         assert len(ve_gates) == self.num_layers
-        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        qk_all = self.qk_bank[:self._num_qk_groups].view(self._num_attn_layers, -1, self.qk_bank.shape[-1])
+        vo_flat = self.vo_bank[:self._num_attn_layers * 2].view(self._num_attn_layers, 2, *self.vo_bank.shape[1:]).flatten(1, 2)
+        attn_weights = torch.cat([qk_all, vo_flat], dim=1).unbind(0)
         mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
         mlp_fcs = mlp_all[0::2]    # even indices: c_fc
         mlp_projs = mlp_all[1::2]  # odd indices: c_proj
@@ -1322,7 +1335,8 @@ class GPT(nn.Module):
                 train_max_seq_len=train_max_seq_len
             )
             # Select weights from banks
-            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            attn_idx = i - (i > 6) if i != 6 else None
+            qkvo_w = attn_weights[attn_idx] if attn_idx is not None else None
             c_fc = mlp_fcs[i]
             c_proj = mlp_projs[i]
 
@@ -1551,7 +1565,7 @@ class Hyperparameters:
     # batch sizes
     val_batch_size: int = 4 * 64 * 1024 * 8
     # schedule
-    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_scheduled_iterations: int = 1440  # number of steps to complete lr and ws schedule
     num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
     # evaluation and logging
     run_id: str = f"{uuid.uuid4()}"
@@ -1677,7 +1691,8 @@ class TrainingManager():
         # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
         # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
         self.param_table = {
-            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "qk_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "vo_bank":        {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
             "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
             "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
             "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
@@ -1700,7 +1715,7 @@ class TrainingManager():
             "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
             "value_embeds", "bigram_embed",  # Medium
             "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
-            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+            "qk_bank", "vo_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
         ]
 
         adam_defaults = dict(
@@ -1883,7 +1898,8 @@ for m in model.modules():
         m.weight.data = m.weight.data.bfloat16()
 model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
 model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
-model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.qk_bank.data = model.qk_bank.data.bfloat16()
+model.vo_bank.data = model.vo_bank.data.bfloat16()
 model.mlp_bank.data = model.mlp_bank.data.bfloat16()
 for param in model.parameters():
     dist.broadcast(param.detach(), 0)


### PR DESCRIPTION
# Paired-head Muon groups

Treat each paired-head in K and V as its own Muon group, reducing loss/step and allowing us to reduce step count by 10 and still meet 3.28 loss target.


```bash
                 Runs  Steps   Time μ   Time σ  Time +/-   Time p   Loss μ   Loss σ  Loss +/-   Loss p
  baseline-1490     4   1490  93.0205   0.1629    0.0000      nan   3.2782   0.0010   -0.0018    0.0187
  baseline-1480     8   1480  92.5491   0.0588   -0.4714   0.0040   3.2800   0.0017    0.0000    0.5000
        this PR     8   1480  92.6259   0.2129   -0.3946   0.0038   3.2788   0.0009   -0.0012    0.0029
```

Previously, Muon treated each of Q, K, V, O as one `(hdim, hdim)` group per layer, lumping all heads together within each group. Given heads often specialize, it seemed intuitive that treating each *head* as its own Muon group would further improve optimization. I split K/V into per-**head-pair** groups (because of paired head attention in some layers). This gives each head pair its own independent polar decomposition. Treating each head-pair in K and V as its own Muon group improved loss per step while increasing time/step by ~.1% (this overhead can probably be reduced, splitting Muon groups further should reduce flops).

Now, we can reach the target loss in 10 less steps, saving ~0.4s. If we reduce the baseline by 10 steps without adding the per-head-pair Muon groups, the loss does not meet the target.

**Note on timing:** not sure why my 8xh100 is so slow -- ~8% slower per step for the baseline. However, given that the speedup comes from reducing steps, I think this will hold in a more controlled setup. Also, I see there have been other optimizations that have not yet been merged, but they are orthogonal to this PR.