### PR TITLE
New Record: Polar Express Optimization (~440ms)

### DIFF
--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/README.md
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/README.md
@@ -1,0 +1,84 @@
+# Polar Express Optimization
+
+## Optimizations
+
+All changes are confined to the **Polar Express orthogonalization** step and the **sparse communication** routines used during distributed training. The model architecture, hyperparameters, training schedule, and all other code remain identical.
+
+### 1. Gram-Trace Normalization with Diagonal Fold
+
+**Before:** The spectral norm of the input matrix is bounded by dividing by the Frobenius norm — a full-matrix operation that materializes a normalized copy every iteration.
+
+```python
+X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+```
+
+**After:** Normalization uses the Gram matrix diagonal (trace of X^T X), which is already computed for the iteration. The scale factor is folded into the first polynomial coefficient via diagonal addition, avoiding a separate full-matrix division.
+
+```python
+scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+# ... first iteration ...
+B.diagonal(dim1=-2, dim2=-1).add_(_P0A)  # fold aI into polynomial
+B.mul_(scale[..., None].to(dtype=B.dtype))
+```
+
+This eliminates the `aX + X @ B` fused addmm/baddbmm pattern (which required referencing X twice and triggered defensive copies in PyTorch) and replaces it with a single `bmm` per iteration.
+
+### 2. Specialized Tall-Matrix Paths (MLP Weights)
+
+The MLP weight bank has shape (3072, 768) per matrix — a 4:1 tall aspect ratio. The baseline uses the same iteration loop for all shapes, performing 5 tall-matrix multiplications per step.
+
+**After:** Two dedicated tall-matrix paths are introduced:
+
+- **3-step accumulated transform** (`_polar_express_tall_transform_batched`, used for steps < 500): Propagates the Gram and accumulated transform entirely on the small n×n factor, touching the tall m×n matrix only twice (initial XTX, final bmm). This cuts 3 expensive tall-matrix bmm operations per step.
+
+- **5-step standard path** (`_polar_express_tall_standard_batched`, used for steps ≥ 500): Uses the full 5-step self-correcting iteration with Gram-trace normalization for higher quality convergence in later training.
+
+The transition at step 500 (`_POLAR_SWITCH_STEP`) balances speed in early training against quality in later training.
+
+### 3. Fully Unrolled Iterations
+
+**Before:** Polar Express iterations are written as a Python `for` loop over the coefficient list, which prevents `torch.compile` from fully optimizing memory reuse across iterations.
+
+**After:** Each specialized function has all 5 (or 3) iterations fully unrolled with pre-extracted scalar coefficients (`_P0A`, `_P0B`, ..., `_P4C`). Combined with `fullgraph=True`, this allows the compiler to fuse operations across iteration boundaries and optimize buffer reuse.
+
+### 4. Sparse Communication Improvements
+
+Several micro-optimizations to the distributed sparse gradient communication:
+
+- **Cached partition boundaries** (`_sparse_partition_boundaries`): The `searchsorted` boundary array is computed once per (N, world_size) pair and reused, avoiding repeated allocation.
+- **In-place index slicing**: Local rank's rows are excluded via `narrow` + conditional `copy_` instead of `torch.cat` with two slices, reducing CPU-side allocations.
+- **Local gradient merge**: `sparse_comms_merge_gradients` now operates on a `narrow`ed local slice with adjusted indices (`recv_idx.sub(start)`), avoiding the final full-tensor slice.
+
+## Results
+
+All experiments run on 8×H100 GPUs with identical seeds, hyperparameters, and training schedule. Each configuration was run multiple times to assess variance.
+
+| Configuration | Runs | Mean Time (ms) | Mean Val Loss | Time Saved |
+|---|---|---|---|---|
+| **Baseline (03/22/26)** | 5 | 85,658 | 3.2786 | — |
+| **Baseline + Polar Express Optimization** | 5 | 85,219 | 3.2777 | **439 ms (0.51%)** |
+| **PR#251** | 4 | 84,930 | 3.2788 | — |
+| **PR#251 + Polar Express Optimization** | 5 | 84,545 | 3.2795 | **385 ms (0.45%)** |
+
+All configurations achieve val_loss < 3.28.
+
+## Applicability
+
+The Polar Express optimizations are independent of other code changes and can be applied separately:
+
+- **On the baseline codebase**: The polar version saves ~439 ms on average while producing equivalent or slightly better val_loss.
+
+- **On top of existing PR#251**: The polar version saves ~385 ms on average, demonstrating that the optimizations compose cleanly with the independent changes in PR#251.
+
+## Log Files
+
+Training logs for each configuration are stored as text files named by UUID:
+
+```
+./baseline/     # 5 runs of baseline (03/22/26)
+./baseline_plus_polar/        # 5 runs of official + polar optimizations
+./pr251/           # 4 runs of PR#251
+./pr251_plus_polar/     # 5 runs of PR#251 + polar optimizations
+```

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/475f692c-faf5-4f9a-a0ff-6aa7bdf310e6.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/475f692c-faf5-4f9a-a0ff-6aa7bdf310e6.txt
@@ -1,0 +1,4449 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 00:26:00 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8283 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:102ms step_avg:102.22ms
+step:2/1490 train_time:129ms step_avg:64.55ms
+step:3/1490 train_time:151ms step_avg:50.39ms
+step:4/1490 train_time:174ms step_avg:43.62ms
+step:5/1490 train_time:193ms step_avg:38.70ms
+step:6/1490 train_time:222ms step_avg:36.95ms
+step:7/1490 train_time:249ms step_avg:35.59ms
+step:8/1490 train_time:283ms step_avg:35.43ms
+step:9/1490 train_time:311ms step_avg:34.55ms
+step:10/1490 train_time:345ms step_avg:34.54ms
+step:11/1490 train_time:373ms step_avg:33.91ms
+step:12/1490 train_time:408ms step_avg:33.97ms
+step:13/1490 train_time:435ms step_avg:33.50ms
+step:14/1490 train_time:470ms step_avg:33.55ms
+step:15/1490 train_time:497ms step_avg:33.16ms
+step:16/1490 train_time:532ms step_avg:33.24ms
+step:17/1490 train_time:560ms step_avg:32.93ms
+step:18/1490 train_time:594ms step_avg:33.01ms
+step:19/1490 train_time:622ms step_avg:32.74ms
+step:20/1490 train_time:656ms step_avg:32.81ms
+step:21/1490 train_time:684ms step_avg:32.58ms
+step:22/1490 train_time:718ms step_avg:32.65ms
+step:23/1490 train_time:746ms step_avg:32.45ms
+step:24/1490 train_time:780ms step_avg:32.51ms
+step:25/1490 train_time:808ms step_avg:32.33ms
+step:26/1490 train_time:842ms step_avg:32.40ms
+step:27/1490 train_time:870ms step_avg:32.22ms
+step:28/1490 train_time:904ms step_avg:32.30ms
+step:29/1490 train_time:932ms step_avg:32.15ms
+step:30/1490 train_time:967ms step_avg:32.22ms
+step:31/1490 train_time:995ms step_avg:32.10ms
+step:32/1490 train_time:1031ms step_avg:32.21ms
+step:33/1490 train_time:1060ms step_avg:32.11ms
+step:34/1490 train_time:1095ms step_avg:32.20ms
+step:35/1490 train_time:1123ms step_avg:32.09ms
+step:36/1490 train_time:1158ms step_avg:32.16ms
+step:37/1490 train_time:1187ms step_avg:32.09ms
+step:38/1490 train_time:1221ms step_avg:32.14ms
+step:39/1490 train_time:1250ms step_avg:32.05ms
+step:40/1490 train_time:1284ms step_avg:32.10ms
+step:41/1490 train_time:1313ms step_avg:32.01ms
+step:42/1490 train_time:1346ms step_avg:32.06ms
+step:43/1490 train_time:1374ms step_avg:31.96ms
+step:44/1490 train_time:1409ms step_avg:32.02ms
+step:45/1490 train_time:1437ms step_avg:31.93ms
+step:46/1490 train_time:1471ms step_avg:31.98ms
+step:47/1490 train_time:1499ms step_avg:31.90ms
+step:48/1490 train_time:1533ms step_avg:31.95ms
+step:49/1490 train_time:1562ms step_avg:31.87ms
+step:50/1490 train_time:1596ms step_avg:31.92ms
+step:51/1490 train_time:1625ms step_avg:31.86ms
+step:52/1490 train_time:1659ms step_avg:31.91ms
+step:53/1490 train_time:1687ms step_avg:31.84ms
+step:54/1490 train_time:1722ms step_avg:31.88ms
+step:55/1490 train_time:1750ms step_avg:31.81ms
+step:56/1490 train_time:1784ms step_avg:31.85ms
+step:57/1490 train_time:1812ms step_avg:31.78ms
+step:58/1490 train_time:1846ms step_avg:31.83ms
+step:59/1490 train_time:1874ms step_avg:31.76ms
+step:60/1490 train_time:1909ms step_avg:31.81ms
+step:61/1490 train_time:1937ms step_avg:31.75ms
+step:62/1490 train_time:1972ms step_avg:31.80ms
+step:63/1490 train_time:2000ms step_avg:31.74ms
+step:64/1490 train_time:2035ms step_avg:31.79ms
+step:65/1490 train_time:2064ms step_avg:31.75ms
+step:66/1490 train_time:2100ms step_avg:31.82ms
+step:67/1490 train_time:2127ms step_avg:31.75ms
+step:68/1490 train_time:2163ms step_avg:31.81ms
+step:69/1490 train_time:2190ms step_avg:31.73ms
+step:70/1490 train_time:2226ms step_avg:31.79ms
+step:71/1490 train_time:2252ms step_avg:31.72ms
+step:72/1490 train_time:2288ms step_avg:31.78ms
+step:73/1490 train_time:2315ms step_avg:31.71ms
+step:74/1490 train_time:2352ms step_avg:31.79ms
+step:75/1490 train_time:2377ms step_avg:31.70ms
+step:76/1490 train_time:2413ms step_avg:31.75ms
+step:77/1490 train_time:2439ms step_avg:31.68ms
+step:78/1490 train_time:2473ms step_avg:31.71ms
+step:79/1490 train_time:2501ms step_avg:31.66ms
+step:80/1490 train_time:2536ms step_avg:31.70ms
+step:81/1490 train_time:2564ms step_avg:31.66ms
+step:82/1490 train_time:2598ms step_avg:31.69ms
+step:83/1490 train_time:2626ms step_avg:31.64ms
+step:84/1490 train_time:2661ms step_avg:31.68ms
+step:85/1490 train_time:2689ms step_avg:31.63ms
+step:86/1490 train_time:2723ms step_avg:31.66ms
+step:87/1490 train_time:2751ms step_avg:31.62ms
+step:88/1490 train_time:2785ms step_avg:31.65ms
+step:89/1490 train_time:2813ms step_avg:31.61ms
+step:90/1490 train_time:2848ms step_avg:31.65ms
+step:91/1490 train_time:2876ms step_avg:31.61ms
+step:92/1490 train_time:2911ms step_avg:31.64ms
+step:93/1490 train_time:2939ms step_avg:31.60ms
+step:94/1490 train_time:2974ms step_avg:31.63ms
+step:95/1490 train_time:3002ms step_avg:31.60ms
+step:96/1490 train_time:3036ms step_avg:31.62ms
+step:97/1490 train_time:3064ms step_avg:31.59ms
+step:98/1490 train_time:3099ms step_avg:31.62ms
+step:99/1490 train_time:3127ms step_avg:31.59ms
+step:100/1490 train_time:3161ms step_avg:31.61ms
+step:101/1490 train_time:3189ms step_avg:31.58ms
+step:102/1490 train_time:3226ms step_avg:31.63ms
+step:103/1490 train_time:3252ms step_avg:31.57ms
+step:104/1490 train_time:3287ms step_avg:31.60ms
+step:105/1490 train_time:3315ms step_avg:31.57ms
+step:106/1490 train_time:3350ms step_avg:31.60ms
+step:107/1490 train_time:3377ms step_avg:31.56ms
+step:108/1490 train_time:3411ms step_avg:31.59ms
+step:109/1490 train_time:3439ms step_avg:31.55ms
+step:110/1490 train_time:3475ms step_avg:31.59ms
+step:111/1490 train_time:3503ms step_avg:31.56ms
+step:112/1490 train_time:3537ms step_avg:31.58ms
+step:113/1490 train_time:3565ms step_avg:31.55ms
+step:114/1490 train_time:3599ms step_avg:31.57ms
+step:115/1490 train_time:3627ms step_avg:31.54ms
+step:116/1490 train_time:3661ms step_avg:31.56ms
+step:117/1490 train_time:3690ms step_avg:31.54ms
+step:118/1490 train_time:3724ms step_avg:31.56ms
+step:119/1490 train_time:3752ms step_avg:31.53ms
+step:120/1490 train_time:3786ms step_avg:31.55ms
+step:121/1490 train_time:3814ms step_avg:31.52ms
+step:122/1490 train_time:3849ms step_avg:31.55ms
+step:123/1490 train_time:3877ms step_avg:31.52ms
+step:124/1490 train_time:3911ms step_avg:31.54ms
+step:125/1490 train_time:3939ms step_avg:31.51ms
+step:126/1490 train_time:3974ms step_avg:31.54ms
+step:127/1490 train_time:4001ms step_avg:31.51ms
+step:128/1490 train_time:4036ms step_avg:31.53ms
+step:129/1490 train_time:4064ms step_avg:31.50ms
+step:130/1490 train_time:4098ms step_avg:31.52ms
+step:131/1490 train_time:4126ms step_avg:31.50ms
+step:132/1490 train_time:4161ms step_avg:31.52ms
+step:133/1490 train_time:4189ms step_avg:31.49ms
+step:134/1490 train_time:4223ms step_avg:31.51ms
+step:135/1490 train_time:4251ms step_avg:31.49ms
+step:136/1490 train_time:4286ms step_avg:31.51ms
+step:137/1490 train_time:4314ms step_avg:31.49ms
+step:138/1490 train_time:4348ms step_avg:31.51ms
+step:139/1490 train_time:4376ms step_avg:31.48ms
+step:140/1490 train_time:4411ms step_avg:31.51ms
+step:141/1490 train_time:4439ms step_avg:31.48ms
+step:142/1490 train_time:4474ms step_avg:31.51ms
+step:143/1490 train_time:4502ms step_avg:31.48ms
+step:144/1490 train_time:4536ms step_avg:31.50ms
+step:145/1490 train_time:4564ms step_avg:31.48ms
+step:146/1490 train_time:4599ms step_avg:31.50ms
+step:147/1490 train_time:4627ms step_avg:31.47ms
+step:148/1490 train_time:4661ms step_avg:31.49ms
+step:149/1490 train_time:4689ms step_avg:31.47ms
+step:150/1490 train_time:4723ms step_avg:31.49ms
+step:151/1490 train_time:4751ms step_avg:31.47ms
+step:152/1490 train_time:4786ms step_avg:31.49ms
+step:153/1490 train_time:4814ms step_avg:31.46ms
+step:154/1490 train_time:4848ms step_avg:31.48ms
+step:155/1490 train_time:4876ms step_avg:31.46ms
+step:156/1490 train_time:4910ms step_avg:31.48ms
+step:157/1490 train_time:4938ms step_avg:31.45ms
+step:158/1490 train_time:4973ms step_avg:31.47ms
+step:159/1490 train_time:5001ms step_avg:31.45ms
+step:160/1490 train_time:5035ms step_avg:31.47ms
+step:161/1490 train_time:5063ms step_avg:31.45ms
+step:162/1490 train_time:5097ms step_avg:31.46ms
+step:163/1490 train_time:5126ms step_avg:31.45ms
+step:164/1490 train_time:5160ms step_avg:31.46ms
+step:165/1490 train_time:5189ms step_avg:31.45ms
+step:166/1490 train_time:5223ms step_avg:31.46ms
+step:167/1490 train_time:5251ms step_avg:31.44ms
+step:168/1490 train_time:5286ms step_avg:31.46ms
+step:169/1490 train_time:5314ms step_avg:31.44ms
+step:170/1490 train_time:5349ms step_avg:31.46ms
+step:171/1490 train_time:5377ms step_avg:31.45ms
+step:172/1490 train_time:5412ms step_avg:31.46ms
+step:173/1490 train_time:5440ms step_avg:31.44ms
+step:174/1490 train_time:5474ms step_avg:31.46ms
+step:175/1490 train_time:5502ms step_avg:31.44ms
+step:176/1490 train_time:5536ms step_avg:31.46ms
+step:177/1490 train_time:5564ms step_avg:31.44ms
+step:178/1490 train_time:5598ms step_avg:31.45ms
+step:179/1490 train_time:5626ms step_avg:31.43ms
+step:180/1490 train_time:5660ms step_avg:31.45ms
+step:181/1490 train_time:5688ms step_avg:31.43ms
+step:182/1490 train_time:5723ms step_avg:31.44ms
+step:183/1490 train_time:5751ms step_avg:31.43ms
+step:184/1490 train_time:5786ms step_avg:31.44ms
+step:185/1490 train_time:5814ms step_avg:31.42ms
+step:186/1490 train_time:5848ms step_avg:31.44ms
+step:187/1490 train_time:5876ms step_avg:31.42ms
+step:188/1490 train_time:5911ms step_avg:31.44ms
+step:189/1490 train_time:5938ms step_avg:31.42ms
+step:190/1490 train_time:5973ms step_avg:31.44ms
+step:191/1490 train_time:6000ms step_avg:31.42ms
+step:192/1490 train_time:6035ms step_avg:31.43ms
+step:193/1490 train_time:6063ms step_avg:31.41ms
+step:194/1490 train_time:6097ms step_avg:31.43ms
+step:195/1490 train_time:6125ms step_avg:31.41ms
+step:196/1490 train_time:6159ms step_avg:31.42ms
+step:197/1490 train_time:6187ms step_avg:31.40ms
+step:198/1490 train_time:6220ms step_avg:31.42ms
+step:199/1490 train_time:6249ms step_avg:31.40ms
+step:200/1490 train_time:6283ms step_avg:31.42ms
+step:201/1490 train_time:6311ms step_avg:31.40ms
+step:202/1490 train_time:6345ms step_avg:31.41ms
+step:203/1490 train_time:6373ms step_avg:31.40ms
+step:204/1490 train_time:6408ms step_avg:31.41ms
+step:205/1490 train_time:6436ms step_avg:31.39ms
+step:206/1490 train_time:6470ms step_avg:31.41ms
+step:207/1490 train_time:6498ms step_avg:31.39ms
+step:208/1490 train_time:6532ms step_avg:31.40ms
+step:209/1490 train_time:6560ms step_avg:31.39ms
+step:210/1490 train_time:6595ms step_avg:31.40ms
+step:211/1490 train_time:6623ms step_avg:31.39ms
+step:212/1490 train_time:6657ms step_avg:31.40ms
+step:213/1490 train_time:6685ms step_avg:31.39ms
+step:214/1490 train_time:6719ms step_avg:31.40ms
+step:215/1490 train_time:6747ms step_avg:31.38ms
+step:216/1490 train_time:6781ms step_avg:31.39ms
+step:217/1490 train_time:6809ms step_avg:31.38ms
+step:218/1490 train_time:6843ms step_avg:31.39ms
+step:219/1490 train_time:6872ms step_avg:31.38ms
+step:220/1490 train_time:6906ms step_avg:31.39ms
+step:221/1490 train_time:6934ms step_avg:31.38ms
+step:222/1490 train_time:6969ms step_avg:31.39ms
+step:223/1490 train_time:6997ms step_avg:31.38ms
+step:224/1490 train_time:7031ms step_avg:31.39ms
+step:225/1490 train_time:7059ms step_avg:31.37ms
+step:226/1490 train_time:7093ms step_avg:31.39ms
+step:227/1490 train_time:7122ms step_avg:31.37ms
+step:228/1490 train_time:7156ms step_avg:31.39ms
+step:229/1490 train_time:7184ms step_avg:31.37ms
+step:230/1490 train_time:7218ms step_avg:31.38ms
+step:231/1490 train_time:7246ms step_avg:31.37ms
+step:232/1490 train_time:7280ms step_avg:31.38ms
+step:233/1490 train_time:7308ms step_avg:31.37ms
+step:234/1490 train_time:7342ms step_avg:31.38ms
+step:235/1490 train_time:7370ms step_avg:31.36ms
+step:236/1490 train_time:7404ms step_avg:31.37ms
+step:237/1490 train_time:7433ms step_avg:31.36ms
+step:238/1490 train_time:7467ms step_avg:31.37ms
+step:239/1490 train_time:7495ms step_avg:31.36ms
+step:240/1490 train_time:7529ms step_avg:31.37ms
+step:241/1490 train_time:7557ms step_avg:31.36ms
+step:242/1490 train_time:7593ms step_avg:31.37ms
+step:243/1490 train_time:7620ms step_avg:31.36ms
+step:244/1490 train_time:7654ms step_avg:31.37ms
+step:245/1490 train_time:7683ms step_avg:31.36ms
+step:246/1490 train_time:7717ms step_avg:31.37ms
+step:247/1490 train_time:7745ms step_avg:31.36ms
+step:248/1490 train_time:7779ms step_avg:31.37ms
+step:249/1490 train_time:7807ms step_avg:31.36ms
+step:250/1490 train_time:7842ms step_avg:31.37ms
+step:250/1490 val_loss:4.5048 train_time:7885ms step_avg:31.54ms
+step:251/1490 train_time:7906ms step_avg:31.50ms
+step:252/1490 train_time:7926ms step_avg:31.45ms
+step:253/1490 train_time:7941ms step_avg:31.39ms
+step:254/1490 train_time:7972ms step_avg:31.39ms
+step:255/1490 train_time:8001ms step_avg:31.37ms
+step:256/1490 train_time:8036ms step_avg:31.39ms
+step:257/1490 train_time:8064ms step_avg:31.38ms
+step:258/1490 train_time:8099ms step_avg:31.39ms
+step:259/1490 train_time:8127ms step_avg:31.38ms
+step:260/1490 train_time:8162ms step_avg:31.39ms
+step:261/1490 train_time:8190ms step_avg:31.38ms
+step:262/1490 train_time:8224ms step_avg:31.39ms
+step:263/1490 train_time:8252ms step_avg:31.38ms
+step:264/1490 train_time:8287ms step_avg:31.39ms
+step:265/1490 train_time:8314ms step_avg:31.37ms
+step:266/1490 train_time:8348ms step_avg:31.38ms
+step:267/1490 train_time:8376ms step_avg:31.37ms
+step:268/1490 train_time:8410ms step_avg:31.38ms
+step:269/1490 train_time:8437ms step_avg:31.37ms
+step:270/1490 train_time:8471ms step_avg:31.38ms
+step:271/1490 train_time:8499ms step_avg:31.36ms
+step:272/1490 train_time:8533ms step_avg:31.37ms
+step:273/1490 train_time:8561ms step_avg:31.36ms
+step:274/1490 train_time:8595ms step_avg:31.37ms
+step:275/1490 train_time:8622ms step_avg:31.35ms
+step:276/1490 train_time:8656ms step_avg:31.36ms
+step:277/1490 train_time:8684ms step_avg:31.35ms
+step:278/1490 train_time:8719ms step_avg:31.36ms
+step:279/1490 train_time:8746ms step_avg:31.35ms
+step:280/1490 train_time:8781ms step_avg:31.36ms
+step:281/1490 train_time:8808ms step_avg:31.35ms
+step:282/1490 train_time:8843ms step_avg:31.36ms
+step:283/1490 train_time:8871ms step_avg:31.35ms
+step:284/1490 train_time:8906ms step_avg:31.36ms
+step:285/1490 train_time:8934ms step_avg:31.35ms
+step:286/1490 train_time:8968ms step_avg:31.36ms
+step:287/1490 train_time:8997ms step_avg:31.35ms
+step:288/1490 train_time:9031ms step_avg:31.36ms
+step:289/1490 train_time:9060ms step_avg:31.35ms
+step:290/1490 train_time:9094ms step_avg:31.36ms
+step:291/1490 train_time:9123ms step_avg:31.35ms
+step:292/1490 train_time:9158ms step_avg:31.36ms
+step:293/1490 train_time:9186ms step_avg:31.35ms
+step:294/1490 train_time:9221ms step_avg:31.36ms
+step:295/1490 train_time:9248ms step_avg:31.35ms
+step:296/1490 train_time:9283ms step_avg:31.36ms
+step:297/1490 train_time:9311ms step_avg:31.35ms
+step:298/1490 train_time:9345ms step_avg:31.36ms
+step:299/1490 train_time:9373ms step_avg:31.35ms
+step:300/1490 train_time:9408ms step_avg:31.36ms
+step:301/1490 train_time:9435ms step_avg:31.35ms
+step:302/1490 train_time:9470ms step_avg:31.36ms
+step:303/1490 train_time:9497ms step_avg:31.34ms
+step:304/1490 train_time:9532ms step_avg:31.36ms
+step:305/1490 train_time:9559ms step_avg:31.34ms
+step:306/1490 train_time:9594ms step_avg:31.35ms
+step:307/1490 train_time:9621ms step_avg:31.34ms
+step:308/1490 train_time:9655ms step_avg:31.35ms
+step:309/1490 train_time:9682ms step_avg:31.33ms
+step:310/1490 train_time:9717ms step_avg:31.35ms
+step:311/1490 train_time:9745ms step_avg:31.33ms
+step:312/1490 train_time:9780ms step_avg:31.34ms
+step:313/1490 train_time:9807ms step_avg:31.33ms
+step:314/1490 train_time:9841ms step_avg:31.34ms
+step:315/1490 train_time:9869ms step_avg:31.33ms
+step:316/1490 train_time:9904ms step_avg:31.34ms
+step:317/1490 train_time:9931ms step_avg:31.33ms
+step:318/1490 train_time:9966ms step_avg:31.34ms
+step:319/1490 train_time:9994ms step_avg:31.33ms
+step:320/1490 train_time:10030ms step_avg:31.34ms
+step:321/1490 train_time:10057ms step_avg:31.33ms
+step:322/1490 train_time:10091ms step_avg:31.34ms
+step:323/1490 train_time:10119ms step_avg:31.33ms
+step:324/1490 train_time:10153ms step_avg:31.34ms
+step:325/1490 train_time:10181ms step_avg:31.33ms
+step:326/1490 train_time:10216ms step_avg:31.34ms
+step:327/1490 train_time:10243ms step_avg:31.32ms
+step:328/1490 train_time:10278ms step_avg:31.34ms
+step:329/1490 train_time:10307ms step_avg:31.33ms
+step:330/1490 train_time:10342ms step_avg:31.34ms
+step:331/1490 train_time:10369ms step_avg:31.33ms
+step:332/1490 train_time:10404ms step_avg:31.34ms
+step:333/1490 train_time:10431ms step_avg:31.32ms
+step:334/1490 train_time:10467ms step_avg:31.34ms
+step:335/1490 train_time:10493ms step_avg:31.32ms
+step:336/1490 train_time:10528ms step_avg:31.33ms
+step:337/1490 train_time:10556ms step_avg:31.32ms
+step:338/1490 train_time:10590ms step_avg:31.33ms
+step:339/1490 train_time:10618ms step_avg:31.32ms
+step:340/1490 train_time:10652ms step_avg:31.33ms
+step:341/1490 train_time:10680ms step_avg:31.32ms
+step:342/1490 train_time:10715ms step_avg:31.33ms
+step:343/1490 train_time:10742ms step_avg:31.32ms
+step:344/1490 train_time:10777ms step_avg:31.33ms
+step:345/1490 train_time:10805ms step_avg:31.32ms
+step:346/1490 train_time:10839ms step_avg:31.33ms
+step:347/1490 train_time:10867ms step_avg:31.32ms
+step:348/1490 train_time:10902ms step_avg:31.33ms
+step:349/1490 train_time:10929ms step_avg:31.32ms
+step:350/1490 train_time:10964ms step_avg:31.32ms
+step:351/1490 train_time:10991ms step_avg:31.31ms
+step:352/1490 train_time:11026ms step_avg:31.32ms
+step:353/1490 train_time:11053ms step_avg:31.31ms
+step:354/1490 train_time:11088ms step_avg:31.32ms
+step:355/1490 train_time:11116ms step_avg:31.31ms
+step:356/1490 train_time:11151ms step_avg:31.32ms
+step:357/1490 train_time:11179ms step_avg:31.31ms
+step:358/1490 train_time:11213ms step_avg:31.32ms
+step:359/1490 train_time:11241ms step_avg:31.31ms
+step:360/1490 train_time:11276ms step_avg:31.32ms
+step:361/1490 train_time:11303ms step_avg:31.31ms
+step:362/1490 train_time:11338ms step_avg:31.32ms
+step:363/1490 train_time:11366ms step_avg:31.31ms
+step:364/1490 train_time:11401ms step_avg:31.32ms
+step:365/1490 train_time:11429ms step_avg:31.31ms
+step:366/1490 train_time:11464ms step_avg:31.32ms
+step:367/1490 train_time:11491ms step_avg:31.31ms
+step:368/1490 train_time:11526ms step_avg:31.32ms
+step:369/1490 train_time:11553ms step_avg:31.31ms
+step:370/1490 train_time:11588ms step_avg:31.32ms
+step:371/1490 train_time:11616ms step_avg:31.31ms
+step:372/1490 train_time:11649ms step_avg:31.32ms
+step:373/1490 train_time:11678ms step_avg:31.31ms
+step:374/1490 train_time:11712ms step_avg:31.31ms
+step:375/1490 train_time:11740ms step_avg:31.31ms
+step:376/1490 train_time:11774ms step_avg:31.31ms
+step:377/1490 train_time:11802ms step_avg:31.30ms
+step:378/1490 train_time:11836ms step_avg:31.31ms
+step:379/1490 train_time:11865ms step_avg:31.31ms
+step:380/1490 train_time:11899ms step_avg:31.31ms
+step:381/1490 train_time:11927ms step_avg:31.30ms
+step:382/1490 train_time:11961ms step_avg:31.31ms
+step:383/1490 train_time:11989ms step_avg:31.30ms
+step:384/1490 train_time:12023ms step_avg:31.31ms
+step:385/1490 train_time:12051ms step_avg:31.30ms
+step:386/1490 train_time:12085ms step_avg:31.31ms
+step:387/1490 train_time:12113ms step_avg:31.30ms
+step:388/1490 train_time:12147ms step_avg:31.31ms
+step:389/1490 train_time:12176ms step_avg:31.30ms
+step:390/1490 train_time:12210ms step_avg:31.31ms
+step:391/1490 train_time:12238ms step_avg:31.30ms
+step:392/1490 train_time:12271ms step_avg:31.30ms
+step:393/1490 train_time:12300ms step_avg:31.30ms
+step:394/1490 train_time:12334ms step_avg:31.30ms
+step:395/1490 train_time:12362ms step_avg:31.30ms
+step:396/1490 train_time:12400ms step_avg:31.31ms
+step:397/1490 train_time:12424ms step_avg:31.30ms
+step:398/1490 train_time:12459ms step_avg:31.30ms
+step:399/1490 train_time:12487ms step_avg:31.30ms
+step:400/1490 train_time:12521ms step_avg:31.30ms
+step:401/1490 train_time:12549ms step_avg:31.29ms
+step:402/1490 train_time:12583ms step_avg:31.30ms
+step:403/1490 train_time:12611ms step_avg:31.29ms
+step:404/1490 train_time:12646ms step_avg:31.30ms
+step:405/1490 train_time:12674ms step_avg:31.29ms
+step:406/1490 train_time:12708ms step_avg:31.30ms
+step:407/1490 train_time:12736ms step_avg:31.29ms
+step:408/1490 train_time:12770ms step_avg:31.30ms
+step:409/1490 train_time:12798ms step_avg:31.29ms
+step:410/1490 train_time:12832ms step_avg:31.30ms
+step:411/1490 train_time:12860ms step_avg:31.29ms
+step:412/1490 train_time:12894ms step_avg:31.30ms
+step:413/1490 train_time:12922ms step_avg:31.29ms
+step:414/1490 train_time:12957ms step_avg:31.30ms
+step:415/1490 train_time:12984ms step_avg:31.29ms
+step:416/1490 train_time:13020ms step_avg:31.30ms
+step:417/1490 train_time:13047ms step_avg:31.29ms
+step:418/1490 train_time:13081ms step_avg:31.29ms
+step:419/1490 train_time:13109ms step_avg:31.29ms
+step:420/1490 train_time:13144ms step_avg:31.29ms
+step:421/1490 train_time:13171ms step_avg:31.29ms
+step:422/1490 train_time:13206ms step_avg:31.29ms
+step:423/1490 train_time:13233ms step_avg:31.28ms
+step:424/1490 train_time:13268ms step_avg:31.29ms
+step:425/1490 train_time:13296ms step_avg:31.28ms
+step:426/1490 train_time:13329ms step_avg:31.29ms
+step:427/1490 train_time:13357ms step_avg:31.28ms
+step:428/1490 train_time:13392ms step_avg:31.29ms
+step:429/1490 train_time:13420ms step_avg:31.28ms
+step:430/1490 train_time:13454ms step_avg:31.29ms
+step:431/1490 train_time:13482ms step_avg:31.28ms
+step:432/1490 train_time:13517ms step_avg:31.29ms
+step:433/1490 train_time:13545ms step_avg:31.28ms
+step:434/1490 train_time:13579ms step_avg:31.29ms
+step:435/1490 train_time:13607ms step_avg:31.28ms
+step:436/1490 train_time:13642ms step_avg:31.29ms
+step:437/1490 train_time:13670ms step_avg:31.28ms
+step:438/1490 train_time:13704ms step_avg:31.29ms
+step:439/1490 train_time:13733ms step_avg:31.28ms
+step:440/1490 train_time:13767ms step_avg:31.29ms
+step:441/1490 train_time:13794ms step_avg:31.28ms
+step:442/1490 train_time:13829ms step_avg:31.29ms
+step:443/1490 train_time:13857ms step_avg:31.28ms
+step:444/1490 train_time:13891ms step_avg:31.28ms
+step:445/1490 train_time:13919ms step_avg:31.28ms
+step:446/1490 train_time:13953ms step_avg:31.29ms
+step:447/1490 train_time:13981ms step_avg:31.28ms
+step:448/1490 train_time:14016ms step_avg:31.29ms
+step:449/1490 train_time:14044ms step_avg:31.28ms
+step:450/1490 train_time:14078ms step_avg:31.28ms
+step:451/1490 train_time:14106ms step_avg:31.28ms
+step:452/1490 train_time:14140ms step_avg:31.28ms
+step:453/1490 train_time:14168ms step_avg:31.28ms
+step:454/1490 train_time:14202ms step_avg:31.28ms
+step:455/1490 train_time:14230ms step_avg:31.27ms
+step:456/1490 train_time:14264ms step_avg:31.28ms
+step:457/1490 train_time:14292ms step_avg:31.27ms
+step:458/1490 train_time:14326ms step_avg:31.28ms
+step:459/1490 train_time:14355ms step_avg:31.27ms
+step:460/1490 train_time:14388ms step_avg:31.28ms
+step:461/1490 train_time:14417ms step_avg:31.27ms
+step:462/1490 train_time:14451ms step_avg:31.28ms
+step:463/1490 train_time:14479ms step_avg:31.27ms
+step:464/1490 train_time:14513ms step_avg:31.28ms
+step:465/1490 train_time:14543ms step_avg:31.28ms
+step:466/1490 train_time:14578ms step_avg:31.28ms
+step:467/1490 train_time:14604ms step_avg:31.27ms
+step:468/1490 train_time:14639ms step_avg:31.28ms
+step:469/1490 train_time:14666ms step_avg:31.27ms
+step:470/1490 train_time:14701ms step_avg:31.28ms
+step:471/1490 train_time:14729ms step_avg:31.27ms
+step:472/1490 train_time:14763ms step_avg:31.28ms
+step:473/1490 train_time:14791ms step_avg:31.27ms
+step:474/1490 train_time:14825ms step_avg:31.28ms
+step:475/1490 train_time:14853ms step_avg:31.27ms
+step:476/1490 train_time:14888ms step_avg:31.28ms
+step:477/1490 train_time:14916ms step_avg:31.27ms
+step:478/1490 train_time:14949ms step_avg:31.27ms
+step:479/1490 train_time:14978ms step_avg:31.27ms
+step:480/1490 train_time:15011ms step_avg:31.27ms
+step:481/1490 train_time:15040ms step_avg:31.27ms
+step:482/1490 train_time:15074ms step_avg:31.27ms
+step:483/1490 train_time:15102ms step_avg:31.27ms
+step:484/1490 train_time:15139ms step_avg:31.28ms
+step:485/1490 train_time:15190ms step_avg:31.32ms
+step:486/1490 train_time:15249ms step_avg:31.38ms
+step:487/1490 train_time:15304ms step_avg:31.42ms
+step:488/1490 train_time:15362ms step_avg:31.48ms
+step:489/1490 train_time:15416ms step_avg:31.53ms
+step:490/1490 train_time:15474ms step_avg:31.58ms
+step:491/1490 train_time:15528ms step_avg:31.63ms
+step:492/1490 train_time:15588ms step_avg:31.68ms
+step:493/1490 train_time:15642ms step_avg:31.73ms
+step:494/1490 train_time:15702ms step_avg:31.79ms
+step:495/1490 train_time:15756ms step_avg:31.83ms
+step:496/1490 train_time:15815ms step_avg:31.89ms
+step:497/1490 train_time:15869ms step_avg:31.93ms
+step:498/1490 train_time:15929ms step_avg:31.99ms
+step:499/1490 train_time:15984ms step_avg:32.03ms
+step:500/1490 train_time:16043ms step_avg:32.09ms
+step:500/1490 val_loss:4.2257 train_time:16114ms step_avg:32.23ms
+step:501/1490 train_time:16140ms step_avg:32.22ms
+step:502/1490 train_time:16161ms step_avg:32.19ms
+step:503/1490 train_time:16218ms step_avg:32.24ms
+step:504/1490 train_time:16280ms step_avg:32.30ms
+step:505/1490 train_time:16334ms step_avg:32.34ms
+step:506/1490 train_time:16394ms step_avg:32.40ms
+step:507/1490 train_time:16447ms step_avg:32.44ms
+step:508/1490 train_time:16506ms step_avg:32.49ms
+step:509/1490 train_time:16560ms step_avg:32.53ms
+step:510/1490 train_time:16618ms step_avg:32.58ms
+step:511/1490 train_time:16671ms step_avg:32.63ms
+step:512/1490 train_time:16730ms step_avg:32.68ms
+step:513/1490 train_time:16783ms step_avg:32.72ms
+step:514/1490 train_time:16841ms step_avg:32.77ms
+step:515/1490 train_time:16895ms step_avg:32.81ms
+step:516/1490 train_time:16954ms step_avg:32.86ms
+step:517/1490 train_time:17006ms step_avg:32.89ms
+step:518/1490 train_time:17066ms step_avg:32.95ms
+step:519/1490 train_time:17121ms step_avg:32.99ms
+step:520/1490 train_time:17182ms step_avg:33.04ms
+step:521/1490 train_time:17237ms step_avg:33.09ms
+step:522/1490 train_time:17297ms step_avg:33.14ms
+step:523/1490 train_time:17352ms step_avg:33.18ms
+step:524/1490 train_time:17411ms step_avg:33.23ms
+step:525/1490 train_time:17465ms step_avg:33.27ms
+step:526/1490 train_time:17524ms step_avg:33.32ms
+step:527/1490 train_time:17577ms step_avg:33.35ms
+step:528/1490 train_time:17636ms step_avg:33.40ms
+step:529/1490 train_time:17689ms step_avg:33.44ms
+step:530/1490 train_time:17748ms step_avg:33.49ms
+step:531/1490 train_time:17801ms step_avg:33.52ms
+step:532/1490 train_time:17860ms step_avg:33.57ms
+step:533/1490 train_time:17914ms step_avg:33.61ms
+step:534/1490 train_time:17973ms step_avg:33.66ms
+step:535/1490 train_time:18027ms step_avg:33.69ms
+step:536/1490 train_time:18086ms step_avg:33.74ms
+step:537/1490 train_time:18141ms step_avg:33.78ms
+step:538/1490 train_time:18201ms step_avg:33.83ms
+step:539/1490 train_time:18256ms step_avg:33.87ms
+step:540/1490 train_time:18316ms step_avg:33.92ms
+step:541/1490 train_time:18371ms step_avg:33.96ms
+step:542/1490 train_time:18430ms step_avg:34.00ms
+step:543/1490 train_time:18483ms step_avg:34.04ms
+step:544/1490 train_time:18544ms step_avg:34.09ms
+step:545/1490 train_time:18597ms step_avg:34.12ms
+step:546/1490 train_time:18656ms step_avg:34.17ms
+step:547/1490 train_time:18709ms step_avg:34.20ms
+step:548/1490 train_time:18767ms step_avg:34.25ms
+step:549/1490 train_time:18822ms step_avg:34.28ms
+step:550/1490 train_time:18880ms step_avg:34.33ms
+step:551/1490 train_time:18933ms step_avg:34.36ms
+step:552/1490 train_time:18992ms step_avg:34.41ms
+step:553/1490 train_time:19046ms step_avg:34.44ms
+step:554/1490 train_time:19106ms step_avg:34.49ms
+step:555/1490 train_time:19160ms step_avg:34.52ms
+step:556/1490 train_time:19220ms step_avg:34.57ms
+step:557/1490 train_time:19274ms step_avg:34.60ms
+step:558/1490 train_time:19334ms step_avg:34.65ms
+step:559/1490 train_time:19387ms step_avg:34.68ms
+step:560/1490 train_time:19447ms step_avg:34.73ms
+step:561/1490 train_time:19501ms step_avg:34.76ms
+step:562/1490 train_time:19560ms step_avg:34.81ms
+step:563/1490 train_time:19614ms step_avg:34.84ms
+step:564/1490 train_time:19673ms step_avg:34.88ms
+step:565/1490 train_time:19727ms step_avg:34.91ms
+step:566/1490 train_time:19786ms step_avg:34.96ms
+step:567/1490 train_time:19839ms step_avg:34.99ms
+step:568/1490 train_time:19899ms step_avg:35.03ms
+step:569/1490 train_time:19952ms step_avg:35.07ms
+step:570/1490 train_time:20011ms step_avg:35.11ms
+step:571/1490 train_time:20065ms step_avg:35.14ms
+step:572/1490 train_time:20125ms step_avg:35.18ms
+step:573/1490 train_time:20178ms step_avg:35.21ms
+step:574/1490 train_time:20238ms step_avg:35.26ms
+step:575/1490 train_time:20292ms step_avg:35.29ms
+step:576/1490 train_time:20351ms step_avg:35.33ms
+step:577/1490 train_time:20404ms step_avg:35.36ms
+step:578/1490 train_time:20463ms step_avg:35.40ms
+step:579/1490 train_time:20518ms step_avg:35.44ms
+step:580/1490 train_time:20577ms step_avg:35.48ms
+step:581/1490 train_time:20631ms step_avg:35.51ms
+step:582/1490 train_time:20690ms step_avg:35.55ms
+step:583/1490 train_time:20743ms step_avg:35.58ms
+step:584/1490 train_time:20802ms step_avg:35.62ms
+step:585/1490 train_time:20857ms step_avg:35.65ms
+step:586/1490 train_time:20916ms step_avg:35.69ms
+step:587/1490 train_time:20970ms step_avg:35.72ms
+step:588/1490 train_time:21029ms step_avg:35.76ms
+step:589/1490 train_time:21083ms step_avg:35.79ms
+step:590/1490 train_time:21142ms step_avg:35.83ms
+step:591/1490 train_time:21196ms step_avg:35.86ms
+step:592/1490 train_time:21255ms step_avg:35.90ms
+step:593/1490 train_time:21309ms step_avg:35.93ms
+step:594/1490 train_time:21368ms step_avg:35.97ms
+step:595/1490 train_time:21423ms step_avg:36.00ms
+step:596/1490 train_time:21482ms step_avg:36.04ms
+step:597/1490 train_time:21536ms step_avg:36.07ms
+step:598/1490 train_time:21596ms step_avg:36.11ms
+step:599/1490 train_time:21649ms step_avg:36.14ms
+step:600/1490 train_time:21708ms step_avg:36.18ms
+step:601/1490 train_time:21763ms step_avg:36.21ms
+step:602/1490 train_time:21822ms step_avg:36.25ms
+step:603/1490 train_time:21875ms step_avg:36.28ms
+step:604/1490 train_time:21935ms step_avg:36.32ms
+step:605/1490 train_time:21988ms step_avg:36.34ms
+step:606/1490 train_time:22047ms step_avg:36.38ms
+step:607/1490 train_time:22101ms step_avg:36.41ms
+step:608/1490 train_time:22160ms step_avg:36.45ms
+step:609/1490 train_time:22214ms step_avg:36.48ms
+step:610/1490 train_time:22273ms step_avg:36.51ms
+step:611/1490 train_time:22327ms step_avg:36.54ms
+step:612/1490 train_time:22387ms step_avg:36.58ms
+step:613/1490 train_time:22440ms step_avg:36.61ms
+step:614/1490 train_time:22500ms step_avg:36.65ms
+step:615/1490 train_time:22554ms step_avg:36.67ms
+step:616/1490 train_time:22614ms step_avg:36.71ms
+step:617/1490 train_time:22667ms step_avg:36.74ms
+step:618/1490 train_time:22727ms step_avg:36.77ms
+step:619/1490 train_time:22780ms step_avg:36.80ms
+step:620/1490 train_time:22840ms step_avg:36.84ms
+step:621/1490 train_time:22894ms step_avg:36.87ms
+step:622/1490 train_time:22953ms step_avg:36.90ms
+step:623/1490 train_time:23006ms step_avg:36.93ms
+step:624/1490 train_time:23065ms step_avg:36.96ms
+step:625/1490 train_time:23120ms step_avg:36.99ms
+step:626/1490 train_time:23179ms step_avg:37.03ms
+step:627/1490 train_time:23233ms step_avg:37.05ms
+step:628/1490 train_time:23292ms step_avg:37.09ms
+step:629/1490 train_time:23345ms step_avg:37.12ms
+step:630/1490 train_time:23405ms step_avg:37.15ms
+step:631/1490 train_time:23459ms step_avg:37.18ms
+step:632/1490 train_time:23519ms step_avg:37.21ms
+step:633/1490 train_time:23573ms step_avg:37.24ms
+step:634/1490 train_time:23632ms step_avg:37.27ms
+step:635/1490 train_time:23685ms step_avg:37.30ms
+step:636/1490 train_time:23744ms step_avg:37.33ms
+step:637/1490 train_time:23798ms step_avg:37.36ms
+step:638/1490 train_time:23858ms step_avg:37.39ms
+step:639/1490 train_time:23911ms step_avg:37.42ms
+step:640/1490 train_time:23970ms step_avg:37.45ms
+step:641/1490 train_time:24024ms step_avg:37.48ms
+step:642/1490 train_time:24083ms step_avg:37.51ms
+step:643/1490 train_time:24136ms step_avg:37.54ms
+step:644/1490 train_time:24196ms step_avg:37.57ms
+step:645/1490 train_time:24249ms step_avg:37.60ms
+step:646/1490 train_time:24308ms step_avg:37.63ms
+step:647/1490 train_time:24362ms step_avg:37.65ms
+step:648/1490 train_time:24422ms step_avg:37.69ms
+step:649/1490 train_time:24475ms step_avg:37.71ms
+step:650/1490 train_time:24535ms step_avg:37.75ms
+step:651/1490 train_time:24588ms step_avg:37.77ms
+step:652/1490 train_time:24648ms step_avg:37.80ms
+step:653/1490 train_time:24702ms step_avg:37.83ms
+step:654/1490 train_time:24761ms step_avg:37.86ms
+step:655/1490 train_time:24814ms step_avg:37.88ms
+step:656/1490 train_time:24873ms step_avg:37.92ms
+step:657/1490 train_time:24927ms step_avg:37.94ms
+step:658/1490 train_time:24985ms step_avg:37.97ms
+step:659/1490 train_time:25040ms step_avg:38.00ms
+step:660/1490 train_time:25099ms step_avg:38.03ms
+step:661/1490 train_time:25153ms step_avg:38.05ms
+step:662/1490 train_time:25212ms step_avg:38.09ms
+step:663/1490 train_time:25266ms step_avg:38.11ms
+step:664/1490 train_time:25325ms step_avg:38.14ms
+step:665/1490 train_time:25378ms step_avg:38.16ms
+step:666/1490 train_time:25438ms step_avg:38.20ms
+step:667/1490 train_time:25492ms step_avg:38.22ms
+step:668/1490 train_time:25551ms step_avg:38.25ms
+step:669/1490 train_time:25604ms step_avg:38.27ms
+step:670/1490 train_time:25664ms step_avg:38.30ms
+step:671/1490 train_time:25718ms step_avg:38.33ms
+step:672/1490 train_time:25777ms step_avg:38.36ms
+step:673/1490 train_time:25831ms step_avg:38.38ms
+step:674/1490 train_time:25890ms step_avg:38.41ms
+step:675/1490 train_time:25944ms step_avg:38.44ms
+step:676/1490 train_time:26004ms step_avg:38.47ms
+step:677/1490 train_time:26057ms step_avg:38.49ms
+step:678/1490 train_time:26117ms step_avg:38.52ms
+step:679/1490 train_time:26170ms step_avg:38.54ms
+step:680/1490 train_time:26230ms step_avg:38.57ms
+step:681/1490 train_time:26283ms step_avg:38.60ms
+step:682/1490 train_time:26343ms step_avg:38.63ms
+step:683/1490 train_time:26396ms step_avg:38.65ms
+step:684/1490 train_time:26456ms step_avg:38.68ms
+step:685/1490 train_time:26511ms step_avg:38.70ms
+step:686/1490 train_time:26570ms step_avg:38.73ms
+step:687/1490 train_time:26623ms step_avg:38.75ms
+step:688/1490 train_time:26683ms step_avg:38.78ms
+step:689/1490 train_time:26737ms step_avg:38.81ms
+step:690/1490 train_time:26797ms step_avg:38.84ms
+step:691/1490 train_time:26852ms step_avg:38.86ms
+step:692/1490 train_time:26910ms step_avg:38.89ms
+step:693/1490 train_time:26963ms step_avg:38.91ms
+step:694/1490 train_time:27025ms step_avg:38.94ms
+step:695/1490 train_time:27076ms step_avg:38.96ms
+step:696/1490 train_time:27136ms step_avg:38.99ms
+step:697/1490 train_time:27189ms step_avg:39.01ms
+step:698/1490 train_time:27248ms step_avg:39.04ms
+step:699/1490 train_time:27302ms step_avg:39.06ms
+step:700/1490 train_time:27362ms step_avg:39.09ms
+step:701/1490 train_time:27416ms step_avg:39.11ms
+step:702/1490 train_time:27476ms step_avg:39.14ms
+step:703/1490 train_time:27529ms step_avg:39.16ms
+step:704/1490 train_time:27588ms step_avg:39.19ms
+step:705/1490 train_time:27643ms step_avg:39.21ms
+step:706/1490 train_time:27702ms step_avg:39.24ms
+step:707/1490 train_time:27756ms step_avg:39.26ms
+step:708/1490 train_time:27815ms step_avg:39.29ms
+step:709/1490 train_time:27868ms step_avg:39.31ms
+step:710/1490 train_time:27928ms step_avg:39.34ms
+step:711/1490 train_time:27981ms step_avg:39.35ms
+step:712/1490 train_time:28042ms step_avg:39.38ms
+step:713/1490 train_time:28095ms step_avg:39.40ms
+step:714/1490 train_time:28155ms step_avg:39.43ms
+step:715/1490 train_time:28209ms step_avg:39.45ms
+step:716/1490 train_time:28268ms step_avg:39.48ms
+step:717/1490 train_time:28322ms step_avg:39.50ms
+step:718/1490 train_time:28381ms step_avg:39.53ms
+step:719/1490 train_time:28434ms step_avg:39.55ms
+step:720/1490 train_time:28494ms step_avg:39.58ms
+step:721/1490 train_time:28547ms step_avg:39.59ms
+step:722/1490 train_time:28606ms step_avg:39.62ms
+step:723/1490 train_time:28661ms step_avg:39.64ms
+step:724/1490 train_time:28720ms step_avg:39.67ms
+step:725/1490 train_time:28774ms step_avg:39.69ms
+step:726/1490 train_time:28833ms step_avg:39.72ms
+step:727/1490 train_time:28886ms step_avg:39.73ms
+step:728/1490 train_time:28945ms step_avg:39.76ms
+step:729/1490 train_time:29000ms step_avg:39.78ms
+step:730/1490 train_time:29059ms step_avg:39.81ms
+step:731/1490 train_time:29113ms step_avg:39.83ms
+step:732/1490 train_time:29172ms step_avg:39.85ms
+step:733/1490 train_time:29226ms step_avg:39.87ms
+step:734/1490 train_time:29286ms step_avg:39.90ms
+step:735/1490 train_time:29340ms step_avg:39.92ms
+step:736/1490 train_time:29398ms step_avg:39.94ms
+step:737/1490 train_time:29453ms step_avg:39.96ms
+step:738/1490 train_time:29512ms step_avg:39.99ms
+step:739/1490 train_time:29565ms step_avg:40.01ms
+step:740/1490 train_time:29625ms step_avg:40.03ms
+step:741/1490 train_time:29678ms step_avg:40.05ms
+step:742/1490 train_time:29737ms step_avg:40.08ms
+step:743/1490 train_time:29792ms step_avg:40.10ms
+step:744/1490 train_time:29852ms step_avg:40.12ms
+step:745/1490 train_time:29904ms step_avg:40.14ms
+step:746/1490 train_time:29964ms step_avg:40.17ms
+step:747/1490 train_time:30017ms step_avg:40.18ms
+step:748/1490 train_time:30077ms step_avg:40.21ms
+step:749/1490 train_time:30131ms step_avg:40.23ms
+step:750/1490 train_time:30189ms step_avg:40.25ms
+step:750/1490 val_loss:3.8120 train_time:30261ms step_avg:40.35ms
+step:751/1490 train_time:30284ms step_avg:40.33ms
+step:752/1490 train_time:30305ms step_avg:40.30ms
+step:753/1490 train_time:30361ms step_avg:40.32ms
+step:754/1490 train_time:30424ms step_avg:40.35ms
+step:755/1490 train_time:30481ms step_avg:40.37ms
+step:756/1490 train_time:30541ms step_avg:40.40ms
+step:757/1490 train_time:30595ms step_avg:40.42ms
+step:758/1490 train_time:30656ms step_avg:40.44ms
+step:759/1490 train_time:30710ms step_avg:40.46ms
+step:760/1490 train_time:30768ms step_avg:40.48ms
+step:761/1490 train_time:30821ms step_avg:40.50ms
+step:762/1490 train_time:30880ms step_avg:40.52ms
+step:763/1490 train_time:30933ms step_avg:40.54ms
+step:764/1490 train_time:30991ms step_avg:40.56ms
+step:765/1490 train_time:31044ms step_avg:40.58ms
+step:766/1490 train_time:31102ms step_avg:40.60ms
+step:767/1490 train_time:31156ms step_avg:40.62ms
+step:768/1490 train_time:31215ms step_avg:40.64ms
+step:769/1490 train_time:31270ms step_avg:40.66ms
+step:770/1490 train_time:31331ms step_avg:40.69ms
+step:771/1490 train_time:31387ms step_avg:40.71ms
+step:772/1490 train_time:31447ms step_avg:40.73ms
+step:773/1490 train_time:31502ms step_avg:40.75ms
+step:774/1490 train_time:31562ms step_avg:40.78ms
+step:775/1490 train_time:31617ms step_avg:40.80ms
+step:776/1490 train_time:31677ms step_avg:40.82ms
+step:777/1490 train_time:31730ms step_avg:40.84ms
+step:778/1490 train_time:31788ms step_avg:40.86ms
+step:779/1490 train_time:31841ms step_avg:40.87ms
+step:780/1490 train_time:31900ms step_avg:40.90ms
+step:781/1490 train_time:31953ms step_avg:40.91ms
+step:782/1490 train_time:32013ms step_avg:40.94ms
+step:783/1490 train_time:32065ms step_avg:40.95ms
+step:784/1490 train_time:32124ms step_avg:40.97ms
+step:785/1490 train_time:32177ms step_avg:40.99ms
+step:786/1490 train_time:32237ms step_avg:41.01ms
+step:787/1490 train_time:32292ms step_avg:41.03ms
+step:788/1490 train_time:32352ms step_avg:41.06ms
+step:789/1490 train_time:32406ms step_avg:41.07ms
+step:790/1490 train_time:32467ms step_avg:41.10ms
+step:791/1490 train_time:32521ms step_avg:41.11ms
+step:792/1490 train_time:32581ms step_avg:41.14ms
+step:793/1490 train_time:32635ms step_avg:41.15ms
+step:794/1490 train_time:32694ms step_avg:41.18ms
+step:795/1490 train_time:32748ms step_avg:41.19ms
+step:796/1490 train_time:32806ms step_avg:41.21ms
+step:797/1490 train_time:32860ms step_avg:41.23ms
+step:798/1490 train_time:32919ms step_avg:41.25ms
+step:799/1490 train_time:32972ms step_avg:41.27ms
+step:800/1490 train_time:33031ms step_avg:41.29ms
+step:801/1490 train_time:33084ms step_avg:41.30ms
+step:802/1490 train_time:33143ms step_avg:41.33ms
+step:803/1490 train_time:33196ms step_avg:41.34ms
+step:804/1490 train_time:33256ms step_avg:41.36ms
+step:805/1490 train_time:33310ms step_avg:41.38ms
+step:806/1490 train_time:33370ms step_avg:41.40ms
+step:807/1490 train_time:33423ms step_avg:41.42ms
+step:808/1490 train_time:33484ms step_avg:41.44ms
+step:809/1490 train_time:33539ms step_avg:41.46ms
+step:810/1490 train_time:33599ms step_avg:41.48ms
+step:811/1490 train_time:33653ms step_avg:41.50ms
+step:812/1490 train_time:33712ms step_avg:41.52ms
+step:813/1490 train_time:33765ms step_avg:41.53ms
+step:814/1490 train_time:33825ms step_avg:41.55ms
+step:815/1490 train_time:33878ms step_avg:41.57ms
+step:816/1490 train_time:33937ms step_avg:41.59ms
+step:817/1490 train_time:33990ms step_avg:41.60ms
+step:818/1490 train_time:34049ms step_avg:41.62ms
+step:819/1490 train_time:34102ms step_avg:41.64ms
+step:820/1490 train_time:34161ms step_avg:41.66ms
+step:821/1490 train_time:34214ms step_avg:41.67ms
+step:822/1490 train_time:34274ms step_avg:41.70ms
+step:823/1490 train_time:34329ms step_avg:41.71ms
+step:824/1490 train_time:34389ms step_avg:41.73ms
+step:825/1490 train_time:34443ms step_avg:41.75ms
+step:826/1490 train_time:34502ms step_avg:41.77ms
+step:827/1490 train_time:34556ms step_avg:41.78ms
+step:828/1490 train_time:34615ms step_avg:41.81ms
+step:829/1490 train_time:34670ms step_avg:41.82ms
+step:830/1490 train_time:34728ms step_avg:41.84ms
+step:831/1490 train_time:34782ms step_avg:41.86ms
+step:832/1490 train_time:34841ms step_avg:41.88ms
+step:833/1490 train_time:34894ms step_avg:41.89ms
+step:834/1490 train_time:34953ms step_avg:41.91ms
+step:835/1490 train_time:35007ms step_avg:41.92ms
+step:836/1490 train_time:35065ms step_avg:41.94ms
+step:837/1490 train_time:35119ms step_avg:41.96ms
+step:838/1490 train_time:35179ms step_avg:41.98ms
+step:839/1490 train_time:35233ms step_avg:41.99ms
+step:840/1490 train_time:35291ms step_avg:42.01ms
+step:841/1490 train_time:35345ms step_avg:42.03ms
+step:842/1490 train_time:35405ms step_avg:42.05ms
+step:843/1490 train_time:35460ms step_avg:42.06ms
+step:844/1490 train_time:35519ms step_avg:42.08ms
+step:845/1490 train_time:35573ms step_avg:42.10ms
+step:846/1490 train_time:35632ms step_avg:42.12ms
+step:847/1490 train_time:35687ms step_avg:42.13ms
+step:848/1490 train_time:35746ms step_avg:42.15ms
+step:849/1490 train_time:35800ms step_avg:42.17ms
+step:850/1490 train_time:35859ms step_avg:42.19ms
+step:851/1490 train_time:35912ms step_avg:42.20ms
+step:852/1490 train_time:35971ms step_avg:42.22ms
+step:853/1490 train_time:36024ms step_avg:42.23ms
+step:854/1490 train_time:36084ms step_avg:42.25ms
+step:855/1490 train_time:36137ms step_avg:42.27ms
+step:856/1490 train_time:36197ms step_avg:42.29ms
+step:857/1490 train_time:36251ms step_avg:42.30ms
+step:858/1490 train_time:36311ms step_avg:42.32ms
+step:859/1490 train_time:36364ms step_avg:42.33ms
+step:860/1490 train_time:36424ms step_avg:42.35ms
+step:861/1490 train_time:36477ms step_avg:42.37ms
+step:862/1490 train_time:36537ms step_avg:42.39ms
+step:863/1490 train_time:36590ms step_avg:42.40ms
+step:864/1490 train_time:36650ms step_avg:42.42ms
+step:865/1490 train_time:36703ms step_avg:42.43ms
+step:866/1490 train_time:36763ms step_avg:42.45ms
+step:867/1490 train_time:36817ms step_avg:42.47ms
+step:868/1490 train_time:36877ms step_avg:42.48ms
+step:869/1490 train_time:36931ms step_avg:42.50ms
+step:870/1490 train_time:36990ms step_avg:42.52ms
+step:871/1490 train_time:37043ms step_avg:42.53ms
+step:872/1490 train_time:37102ms step_avg:42.55ms
+step:873/1490 train_time:37156ms step_avg:42.56ms
+step:874/1490 train_time:37216ms step_avg:42.58ms
+step:875/1490 train_time:37269ms step_avg:42.59ms
+step:876/1490 train_time:37327ms step_avg:42.61ms
+step:877/1490 train_time:37382ms step_avg:42.62ms
+step:878/1490 train_time:37441ms step_avg:42.64ms
+step:879/1490 train_time:37494ms step_avg:42.66ms
+step:880/1490 train_time:37554ms step_avg:42.68ms
+step:881/1490 train_time:37609ms step_avg:42.69ms
+step:882/1490 train_time:37668ms step_avg:42.71ms
+step:883/1490 train_time:37721ms step_avg:42.72ms
+step:884/1490 train_time:37780ms step_avg:42.74ms
+step:885/1490 train_time:37834ms step_avg:42.75ms
+step:886/1490 train_time:37892ms step_avg:42.77ms
+step:887/1490 train_time:37947ms step_avg:42.78ms
+step:888/1490 train_time:38005ms step_avg:42.80ms
+step:889/1490 train_time:38060ms step_avg:42.81ms
+step:890/1490 train_time:38118ms step_avg:42.83ms
+step:891/1490 train_time:38172ms step_avg:42.84ms
+step:892/1490 train_time:38231ms step_avg:42.86ms
+step:893/1490 train_time:38284ms step_avg:42.87ms
+step:894/1490 train_time:38344ms step_avg:42.89ms
+step:895/1490 train_time:38397ms step_avg:42.90ms
+step:896/1490 train_time:38457ms step_avg:42.92ms
+step:897/1490 train_time:38512ms step_avg:42.93ms
+step:898/1490 train_time:38569ms step_avg:42.95ms
+step:899/1490 train_time:38623ms step_avg:42.96ms
+step:900/1490 train_time:38682ms step_avg:42.98ms
+step:901/1490 train_time:38736ms step_avg:42.99ms
+step:902/1490 train_time:38796ms step_avg:43.01ms
+step:903/1490 train_time:38850ms step_avg:43.02ms
+step:904/1490 train_time:38910ms step_avg:43.04ms
+step:905/1490 train_time:38964ms step_avg:43.05ms
+step:906/1490 train_time:39023ms step_avg:43.07ms
+step:907/1490 train_time:39076ms step_avg:43.08ms
+step:908/1490 train_time:39137ms step_avg:43.10ms
+step:909/1490 train_time:39190ms step_avg:43.11ms
+step:910/1490 train_time:39250ms step_avg:43.13ms
+step:911/1490 train_time:39302ms step_avg:43.14ms
+step:912/1490 train_time:39362ms step_avg:43.16ms
+step:913/1490 train_time:39416ms step_avg:43.17ms
+step:914/1490 train_time:39475ms step_avg:43.19ms
+step:915/1490 train_time:39529ms step_avg:43.20ms
+step:916/1490 train_time:39588ms step_avg:43.22ms
+step:917/1490 train_time:39642ms step_avg:43.23ms
+step:918/1490 train_time:39701ms step_avg:43.25ms
+step:919/1490 train_time:39755ms step_avg:43.26ms
+step:920/1490 train_time:39814ms step_avg:43.28ms
+step:921/1490 train_time:39867ms step_avg:43.29ms
+step:922/1490 train_time:39927ms step_avg:43.30ms
+step:923/1490 train_time:39980ms step_avg:43.32ms
+step:924/1490 train_time:40040ms step_avg:43.33ms
+step:925/1490 train_time:40093ms step_avg:43.34ms
+step:926/1490 train_time:40152ms step_avg:43.36ms
+step:927/1490 train_time:40206ms step_avg:43.37ms
+step:928/1490 train_time:40265ms step_avg:43.39ms
+step:929/1490 train_time:40318ms step_avg:43.40ms
+step:930/1490 train_time:40378ms step_avg:43.42ms
+step:931/1490 train_time:40433ms step_avg:43.43ms
+step:932/1490 train_time:40492ms step_avg:43.45ms
+step:933/1490 train_time:40546ms step_avg:43.46ms
+step:934/1490 train_time:40605ms step_avg:43.47ms
+step:935/1490 train_time:40659ms step_avg:43.49ms
+step:936/1490 train_time:40718ms step_avg:43.50ms
+step:937/1490 train_time:40771ms step_avg:43.51ms
+step:938/1490 train_time:40831ms step_avg:43.53ms
+step:939/1490 train_time:40884ms step_avg:43.54ms
+step:940/1490 train_time:40944ms step_avg:43.56ms
+step:941/1490 train_time:40998ms step_avg:43.57ms
+step:942/1490 train_time:41057ms step_avg:43.58ms
+step:943/1490 train_time:41110ms step_avg:43.60ms
+step:944/1490 train_time:41170ms step_avg:43.61ms
+step:945/1490 train_time:41223ms step_avg:43.62ms
+step:946/1490 train_time:41281ms step_avg:43.64ms
+step:947/1490 train_time:41335ms step_avg:43.65ms
+step:948/1490 train_time:41394ms step_avg:43.66ms
+step:949/1490 train_time:41448ms step_avg:43.68ms
+step:950/1490 train_time:41507ms step_avg:43.69ms
+step:951/1490 train_time:41561ms step_avg:43.70ms
+step:952/1490 train_time:41620ms step_avg:43.72ms
+step:953/1490 train_time:41675ms step_avg:43.73ms
+step:954/1490 train_time:41734ms step_avg:43.75ms
+step:955/1490 train_time:41788ms step_avg:43.76ms
+step:956/1490 train_time:41847ms step_avg:43.77ms
+step:957/1490 train_time:41901ms step_avg:43.78ms
+step:958/1490 train_time:41960ms step_avg:43.80ms
+step:959/1490 train_time:42015ms step_avg:43.81ms
+step:960/1490 train_time:42075ms step_avg:43.83ms
+step:961/1490 train_time:42128ms step_avg:43.84ms
+step:962/1490 train_time:42188ms step_avg:43.85ms
+step:963/1490 train_time:42242ms step_avg:43.86ms
+step:964/1490 train_time:42301ms step_avg:43.88ms
+step:965/1490 train_time:42355ms step_avg:43.89ms
+step:966/1490 train_time:42414ms step_avg:43.91ms
+step:967/1490 train_time:42469ms step_avg:43.92ms
+step:968/1490 train_time:42532ms step_avg:43.94ms
+step:969/1490 train_time:42609ms step_avg:43.97ms
+step:970/1490 train_time:42696ms step_avg:44.02ms
+step:971/1490 train_time:42776ms step_avg:44.05ms
+step:972/1490 train_time:42860ms step_avg:44.09ms
+step:973/1490 train_time:42939ms step_avg:44.13ms
+step:974/1490 train_time:43024ms step_avg:44.17ms
+step:975/1490 train_time:43104ms step_avg:44.21ms
+step:976/1490 train_time:43189ms step_avg:44.25ms
+step:977/1490 train_time:43268ms step_avg:44.29ms
+step:978/1490 train_time:43353ms step_avg:44.33ms
+step:979/1490 train_time:43433ms step_avg:44.37ms
+step:980/1490 train_time:43517ms step_avg:44.40ms
+step:981/1490 train_time:43597ms step_avg:44.44ms
+step:982/1490 train_time:43682ms step_avg:44.48ms
+step:983/1490 train_time:43762ms step_avg:44.52ms
+step:984/1490 train_time:43850ms step_avg:44.56ms
+step:985/1490 train_time:43926ms step_avg:44.59ms
+step:986/1490 train_time:44011ms step_avg:44.64ms
+step:987/1490 train_time:44091ms step_avg:44.67ms
+step:988/1490 train_time:44176ms step_avg:44.71ms
+step:989/1490 train_time:44255ms step_avg:44.75ms
+step:990/1490 train_time:44340ms step_avg:44.79ms
+step:991/1490 train_time:44420ms step_avg:44.82ms
+step:992/1490 train_time:44507ms step_avg:44.87ms
+step:993/1490 train_time:44584ms step_avg:44.90ms
+step:994/1490 train_time:44669ms step_avg:44.94ms
+step:995/1490 train_time:44750ms step_avg:44.97ms
+step:996/1490 train_time:44834ms step_avg:45.01ms
+step:997/1490 train_time:44914ms step_avg:45.05ms
+step:998/1490 train_time:44998ms step_avg:45.09ms
+step:999/1490 train_time:45077ms step_avg:45.12ms
+step:1000/1490 train_time:45162ms step_avg:45.16ms
+step:1000/1490 val_loss:3.5165 train_time:45264ms step_avg:45.26ms
+step:1001/1490 train_time:45284ms step_avg:45.24ms
+step:1002/1490 train_time:45329ms step_avg:45.24ms
+step:1003/1490 train_time:45411ms step_avg:45.28ms
+step:1004/1490 train_time:45500ms step_avg:45.32ms
+step:1005/1490 train_time:45580ms step_avg:45.35ms
+step:1006/1490 train_time:45664ms step_avg:45.39ms
+step:1007/1490 train_time:45743ms step_avg:45.42ms
+step:1008/1490 train_time:45826ms step_avg:45.46ms
+step:1009/1490 train_time:45905ms step_avg:45.50ms
+step:1010/1490 train_time:45988ms step_avg:45.53ms
+step:1011/1490 train_time:46068ms step_avg:45.57ms
+step:1012/1490 train_time:46151ms step_avg:45.60ms
+step:1013/1490 train_time:46231ms step_avg:45.64ms
+step:1014/1490 train_time:46319ms step_avg:45.68ms
+step:1015/1490 train_time:46405ms step_avg:45.72ms
+step:1016/1490 train_time:46491ms step_avg:45.76ms
+step:1017/1490 train_time:46572ms step_avg:45.79ms
+step:1018/1490 train_time:46657ms step_avg:45.83ms
+step:1019/1490 train_time:46735ms step_avg:45.86ms
+step:1020/1490 train_time:46821ms step_avg:45.90ms
+step:1021/1490 train_time:46898ms step_avg:45.93ms
+step:1022/1490 train_time:46982ms step_avg:45.97ms
+step:1023/1490 train_time:47061ms step_avg:46.00ms
+step:1024/1490 train_time:47144ms step_avg:46.04ms
+step:1025/1490 train_time:47224ms step_avg:46.07ms
+step:1026/1490 train_time:47310ms step_avg:46.11ms
+step:1027/1490 train_time:47390ms step_avg:46.14ms
+step:1028/1490 train_time:47477ms step_avg:46.18ms
+step:1029/1490 train_time:47558ms step_avg:46.22ms
+step:1030/1490 train_time:47641ms step_avg:46.25ms
+step:1031/1490 train_time:47720ms step_avg:46.29ms
+step:1032/1490 train_time:47805ms step_avg:46.32ms
+step:1033/1490 train_time:47883ms step_avg:46.35ms
+step:1034/1490 train_time:47967ms step_avg:46.39ms
+step:1035/1490 train_time:48045ms step_avg:46.42ms
+step:1036/1490 train_time:48130ms step_avg:46.46ms
+step:1037/1490 train_time:48210ms step_avg:46.49ms
+step:1038/1490 train_time:48295ms step_avg:46.53ms
+step:1039/1490 train_time:48376ms step_avg:46.56ms
+step:1040/1490 train_time:48462ms step_avg:46.60ms
+step:1041/1490 train_time:48542ms step_avg:46.63ms
+step:1042/1490 train_time:48627ms step_avg:46.67ms
+step:1043/1490 train_time:48707ms step_avg:46.70ms
+step:1044/1490 train_time:48792ms step_avg:46.74ms
+step:1045/1490 train_time:48870ms step_avg:46.77ms
+step:1046/1490 train_time:48954ms step_avg:46.80ms
+step:1047/1490 train_time:49034ms step_avg:46.83ms
+step:1048/1490 train_time:49119ms step_avg:46.87ms
+step:1049/1490 train_time:49199ms step_avg:46.90ms
+step:1050/1490 train_time:49284ms step_avg:46.94ms
+step:1051/1490 train_time:49365ms step_avg:46.97ms
+step:1052/1490 train_time:49450ms step_avg:47.01ms
+step:1053/1490 train_time:49530ms step_avg:47.04ms
+step:1054/1490 train_time:49615ms step_avg:47.07ms
+step:1055/1490 train_time:49696ms step_avg:47.10ms
+step:1056/1490 train_time:49779ms step_avg:47.14ms
+step:1057/1490 train_time:49859ms step_avg:47.17ms
+step:1058/1490 train_time:49943ms step_avg:47.21ms
+step:1059/1490 train_time:50021ms step_avg:47.23ms
+step:1060/1490 train_time:50107ms step_avg:47.27ms
+step:1061/1490 train_time:50186ms step_avg:47.30ms
+step:1062/1490 train_time:50272ms step_avg:47.34ms
+step:1063/1490 train_time:50352ms step_avg:47.37ms
+step:1064/1490 train_time:50437ms step_avg:47.40ms
+step:1065/1490 train_time:50517ms step_avg:47.43ms
+step:1066/1490 train_time:50603ms step_avg:47.47ms
+step:1067/1490 train_time:50684ms step_avg:47.50ms
+step:1068/1490 train_time:50769ms step_avg:47.54ms
+step:1069/1490 train_time:50847ms step_avg:47.56ms
+step:1070/1490 train_time:50931ms step_avg:47.60ms
+step:1071/1490 train_time:51011ms step_avg:47.63ms
+step:1072/1490 train_time:51094ms step_avg:47.66ms
+step:1073/1490 train_time:51174ms step_avg:47.69ms
+step:1074/1490 train_time:51260ms step_avg:47.73ms
+step:1075/1490 train_time:51340ms step_avg:47.76ms
+step:1076/1490 train_time:51425ms step_avg:47.79ms
+step:1077/1490 train_time:51505ms step_avg:47.82ms
+step:1078/1490 train_time:51590ms step_avg:47.86ms
+step:1079/1490 train_time:51669ms step_avg:47.89ms
+step:1080/1490 train_time:51753ms step_avg:47.92ms
+step:1081/1490 train_time:51832ms step_avg:47.95ms
+step:1082/1490 train_time:51917ms step_avg:47.98ms
+step:1083/1490 train_time:51997ms step_avg:48.01ms
+step:1084/1490 train_time:52082ms step_avg:48.05ms
+step:1085/1490 train_time:52160ms step_avg:48.07ms
+step:1086/1490 train_time:52244ms step_avg:48.11ms
+step:1087/1490 train_time:52324ms step_avg:48.14ms
+step:1088/1490 train_time:52410ms step_avg:48.17ms
+step:1089/1490 train_time:52489ms step_avg:48.20ms
+step:1090/1490 train_time:52575ms step_avg:48.23ms
+step:1091/1490 train_time:52656ms step_avg:48.26ms
+step:1092/1490 train_time:52741ms step_avg:48.30ms
+step:1093/1490 train_time:52820ms step_avg:48.33ms
+step:1094/1490 train_time:52906ms step_avg:48.36ms
+step:1095/1490 train_time:52985ms step_avg:48.39ms
+step:1096/1490 train_time:53070ms step_avg:48.42ms
+step:1097/1490 train_time:53148ms step_avg:48.45ms
+step:1098/1490 train_time:53232ms step_avg:48.48ms
+step:1099/1490 train_time:53312ms step_avg:48.51ms
+step:1100/1490 train_time:53398ms step_avg:48.54ms
+step:1101/1490 train_time:53477ms step_avg:48.57ms
+step:1102/1490 train_time:53563ms step_avg:48.61ms
+step:1103/1490 train_time:53642ms step_avg:48.63ms
+step:1104/1490 train_time:53727ms step_avg:48.67ms
+step:1105/1490 train_time:53806ms step_avg:48.69ms
+step:1106/1490 train_time:53890ms step_avg:48.73ms
+step:1107/1490 train_time:53970ms step_avg:48.75ms
+step:1108/1490 train_time:54055ms step_avg:48.79ms
+step:1109/1490 train_time:54136ms step_avg:48.81ms
+step:1110/1490 train_time:54219ms step_avg:48.85ms
+step:1111/1490 train_time:54299ms step_avg:48.87ms
+step:1112/1490 train_time:54383ms step_avg:48.91ms
+step:1113/1490 train_time:54463ms step_avg:48.93ms
+step:1114/1490 train_time:54548ms step_avg:48.97ms
+step:1115/1490 train_time:54628ms step_avg:48.99ms
+step:1116/1490 train_time:54712ms step_avg:49.02ms
+step:1117/1490 train_time:54792ms step_avg:49.05ms
+step:1118/1490 train_time:54878ms step_avg:49.09ms
+step:1119/1490 train_time:54958ms step_avg:49.11ms
+step:1120/1490 train_time:55042ms step_avg:49.14ms
+step:1121/1490 train_time:55120ms step_avg:49.17ms
+step:1122/1490 train_time:55204ms step_avg:49.20ms
+step:1123/1490 train_time:55284ms step_avg:49.23ms
+step:1124/1490 train_time:55370ms step_avg:49.26ms
+step:1125/1490 train_time:55448ms step_avg:49.29ms
+step:1126/1490 train_time:55534ms step_avg:49.32ms
+step:1127/1490 train_time:55614ms step_avg:49.35ms
+step:1128/1490 train_time:55699ms step_avg:49.38ms
+step:1129/1490 train_time:55777ms step_avg:49.40ms
+step:1130/1490 train_time:55863ms step_avg:49.44ms
+step:1131/1490 train_time:55943ms step_avg:49.46ms
+step:1132/1490 train_time:56027ms step_avg:49.49ms
+step:1133/1490 train_time:56105ms step_avg:49.52ms
+step:1134/1490 train_time:56191ms step_avg:49.55ms
+step:1135/1490 train_time:56271ms step_avg:49.58ms
+step:1136/1490 train_time:56355ms step_avg:49.61ms
+step:1137/1490 train_time:56434ms step_avg:49.63ms
+step:1138/1490 train_time:56519ms step_avg:49.67ms
+step:1139/1490 train_time:56599ms step_avg:49.69ms
+step:1140/1490 train_time:56685ms step_avg:49.72ms
+step:1141/1490 train_time:56765ms step_avg:49.75ms
+step:1142/1490 train_time:56849ms step_avg:49.78ms
+step:1143/1490 train_time:56929ms step_avg:49.81ms
+step:1144/1490 train_time:57013ms step_avg:49.84ms
+step:1145/1490 train_time:57092ms step_avg:49.86ms
+step:1146/1490 train_time:57177ms step_avg:49.89ms
+step:1147/1490 train_time:57256ms step_avg:49.92ms
+step:1148/1490 train_time:57340ms step_avg:49.95ms
+step:1149/1490 train_time:57420ms step_avg:49.97ms
+step:1150/1490 train_time:57506ms step_avg:50.01ms
+step:1151/1490 train_time:57586ms step_avg:50.03ms
+step:1152/1490 train_time:57671ms step_avg:50.06ms
+step:1153/1490 train_time:57750ms step_avg:50.09ms
+step:1154/1490 train_time:57835ms step_avg:50.12ms
+step:1155/1490 train_time:57915ms step_avg:50.14ms
+step:1156/1490 train_time:58000ms step_avg:50.17ms
+step:1157/1490 train_time:58079ms step_avg:50.20ms
+step:1158/1490 train_time:58166ms step_avg:50.23ms
+step:1159/1490 train_time:58245ms step_avg:50.25ms
+step:1160/1490 train_time:58329ms step_avg:50.28ms
+step:1161/1490 train_time:58409ms step_avg:50.31ms
+step:1162/1490 train_time:58493ms step_avg:50.34ms
+step:1163/1490 train_time:58574ms step_avg:50.36ms
+step:1164/1490 train_time:58659ms step_avg:50.39ms
+step:1165/1490 train_time:58738ms step_avg:50.42ms
+step:1166/1490 train_time:58824ms step_avg:50.45ms
+step:1167/1490 train_time:58904ms step_avg:50.47ms
+step:1168/1490 train_time:58987ms step_avg:50.50ms
+step:1169/1490 train_time:59066ms step_avg:50.53ms
+step:1170/1490 train_time:59152ms step_avg:50.56ms
+step:1171/1490 train_time:59231ms step_avg:50.58ms
+step:1172/1490 train_time:59315ms step_avg:50.61ms
+step:1173/1490 train_time:59395ms step_avg:50.64ms
+step:1174/1490 train_time:59479ms step_avg:50.66ms
+step:1175/1490 train_time:59559ms step_avg:50.69ms
+step:1176/1490 train_time:59643ms step_avg:50.72ms
+step:1177/1490 train_time:59722ms step_avg:50.74ms
+step:1178/1490 train_time:59808ms step_avg:50.77ms
+step:1179/1490 train_time:59887ms step_avg:50.79ms
+step:1180/1490 train_time:59973ms step_avg:50.82ms
+step:1181/1490 train_time:60052ms step_avg:50.85ms
+step:1182/1490 train_time:60137ms step_avg:50.88ms
+step:1183/1490 train_time:60217ms step_avg:50.90ms
+step:1184/1490 train_time:60302ms step_avg:50.93ms
+step:1185/1490 train_time:60380ms step_avg:50.95ms
+step:1186/1490 train_time:60466ms step_avg:50.98ms
+step:1187/1490 train_time:60546ms step_avg:51.01ms
+step:1188/1490 train_time:60630ms step_avg:51.04ms
+step:1189/1490 train_time:60711ms step_avg:51.06ms
+step:1190/1490 train_time:60796ms step_avg:51.09ms
+step:1191/1490 train_time:60876ms step_avg:51.11ms
+step:1192/1490 train_time:60961ms step_avg:51.14ms
+step:1193/1490 train_time:61039ms step_avg:51.16ms
+step:1194/1490 train_time:61125ms step_avg:51.19ms
+step:1195/1490 train_time:61203ms step_avg:51.22ms
+step:1196/1490 train_time:61288ms step_avg:51.24ms
+step:1197/1490 train_time:61368ms step_avg:51.27ms
+step:1198/1490 train_time:61453ms step_avg:51.30ms
+step:1199/1490 train_time:61532ms step_avg:51.32ms
+step:1200/1490 train_time:61617ms step_avg:51.35ms
+step:1201/1490 train_time:61696ms step_avg:51.37ms
+step:1202/1490 train_time:61781ms step_avg:51.40ms
+step:1203/1490 train_time:61861ms step_avg:51.42ms
+step:1204/1490 train_time:61946ms step_avg:51.45ms
+step:1205/1490 train_time:62026ms step_avg:51.47ms
+step:1206/1490 train_time:62111ms step_avg:51.50ms
+step:1207/1490 train_time:62190ms step_avg:51.52ms
+step:1208/1490 train_time:62275ms step_avg:51.55ms
+step:1209/1490 train_time:62354ms step_avg:51.58ms
+step:1210/1490 train_time:62439ms step_avg:51.60ms
+step:1211/1490 train_time:62519ms step_avg:51.63ms
+step:1212/1490 train_time:62604ms step_avg:51.65ms
+step:1213/1490 train_time:62684ms step_avg:51.68ms
+step:1214/1490 train_time:62769ms step_avg:51.70ms
+step:1215/1490 train_time:62848ms step_avg:51.73ms
+step:1216/1490 train_time:62933ms step_avg:51.75ms
+step:1217/1490 train_time:63012ms step_avg:51.78ms
+step:1218/1490 train_time:63097ms step_avg:51.80ms
+step:1219/1490 train_time:63177ms step_avg:51.83ms
+step:1220/1490 train_time:63263ms step_avg:51.86ms
+step:1221/1490 train_time:63342ms step_avg:51.88ms
+step:1222/1490 train_time:63427ms step_avg:51.90ms
+step:1223/1490 train_time:63506ms step_avg:51.93ms
+step:1224/1490 train_time:63592ms step_avg:51.95ms
+step:1225/1490 train_time:63671ms step_avg:51.98ms
+step:1226/1490 train_time:63755ms step_avg:52.00ms
+step:1227/1490 train_time:63834ms step_avg:52.02ms
+step:1228/1490 train_time:63919ms step_avg:52.05ms
+step:1229/1490 train_time:63998ms step_avg:52.07ms
+step:1230/1490 train_time:64082ms step_avg:52.10ms
+step:1231/1490 train_time:64162ms step_avg:52.12ms
+step:1232/1490 train_time:64248ms step_avg:52.15ms
+step:1233/1490 train_time:64327ms step_avg:52.17ms
+step:1234/1490 train_time:64412ms step_avg:52.20ms
+step:1235/1490 train_time:64491ms step_avg:52.22ms
+step:1236/1490 train_time:64575ms step_avg:52.24ms
+step:1237/1490 train_time:64655ms step_avg:52.27ms
+step:1238/1490 train_time:64739ms step_avg:52.29ms
+step:1239/1490 train_time:64818ms step_avg:52.32ms
+step:1240/1490 train_time:64904ms step_avg:52.34ms
+step:1241/1490 train_time:64983ms step_avg:52.36ms
+step:1242/1490 train_time:65068ms step_avg:52.39ms
+step:1243/1490 train_time:65147ms step_avg:52.41ms
+step:1244/1490 train_time:65231ms step_avg:52.44ms
+step:1245/1490 train_time:65310ms step_avg:52.46ms
+step:1246/1490 train_time:65394ms step_avg:52.48ms
+step:1247/1490 train_time:65475ms step_avg:52.51ms
+step:1248/1490 train_time:65560ms step_avg:52.53ms
+step:1249/1490 train_time:65639ms step_avg:52.55ms
+step:1250/1490 train_time:65725ms step_avg:52.58ms
+step:1250/1490 val_loss:3.3709 train_time:65827ms step_avg:52.66ms
+step:1251/1490 train_time:65849ms step_avg:52.64ms
+step:1252/1490 train_time:65895ms step_avg:52.63ms
+step:1253/1490 train_time:65979ms step_avg:52.66ms
+step:1254/1490 train_time:66064ms step_avg:52.68ms
+step:1255/1490 train_time:66145ms step_avg:52.71ms
+step:1256/1490 train_time:66228ms step_avg:52.73ms
+step:1257/1490 train_time:66307ms step_avg:52.75ms
+step:1258/1490 train_time:66391ms step_avg:52.77ms
+step:1259/1490 train_time:66469ms step_avg:52.80ms
+step:1260/1490 train_time:66553ms step_avg:52.82ms
+step:1261/1490 train_time:66633ms step_avg:52.84ms
+step:1262/1490 train_time:66716ms step_avg:52.87ms
+step:1263/1490 train_time:66796ms step_avg:52.89ms
+step:1264/1490 train_time:66882ms step_avg:52.91ms
+step:1265/1490 train_time:66964ms step_avg:52.94ms
+step:1266/1490 train_time:67051ms step_avg:52.96ms
+step:1267/1490 train_time:67130ms step_avg:52.98ms
+step:1268/1490 train_time:67216ms step_avg:53.01ms
+step:1269/1490 train_time:67295ms step_avg:53.03ms
+step:1270/1490 train_time:67379ms step_avg:53.05ms
+step:1271/1490 train_time:67457ms step_avg:53.07ms
+step:1272/1490 train_time:67541ms step_avg:53.10ms
+step:1273/1490 train_time:67620ms step_avg:53.12ms
+step:1274/1490 train_time:67704ms step_avg:53.14ms
+step:1275/1490 train_time:67784ms step_avg:53.16ms
+step:1276/1490 train_time:67870ms step_avg:53.19ms
+step:1277/1490 train_time:67951ms step_avg:53.21ms
+step:1278/1490 train_time:68037ms step_avg:53.24ms
+step:1279/1490 train_time:68118ms step_avg:53.26ms
+step:1280/1490 train_time:68203ms step_avg:53.28ms
+step:1281/1490 train_time:68284ms step_avg:53.30ms
+step:1282/1490 train_time:68368ms step_avg:53.33ms
+step:1283/1490 train_time:68446ms step_avg:53.35ms
+step:1284/1490 train_time:68531ms step_avg:53.37ms
+step:1285/1490 train_time:68609ms step_avg:53.39ms
+step:1286/1490 train_time:68693ms step_avg:53.42ms
+step:1287/1490 train_time:68773ms step_avg:53.44ms
+step:1288/1490 train_time:68859ms step_avg:53.46ms
+step:1289/1490 train_time:68938ms step_avg:53.48ms
+step:1290/1490 train_time:69024ms step_avg:53.51ms
+step:1291/1490 train_time:69105ms step_avg:53.53ms
+step:1292/1490 train_time:69190ms step_avg:53.55ms
+step:1293/1490 train_time:69271ms step_avg:53.57ms
+step:1294/1490 train_time:69356ms step_avg:53.60ms
+step:1295/1490 train_time:69434ms step_avg:53.62ms
+step:1296/1490 train_time:69518ms step_avg:53.64ms
+step:1297/1490 train_time:69597ms step_avg:53.66ms
+step:1298/1490 train_time:69682ms step_avg:53.68ms
+step:1299/1490 train_time:69762ms step_avg:53.70ms
+step:1300/1490 train_time:69847ms step_avg:53.73ms
+step:1301/1490 train_time:69928ms step_avg:53.75ms
+step:1302/1490 train_time:70013ms step_avg:53.77ms
+step:1303/1490 train_time:70091ms step_avg:53.79ms
+step:1304/1490 train_time:70177ms step_avg:53.82ms
+step:1305/1490 train_time:70255ms step_avg:53.84ms
+step:1306/1490 train_time:70339ms step_avg:53.86ms
+step:1307/1490 train_time:70418ms step_avg:53.88ms
+step:1308/1490 train_time:70503ms step_avg:53.90ms
+step:1309/1490 train_time:70584ms step_avg:53.92ms
+step:1310/1490 train_time:70668ms step_avg:53.95ms
+step:1311/1490 train_time:70749ms step_avg:53.97ms
+step:1312/1490 train_time:70834ms step_avg:53.99ms
+step:1313/1490 train_time:70914ms step_avg:54.01ms
+step:1314/1490 train_time:70999ms step_avg:54.03ms
+step:1315/1490 train_time:71079ms step_avg:54.05ms
+step:1316/1490 train_time:71163ms step_avg:54.08ms
+step:1317/1490 train_time:71244ms step_avg:54.10ms
+step:1318/1490 train_time:71329ms step_avg:54.12ms
+step:1319/1490 train_time:71408ms step_avg:54.14ms
+step:1320/1490 train_time:71493ms step_avg:54.16ms
+step:1321/1490 train_time:71573ms step_avg:54.18ms
+step:1322/1490 train_time:71657ms step_avg:54.20ms
+step:1323/1490 train_time:71736ms step_avg:54.22ms
+step:1324/1490 train_time:71822ms step_avg:54.25ms
+step:1325/1490 train_time:71901ms step_avg:54.27ms
+step:1326/1490 train_time:71987ms step_avg:54.29ms
+step:1327/1490 train_time:72068ms step_avg:54.31ms
+step:1328/1490 train_time:72152ms step_avg:54.33ms
+step:1329/1490 train_time:72231ms step_avg:54.35ms
+step:1330/1490 train_time:72317ms step_avg:54.37ms
+step:1331/1490 train_time:72396ms step_avg:54.39ms
+step:1332/1490 train_time:72481ms step_avg:54.42ms
+step:1333/1490 train_time:72560ms step_avg:54.43ms
+step:1334/1490 train_time:72644ms step_avg:54.46ms
+step:1335/1490 train_time:72725ms step_avg:54.48ms
+step:1336/1490 train_time:72810ms step_avg:54.50ms
+step:1337/1490 train_time:72891ms step_avg:54.52ms
+step:1338/1490 train_time:72975ms step_avg:54.54ms
+step:1339/1490 train_time:73054ms step_avg:54.56ms
+step:1340/1490 train_time:73139ms step_avg:54.58ms
+step:1341/1490 train_time:73218ms step_avg:54.60ms
+step:1342/1490 train_time:73303ms step_avg:54.62ms
+step:1343/1490 train_time:73382ms step_avg:54.64ms
+step:1344/1490 train_time:73468ms step_avg:54.66ms
+step:1345/1490 train_time:73547ms step_avg:54.68ms
+step:1346/1490 train_time:73631ms step_avg:54.70ms
+step:1347/1490 train_time:73711ms step_avg:54.72ms
+step:1348/1490 train_time:73798ms step_avg:54.75ms
+step:1349/1490 train_time:73877ms step_avg:54.76ms
+step:1350/1490 train_time:73962ms step_avg:54.79ms
+step:1351/1490 train_time:74041ms step_avg:54.80ms
+step:1352/1490 train_time:74126ms step_avg:54.83ms
+step:1353/1490 train_time:74206ms step_avg:54.85ms
+step:1354/1490 train_time:74290ms step_avg:54.87ms
+step:1355/1490 train_time:74369ms step_avg:54.88ms
+step:1356/1490 train_time:74455ms step_avg:54.91ms
+step:1357/1490 train_time:74533ms step_avg:54.92ms
+step:1358/1490 train_time:74617ms step_avg:54.95ms
+step:1359/1490 train_time:74696ms step_avg:54.96ms
+step:1360/1490 train_time:74783ms step_avg:54.99ms
+step:1361/1490 train_time:74862ms step_avg:55.00ms
+step:1362/1490 train_time:74948ms step_avg:55.03ms
+step:1363/1490 train_time:75028ms step_avg:55.05ms
+step:1364/1490 train_time:75113ms step_avg:55.07ms
+step:1365/1490 train_time:75194ms step_avg:55.09ms
+step:1366/1490 train_time:75278ms step_avg:55.11ms
+step:1367/1490 train_time:75355ms step_avg:55.12ms
+step:1368/1490 train_time:75441ms step_avg:55.15ms
+step:1369/1490 train_time:75522ms step_avg:55.17ms
+step:1370/1490 train_time:75607ms step_avg:55.19ms
+step:1371/1490 train_time:75686ms step_avg:55.21ms
+step:1372/1490 train_time:75771ms step_avg:55.23ms
+step:1373/1490 train_time:75851ms step_avg:55.24ms
+step:1374/1490 train_time:75937ms step_avg:55.27ms
+step:1375/1490 train_time:76017ms step_avg:55.28ms
+step:1376/1490 train_time:76103ms step_avg:55.31ms
+step:1377/1490 train_time:76183ms step_avg:55.33ms
+step:1378/1490 train_time:76267ms step_avg:55.35ms
+step:1379/1490 train_time:76346ms step_avg:55.36ms
+step:1380/1490 train_time:76431ms step_avg:55.38ms
+step:1381/1490 train_time:76509ms step_avg:55.40ms
+step:1382/1490 train_time:76595ms step_avg:55.42ms
+step:1383/1490 train_time:76674ms step_avg:55.44ms
+step:1384/1490 train_time:76757ms step_avg:55.46ms
+step:1385/1490 train_time:76837ms step_avg:55.48ms
+step:1386/1490 train_time:76921ms step_avg:55.50ms
+step:1387/1490 train_time:77000ms step_avg:55.52ms
+step:1388/1490 train_time:77087ms step_avg:55.54ms
+step:1389/1490 train_time:77167ms step_avg:55.56ms
+step:1390/1490 train_time:77253ms step_avg:55.58ms
+step:1391/1490 train_time:77332ms step_avg:55.59ms
+step:1392/1490 train_time:77416ms step_avg:55.61ms
+step:1393/1490 train_time:77496ms step_avg:55.63ms
+step:1394/1490 train_time:77581ms step_avg:55.65ms
+step:1395/1490 train_time:77662ms step_avg:55.67ms
+step:1396/1490 train_time:77746ms step_avg:55.69ms
+step:1397/1490 train_time:77826ms step_avg:55.71ms
+step:1398/1490 train_time:77911ms step_avg:55.73ms
+step:1399/1490 train_time:77989ms step_avg:55.75ms
+step:1400/1490 train_time:78075ms step_avg:55.77ms
+step:1401/1490 train_time:78153ms step_avg:55.78ms
+step:1402/1490 train_time:78240ms step_avg:55.81ms
+step:1403/1490 train_time:78320ms step_avg:55.82ms
+step:1404/1490 train_time:78405ms step_avg:55.84ms
+step:1405/1490 train_time:78485ms step_avg:55.86ms
+step:1406/1490 train_time:78570ms step_avg:55.88ms
+step:1407/1490 train_time:78648ms step_avg:55.90ms
+step:1408/1490 train_time:78734ms step_avg:55.92ms
+step:1409/1490 train_time:78814ms step_avg:55.94ms
+step:1410/1490 train_time:78898ms step_avg:55.96ms
+step:1411/1490 train_time:78978ms step_avg:55.97ms
+step:1412/1490 train_time:79062ms step_avg:55.99ms
+step:1413/1490 train_time:79142ms step_avg:56.01ms
+step:1414/1490 train_time:79227ms step_avg:56.03ms
+step:1415/1490 train_time:79308ms step_avg:56.05ms
+step:1416/1490 train_time:79393ms step_avg:56.07ms
+step:1417/1490 train_time:79472ms step_avg:56.08ms
+step:1418/1490 train_time:79557ms step_avg:56.10ms
+step:1419/1490 train_time:79636ms step_avg:56.12ms
+step:1420/1490 train_time:79720ms step_avg:56.14ms
+step:1421/1490 train_time:79799ms step_avg:56.16ms
+step:1422/1490 train_time:79884ms step_avg:56.18ms
+step:1423/1490 train_time:79964ms step_avg:56.19ms
+step:1424/1490 train_time:80051ms step_avg:56.22ms
+step:1425/1490 train_time:80131ms step_avg:56.23ms
+step:1426/1490 train_time:80216ms step_avg:56.25ms
+step:1427/1490 train_time:80294ms step_avg:56.27ms
+step:1428/1490 train_time:80379ms step_avg:56.29ms
+step:1429/1490 train_time:80458ms step_avg:56.30ms
+step:1430/1490 train_time:80542ms step_avg:56.32ms
+step:1431/1490 train_time:80624ms step_avg:56.34ms
+step:1432/1490 train_time:80709ms step_avg:56.36ms
+step:1433/1490 train_time:80788ms step_avg:56.38ms
+step:1434/1490 train_time:80873ms step_avg:56.40ms
+step:1435/1490 train_time:80951ms step_avg:56.41ms
+step:1436/1490 train_time:81038ms step_avg:56.43ms
+step:1437/1490 train_time:81116ms step_avg:56.45ms
+step:1438/1490 train_time:81201ms step_avg:56.47ms
+step:1439/1490 train_time:81283ms step_avg:56.49ms
+step:1440/1490 train_time:81367ms step_avg:56.50ms
+step:1441/1490 train_time:81446ms step_avg:56.52ms
+step:1442/1490 train_time:81531ms step_avg:56.54ms
+step:1443/1490 train_time:81610ms step_avg:56.56ms
+step:1444/1490 train_time:81695ms step_avg:56.58ms
+step:1445/1490 train_time:81773ms step_avg:56.59ms
+step:1446/1490 train_time:81859ms step_avg:56.61ms
+step:1447/1490 train_time:81937ms step_avg:56.63ms
+step:1448/1490 train_time:82023ms step_avg:56.65ms
+step:1449/1490 train_time:82103ms step_avg:56.66ms
+step:1450/1490 train_time:82188ms step_avg:56.68ms
+step:1451/1490 train_time:82271ms step_avg:56.70ms
+step:1452/1490 train_time:82357ms step_avg:56.72ms
+step:1453/1490 train_time:82436ms step_avg:56.74ms
+step:1454/1490 train_time:82522ms step_avg:56.76ms
+step:1455/1490 train_time:82602ms step_avg:56.77ms
+step:1456/1490 train_time:82689ms step_avg:56.79ms
+step:1457/1490 train_time:82769ms step_avg:56.81ms
+step:1458/1490 train_time:82854ms step_avg:56.83ms
+step:1459/1490 train_time:82935ms step_avg:56.84ms
+step:1460/1490 train_time:83019ms step_avg:56.86ms
+step:1461/1490 train_time:83099ms step_avg:56.88ms
+step:1462/1490 train_time:83185ms step_avg:56.90ms
+step:1463/1490 train_time:83266ms step_avg:56.91ms
+step:1464/1490 train_time:83350ms step_avg:56.93ms
+step:1465/1490 train_time:83430ms step_avg:56.95ms
+step:1466/1490 train_time:83518ms step_avg:56.97ms
+step:1467/1490 train_time:83597ms step_avg:56.98ms
+step:1468/1490 train_time:83682ms step_avg:57.00ms
+step:1469/1490 train_time:83762ms step_avg:57.02ms
+step:1470/1490 train_time:83847ms step_avg:57.04ms
+step:1471/1490 train_time:83927ms step_avg:57.05ms
+step:1472/1490 train_time:84012ms step_avg:57.07ms
+step:1473/1490 train_time:84091ms step_avg:57.09ms
+step:1474/1490 train_time:84176ms step_avg:57.11ms
+step:1475/1490 train_time:84256ms step_avg:57.12ms
+step:1476/1490 train_time:84340ms step_avg:57.14ms
+step:1477/1490 train_time:84421ms step_avg:57.16ms
+step:1478/1490 train_time:84507ms step_avg:57.18ms
+step:1479/1490 train_time:84588ms step_avg:57.19ms
+step:1480/1490 train_time:84674ms step_avg:57.21ms
+step:1481/1490 train_time:84752ms step_avg:57.23ms
+step:1482/1490 train_time:84837ms step_avg:57.25ms
+step:1483/1490 train_time:84918ms step_avg:57.26ms
+step:1484/1490 train_time:85003ms step_avg:57.28ms
+step:1485/1490 train_time:85083ms step_avg:57.30ms
+step:1486/1490 train_time:85169ms step_avg:57.31ms
+step:1487/1490 train_time:85248ms step_avg:57.33ms
+step:1488/1490 train_time:85334ms step_avg:57.35ms
+step:1489/1490 train_time:85414ms step_avg:57.36ms
+step:1490/1490 train_time:85499ms step_avg:57.38ms
+step:1490/1490 val_loss:3.2783 train_time:85602ms step_avg:57.45ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/99d81c78-d785-4251-bfa4-f217af5aa11b.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/99d81c78-d785-4251-bfa4-f217af5aa11b.txt
@@ -1,0 +1,4449 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 00:21:58 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   31C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8333 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:83ms step_avg:82.98ms
+step:2/1490 train_time:123ms step_avg:61.40ms
+step:3/1490 train_time:140ms step_avg:46.75ms
+step:4/1490 train_time:165ms step_avg:41.24ms
+step:5/1490 train_time:192ms step_avg:38.35ms
+step:6/1490 train_time:226ms step_avg:37.70ms
+step:7/1490 train_time:253ms step_avg:36.19ms
+step:8/1490 train_time:288ms step_avg:36.02ms
+step:9/1490 train_time:315ms step_avg:35.01ms
+step:10/1490 train_time:350ms step_avg:34.95ms
+step:11/1490 train_time:377ms step_avg:34.29ms
+step:12/1490 train_time:412ms step_avg:34.31ms
+step:13/1490 train_time:440ms step_avg:33.83ms
+step:14/1490 train_time:474ms step_avg:33.85ms
+step:15/1490 train_time:502ms step_avg:33.47ms
+step:16/1490 train_time:536ms step_avg:33.51ms
+step:17/1490 train_time:564ms step_avg:33.18ms
+step:18/1490 train_time:599ms step_avg:33.26ms
+step:19/1490 train_time:626ms step_avg:32.94ms
+step:20/1490 train_time:660ms step_avg:33.00ms
+step:21/1490 train_time:688ms step_avg:32.75ms
+step:22/1490 train_time:722ms step_avg:32.81ms
+step:23/1490 train_time:750ms step_avg:32.60ms
+step:24/1490 train_time:784ms step_avg:32.68ms
+step:25/1490 train_time:812ms step_avg:32.48ms
+step:26/1490 train_time:846ms step_avg:32.55ms
+step:27/1490 train_time:874ms step_avg:32.38ms
+step:28/1490 train_time:909ms step_avg:32.46ms
+step:29/1490 train_time:937ms step_avg:32.30ms
+step:30/1490 train_time:972ms step_avg:32.39ms
+step:31/1490 train_time:1000ms step_avg:32.26ms
+step:32/1490 train_time:1035ms step_avg:32.34ms
+step:33/1490 train_time:1064ms step_avg:32.25ms
+step:34/1490 train_time:1099ms step_avg:32.33ms
+step:35/1490 train_time:1128ms step_avg:32.22ms
+step:36/1490 train_time:1163ms step_avg:32.30ms
+step:37/1490 train_time:1191ms step_avg:32.18ms
+step:38/1490 train_time:1226ms step_avg:32.25ms
+step:39/1490 train_time:1254ms step_avg:32.14ms
+step:40/1490 train_time:1288ms step_avg:32.21ms
+step:41/1490 train_time:1316ms step_avg:32.10ms
+step:42/1490 train_time:1351ms step_avg:32.16ms
+step:43/1490 train_time:1379ms step_avg:32.07ms
+step:44/1490 train_time:1413ms step_avg:32.12ms
+step:45/1490 train_time:1441ms step_avg:32.03ms
+step:46/1490 train_time:1475ms step_avg:32.07ms
+step:47/1490 train_time:1503ms step_avg:31.98ms
+step:48/1490 train_time:1537ms step_avg:32.02ms
+step:49/1490 train_time:1565ms step_avg:31.95ms
+step:50/1490 train_time:1600ms step_avg:31.99ms
+step:51/1490 train_time:1628ms step_avg:31.91ms
+step:52/1490 train_time:1662ms step_avg:31.96ms
+step:53/1490 train_time:1690ms step_avg:31.88ms
+step:54/1490 train_time:1724ms step_avg:31.93ms
+step:55/1490 train_time:1752ms step_avg:31.86ms
+step:56/1490 train_time:1787ms step_avg:31.91ms
+step:57/1490 train_time:1815ms step_avg:31.83ms
+step:58/1490 train_time:1849ms step_avg:31.88ms
+step:59/1490 train_time:1877ms step_avg:31.82ms
+step:60/1490 train_time:1912ms step_avg:31.86ms
+step:61/1490 train_time:1940ms step_avg:31.81ms
+step:62/1490 train_time:1975ms step_avg:31.85ms
+step:63/1490 train_time:2003ms step_avg:31.79ms
+step:64/1490 train_time:2037ms step_avg:31.83ms
+step:65/1490 train_time:2065ms step_avg:31.77ms
+step:66/1490 train_time:2100ms step_avg:31.81ms
+step:67/1490 train_time:2128ms step_avg:31.76ms
+step:68/1490 train_time:2163ms step_avg:31.80ms
+step:69/1490 train_time:2190ms step_avg:31.75ms
+step:70/1490 train_time:2226ms step_avg:31.80ms
+step:71/1490 train_time:2254ms step_avg:31.74ms
+step:72/1490 train_time:2289ms step_avg:31.79ms
+step:73/1490 train_time:2317ms step_avg:31.74ms
+step:74/1490 train_time:2352ms step_avg:31.78ms
+step:75/1490 train_time:2380ms step_avg:31.73ms
+step:76/1490 train_time:2414ms step_avg:31.77ms
+step:77/1490 train_time:2442ms step_avg:31.72ms
+step:78/1490 train_time:2476ms step_avg:31.75ms
+step:79/1490 train_time:2504ms step_avg:31.70ms
+step:80/1490 train_time:2538ms step_avg:31.73ms
+step:81/1490 train_time:2566ms step_avg:31.68ms
+step:82/1490 train_time:2601ms step_avg:31.71ms
+step:83/1490 train_time:2629ms step_avg:31.67ms
+step:84/1490 train_time:2663ms step_avg:31.71ms
+step:85/1490 train_time:2691ms step_avg:31.66ms
+step:86/1490 train_time:2725ms step_avg:31.69ms
+step:87/1490 train_time:2753ms step_avg:31.64ms
+step:88/1490 train_time:2788ms step_avg:31.68ms
+step:89/1490 train_time:2816ms step_avg:31.64ms
+step:90/1490 train_time:2850ms step_avg:31.67ms
+step:91/1490 train_time:2878ms step_avg:31.63ms
+step:92/1490 train_time:2913ms step_avg:31.66ms
+step:93/1490 train_time:2941ms step_avg:31.62ms
+step:94/1490 train_time:2975ms step_avg:31.65ms
+step:95/1490 train_time:3003ms step_avg:31.61ms
+step:96/1490 train_time:3036ms step_avg:31.63ms
+step:97/1490 train_time:3065ms step_avg:31.60ms
+step:98/1490 train_time:3100ms step_avg:31.64ms
+step:99/1490 train_time:3127ms step_avg:31.59ms
+step:100/1490 train_time:3162ms step_avg:31.62ms
+step:101/1490 train_time:3190ms step_avg:31.59ms
+step:102/1490 train_time:3225ms step_avg:31.61ms
+step:103/1490 train_time:3252ms step_avg:31.58ms
+step:104/1490 train_time:3287ms step_avg:31.61ms
+step:105/1490 train_time:3315ms step_avg:31.57ms
+step:106/1490 train_time:3350ms step_avg:31.60ms
+step:107/1490 train_time:3378ms step_avg:31.57ms
+step:108/1490 train_time:3412ms step_avg:31.60ms
+step:109/1490 train_time:3441ms step_avg:31.57ms
+step:110/1490 train_time:3475ms step_avg:31.59ms
+step:111/1490 train_time:3503ms step_avg:31.56ms
+step:112/1490 train_time:3538ms step_avg:31.59ms
+step:113/1490 train_time:3565ms step_avg:31.55ms
+step:114/1490 train_time:3600ms step_avg:31.58ms
+step:115/1490 train_time:3628ms step_avg:31.54ms
+step:116/1490 train_time:3663ms step_avg:31.58ms
+step:117/1490 train_time:3690ms step_avg:31.54ms
+step:118/1490 train_time:3725ms step_avg:31.57ms
+step:119/1490 train_time:3753ms step_avg:31.53ms
+step:120/1490 train_time:3787ms step_avg:31.56ms
+step:121/1490 train_time:3815ms step_avg:31.53ms
+step:122/1490 train_time:3850ms step_avg:31.55ms
+step:123/1490 train_time:3877ms step_avg:31.52ms
+step:124/1490 train_time:3912ms step_avg:31.55ms
+step:125/1490 train_time:3940ms step_avg:31.52ms
+step:126/1490 train_time:3974ms step_avg:31.54ms
+step:127/1490 train_time:4002ms step_avg:31.51ms
+step:128/1490 train_time:4036ms step_avg:31.54ms
+step:129/1490 train_time:4064ms step_avg:31.51ms
+step:130/1490 train_time:4099ms step_avg:31.53ms
+step:131/1490 train_time:4126ms step_avg:31.50ms
+step:132/1490 train_time:4161ms step_avg:31.52ms
+step:133/1490 train_time:4189ms step_avg:31.49ms
+step:134/1490 train_time:4224ms step_avg:31.52ms
+step:135/1490 train_time:4252ms step_avg:31.49ms
+step:136/1490 train_time:4287ms step_avg:31.52ms
+step:137/1490 train_time:4314ms step_avg:31.49ms
+step:138/1490 train_time:4349ms step_avg:31.52ms
+step:139/1490 train_time:4377ms step_avg:31.49ms
+step:140/1490 train_time:4412ms step_avg:31.51ms
+step:141/1490 train_time:4439ms step_avg:31.48ms
+step:142/1490 train_time:4474ms step_avg:31.51ms
+step:143/1490 train_time:4502ms step_avg:31.48ms
+step:144/1490 train_time:4536ms step_avg:31.50ms
+step:145/1490 train_time:4564ms step_avg:31.48ms
+step:146/1490 train_time:4599ms step_avg:31.50ms
+step:147/1490 train_time:4626ms step_avg:31.47ms
+step:148/1490 train_time:4662ms step_avg:31.50ms
+step:149/1490 train_time:4689ms step_avg:31.47ms
+step:150/1490 train_time:4724ms step_avg:31.50ms
+step:151/1490 train_time:4752ms step_avg:31.47ms
+step:152/1490 train_time:4787ms step_avg:31.49ms
+step:153/1490 train_time:4814ms step_avg:31.47ms
+step:154/1490 train_time:4849ms step_avg:31.49ms
+step:155/1490 train_time:4877ms step_avg:31.46ms
+step:156/1490 train_time:4912ms step_avg:31.49ms
+step:157/1490 train_time:4939ms step_avg:31.46ms
+step:158/1490 train_time:4974ms step_avg:31.48ms
+step:159/1490 train_time:5002ms step_avg:31.46ms
+step:160/1490 train_time:5036ms step_avg:31.47ms
+step:161/1490 train_time:5064ms step_avg:31.45ms
+step:162/1490 train_time:5099ms step_avg:31.47ms
+step:163/1490 train_time:5126ms step_avg:31.45ms
+step:164/1490 train_time:5160ms step_avg:31.47ms
+step:165/1490 train_time:5188ms step_avg:31.44ms
+step:166/1490 train_time:5223ms step_avg:31.46ms
+step:167/1490 train_time:5251ms step_avg:31.44ms
+step:168/1490 train_time:5286ms step_avg:31.46ms
+step:169/1490 train_time:5313ms step_avg:31.44ms
+step:170/1490 train_time:5349ms step_avg:31.46ms
+step:171/1490 train_time:5377ms step_avg:31.44ms
+step:172/1490 train_time:5412ms step_avg:31.46ms
+step:173/1490 train_time:5439ms step_avg:31.44ms
+step:174/1490 train_time:5474ms step_avg:31.46ms
+step:175/1490 train_time:5502ms step_avg:31.44ms
+step:176/1490 train_time:5536ms step_avg:31.46ms
+step:177/1490 train_time:5564ms step_avg:31.44ms
+step:178/1490 train_time:5598ms step_avg:31.45ms
+step:179/1490 train_time:5626ms step_avg:31.43ms
+step:180/1490 train_time:5661ms step_avg:31.45ms
+step:181/1490 train_time:5689ms step_avg:31.43ms
+step:182/1490 train_time:5723ms step_avg:31.45ms
+step:183/1490 train_time:5751ms step_avg:31.43ms
+step:184/1490 train_time:5786ms step_avg:31.44ms
+step:185/1490 train_time:5813ms step_avg:31.42ms
+step:186/1490 train_time:5849ms step_avg:31.44ms
+step:187/1490 train_time:5876ms step_avg:31.43ms
+step:188/1490 train_time:5911ms step_avg:31.44ms
+step:189/1490 train_time:5939ms step_avg:31.42ms
+step:190/1490 train_time:5973ms step_avg:31.44ms
+step:191/1490 train_time:6001ms step_avg:31.42ms
+step:192/1490 train_time:6035ms step_avg:31.43ms
+step:193/1490 train_time:6063ms step_avg:31.41ms
+step:194/1490 train_time:6098ms step_avg:31.43ms
+step:195/1490 train_time:6125ms step_avg:31.41ms
+step:196/1490 train_time:6160ms step_avg:31.43ms
+step:197/1490 train_time:6193ms step_avg:31.43ms
+step:198/1490 train_time:6222ms step_avg:31.43ms
+step:199/1490 train_time:6251ms step_avg:31.41ms
+step:200/1490 train_time:6285ms step_avg:31.43ms
+step:201/1490 train_time:6312ms step_avg:31.40ms
+step:202/1490 train_time:6346ms step_avg:31.42ms
+step:203/1490 train_time:6375ms step_avg:31.40ms
+step:204/1490 train_time:6409ms step_avg:31.42ms
+step:205/1490 train_time:6437ms step_avg:31.40ms
+step:206/1490 train_time:6472ms step_avg:31.42ms
+step:207/1490 train_time:6500ms step_avg:31.40ms
+step:208/1490 train_time:6534ms step_avg:31.41ms
+step:209/1490 train_time:6562ms step_avg:31.40ms
+step:210/1490 train_time:6597ms step_avg:31.41ms
+step:211/1490 train_time:6625ms step_avg:31.40ms
+step:212/1490 train_time:6659ms step_avg:31.41ms
+step:213/1490 train_time:6687ms step_avg:31.40ms
+step:214/1490 train_time:6721ms step_avg:31.41ms
+step:215/1490 train_time:6749ms step_avg:31.39ms
+step:216/1490 train_time:6784ms step_avg:31.41ms
+step:217/1490 train_time:6812ms step_avg:31.39ms
+step:218/1490 train_time:6846ms step_avg:31.40ms
+step:219/1490 train_time:6875ms step_avg:31.39ms
+step:220/1490 train_time:6909ms step_avg:31.41ms
+step:221/1490 train_time:6937ms step_avg:31.39ms
+step:222/1490 train_time:6971ms step_avg:31.40ms
+step:223/1490 train_time:6999ms step_avg:31.39ms
+step:224/1490 train_time:7033ms step_avg:31.40ms
+step:225/1490 train_time:7061ms step_avg:31.38ms
+step:226/1490 train_time:7095ms step_avg:31.39ms
+step:227/1490 train_time:7124ms step_avg:31.38ms
+step:228/1490 train_time:7158ms step_avg:31.39ms
+step:229/1490 train_time:7186ms step_avg:31.38ms
+step:230/1490 train_time:7221ms step_avg:31.39ms
+step:231/1490 train_time:7249ms step_avg:31.38ms
+step:232/1490 train_time:7283ms step_avg:31.39ms
+step:233/1490 train_time:7311ms step_avg:31.38ms
+step:234/1490 train_time:7346ms step_avg:31.39ms
+step:235/1490 train_time:7374ms step_avg:31.38ms
+step:236/1490 train_time:7408ms step_avg:31.39ms
+step:237/1490 train_time:7436ms step_avg:31.38ms
+step:238/1490 train_time:7470ms step_avg:31.39ms
+step:239/1490 train_time:7499ms step_avg:31.38ms
+step:240/1490 train_time:7533ms step_avg:31.39ms
+step:241/1490 train_time:7561ms step_avg:31.37ms
+step:242/1490 train_time:7595ms step_avg:31.38ms
+step:243/1490 train_time:7623ms step_avg:31.37ms
+step:244/1490 train_time:7657ms step_avg:31.38ms
+step:245/1490 train_time:7685ms step_avg:31.37ms
+step:246/1490 train_time:7720ms step_avg:31.38ms
+step:247/1490 train_time:7748ms step_avg:31.37ms
+step:248/1490 train_time:7782ms step_avg:31.38ms
+step:249/1490 train_time:7810ms step_avg:31.36ms
+step:250/1490 train_time:7844ms step_avg:31.38ms
+step:250/1490 val_loss:4.4987 train_time:7886ms step_avg:31.55ms
+step:251/1490 train_time:7902ms step_avg:31.48ms
+step:252/1490 train_time:7920ms step_avg:31.43ms
+step:253/1490 train_time:7937ms step_avg:31.37ms
+step:254/1490 train_time:7972ms step_avg:31.39ms
+step:255/1490 train_time:8002ms step_avg:31.38ms
+step:256/1490 train_time:8036ms step_avg:31.39ms
+step:257/1490 train_time:8066ms step_avg:31.39ms
+step:258/1490 train_time:8101ms step_avg:31.40ms
+step:259/1490 train_time:8129ms step_avg:31.39ms
+step:260/1490 train_time:8164ms step_avg:31.40ms
+step:261/1490 train_time:8192ms step_avg:31.39ms
+step:262/1490 train_time:8226ms step_avg:31.40ms
+step:263/1490 train_time:8254ms step_avg:31.38ms
+step:264/1490 train_time:8288ms step_avg:31.39ms
+step:265/1490 train_time:8316ms step_avg:31.38ms
+step:266/1490 train_time:8350ms step_avg:31.39ms
+step:267/1490 train_time:8378ms step_avg:31.38ms
+step:268/1490 train_time:8412ms step_avg:31.39ms
+step:269/1490 train_time:8440ms step_avg:31.37ms
+step:270/1490 train_time:8474ms step_avg:31.38ms
+step:271/1490 train_time:8502ms step_avg:31.37ms
+step:272/1490 train_time:8536ms step_avg:31.38ms
+step:273/1490 train_time:8563ms step_avg:31.37ms
+step:274/1490 train_time:8597ms step_avg:31.38ms
+step:275/1490 train_time:8625ms step_avg:31.36ms
+step:276/1490 train_time:8659ms step_avg:31.37ms
+step:277/1490 train_time:8687ms step_avg:31.36ms
+step:278/1490 train_time:8721ms step_avg:31.37ms
+step:279/1490 train_time:8748ms step_avg:31.36ms
+step:280/1490 train_time:8783ms step_avg:31.37ms
+step:281/1490 train_time:8810ms step_avg:31.35ms
+step:282/1490 train_time:8845ms step_avg:31.36ms
+step:283/1490 train_time:8872ms step_avg:31.35ms
+step:284/1490 train_time:8907ms step_avg:31.36ms
+step:285/1490 train_time:8935ms step_avg:31.35ms
+step:286/1490 train_time:8971ms step_avg:31.37ms
+step:287/1490 train_time:8999ms step_avg:31.35ms
+step:288/1490 train_time:9033ms step_avg:31.37ms
+step:289/1490 train_time:9061ms step_avg:31.35ms
+step:290/1490 train_time:9096ms step_avg:31.36ms
+step:291/1490 train_time:9124ms step_avg:31.35ms
+step:292/1490 train_time:9159ms step_avg:31.37ms
+step:293/1490 train_time:9187ms step_avg:31.36ms
+step:294/1490 train_time:9222ms step_avg:31.37ms
+step:295/1490 train_time:9250ms step_avg:31.36ms
+step:296/1490 train_time:9285ms step_avg:31.37ms
+step:297/1490 train_time:9313ms step_avg:31.36ms
+step:298/1490 train_time:9347ms step_avg:31.37ms
+step:299/1490 train_time:9375ms step_avg:31.35ms
+step:300/1490 train_time:9409ms step_avg:31.36ms
+step:301/1490 train_time:9437ms step_avg:31.35ms
+step:302/1490 train_time:9471ms step_avg:31.36ms
+step:303/1490 train_time:9500ms step_avg:31.35ms
+step:304/1490 train_time:9534ms step_avg:31.36ms
+step:305/1490 train_time:9562ms step_avg:31.35ms
+step:306/1490 train_time:9595ms step_avg:31.36ms
+step:307/1490 train_time:9623ms step_avg:31.35ms
+step:308/1490 train_time:9657ms step_avg:31.35ms
+step:309/1490 train_time:9685ms step_avg:31.34ms
+step:310/1490 train_time:9719ms step_avg:31.35ms
+step:311/1490 train_time:9747ms step_avg:31.34ms
+step:312/1490 train_time:9782ms step_avg:31.35ms
+step:313/1490 train_time:9809ms step_avg:31.34ms
+step:314/1490 train_time:9844ms step_avg:31.35ms
+step:315/1490 train_time:9871ms step_avg:31.34ms
+step:316/1490 train_time:9906ms step_avg:31.35ms
+step:317/1490 train_time:9934ms step_avg:31.34ms
+step:318/1490 train_time:9969ms step_avg:31.35ms
+step:319/1490 train_time:9997ms step_avg:31.34ms
+step:320/1490 train_time:10031ms step_avg:31.35ms
+step:321/1490 train_time:10059ms step_avg:31.34ms
+step:322/1490 train_time:10093ms step_avg:31.34ms
+step:323/1490 train_time:10121ms step_avg:31.33ms
+step:324/1490 train_time:10156ms step_avg:31.35ms
+step:325/1490 train_time:10184ms step_avg:31.33ms
+step:326/1490 train_time:10218ms step_avg:31.34ms
+step:327/1490 train_time:10246ms step_avg:31.33ms
+step:328/1490 train_time:10281ms step_avg:31.35ms
+step:329/1490 train_time:10309ms step_avg:31.34ms
+step:330/1490 train_time:10344ms step_avg:31.34ms
+step:331/1490 train_time:10372ms step_avg:31.33ms
+step:332/1490 train_time:10406ms step_avg:31.34ms
+step:333/1490 train_time:10434ms step_avg:31.33ms
+step:334/1490 train_time:10469ms step_avg:31.34ms
+step:335/1490 train_time:10497ms step_avg:31.33ms
+step:336/1490 train_time:10531ms step_avg:31.34ms
+step:337/1490 train_time:10559ms step_avg:31.33ms
+step:338/1490 train_time:10593ms step_avg:31.34ms
+step:339/1490 train_time:10621ms step_avg:31.33ms
+step:340/1490 train_time:10655ms step_avg:31.34ms
+step:341/1490 train_time:10683ms step_avg:31.33ms
+step:342/1490 train_time:10717ms step_avg:31.34ms
+step:343/1490 train_time:10745ms step_avg:31.33ms
+step:344/1490 train_time:10780ms step_avg:31.34ms
+step:345/1490 train_time:10808ms step_avg:31.33ms
+step:346/1490 train_time:10842ms step_avg:31.34ms
+step:347/1490 train_time:10870ms step_avg:31.33ms
+step:348/1490 train_time:10904ms step_avg:31.33ms
+step:349/1490 train_time:10932ms step_avg:31.32ms
+step:350/1490 train_time:10967ms step_avg:31.33ms
+step:351/1490 train_time:10995ms step_avg:31.32ms
+step:352/1490 train_time:11029ms step_avg:31.33ms
+step:353/1490 train_time:11057ms step_avg:31.32ms
+step:354/1490 train_time:11092ms step_avg:31.33ms
+step:355/1490 train_time:11120ms step_avg:31.32ms
+step:356/1490 train_time:11154ms step_avg:31.33ms
+step:357/1490 train_time:11182ms step_avg:31.32ms
+step:358/1490 train_time:11216ms step_avg:31.33ms
+step:359/1490 train_time:11245ms step_avg:31.32ms
+step:360/1490 train_time:11279ms step_avg:31.33ms
+step:361/1490 train_time:11307ms step_avg:31.32ms
+step:362/1490 train_time:11343ms step_avg:31.33ms
+step:363/1490 train_time:11370ms step_avg:31.32ms
+step:364/1490 train_time:11405ms step_avg:31.33ms
+step:365/1490 train_time:11432ms step_avg:31.32ms
+step:366/1490 train_time:11467ms step_avg:31.33ms
+step:367/1490 train_time:11495ms step_avg:31.32ms
+step:368/1490 train_time:11529ms step_avg:31.33ms
+step:369/1490 train_time:11557ms step_avg:31.32ms
+step:370/1490 train_time:11592ms step_avg:31.33ms
+step:371/1490 train_time:11620ms step_avg:31.32ms
+step:372/1490 train_time:11654ms step_avg:31.33ms
+step:373/1490 train_time:11682ms step_avg:31.32ms
+step:374/1490 train_time:11716ms step_avg:31.33ms
+step:375/1490 train_time:11744ms step_avg:31.32ms
+step:376/1490 train_time:11778ms step_avg:31.32ms
+step:377/1490 train_time:11806ms step_avg:31.31ms
+step:378/1490 train_time:11841ms step_avg:31.33ms
+step:379/1490 train_time:11868ms step_avg:31.31ms
+step:380/1490 train_time:11902ms step_avg:31.32ms
+step:381/1490 train_time:11930ms step_avg:31.31ms
+step:382/1490 train_time:11964ms step_avg:31.32ms
+step:383/1490 train_time:11992ms step_avg:31.31ms
+step:384/1490 train_time:12027ms step_avg:31.32ms
+step:385/1490 train_time:12055ms step_avg:31.31ms
+step:386/1490 train_time:12089ms step_avg:31.32ms
+step:387/1490 train_time:12117ms step_avg:31.31ms
+step:388/1490 train_time:12151ms step_avg:31.32ms
+step:389/1490 train_time:12179ms step_avg:31.31ms
+step:390/1490 train_time:12213ms step_avg:31.32ms
+step:391/1490 train_time:12242ms step_avg:31.31ms
+step:392/1490 train_time:12276ms step_avg:31.32ms
+step:393/1490 train_time:12304ms step_avg:31.31ms
+step:394/1490 train_time:12339ms step_avg:31.32ms
+step:395/1490 train_time:12367ms step_avg:31.31ms
+step:396/1490 train_time:12401ms step_avg:31.32ms
+step:397/1490 train_time:12429ms step_avg:31.31ms
+step:398/1490 train_time:12463ms step_avg:31.32ms
+step:399/1490 train_time:12492ms step_avg:31.31ms
+step:400/1490 train_time:12526ms step_avg:31.32ms
+step:401/1490 train_time:12554ms step_avg:31.31ms
+step:402/1490 train_time:12589ms step_avg:31.31ms
+step:403/1490 train_time:12616ms step_avg:31.31ms
+step:404/1490 train_time:12651ms step_avg:31.31ms
+step:405/1490 train_time:12679ms step_avg:31.31ms
+step:406/1490 train_time:12713ms step_avg:31.31ms
+step:407/1490 train_time:12741ms step_avg:31.30ms
+step:408/1490 train_time:12776ms step_avg:31.31ms
+step:409/1490 train_time:12803ms step_avg:31.30ms
+step:410/1490 train_time:12838ms step_avg:31.31ms
+step:411/1490 train_time:12865ms step_avg:31.30ms
+step:412/1490 train_time:12900ms step_avg:31.31ms
+step:413/1490 train_time:12928ms step_avg:31.30ms
+step:414/1490 train_time:12962ms step_avg:31.31ms
+step:415/1490 train_time:12990ms step_avg:31.30ms
+step:416/1490 train_time:13024ms step_avg:31.31ms
+step:417/1490 train_time:13052ms step_avg:31.30ms
+step:418/1490 train_time:13087ms step_avg:31.31ms
+step:419/1490 train_time:13115ms step_avg:31.30ms
+step:420/1490 train_time:13149ms step_avg:31.31ms
+step:421/1490 train_time:13177ms step_avg:31.30ms
+step:422/1490 train_time:13211ms step_avg:31.30ms
+step:423/1490 train_time:13239ms step_avg:31.30ms
+step:424/1490 train_time:13273ms step_avg:31.30ms
+step:425/1490 train_time:13301ms step_avg:31.30ms
+step:426/1490 train_time:13335ms step_avg:31.30ms
+step:427/1490 train_time:13363ms step_avg:31.29ms
+step:428/1490 train_time:13397ms step_avg:31.30ms
+step:429/1490 train_time:13425ms step_avg:31.29ms
+step:430/1490 train_time:13460ms step_avg:31.30ms
+step:431/1490 train_time:13488ms step_avg:31.29ms
+step:432/1490 train_time:13522ms step_avg:31.30ms
+step:433/1490 train_time:13550ms step_avg:31.29ms
+step:434/1490 train_time:13584ms step_avg:31.30ms
+step:435/1490 train_time:13612ms step_avg:31.29ms
+step:436/1490 train_time:13647ms step_avg:31.30ms
+step:437/1490 train_time:13675ms step_avg:31.29ms
+step:438/1490 train_time:13709ms step_avg:31.30ms
+step:439/1490 train_time:13737ms step_avg:31.29ms
+step:440/1490 train_time:13771ms step_avg:31.30ms
+step:441/1490 train_time:13799ms step_avg:31.29ms
+step:442/1490 train_time:13834ms step_avg:31.30ms
+step:443/1490 train_time:13862ms step_avg:31.29ms
+step:444/1490 train_time:13897ms step_avg:31.30ms
+step:445/1490 train_time:13924ms step_avg:31.29ms
+step:446/1490 train_time:13960ms step_avg:31.30ms
+step:447/1490 train_time:13987ms step_avg:31.29ms
+step:448/1490 train_time:14021ms step_avg:31.30ms
+step:449/1490 train_time:14049ms step_avg:31.29ms
+step:450/1490 train_time:14084ms step_avg:31.30ms
+step:451/1490 train_time:14111ms step_avg:31.29ms
+step:452/1490 train_time:14146ms step_avg:31.30ms
+step:453/1490 train_time:14174ms step_avg:31.29ms
+step:454/1490 train_time:14208ms step_avg:31.30ms
+step:455/1490 train_time:14236ms step_avg:31.29ms
+step:456/1490 train_time:14270ms step_avg:31.29ms
+step:457/1490 train_time:14298ms step_avg:31.29ms
+step:458/1490 train_time:14332ms step_avg:31.29ms
+step:459/1490 train_time:14360ms step_avg:31.29ms
+step:460/1490 train_time:14394ms step_avg:31.29ms
+step:461/1490 train_time:14422ms step_avg:31.28ms
+step:462/1490 train_time:14457ms step_avg:31.29ms
+step:463/1490 train_time:14485ms step_avg:31.28ms
+step:464/1490 train_time:14519ms step_avg:31.29ms
+step:465/1490 train_time:14547ms step_avg:31.28ms
+step:466/1490 train_time:14582ms step_avg:31.29ms
+step:467/1490 train_time:14610ms step_avg:31.28ms
+step:468/1490 train_time:14644ms step_avg:31.29ms
+step:469/1490 train_time:14672ms step_avg:31.28ms
+step:470/1490 train_time:14706ms step_avg:31.29ms
+step:471/1490 train_time:14734ms step_avg:31.28ms
+step:472/1490 train_time:14768ms step_avg:31.29ms
+step:473/1490 train_time:14797ms step_avg:31.28ms
+step:474/1490 train_time:14831ms step_avg:31.29ms
+step:475/1490 train_time:14859ms step_avg:31.28ms
+step:476/1490 train_time:14893ms step_avg:31.29ms
+step:477/1490 train_time:14921ms step_avg:31.28ms
+step:478/1490 train_time:14956ms step_avg:31.29ms
+step:479/1490 train_time:14984ms step_avg:31.28ms
+step:480/1490 train_time:15018ms step_avg:31.29ms
+step:481/1490 train_time:15046ms step_avg:31.28ms
+step:482/1490 train_time:15081ms step_avg:31.29ms
+step:483/1490 train_time:15109ms step_avg:31.28ms
+step:484/1490 train_time:15146ms step_avg:31.29ms
+step:485/1490 train_time:15197ms step_avg:31.33ms
+step:486/1490 train_time:15255ms step_avg:31.39ms
+step:487/1490 train_time:15309ms step_avg:31.44ms
+step:488/1490 train_time:15368ms step_avg:31.49ms
+step:489/1490 train_time:15421ms step_avg:31.54ms
+step:490/1490 train_time:15481ms step_avg:31.59ms
+step:491/1490 train_time:15536ms step_avg:31.64ms
+step:492/1490 train_time:15595ms step_avg:31.70ms
+step:493/1490 train_time:15649ms step_avg:31.74ms
+step:494/1490 train_time:15708ms step_avg:31.80ms
+step:495/1490 train_time:15762ms step_avg:31.84ms
+step:496/1490 train_time:15822ms step_avg:31.90ms
+step:497/1490 train_time:15876ms step_avg:31.94ms
+step:498/1490 train_time:15934ms step_avg:32.00ms
+step:499/1490 train_time:15988ms step_avg:32.04ms
+step:500/1490 train_time:16048ms step_avg:32.10ms
+step:500/1490 val_loss:4.2060 train_time:16120ms step_avg:32.24ms
+step:501/1490 train_time:16140ms step_avg:32.22ms
+step:502/1490 train_time:16165ms step_avg:32.20ms
+step:503/1490 train_time:16222ms step_avg:32.25ms
+step:504/1490 train_time:16286ms step_avg:32.31ms
+step:505/1490 train_time:16340ms step_avg:32.36ms
+step:506/1490 train_time:16399ms step_avg:32.41ms
+step:507/1490 train_time:16454ms step_avg:32.45ms
+step:508/1490 train_time:16511ms step_avg:32.50ms
+step:509/1490 train_time:16565ms step_avg:32.54ms
+step:510/1490 train_time:16624ms step_avg:32.60ms
+step:511/1490 train_time:16676ms step_avg:32.63ms
+step:512/1490 train_time:16735ms step_avg:32.69ms
+step:513/1490 train_time:16788ms step_avg:32.73ms
+step:514/1490 train_time:16846ms step_avg:32.78ms
+step:515/1490 train_time:16899ms step_avg:32.81ms
+step:516/1490 train_time:16958ms step_avg:32.86ms
+step:517/1490 train_time:17011ms step_avg:32.90ms
+step:518/1490 train_time:17069ms step_avg:32.95ms
+step:519/1490 train_time:17124ms step_avg:33.00ms
+step:520/1490 train_time:17186ms step_avg:33.05ms
+step:521/1490 train_time:17241ms step_avg:33.09ms
+step:522/1490 train_time:17301ms step_avg:33.14ms
+step:523/1490 train_time:17355ms step_avg:33.18ms
+step:524/1490 train_time:17414ms step_avg:33.23ms
+step:525/1490 train_time:17469ms step_avg:33.27ms
+step:526/1490 train_time:17528ms step_avg:33.32ms
+step:527/1490 train_time:17582ms step_avg:33.36ms
+step:528/1490 train_time:17640ms step_avg:33.41ms
+step:529/1490 train_time:17693ms step_avg:33.45ms
+step:530/1490 train_time:17752ms step_avg:33.49ms
+step:531/1490 train_time:17805ms step_avg:33.53ms
+step:532/1490 train_time:17863ms step_avg:33.58ms
+step:533/1490 train_time:17916ms step_avg:33.61ms
+step:534/1490 train_time:17975ms step_avg:33.66ms
+step:535/1490 train_time:18028ms step_avg:33.70ms
+step:536/1490 train_time:18089ms step_avg:33.75ms
+step:537/1490 train_time:18144ms step_avg:33.79ms
+step:538/1490 train_time:18204ms step_avg:33.84ms
+step:539/1490 train_time:18259ms step_avg:33.88ms
+step:540/1490 train_time:18319ms step_avg:33.92ms
+step:541/1490 train_time:18372ms step_avg:33.96ms
+step:542/1490 train_time:18431ms step_avg:34.01ms
+step:543/1490 train_time:18486ms step_avg:34.04ms
+step:544/1490 train_time:18546ms step_avg:34.09ms
+step:545/1490 train_time:18599ms step_avg:34.13ms
+step:546/1490 train_time:18657ms step_avg:34.17ms
+step:547/1490 train_time:18711ms step_avg:34.21ms
+step:548/1490 train_time:18770ms step_avg:34.25ms
+step:549/1490 train_time:18824ms step_avg:34.29ms
+step:550/1490 train_time:18883ms step_avg:34.33ms
+step:551/1490 train_time:18935ms step_avg:34.37ms
+step:552/1490 train_time:18995ms step_avg:34.41ms
+step:553/1490 train_time:19049ms step_avg:34.45ms
+step:554/1490 train_time:19108ms step_avg:34.49ms
+step:555/1490 train_time:19162ms step_avg:34.53ms
+step:556/1490 train_time:19222ms step_avg:34.57ms
+step:557/1490 train_time:19277ms step_avg:34.61ms
+step:558/1490 train_time:19337ms step_avg:34.65ms
+step:559/1490 train_time:19391ms step_avg:34.69ms
+step:560/1490 train_time:19451ms step_avg:34.73ms
+step:561/1490 train_time:19504ms step_avg:34.77ms
+step:562/1490 train_time:19564ms step_avg:34.81ms
+step:563/1490 train_time:19617ms step_avg:34.84ms
+step:564/1490 train_time:19676ms step_avg:34.89ms
+step:565/1490 train_time:19729ms step_avg:34.92ms
+step:566/1490 train_time:19788ms step_avg:34.96ms
+step:567/1490 train_time:19842ms step_avg:35.00ms
+step:568/1490 train_time:19901ms step_avg:35.04ms
+step:569/1490 train_time:19954ms step_avg:35.07ms
+step:570/1490 train_time:20013ms step_avg:35.11ms
+step:571/1490 train_time:20066ms step_avg:35.14ms
+step:572/1490 train_time:20126ms step_avg:35.19ms
+step:573/1490 train_time:20180ms step_avg:35.22ms
+step:574/1490 train_time:20240ms step_avg:35.26ms
+step:575/1490 train_time:20294ms step_avg:35.29ms
+step:576/1490 train_time:20354ms step_avg:35.34ms
+step:577/1490 train_time:20408ms step_avg:35.37ms
+step:578/1490 train_time:20468ms step_avg:35.41ms
+step:579/1490 train_time:20522ms step_avg:35.44ms
+step:580/1490 train_time:20580ms step_avg:35.48ms
+step:581/1490 train_time:20634ms step_avg:35.51ms
+step:582/1490 train_time:20693ms step_avg:35.55ms
+step:583/1490 train_time:20746ms step_avg:35.59ms
+step:584/1490 train_time:20805ms step_avg:35.63ms
+step:585/1490 train_time:20859ms step_avg:35.66ms
+step:586/1490 train_time:20917ms step_avg:35.69ms
+step:587/1490 train_time:20971ms step_avg:35.73ms
+step:588/1490 train_time:21030ms step_avg:35.77ms
+step:589/1490 train_time:21083ms step_avg:35.80ms
+step:590/1490 train_time:21143ms step_avg:35.84ms
+step:591/1490 train_time:21197ms step_avg:35.87ms
+step:592/1490 train_time:21257ms step_avg:35.91ms
+step:593/1490 train_time:21311ms step_avg:35.94ms
+step:594/1490 train_time:21371ms step_avg:35.98ms
+step:595/1490 train_time:21425ms step_avg:36.01ms
+step:596/1490 train_time:21483ms step_avg:36.05ms
+step:597/1490 train_time:21537ms step_avg:36.08ms
+step:598/1490 train_time:21596ms step_avg:36.11ms
+step:599/1490 train_time:21651ms step_avg:36.14ms
+step:600/1490 train_time:21709ms step_avg:36.18ms
+step:601/1490 train_time:21762ms step_avg:36.21ms
+step:602/1490 train_time:21821ms step_avg:36.25ms
+step:603/1490 train_time:21874ms step_avg:36.28ms
+step:604/1490 train_time:21934ms step_avg:36.32ms
+step:605/1490 train_time:21988ms step_avg:36.34ms
+step:606/1490 train_time:22048ms step_avg:36.38ms
+step:607/1490 train_time:22102ms step_avg:36.41ms
+step:608/1490 train_time:22161ms step_avg:36.45ms
+step:609/1490 train_time:22214ms step_avg:36.48ms
+step:610/1490 train_time:22274ms step_avg:36.51ms
+step:611/1490 train_time:22328ms step_avg:36.54ms
+step:612/1490 train_time:22388ms step_avg:36.58ms
+step:613/1490 train_time:22441ms step_avg:36.61ms
+step:614/1490 train_time:22500ms step_avg:36.64ms
+step:615/1490 train_time:22554ms step_avg:36.67ms
+step:616/1490 train_time:22613ms step_avg:36.71ms
+step:617/1490 train_time:22667ms step_avg:36.74ms
+step:618/1490 train_time:22726ms step_avg:36.77ms
+step:619/1490 train_time:22780ms step_avg:36.80ms
+step:620/1490 train_time:22839ms step_avg:36.84ms
+step:621/1490 train_time:22892ms step_avg:36.86ms
+step:622/1490 train_time:22952ms step_avg:36.90ms
+step:623/1490 train_time:23005ms step_avg:36.93ms
+step:624/1490 train_time:23064ms step_avg:36.96ms
+step:625/1490 train_time:23117ms step_avg:36.99ms
+step:626/1490 train_time:23176ms step_avg:37.02ms
+step:627/1490 train_time:23231ms step_avg:37.05ms
+step:628/1490 train_time:23290ms step_avg:37.09ms
+step:629/1490 train_time:23345ms step_avg:37.11ms
+step:630/1490 train_time:23404ms step_avg:37.15ms
+step:631/1490 train_time:23458ms step_avg:37.18ms
+step:632/1490 train_time:23517ms step_avg:37.21ms
+step:633/1490 train_time:23571ms step_avg:37.24ms
+step:634/1490 train_time:23630ms step_avg:37.27ms
+step:635/1490 train_time:23684ms step_avg:37.30ms
+step:636/1490 train_time:23743ms step_avg:37.33ms
+step:637/1490 train_time:23796ms step_avg:37.36ms
+step:638/1490 train_time:23857ms step_avg:37.39ms
+step:639/1490 train_time:23910ms step_avg:37.42ms
+step:640/1490 train_time:23969ms step_avg:37.45ms
+step:641/1490 train_time:24024ms step_avg:37.48ms
+step:642/1490 train_time:24083ms step_avg:37.51ms
+step:643/1490 train_time:24136ms step_avg:37.54ms
+step:644/1490 train_time:24197ms step_avg:37.57ms
+step:645/1490 train_time:24250ms step_avg:37.60ms
+step:646/1490 train_time:24309ms step_avg:37.63ms
+step:647/1490 train_time:24364ms step_avg:37.66ms
+step:648/1490 train_time:24423ms step_avg:37.69ms
+step:649/1490 train_time:24478ms step_avg:37.72ms
+step:650/1490 train_time:24536ms step_avg:37.75ms
+step:651/1490 train_time:24590ms step_avg:37.77ms
+step:652/1490 train_time:24650ms step_avg:37.81ms
+step:653/1490 train_time:24703ms step_avg:37.83ms
+step:654/1490 train_time:24763ms step_avg:37.86ms
+step:655/1490 train_time:24816ms step_avg:37.89ms
+step:656/1490 train_time:24875ms step_avg:37.92ms
+step:657/1490 train_time:24929ms step_avg:37.94ms
+step:658/1490 train_time:24988ms step_avg:37.98ms
+step:659/1490 train_time:25042ms step_avg:38.00ms
+step:660/1490 train_time:25101ms step_avg:38.03ms
+step:661/1490 train_time:25155ms step_avg:38.06ms
+step:662/1490 train_time:25214ms step_avg:38.09ms
+step:663/1490 train_time:25268ms step_avg:38.11ms
+step:664/1490 train_time:25327ms step_avg:38.14ms
+step:665/1490 train_time:25382ms step_avg:38.17ms
+step:666/1490 train_time:25441ms step_avg:38.20ms
+step:667/1490 train_time:25495ms step_avg:38.22ms
+step:668/1490 train_time:25554ms step_avg:38.25ms
+step:669/1490 train_time:25607ms step_avg:38.28ms
+step:670/1490 train_time:25667ms step_avg:38.31ms
+step:671/1490 train_time:25721ms step_avg:38.33ms
+step:672/1490 train_time:25780ms step_avg:38.36ms
+step:673/1490 train_time:25833ms step_avg:38.38ms
+step:674/1490 train_time:25893ms step_avg:38.42ms
+step:675/1490 train_time:25947ms step_avg:38.44ms
+step:676/1490 train_time:26006ms step_avg:38.47ms
+step:677/1490 train_time:26060ms step_avg:38.49ms
+step:678/1490 train_time:26120ms step_avg:38.52ms
+step:679/1490 train_time:26174ms step_avg:38.55ms
+step:680/1490 train_time:26232ms step_avg:38.58ms
+step:681/1490 train_time:26286ms step_avg:38.60ms
+step:682/1490 train_time:26346ms step_avg:38.63ms
+step:683/1490 train_time:26400ms step_avg:38.65ms
+step:684/1490 train_time:26459ms step_avg:38.68ms
+step:685/1490 train_time:26512ms step_avg:38.70ms
+step:686/1490 train_time:26572ms step_avg:38.73ms
+step:687/1490 train_time:26626ms step_avg:38.76ms
+step:688/1490 train_time:26687ms step_avg:38.79ms
+step:689/1490 train_time:26740ms step_avg:38.81ms
+step:690/1490 train_time:26800ms step_avg:38.84ms
+step:691/1490 train_time:26853ms step_avg:38.86ms
+step:692/1490 train_time:26912ms step_avg:38.89ms
+step:693/1490 train_time:26966ms step_avg:38.91ms
+step:694/1490 train_time:27025ms step_avg:38.94ms
+step:695/1490 train_time:27079ms step_avg:38.96ms
+step:696/1490 train_time:27138ms step_avg:38.99ms
+step:697/1490 train_time:27192ms step_avg:39.01ms
+step:698/1490 train_time:27251ms step_avg:39.04ms
+step:699/1490 train_time:27305ms step_avg:39.06ms
+step:700/1490 train_time:27365ms step_avg:39.09ms
+step:701/1490 train_time:27418ms step_avg:39.11ms
+step:702/1490 train_time:27477ms step_avg:39.14ms
+step:703/1490 train_time:27531ms step_avg:39.16ms
+step:704/1490 train_time:27590ms step_avg:39.19ms
+step:705/1490 train_time:27645ms step_avg:39.21ms
+step:706/1490 train_time:27704ms step_avg:39.24ms
+step:707/1490 train_time:27758ms step_avg:39.26ms
+step:708/1490 train_time:27816ms step_avg:39.29ms
+step:709/1490 train_time:27870ms step_avg:39.31ms
+step:710/1490 train_time:27929ms step_avg:39.34ms
+step:711/1490 train_time:27983ms step_avg:39.36ms
+step:712/1490 train_time:28043ms step_avg:39.39ms
+step:713/1490 train_time:28096ms step_avg:39.41ms
+step:714/1490 train_time:28157ms step_avg:39.44ms
+step:715/1490 train_time:28210ms step_avg:39.45ms
+step:716/1490 train_time:28269ms step_avg:39.48ms
+step:717/1490 train_time:28322ms step_avg:39.50ms
+step:718/1490 train_time:28381ms step_avg:39.53ms
+step:719/1490 train_time:28434ms step_avg:39.55ms
+step:720/1490 train_time:28495ms step_avg:39.58ms
+step:721/1490 train_time:28547ms step_avg:39.59ms
+step:722/1490 train_time:28607ms step_avg:39.62ms
+step:723/1490 train_time:28661ms step_avg:39.64ms
+step:724/1490 train_time:28720ms step_avg:39.67ms
+step:725/1490 train_time:28773ms step_avg:39.69ms
+step:726/1490 train_time:28832ms step_avg:39.71ms
+step:727/1490 train_time:28887ms step_avg:39.73ms
+step:728/1490 train_time:28947ms step_avg:39.76ms
+step:729/1490 train_time:29001ms step_avg:39.78ms
+step:730/1490 train_time:29060ms step_avg:39.81ms
+step:731/1490 train_time:29114ms step_avg:39.83ms
+step:732/1490 train_time:29173ms step_avg:39.85ms
+step:733/1490 train_time:29227ms step_avg:39.87ms
+step:734/1490 train_time:29287ms step_avg:39.90ms
+step:735/1490 train_time:29341ms step_avg:39.92ms
+step:736/1490 train_time:29399ms step_avg:39.94ms
+step:737/1490 train_time:29454ms step_avg:39.96ms
+step:738/1490 train_time:29513ms step_avg:39.99ms
+step:739/1490 train_time:29566ms step_avg:40.01ms
+step:740/1490 train_time:29626ms step_avg:40.04ms
+step:741/1490 train_time:29680ms step_avg:40.05ms
+step:742/1490 train_time:29738ms step_avg:40.08ms
+step:743/1490 train_time:29792ms step_avg:40.10ms
+step:744/1490 train_time:29853ms step_avg:40.12ms
+step:745/1490 train_time:29906ms step_avg:40.14ms
+step:746/1490 train_time:29966ms step_avg:40.17ms
+step:747/1490 train_time:30020ms step_avg:40.19ms
+step:748/1490 train_time:30079ms step_avg:40.21ms
+step:749/1490 train_time:30133ms step_avg:40.23ms
+step:750/1490 train_time:30192ms step_avg:40.26ms
+step:750/1490 val_loss:3.8045 train_time:30263ms step_avg:40.35ms
+step:751/1490 train_time:30282ms step_avg:40.32ms
+step:752/1490 train_time:30307ms step_avg:40.30ms
+step:753/1490 train_time:30364ms step_avg:40.32ms
+step:754/1490 train_time:30425ms step_avg:40.35ms
+step:755/1490 train_time:30479ms step_avg:40.37ms
+step:756/1490 train_time:30538ms step_avg:40.39ms
+step:757/1490 train_time:30594ms step_avg:40.41ms
+step:758/1490 train_time:30653ms step_avg:40.44ms
+step:759/1490 train_time:30707ms step_avg:40.46ms
+step:760/1490 train_time:30767ms step_avg:40.48ms
+step:761/1490 train_time:30820ms step_avg:40.50ms
+step:762/1490 train_time:30880ms step_avg:40.52ms
+step:763/1490 train_time:30933ms step_avg:40.54ms
+step:764/1490 train_time:30991ms step_avg:40.56ms
+step:765/1490 train_time:31044ms step_avg:40.58ms
+step:766/1490 train_time:31102ms step_avg:40.60ms
+step:767/1490 train_time:31155ms step_avg:40.62ms
+step:768/1490 train_time:31213ms step_avg:40.64ms
+step:769/1490 train_time:31268ms step_avg:40.66ms
+step:770/1490 train_time:31329ms step_avg:40.69ms
+step:771/1490 train_time:31385ms step_avg:40.71ms
+step:772/1490 train_time:31446ms step_avg:40.73ms
+step:773/1490 train_time:31502ms step_avg:40.75ms
+step:774/1490 train_time:31561ms step_avg:40.78ms
+step:775/1490 train_time:31614ms step_avg:40.79ms
+step:776/1490 train_time:31674ms step_avg:40.82ms
+step:777/1490 train_time:31727ms step_avg:40.83ms
+step:778/1490 train_time:31787ms step_avg:40.86ms
+step:779/1490 train_time:31840ms step_avg:40.87ms
+step:780/1490 train_time:31898ms step_avg:40.90ms
+step:781/1490 train_time:31952ms step_avg:40.91ms
+step:782/1490 train_time:32011ms step_avg:40.94ms
+step:783/1490 train_time:32065ms step_avg:40.95ms
+step:784/1490 train_time:32124ms step_avg:40.97ms
+step:785/1490 train_time:32177ms step_avg:40.99ms
+step:786/1490 train_time:32236ms step_avg:41.01ms
+step:787/1490 train_time:32291ms step_avg:41.03ms
+step:788/1490 train_time:32351ms step_avg:41.05ms
+step:789/1490 train_time:32406ms step_avg:41.07ms
+step:790/1490 train_time:32467ms step_avg:41.10ms
+step:791/1490 train_time:32521ms step_avg:41.11ms
+step:792/1490 train_time:32581ms step_avg:41.14ms
+step:793/1490 train_time:32634ms step_avg:41.15ms
+step:794/1490 train_time:32693ms step_avg:41.18ms
+step:795/1490 train_time:32746ms step_avg:41.19ms
+step:796/1490 train_time:32807ms step_avg:41.21ms
+step:797/1490 train_time:32860ms step_avg:41.23ms
+step:798/1490 train_time:32919ms step_avg:41.25ms
+step:799/1490 train_time:32973ms step_avg:41.27ms
+step:800/1490 train_time:33031ms step_avg:41.29ms
+step:801/1490 train_time:33085ms step_avg:41.30ms
+step:802/1490 train_time:33144ms step_avg:41.33ms
+step:803/1490 train_time:33198ms step_avg:41.34ms
+step:804/1490 train_time:33257ms step_avg:41.36ms
+step:805/1490 train_time:33312ms step_avg:41.38ms
+step:806/1490 train_time:33372ms step_avg:41.40ms
+step:807/1490 train_time:33426ms step_avg:41.42ms
+step:808/1490 train_time:33486ms step_avg:41.44ms
+step:809/1490 train_time:33540ms step_avg:41.46ms
+step:810/1490 train_time:33599ms step_avg:41.48ms
+step:811/1490 train_time:33652ms step_avg:41.49ms
+step:812/1490 train_time:33712ms step_avg:41.52ms
+step:813/1490 train_time:33765ms step_avg:41.53ms
+step:814/1490 train_time:33825ms step_avg:41.55ms
+step:815/1490 train_time:33879ms step_avg:41.57ms
+step:816/1490 train_time:33937ms step_avg:41.59ms
+step:817/1490 train_time:33991ms step_avg:41.60ms
+step:818/1490 train_time:34051ms step_avg:41.63ms
+step:819/1490 train_time:34104ms step_avg:41.64ms
+step:820/1490 train_time:34164ms step_avg:41.66ms
+step:821/1490 train_time:34218ms step_avg:41.68ms
+step:822/1490 train_time:34277ms step_avg:41.70ms
+step:823/1490 train_time:34330ms step_avg:41.71ms
+step:824/1490 train_time:34390ms step_avg:41.74ms
+step:825/1490 train_time:34444ms step_avg:41.75ms
+step:826/1490 train_time:34505ms step_avg:41.77ms
+step:827/1490 train_time:34560ms step_avg:41.79ms
+step:828/1490 train_time:34618ms step_avg:41.81ms
+step:829/1490 train_time:34673ms step_avg:41.83ms
+step:830/1490 train_time:34732ms step_avg:41.85ms
+step:831/1490 train_time:34786ms step_avg:41.86ms
+step:832/1490 train_time:34845ms step_avg:41.88ms
+step:833/1490 train_time:34900ms step_avg:41.90ms
+step:834/1490 train_time:34958ms step_avg:41.92ms
+step:835/1490 train_time:35012ms step_avg:41.93ms
+step:836/1490 train_time:35071ms step_avg:41.95ms
+step:837/1490 train_time:35125ms step_avg:41.96ms
+step:838/1490 train_time:35184ms step_avg:41.99ms
+step:839/1490 train_time:35237ms step_avg:42.00ms
+step:840/1490 train_time:35297ms step_avg:42.02ms
+step:841/1490 train_time:35350ms step_avg:42.03ms
+step:842/1490 train_time:35410ms step_avg:42.05ms
+step:843/1490 train_time:35464ms step_avg:42.07ms
+step:844/1490 train_time:35523ms step_avg:42.09ms
+step:845/1490 train_time:35577ms step_avg:42.10ms
+step:846/1490 train_time:35637ms step_avg:42.12ms
+step:847/1490 train_time:35691ms step_avg:42.14ms
+step:848/1490 train_time:35751ms step_avg:42.16ms
+step:849/1490 train_time:35805ms step_avg:42.17ms
+step:850/1490 train_time:35864ms step_avg:42.19ms
+step:851/1490 train_time:35917ms step_avg:42.21ms
+step:852/1490 train_time:35977ms step_avg:42.23ms
+step:853/1490 train_time:36030ms step_avg:42.24ms
+step:854/1490 train_time:36090ms step_avg:42.26ms
+step:855/1490 train_time:36143ms step_avg:42.27ms
+step:856/1490 train_time:36203ms step_avg:42.29ms
+step:857/1490 train_time:36256ms step_avg:42.31ms
+step:858/1490 train_time:36315ms step_avg:42.33ms
+step:859/1490 train_time:36369ms step_avg:42.34ms
+step:860/1490 train_time:36429ms step_avg:42.36ms
+step:861/1490 train_time:36483ms step_avg:42.37ms
+step:862/1490 train_time:36542ms step_avg:42.39ms
+step:863/1490 train_time:36595ms step_avg:42.40ms
+step:864/1490 train_time:36655ms step_avg:42.42ms
+step:865/1490 train_time:36709ms step_avg:42.44ms
+step:866/1490 train_time:36769ms step_avg:42.46ms
+step:867/1490 train_time:36822ms step_avg:42.47ms
+step:868/1490 train_time:36881ms step_avg:42.49ms
+step:869/1490 train_time:36935ms step_avg:42.50ms
+step:870/1490 train_time:36994ms step_avg:42.52ms
+step:871/1490 train_time:37048ms step_avg:42.54ms
+step:872/1490 train_time:37107ms step_avg:42.55ms
+step:873/1490 train_time:37161ms step_avg:42.57ms
+step:874/1490 train_time:37220ms step_avg:42.59ms
+step:875/1490 train_time:37274ms step_avg:42.60ms
+step:876/1490 train_time:37332ms step_avg:42.62ms
+step:877/1490 train_time:37386ms step_avg:42.63ms
+step:878/1490 train_time:37446ms step_avg:42.65ms
+step:879/1490 train_time:37499ms step_avg:42.66ms
+step:880/1490 train_time:37558ms step_avg:42.68ms
+step:881/1490 train_time:37612ms step_avg:42.69ms
+step:882/1490 train_time:37672ms step_avg:42.71ms
+step:883/1490 train_time:37725ms step_avg:42.72ms
+step:884/1490 train_time:37785ms step_avg:42.74ms
+step:885/1490 train_time:37840ms step_avg:42.76ms
+step:886/1490 train_time:37899ms step_avg:42.78ms
+step:887/1490 train_time:37952ms step_avg:42.79ms
+step:888/1490 train_time:38012ms step_avg:42.81ms
+step:889/1490 train_time:38066ms step_avg:42.82ms
+step:890/1490 train_time:38125ms step_avg:42.84ms
+step:891/1490 train_time:38179ms step_avg:42.85ms
+step:892/1490 train_time:38238ms step_avg:42.87ms
+step:893/1490 train_time:38292ms step_avg:42.88ms
+step:894/1490 train_time:38351ms step_avg:42.90ms
+step:895/1490 train_time:38405ms step_avg:42.91ms
+step:896/1490 train_time:38465ms step_avg:42.93ms
+step:897/1490 train_time:38518ms step_avg:42.94ms
+step:898/1490 train_time:38578ms step_avg:42.96ms
+step:899/1490 train_time:38632ms step_avg:42.97ms
+step:900/1490 train_time:38692ms step_avg:42.99ms
+step:901/1490 train_time:38745ms step_avg:43.00ms
+step:902/1490 train_time:38806ms step_avg:43.02ms
+step:903/1490 train_time:38860ms step_avg:43.03ms
+step:904/1490 train_time:38918ms step_avg:43.05ms
+step:905/1490 train_time:38972ms step_avg:43.06ms
+step:906/1490 train_time:39031ms step_avg:43.08ms
+step:907/1490 train_time:39085ms step_avg:43.09ms
+step:908/1490 train_time:39145ms step_avg:43.11ms
+step:909/1490 train_time:39198ms step_avg:43.12ms
+step:910/1490 train_time:39258ms step_avg:43.14ms
+step:911/1490 train_time:39312ms step_avg:43.15ms
+step:912/1490 train_time:39371ms step_avg:43.17ms
+step:913/1490 train_time:39424ms step_avg:43.18ms
+step:914/1490 train_time:39484ms step_avg:43.20ms
+step:915/1490 train_time:39537ms step_avg:43.21ms
+step:916/1490 train_time:39597ms step_avg:43.23ms
+step:917/1490 train_time:39651ms step_avg:43.24ms
+step:918/1490 train_time:39710ms step_avg:43.26ms
+step:919/1490 train_time:39764ms step_avg:43.27ms
+step:920/1490 train_time:39823ms step_avg:43.29ms
+step:921/1490 train_time:39877ms step_avg:43.30ms
+step:922/1490 train_time:39935ms step_avg:43.31ms
+step:923/1490 train_time:39989ms step_avg:43.33ms
+step:924/1490 train_time:40049ms step_avg:43.34ms
+step:925/1490 train_time:40103ms step_avg:43.35ms
+step:926/1490 train_time:40162ms step_avg:43.37ms
+step:927/1490 train_time:40216ms step_avg:43.38ms
+step:928/1490 train_time:40276ms step_avg:43.40ms
+step:929/1490 train_time:40329ms step_avg:43.41ms
+step:930/1490 train_time:40388ms step_avg:43.43ms
+step:931/1490 train_time:40442ms step_avg:43.44ms
+step:932/1490 train_time:40501ms step_avg:43.46ms
+step:933/1490 train_time:40554ms step_avg:43.47ms
+step:934/1490 train_time:40614ms step_avg:43.48ms
+step:935/1490 train_time:40668ms step_avg:43.49ms
+step:936/1490 train_time:40726ms step_avg:43.51ms
+step:937/1490 train_time:40781ms step_avg:43.52ms
+step:938/1490 train_time:40841ms step_avg:43.54ms
+step:939/1490 train_time:40894ms step_avg:43.55ms
+step:940/1490 train_time:40953ms step_avg:43.57ms
+step:941/1490 train_time:41007ms step_avg:43.58ms
+step:942/1490 train_time:41067ms step_avg:43.60ms
+step:943/1490 train_time:41120ms step_avg:43.61ms
+step:944/1490 train_time:41179ms step_avg:43.62ms
+step:945/1490 train_time:41233ms step_avg:43.63ms
+step:946/1490 train_time:41292ms step_avg:43.65ms
+step:947/1490 train_time:41345ms step_avg:43.66ms
+step:948/1490 train_time:41405ms step_avg:43.68ms
+step:949/1490 train_time:41459ms step_avg:43.69ms
+step:950/1490 train_time:41519ms step_avg:43.70ms
+step:951/1490 train_time:41573ms step_avg:43.71ms
+step:952/1490 train_time:41632ms step_avg:43.73ms
+step:953/1490 train_time:41685ms step_avg:43.74ms
+step:954/1490 train_time:41745ms step_avg:43.76ms
+step:955/1490 train_time:41800ms step_avg:43.77ms
+step:956/1490 train_time:41859ms step_avg:43.79ms
+step:957/1490 train_time:41913ms step_avg:43.80ms
+step:958/1490 train_time:41972ms step_avg:43.81ms
+step:959/1490 train_time:42025ms step_avg:43.82ms
+step:960/1490 train_time:42085ms step_avg:43.84ms
+step:961/1490 train_time:42139ms step_avg:43.85ms
+step:962/1490 train_time:42197ms step_avg:43.86ms
+step:963/1490 train_time:42251ms step_avg:43.87ms
+step:964/1490 train_time:42310ms step_avg:43.89ms
+step:965/1490 train_time:42364ms step_avg:43.90ms
+step:966/1490 train_time:42423ms step_avg:43.92ms
+step:967/1490 train_time:42477ms step_avg:43.93ms
+step:968/1490 train_time:42539ms step_avg:43.95ms
+step:969/1490 train_time:42617ms step_avg:43.98ms
+step:970/1490 train_time:42701ms step_avg:44.02ms
+step:971/1490 train_time:42782ms step_avg:44.06ms
+step:972/1490 train_time:42866ms step_avg:44.10ms
+step:973/1490 train_time:42946ms step_avg:44.14ms
+step:974/1490 train_time:43030ms step_avg:44.18ms
+step:975/1490 train_time:43110ms step_avg:44.22ms
+step:976/1490 train_time:43196ms step_avg:44.26ms
+step:977/1490 train_time:43275ms step_avg:44.29ms
+step:978/1490 train_time:43358ms step_avg:44.33ms
+step:979/1490 train_time:43439ms step_avg:44.37ms
+step:980/1490 train_time:43524ms step_avg:44.41ms
+step:981/1490 train_time:43603ms step_avg:44.45ms
+step:982/1490 train_time:43688ms step_avg:44.49ms
+step:983/1490 train_time:43768ms step_avg:44.53ms
+step:984/1490 train_time:43853ms step_avg:44.57ms
+step:985/1490 train_time:43933ms step_avg:44.60ms
+step:986/1490 train_time:44019ms step_avg:44.64ms
+step:987/1490 train_time:44099ms step_avg:44.68ms
+step:988/1490 train_time:44183ms step_avg:44.72ms
+step:989/1490 train_time:44262ms step_avg:44.75ms
+step:990/1490 train_time:44347ms step_avg:44.79ms
+step:991/1490 train_time:44427ms step_avg:44.83ms
+step:992/1490 train_time:44512ms step_avg:44.87ms
+step:993/1490 train_time:44593ms step_avg:44.91ms
+step:994/1490 train_time:44678ms step_avg:44.95ms
+step:995/1490 train_time:44758ms step_avg:44.98ms
+step:996/1490 train_time:44844ms step_avg:45.02ms
+step:997/1490 train_time:44924ms step_avg:45.06ms
+step:998/1490 train_time:45009ms step_avg:45.10ms
+step:999/1490 train_time:45089ms step_avg:45.13ms
+step:1000/1490 train_time:45173ms step_avg:45.17ms
+step:1000/1490 val_loss:3.5225 train_time:45276ms step_avg:45.28ms
+step:1001/1490 train_time:45302ms step_avg:45.26ms
+step:1002/1490 train_time:45346ms step_avg:45.26ms
+step:1003/1490 train_time:45429ms step_avg:45.29ms
+step:1004/1490 train_time:45516ms step_avg:45.33ms
+step:1005/1490 train_time:45597ms step_avg:45.37ms
+step:1006/1490 train_time:45680ms step_avg:45.41ms
+step:1007/1490 train_time:45760ms step_avg:45.44ms
+step:1008/1490 train_time:45843ms step_avg:45.48ms
+step:1009/1490 train_time:45921ms step_avg:45.51ms
+step:1010/1490 train_time:46006ms step_avg:45.55ms
+step:1011/1490 train_time:46085ms step_avg:45.58ms
+step:1012/1490 train_time:46168ms step_avg:45.62ms
+step:1013/1490 train_time:46250ms step_avg:45.66ms
+step:1014/1490 train_time:46337ms step_avg:45.70ms
+step:1015/1490 train_time:46418ms step_avg:45.73ms
+step:1016/1490 train_time:46506ms step_avg:45.77ms
+step:1017/1490 train_time:46585ms step_avg:45.81ms
+step:1018/1490 train_time:46670ms step_avg:45.84ms
+step:1019/1490 train_time:46749ms step_avg:45.88ms
+step:1020/1490 train_time:46833ms step_avg:45.91ms
+step:1021/1490 train_time:46912ms step_avg:45.95ms
+step:1022/1490 train_time:46997ms step_avg:45.98ms
+step:1023/1490 train_time:47074ms step_avg:46.02ms
+step:1024/1490 train_time:47159ms step_avg:46.05ms
+step:1025/1490 train_time:47238ms step_avg:46.09ms
+step:1026/1490 train_time:47324ms step_avg:46.12ms
+step:1027/1490 train_time:47406ms step_avg:46.16ms
+step:1028/1490 train_time:47492ms step_avg:46.20ms
+step:1029/1490 train_time:47572ms step_avg:46.23ms
+step:1030/1490 train_time:47656ms step_avg:46.27ms
+step:1031/1490 train_time:47736ms step_avg:46.30ms
+step:1032/1490 train_time:47819ms step_avg:46.34ms
+step:1033/1490 train_time:47898ms step_avg:46.37ms
+step:1034/1490 train_time:47982ms step_avg:46.40ms
+step:1035/1490 train_time:48061ms step_avg:46.44ms
+step:1036/1490 train_time:48146ms step_avg:46.47ms
+step:1037/1490 train_time:48225ms step_avg:46.50ms
+step:1038/1490 train_time:48311ms step_avg:46.54ms
+step:1039/1490 train_time:48392ms step_avg:46.58ms
+step:1040/1490 train_time:48477ms step_avg:46.61ms
+step:1041/1490 train_time:48557ms step_avg:46.64ms
+step:1042/1490 train_time:48644ms step_avg:46.68ms
+step:1043/1490 train_time:48724ms step_avg:46.71ms
+step:1044/1490 train_time:48808ms step_avg:46.75ms
+step:1045/1490 train_time:48886ms step_avg:46.78ms
+step:1046/1490 train_time:48970ms step_avg:46.82ms
+step:1047/1490 train_time:49049ms step_avg:46.85ms
+step:1048/1490 train_time:49134ms step_avg:46.88ms
+step:1049/1490 train_time:49213ms step_avg:46.91ms
+step:1050/1490 train_time:49299ms step_avg:46.95ms
+step:1051/1490 train_time:49378ms step_avg:46.98ms
+step:1052/1490 train_time:49465ms step_avg:47.02ms
+step:1053/1490 train_time:49544ms step_avg:47.05ms
+step:1054/1490 train_time:49630ms step_avg:47.09ms
+step:1055/1490 train_time:49709ms step_avg:47.12ms
+step:1056/1490 train_time:49793ms step_avg:47.15ms
+step:1057/1490 train_time:49872ms step_avg:47.18ms
+step:1058/1490 train_time:49957ms step_avg:47.22ms
+step:1059/1490 train_time:50037ms step_avg:47.25ms
+step:1060/1490 train_time:50122ms step_avg:47.28ms
+step:1061/1490 train_time:50201ms step_avg:47.32ms
+step:1062/1490 train_time:50286ms step_avg:47.35ms
+step:1063/1490 train_time:50366ms step_avg:47.38ms
+step:1064/1490 train_time:50452ms step_avg:47.42ms
+step:1065/1490 train_time:50531ms step_avg:47.45ms
+step:1066/1490 train_time:50616ms step_avg:47.48ms
+step:1067/1490 train_time:50696ms step_avg:47.51ms
+step:1068/1490 train_time:50780ms step_avg:47.55ms
+step:1069/1490 train_time:50859ms step_avg:47.58ms
+step:1070/1490 train_time:50945ms step_avg:47.61ms
+step:1071/1490 train_time:51024ms step_avg:47.64ms
+step:1072/1490 train_time:51109ms step_avg:47.68ms
+step:1073/1490 train_time:51186ms step_avg:47.70ms
+step:1074/1490 train_time:51270ms step_avg:47.74ms
+step:1075/1490 train_time:51352ms step_avg:47.77ms
+step:1076/1490 train_time:51437ms step_avg:47.80ms
+step:1077/1490 train_time:51516ms step_avg:47.83ms
+step:1078/1490 train_time:51602ms step_avg:47.87ms
+step:1079/1490 train_time:51681ms step_avg:47.90ms
+step:1080/1490 train_time:51765ms step_avg:47.93ms
+step:1081/1490 train_time:51844ms step_avg:47.96ms
+step:1082/1490 train_time:51929ms step_avg:47.99ms
+step:1083/1490 train_time:52009ms step_avg:48.02ms
+step:1084/1490 train_time:52094ms step_avg:48.06ms
+step:1085/1490 train_time:52174ms step_avg:48.09ms
+step:1086/1490 train_time:52260ms step_avg:48.12ms
+step:1087/1490 train_time:52340ms step_avg:48.15ms
+step:1088/1490 train_time:52425ms step_avg:48.19ms
+step:1089/1490 train_time:52505ms step_avg:48.21ms
+step:1090/1490 train_time:52591ms step_avg:48.25ms
+step:1091/1490 train_time:52670ms step_avg:48.28ms
+step:1092/1490 train_time:52755ms step_avg:48.31ms
+step:1093/1490 train_time:52834ms step_avg:48.34ms
+step:1094/1490 train_time:52919ms step_avg:48.37ms
+step:1095/1490 train_time:52998ms step_avg:48.40ms
+step:1096/1490 train_time:53081ms step_avg:48.43ms
+step:1097/1490 train_time:53160ms step_avg:48.46ms
+step:1098/1490 train_time:53246ms step_avg:48.49ms
+step:1099/1490 train_time:53325ms step_avg:48.52ms
+step:1100/1490 train_time:53410ms step_avg:48.55ms
+step:1101/1490 train_time:53491ms step_avg:48.58ms
+step:1102/1490 train_time:53576ms step_avg:48.62ms
+step:1103/1490 train_time:53656ms step_avg:48.65ms
+step:1104/1490 train_time:53740ms step_avg:48.68ms
+step:1105/1490 train_time:53819ms step_avg:48.70ms
+step:1106/1490 train_time:53903ms step_avg:48.74ms
+step:1107/1490 train_time:53982ms step_avg:48.76ms
+step:1108/1490 train_time:54067ms step_avg:48.80ms
+step:1109/1490 train_time:54147ms step_avg:48.83ms
+step:1110/1490 train_time:54233ms step_avg:48.86ms
+step:1111/1490 train_time:54313ms step_avg:48.89ms
+step:1112/1490 train_time:54396ms step_avg:48.92ms
+step:1113/1490 train_time:54476ms step_avg:48.95ms
+step:1114/1490 train_time:54560ms step_avg:48.98ms
+step:1115/1490 train_time:54639ms step_avg:49.00ms
+step:1116/1490 train_time:54725ms step_avg:49.04ms
+step:1117/1490 train_time:54805ms step_avg:49.06ms
+step:1118/1490 train_time:54890ms step_avg:49.10ms
+step:1119/1490 train_time:54969ms step_avg:49.12ms
+step:1120/1490 train_time:55053ms step_avg:49.15ms
+step:1121/1490 train_time:55135ms step_avg:49.18ms
+step:1122/1490 train_time:55219ms step_avg:49.22ms
+step:1123/1490 train_time:55299ms step_avg:49.24ms
+step:1124/1490 train_time:55385ms step_avg:49.27ms
+step:1125/1490 train_time:55464ms step_avg:49.30ms
+step:1126/1490 train_time:55549ms step_avg:49.33ms
+step:1127/1490 train_time:55629ms step_avg:49.36ms
+step:1128/1490 train_time:55713ms step_avg:49.39ms
+step:1129/1490 train_time:55793ms step_avg:49.42ms
+step:1130/1490 train_time:55878ms step_avg:49.45ms
+step:1131/1490 train_time:55957ms step_avg:49.48ms
+step:1132/1490 train_time:56040ms step_avg:49.51ms
+step:1133/1490 train_time:56119ms step_avg:49.53ms
+step:1134/1490 train_time:56206ms step_avg:49.56ms
+step:1135/1490 train_time:56285ms step_avg:49.59ms
+step:1136/1490 train_time:56369ms step_avg:49.62ms
+step:1137/1490 train_time:56450ms step_avg:49.65ms
+step:1138/1490 train_time:56535ms step_avg:49.68ms
+step:1139/1490 train_time:56615ms step_avg:49.71ms
+step:1140/1490 train_time:56700ms step_avg:49.74ms
+step:1141/1490 train_time:56779ms step_avg:49.76ms
+step:1142/1490 train_time:56864ms step_avg:49.79ms
+step:1143/1490 train_time:56944ms step_avg:49.82ms
+step:1144/1490 train_time:57028ms step_avg:49.85ms
+step:1145/1490 train_time:57107ms step_avg:49.88ms
+step:1146/1490 train_time:57191ms step_avg:49.91ms
+step:1147/1490 train_time:57271ms step_avg:49.93ms
+step:1148/1490 train_time:57356ms step_avg:49.96ms
+step:1149/1490 train_time:57436ms step_avg:49.99ms
+step:1150/1490 train_time:57520ms step_avg:50.02ms
+step:1151/1490 train_time:57599ms step_avg:50.04ms
+step:1152/1490 train_time:57684ms step_avg:50.07ms
+step:1153/1490 train_time:57764ms step_avg:50.10ms
+step:1154/1490 train_time:57849ms step_avg:50.13ms
+step:1155/1490 train_time:57928ms step_avg:50.15ms
+step:1156/1490 train_time:58012ms step_avg:50.18ms
+step:1157/1490 train_time:58093ms step_avg:50.21ms
+step:1158/1490 train_time:58178ms step_avg:50.24ms
+step:1159/1490 train_time:58257ms step_avg:50.27ms
+step:1160/1490 train_time:58343ms step_avg:50.30ms
+step:1161/1490 train_time:58423ms step_avg:50.32ms
+step:1162/1490 train_time:58506ms step_avg:50.35ms
+step:1163/1490 train_time:58585ms step_avg:50.37ms
+step:1164/1490 train_time:58670ms step_avg:50.40ms
+step:1165/1490 train_time:58751ms step_avg:50.43ms
+step:1166/1490 train_time:58837ms step_avg:50.46ms
+step:1167/1490 train_time:58919ms step_avg:50.49ms
+step:1168/1490 train_time:59004ms step_avg:50.52ms
+step:1169/1490 train_time:59083ms step_avg:50.54ms
+step:1170/1490 train_time:59167ms step_avg:50.57ms
+step:1171/1490 train_time:59246ms step_avg:50.59ms
+step:1172/1490 train_time:59332ms step_avg:50.62ms
+step:1173/1490 train_time:59412ms step_avg:50.65ms
+step:1174/1490 train_time:59497ms step_avg:50.68ms
+step:1175/1490 train_time:59576ms step_avg:50.70ms
+step:1176/1490 train_time:59661ms step_avg:50.73ms
+step:1177/1490 train_time:59741ms step_avg:50.76ms
+step:1178/1490 train_time:59826ms step_avg:50.79ms
+step:1179/1490 train_time:59905ms step_avg:50.81ms
+step:1180/1490 train_time:59990ms step_avg:50.84ms
+step:1181/1490 train_time:60070ms step_avg:50.86ms
+step:1182/1490 train_time:60155ms step_avg:50.89ms
+step:1183/1490 train_time:60234ms step_avg:50.92ms
+step:1184/1490 train_time:60319ms step_avg:50.94ms
+step:1185/1490 train_time:60398ms step_avg:50.97ms
+step:1186/1490 train_time:60485ms step_avg:51.00ms
+step:1187/1490 train_time:60563ms step_avg:51.02ms
+step:1188/1490 train_time:60649ms step_avg:51.05ms
+step:1189/1490 train_time:60728ms step_avg:51.07ms
+step:1190/1490 train_time:60813ms step_avg:51.10ms
+step:1191/1490 train_time:60893ms step_avg:51.13ms
+step:1192/1490 train_time:60977ms step_avg:51.16ms
+step:1193/1490 train_time:61056ms step_avg:51.18ms
+step:1194/1490 train_time:61141ms step_avg:51.21ms
+step:1195/1490 train_time:61221ms step_avg:51.23ms
+step:1196/1490 train_time:61305ms step_avg:51.26ms
+step:1197/1490 train_time:61384ms step_avg:51.28ms
+step:1198/1490 train_time:61469ms step_avg:51.31ms
+step:1199/1490 train_time:61548ms step_avg:51.33ms
+step:1200/1490 train_time:61633ms step_avg:51.36ms
+step:1201/1490 train_time:61712ms step_avg:51.38ms
+step:1202/1490 train_time:61797ms step_avg:51.41ms
+step:1203/1490 train_time:61876ms step_avg:51.43ms
+step:1204/1490 train_time:61962ms step_avg:51.46ms
+step:1205/1490 train_time:62043ms step_avg:51.49ms
+step:1206/1490 train_time:62126ms step_avg:51.51ms
+step:1207/1490 train_time:62206ms step_avg:51.54ms
+step:1208/1490 train_time:62291ms step_avg:51.57ms
+step:1209/1490 train_time:62369ms step_avg:51.59ms
+step:1210/1490 train_time:62455ms step_avg:51.62ms
+step:1211/1490 train_time:62534ms step_avg:51.64ms
+step:1212/1490 train_time:62619ms step_avg:51.67ms
+step:1213/1490 train_time:62698ms step_avg:51.69ms
+step:1214/1490 train_time:62784ms step_avg:51.72ms
+step:1215/1490 train_time:62864ms step_avg:51.74ms
+step:1216/1490 train_time:62949ms step_avg:51.77ms
+step:1217/1490 train_time:63028ms step_avg:51.79ms
+step:1218/1490 train_time:63113ms step_avg:51.82ms
+step:1219/1490 train_time:63192ms step_avg:51.84ms
+step:1220/1490 train_time:63277ms step_avg:51.87ms
+step:1221/1490 train_time:63356ms step_avg:51.89ms
+step:1222/1490 train_time:63440ms step_avg:51.92ms
+step:1223/1490 train_time:63521ms step_avg:51.94ms
+step:1224/1490 train_time:63606ms step_avg:51.97ms
+step:1225/1490 train_time:63684ms step_avg:51.99ms
+step:1226/1490 train_time:63770ms step_avg:52.01ms
+step:1227/1490 train_time:63851ms step_avg:52.04ms
+step:1228/1490 train_time:63936ms step_avg:52.07ms
+step:1229/1490 train_time:64015ms step_avg:52.09ms
+step:1230/1490 train_time:64100ms step_avg:52.11ms
+step:1231/1490 train_time:64180ms step_avg:52.14ms
+step:1232/1490 train_time:64264ms step_avg:52.16ms
+step:1233/1490 train_time:64343ms step_avg:52.18ms
+step:1234/1490 train_time:64427ms step_avg:52.21ms
+step:1235/1490 train_time:64507ms step_avg:52.23ms
+step:1236/1490 train_time:64592ms step_avg:52.26ms
+step:1237/1490 train_time:64672ms step_avg:52.28ms
+step:1238/1490 train_time:64756ms step_avg:52.31ms
+step:1239/1490 train_time:64836ms step_avg:52.33ms
+step:1240/1490 train_time:64921ms step_avg:52.36ms
+step:1241/1490 train_time:65000ms step_avg:52.38ms
+step:1242/1490 train_time:65085ms step_avg:52.40ms
+step:1243/1490 train_time:65165ms step_avg:52.43ms
+step:1244/1490 train_time:65250ms step_avg:52.45ms
+step:1245/1490 train_time:65329ms step_avg:52.47ms
+step:1246/1490 train_time:65415ms step_avg:52.50ms
+step:1247/1490 train_time:65494ms step_avg:52.52ms
+step:1248/1490 train_time:65579ms step_avg:52.55ms
+step:1249/1490 train_time:65657ms step_avg:52.57ms
+step:1250/1490 train_time:65742ms step_avg:52.59ms
+step:1250/1490 val_loss:3.3740 train_time:65842ms step_avg:52.67ms
+step:1251/1490 train_time:65859ms step_avg:52.65ms
+step:1252/1490 train_time:65911ms step_avg:52.64ms
+step:1253/1490 train_time:65996ms step_avg:52.67ms
+step:1254/1490 train_time:66081ms step_avg:52.70ms
+step:1255/1490 train_time:66160ms step_avg:52.72ms
+step:1256/1490 train_time:66244ms step_avg:52.74ms
+step:1257/1490 train_time:66323ms step_avg:52.76ms
+step:1258/1490 train_time:66407ms step_avg:52.79ms
+step:1259/1490 train_time:66485ms step_avg:52.81ms
+step:1260/1490 train_time:66567ms step_avg:52.83ms
+step:1261/1490 train_time:66645ms step_avg:52.85ms
+step:1262/1490 train_time:66732ms step_avg:52.88ms
+step:1263/1490 train_time:66813ms step_avg:52.90ms
+step:1264/1490 train_time:66900ms step_avg:52.93ms
+step:1265/1490 train_time:66983ms step_avg:52.95ms
+step:1266/1490 train_time:67070ms step_avg:52.98ms
+step:1267/1490 train_time:67150ms step_avg:53.00ms
+step:1268/1490 train_time:67235ms step_avg:53.02ms
+step:1269/1490 train_time:67315ms step_avg:53.05ms
+step:1270/1490 train_time:67399ms step_avg:53.07ms
+step:1271/1490 train_time:67478ms step_avg:53.09ms
+step:1272/1490 train_time:67562ms step_avg:53.11ms
+step:1273/1490 train_time:67640ms step_avg:53.13ms
+step:1274/1490 train_time:67726ms step_avg:53.16ms
+step:1275/1490 train_time:67806ms step_avg:53.18ms
+step:1276/1490 train_time:67892ms step_avg:53.21ms
+step:1277/1490 train_time:67973ms step_avg:53.23ms
+step:1278/1490 train_time:68060ms step_avg:53.25ms
+step:1279/1490 train_time:68140ms step_avg:53.28ms
+step:1280/1490 train_time:68226ms step_avg:53.30ms
+step:1281/1490 train_time:68307ms step_avg:53.32ms
+step:1282/1490 train_time:68390ms step_avg:53.35ms
+step:1283/1490 train_time:68468ms step_avg:53.37ms
+step:1284/1490 train_time:68552ms step_avg:53.39ms
+step:1285/1490 train_time:68630ms step_avg:53.41ms
+step:1286/1490 train_time:68716ms step_avg:53.43ms
+step:1287/1490 train_time:68797ms step_avg:53.46ms
+step:1288/1490 train_time:68882ms step_avg:53.48ms
+step:1289/1490 train_time:68962ms step_avg:53.50ms
+step:1290/1490 train_time:69048ms step_avg:53.53ms
+step:1291/1490 train_time:69128ms step_avg:53.55ms
+step:1292/1490 train_time:69214ms step_avg:53.57ms
+step:1293/1490 train_time:69293ms step_avg:53.59ms
+step:1294/1490 train_time:69378ms step_avg:53.61ms
+step:1295/1490 train_time:69457ms step_avg:53.63ms
+step:1296/1490 train_time:69540ms step_avg:53.66ms
+step:1297/1490 train_time:69620ms step_avg:53.68ms
+step:1298/1490 train_time:69706ms step_avg:53.70ms
+step:1299/1490 train_time:69784ms step_avg:53.72ms
+step:1300/1490 train_time:69871ms step_avg:53.75ms
+step:1301/1490 train_time:69951ms step_avg:53.77ms
+step:1302/1490 train_time:70036ms step_avg:53.79ms
+step:1303/1490 train_time:70117ms step_avg:53.81ms
+step:1304/1490 train_time:70201ms step_avg:53.84ms
+step:1305/1490 train_time:70281ms step_avg:53.85ms
+step:1306/1490 train_time:70365ms step_avg:53.88ms
+step:1307/1490 train_time:70444ms step_avg:53.90ms
+step:1308/1490 train_time:70527ms step_avg:53.92ms
+step:1309/1490 train_time:70607ms step_avg:53.94ms
+step:1310/1490 train_time:70691ms step_avg:53.96ms
+step:1311/1490 train_time:70771ms step_avg:53.98ms
+step:1312/1490 train_time:70856ms step_avg:54.01ms
+step:1313/1490 train_time:70936ms step_avg:54.03ms
+step:1314/1490 train_time:71021ms step_avg:54.05ms
+step:1315/1490 train_time:71102ms step_avg:54.07ms
+step:1316/1490 train_time:71188ms step_avg:54.09ms
+step:1317/1490 train_time:71267ms step_avg:54.11ms
+step:1318/1490 train_time:71353ms step_avg:54.14ms
+step:1319/1490 train_time:71432ms step_avg:54.16ms
+step:1320/1490 train_time:71516ms step_avg:54.18ms
+step:1321/1490 train_time:71594ms step_avg:54.20ms
+step:1322/1490 train_time:71679ms step_avg:54.22ms
+step:1323/1490 train_time:71761ms step_avg:54.24ms
+step:1324/1490 train_time:71846ms step_avg:54.26ms
+step:1325/1490 train_time:71926ms step_avg:54.28ms
+step:1326/1490 train_time:72012ms step_avg:54.31ms
+step:1327/1490 train_time:72090ms step_avg:54.33ms
+step:1328/1490 train_time:72176ms step_avg:54.35ms
+step:1329/1490 train_time:72256ms step_avg:54.37ms
+step:1330/1490 train_time:72340ms step_avg:54.39ms
+step:1331/1490 train_time:72420ms step_avg:54.41ms
+step:1332/1490 train_time:72504ms step_avg:54.43ms
+step:1333/1490 train_time:72584ms step_avg:54.45ms
+step:1334/1490 train_time:72668ms step_avg:54.47ms
+step:1335/1490 train_time:72747ms step_avg:54.49ms
+step:1336/1490 train_time:72833ms step_avg:54.52ms
+step:1337/1490 train_time:72912ms step_avg:54.53ms
+step:1338/1490 train_time:72997ms step_avg:54.56ms
+step:1339/1490 train_time:73078ms step_avg:54.58ms
+step:1340/1490 train_time:73163ms step_avg:54.60ms
+step:1341/1490 train_time:73243ms step_avg:54.62ms
+step:1342/1490 train_time:73329ms step_avg:54.64ms
+step:1343/1490 train_time:73410ms step_avg:54.66ms
+step:1344/1490 train_time:73494ms step_avg:54.68ms
+step:1345/1490 train_time:73573ms step_avg:54.70ms
+step:1346/1490 train_time:73658ms step_avg:54.72ms
+step:1347/1490 train_time:73738ms step_avg:54.74ms
+step:1348/1490 train_time:73824ms step_avg:54.77ms
+step:1349/1490 train_time:73904ms step_avg:54.78ms
+step:1350/1490 train_time:73989ms step_avg:54.81ms
+step:1351/1490 train_time:74070ms step_avg:54.83ms
+step:1352/1490 train_time:74154ms step_avg:54.85ms
+step:1353/1490 train_time:74233ms step_avg:54.87ms
+step:1354/1490 train_time:74318ms step_avg:54.89ms
+step:1355/1490 train_time:74397ms step_avg:54.91ms
+step:1356/1490 train_time:74483ms step_avg:54.93ms
+step:1357/1490 train_time:74563ms step_avg:54.95ms
+step:1358/1490 train_time:74646ms step_avg:54.97ms
+step:1359/1490 train_time:74725ms step_avg:54.98ms
+step:1360/1490 train_time:74811ms step_avg:55.01ms
+step:1361/1490 train_time:74892ms step_avg:55.03ms
+step:1362/1490 train_time:74975ms step_avg:55.05ms
+step:1363/1490 train_time:75056ms step_avg:55.07ms
+step:1364/1490 train_time:75141ms step_avg:55.09ms
+step:1365/1490 train_time:75222ms step_avg:55.11ms
+step:1366/1490 train_time:75306ms step_avg:55.13ms
+step:1367/1490 train_time:75385ms step_avg:55.15ms
+step:1368/1490 train_time:75470ms step_avg:55.17ms
+step:1369/1490 train_time:75549ms step_avg:55.19ms
+step:1370/1490 train_time:75635ms step_avg:55.21ms
+step:1371/1490 train_time:75714ms step_avg:55.23ms
+step:1372/1490 train_time:75799ms step_avg:55.25ms
+step:1373/1490 train_time:75879ms step_avg:55.26ms
+step:1374/1490 train_time:75964ms step_avg:55.29ms
+step:1375/1490 train_time:76044ms step_avg:55.31ms
+step:1376/1490 train_time:76130ms step_avg:55.33ms
+step:1377/1490 train_time:76210ms step_avg:55.34ms
+step:1378/1490 train_time:76294ms step_avg:55.37ms
+step:1379/1490 train_time:76373ms step_avg:55.38ms
+step:1380/1490 train_time:76458ms step_avg:55.40ms
+step:1381/1490 train_time:76538ms step_avg:55.42ms
+step:1382/1490 train_time:76623ms step_avg:55.44ms
+step:1383/1490 train_time:76703ms step_avg:55.46ms
+step:1384/1490 train_time:76787ms step_avg:55.48ms
+step:1385/1490 train_time:76866ms step_avg:55.50ms
+step:1386/1490 train_time:76952ms step_avg:55.52ms
+step:1387/1490 train_time:77032ms step_avg:55.54ms
+step:1388/1490 train_time:77118ms step_avg:55.56ms
+step:1389/1490 train_time:77199ms step_avg:55.58ms
+step:1390/1490 train_time:77284ms step_avg:55.60ms
+step:1391/1490 train_time:77363ms step_avg:55.62ms
+step:1392/1490 train_time:77447ms step_avg:55.64ms
+step:1393/1490 train_time:77527ms step_avg:55.65ms
+step:1394/1490 train_time:77613ms step_avg:55.68ms
+step:1395/1490 train_time:77692ms step_avg:55.69ms
+step:1396/1490 train_time:77776ms step_avg:55.71ms
+step:1397/1490 train_time:77856ms step_avg:55.73ms
+step:1398/1490 train_time:77940ms step_avg:55.75ms
+step:1399/1490 train_time:78020ms step_avg:55.77ms
+step:1400/1490 train_time:78106ms step_avg:55.79ms
+step:1401/1490 train_time:78184ms step_avg:55.81ms
+step:1402/1490 train_time:78271ms step_avg:55.83ms
+step:1403/1490 train_time:78350ms step_avg:55.84ms
+step:1404/1490 train_time:78433ms step_avg:55.86ms
+step:1405/1490 train_time:78514ms step_avg:55.88ms
+step:1406/1490 train_time:78598ms step_avg:55.90ms
+step:1407/1490 train_time:78677ms step_avg:55.92ms
+step:1408/1490 train_time:78762ms step_avg:55.94ms
+step:1409/1490 train_time:78842ms step_avg:55.96ms
+step:1410/1490 train_time:78927ms step_avg:55.98ms
+step:1411/1490 train_time:79008ms step_avg:55.99ms
+step:1412/1490 train_time:79093ms step_avg:56.01ms
+step:1413/1490 train_time:79172ms step_avg:56.03ms
+step:1414/1490 train_time:79258ms step_avg:56.05ms
+step:1415/1490 train_time:79338ms step_avg:56.07ms
+step:1416/1490 train_time:79423ms step_avg:56.09ms
+step:1417/1490 train_time:79503ms step_avg:56.11ms
+step:1418/1490 train_time:79587ms step_avg:56.13ms
+step:1419/1490 train_time:79667ms step_avg:56.14ms
+step:1420/1490 train_time:79753ms step_avg:56.16ms
+step:1421/1490 train_time:79832ms step_avg:56.18ms
+step:1422/1490 train_time:79917ms step_avg:56.20ms
+step:1423/1490 train_time:79996ms step_avg:56.22ms
+step:1424/1490 train_time:80081ms step_avg:56.24ms
+step:1425/1490 train_time:80161ms step_avg:56.25ms
+step:1426/1490 train_time:80246ms step_avg:56.27ms
+step:1427/1490 train_time:80326ms step_avg:56.29ms
+step:1428/1490 train_time:80410ms step_avg:56.31ms
+step:1429/1490 train_time:80490ms step_avg:56.33ms
+step:1430/1490 train_time:80575ms step_avg:56.35ms
+step:1431/1490 train_time:80654ms step_avg:56.36ms
+step:1432/1490 train_time:80737ms step_avg:56.38ms
+step:1433/1490 train_time:80818ms step_avg:56.40ms
+step:1434/1490 train_time:80904ms step_avg:56.42ms
+step:1435/1490 train_time:80982ms step_avg:56.43ms
+step:1436/1490 train_time:81067ms step_avg:56.45ms
+step:1437/1490 train_time:81147ms step_avg:56.47ms
+step:1438/1490 train_time:81232ms step_avg:56.49ms
+step:1439/1490 train_time:81313ms step_avg:56.51ms
+step:1440/1490 train_time:81397ms step_avg:56.53ms
+step:1441/1490 train_time:81477ms step_avg:56.54ms
+step:1442/1490 train_time:81563ms step_avg:56.56ms
+step:1443/1490 train_time:81643ms step_avg:56.58ms
+step:1444/1490 train_time:81728ms step_avg:56.60ms
+step:1445/1490 train_time:81806ms step_avg:56.61ms
+step:1446/1490 train_time:81893ms step_avg:56.63ms
+step:1447/1490 train_time:81971ms step_avg:56.65ms
+step:1448/1490 train_time:82055ms step_avg:56.67ms
+step:1449/1490 train_time:82136ms step_avg:56.68ms
+step:1450/1490 train_time:82221ms step_avg:56.70ms
+step:1451/1490 train_time:82305ms step_avg:56.72ms
+step:1452/1490 train_time:82391ms step_avg:56.74ms
+step:1453/1490 train_time:82469ms step_avg:56.76ms
+step:1454/1490 train_time:82556ms step_avg:56.78ms
+step:1455/1490 train_time:82636ms step_avg:56.79ms
+step:1456/1490 train_time:82721ms step_avg:56.81ms
+step:1457/1490 train_time:82800ms step_avg:56.83ms
+step:1458/1490 train_time:82886ms step_avg:56.85ms
+step:1459/1490 train_time:82966ms step_avg:56.87ms
+step:1460/1490 train_time:83052ms step_avg:56.88ms
+step:1461/1490 train_time:83132ms step_avg:56.90ms
+step:1462/1490 train_time:83217ms step_avg:56.92ms
+step:1463/1490 train_time:83297ms step_avg:56.94ms
+step:1464/1490 train_time:83383ms step_avg:56.96ms
+step:1465/1490 train_time:83463ms step_avg:56.97ms
+step:1466/1490 train_time:83548ms step_avg:56.99ms
+step:1467/1490 train_time:83630ms step_avg:57.01ms
+step:1468/1490 train_time:83716ms step_avg:57.03ms
+step:1469/1490 train_time:83794ms step_avg:57.04ms
+step:1470/1490 train_time:83878ms step_avg:57.06ms
+step:1471/1490 train_time:83960ms step_avg:57.08ms
+step:1472/1490 train_time:84045ms step_avg:57.10ms
+step:1473/1490 train_time:84124ms step_avg:57.11ms
+step:1474/1490 train_time:84210ms step_avg:57.13ms
+step:1475/1490 train_time:84290ms step_avg:57.15ms
+step:1476/1490 train_time:84376ms step_avg:57.17ms
+step:1477/1490 train_time:84456ms step_avg:57.18ms
+step:1478/1490 train_time:84541ms step_avg:57.20ms
+step:1479/1490 train_time:84621ms step_avg:57.21ms
+step:1480/1490 train_time:84708ms step_avg:57.24ms
+step:1481/1490 train_time:84787ms step_avg:57.25ms
+step:1482/1490 train_time:84871ms step_avg:57.27ms
+step:1483/1490 train_time:84951ms step_avg:57.28ms
+step:1484/1490 train_time:85035ms step_avg:57.30ms
+step:1485/1490 train_time:85115ms step_avg:57.32ms
+step:1486/1490 train_time:85200ms step_avg:57.33ms
+step:1487/1490 train_time:85280ms step_avg:57.35ms
+step:1488/1490 train_time:85367ms step_avg:57.37ms
+step:1489/1490 train_time:85447ms step_avg:57.39ms
+step:1490/1490 train_time:85532ms step_avg:57.40ms
+step:1490/1490 val_loss:3.2808 train_time:85634ms step_avg:57.47ms
+peak memory allocated: 31296 MiB reserved: 47022 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/a45ef316-4b62-4842-8157-228ba522b5fb.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/a45ef316-4b62-4842-8157-228ba522b5fb.txt
@@ -1,0 +1,4449 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 00:30:00 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   31C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8303 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:77ms step_avg:77.28ms
+step:2/1490 train_time:102ms step_avg:50.76ms
+step:3/1490 train_time:121ms step_avg:40.29ms
+step:4/1490 train_time:145ms step_avg:36.18ms
+step:5/1490 train_time:171ms step_avg:34.24ms
+step:6/1490 train_time:206ms step_avg:34.37ms
+step:7/1490 train_time:234ms step_avg:33.37ms
+step:8/1490 train_time:268ms step_avg:33.55ms
+step:9/1490 train_time:296ms step_avg:32.87ms
+step:10/1490 train_time:330ms step_avg:33.03ms
+step:11/1490 train_time:358ms step_avg:32.53ms
+step:12/1490 train_time:392ms step_avg:32.69ms
+step:13/1490 train_time:420ms step_avg:32.31ms
+step:14/1490 train_time:455ms step_avg:32.48ms
+step:15/1490 train_time:482ms step_avg:32.16ms
+step:16/1490 train_time:517ms step_avg:32.34ms
+step:17/1490 train_time:545ms step_avg:32.03ms
+step:18/1490 train_time:579ms step_avg:32.18ms
+step:19/1490 train_time:607ms step_avg:31.94ms
+step:20/1490 train_time:642ms step_avg:32.11ms
+step:21/1490 train_time:670ms step_avg:31.89ms
+step:22/1490 train_time:705ms step_avg:32.02ms
+step:23/1490 train_time:732ms step_avg:31.83ms
+step:24/1490 train_time:767ms step_avg:31.96ms
+step:25/1490 train_time:795ms step_avg:31.79ms
+step:26/1490 train_time:829ms step_avg:31.89ms
+step:27/1490 train_time:857ms step_avg:31.74ms
+step:28/1490 train_time:892ms step_avg:31.84ms
+step:29/1490 train_time:920ms step_avg:31.71ms
+step:30/1490 train_time:954ms step_avg:31.81ms
+step:31/1490 train_time:982ms step_avg:31.69ms
+step:32/1490 train_time:1017ms step_avg:31.78ms
+step:33/1490 train_time:1046ms step_avg:31.70ms
+step:34/1490 train_time:1081ms step_avg:31.80ms
+step:35/1490 train_time:1109ms step_avg:31.69ms
+step:36/1490 train_time:1144ms step_avg:31.79ms
+step:37/1490 train_time:1172ms step_avg:31.69ms
+step:38/1490 train_time:1207ms step_avg:31.77ms
+step:39/1490 train_time:1236ms step_avg:31.68ms
+step:40/1490 train_time:1270ms step_avg:31.76ms
+step:41/1490 train_time:1298ms step_avg:31.67ms
+step:42/1490 train_time:1333ms step_avg:31.74ms
+step:43/1490 train_time:1361ms step_avg:31.66ms
+step:44/1490 train_time:1395ms step_avg:31.71ms
+step:45/1490 train_time:1424ms step_avg:31.63ms
+step:46/1490 train_time:1458ms step_avg:31.70ms
+step:47/1490 train_time:1486ms step_avg:31.61ms
+step:48/1490 train_time:1520ms step_avg:31.67ms
+step:49/1490 train_time:1548ms step_avg:31.59ms
+step:50/1490 train_time:1583ms step_avg:31.66ms
+step:51/1490 train_time:1610ms step_avg:31.58ms
+step:52/1490 train_time:1645ms step_avg:31.64ms
+step:53/1490 train_time:1673ms step_avg:31.57ms
+step:54/1490 train_time:1708ms step_avg:31.62ms
+step:55/1490 train_time:1735ms step_avg:31.55ms
+step:56/1490 train_time:1770ms step_avg:31.61ms
+step:57/1490 train_time:1798ms step_avg:31.54ms
+step:58/1490 train_time:1832ms step_avg:31.59ms
+step:59/1490 train_time:1860ms step_avg:31.53ms
+step:60/1490 train_time:1895ms step_avg:31.58ms
+step:61/1490 train_time:1923ms step_avg:31.52ms
+step:62/1490 train_time:1957ms step_avg:31.57ms
+step:63/1490 train_time:1986ms step_avg:31.52ms
+step:64/1490 train_time:2021ms step_avg:31.57ms
+step:65/1490 train_time:2049ms step_avg:31.52ms
+step:66/1490 train_time:2083ms step_avg:31.57ms
+step:67/1490 train_time:2111ms step_avg:31.51ms
+step:68/1490 train_time:2146ms step_avg:31.56ms
+step:69/1490 train_time:2174ms step_avg:31.51ms
+step:70/1490 train_time:2209ms step_avg:31.56ms
+step:71/1490 train_time:2238ms step_avg:31.51ms
+step:72/1490 train_time:2272ms step_avg:31.56ms
+step:73/1490 train_time:2300ms step_avg:31.51ms
+step:74/1490 train_time:2334ms step_avg:31.55ms
+step:75/1490 train_time:2362ms step_avg:31.50ms
+step:76/1490 train_time:2397ms step_avg:31.54ms
+step:77/1490 train_time:2425ms step_avg:31.49ms
+step:78/1490 train_time:2459ms step_avg:31.53ms
+step:79/1490 train_time:2487ms step_avg:31.48ms
+step:80/1490 train_time:2522ms step_avg:31.53ms
+step:81/1490 train_time:2550ms step_avg:31.48ms
+step:82/1490 train_time:2585ms step_avg:31.52ms
+step:83/1490 train_time:2612ms step_avg:31.47ms
+step:84/1490 train_time:2648ms step_avg:31.52ms
+step:85/1490 train_time:2675ms step_avg:31.47ms
+step:86/1490 train_time:2709ms step_avg:31.51ms
+step:87/1490 train_time:2738ms step_avg:31.47ms
+step:88/1490 train_time:2772ms step_avg:31.50ms
+step:89/1490 train_time:2800ms step_avg:31.46ms
+step:90/1490 train_time:2834ms step_avg:31.49ms
+step:91/1490 train_time:2862ms step_avg:31.45ms
+step:92/1490 train_time:2896ms step_avg:31.48ms
+step:93/1490 train_time:2924ms step_avg:31.44ms
+step:94/1490 train_time:2958ms step_avg:31.47ms
+step:95/1490 train_time:2987ms step_avg:31.44ms
+step:96/1490 train_time:3022ms step_avg:31.48ms
+step:97/1490 train_time:3050ms step_avg:31.44ms
+step:98/1490 train_time:3085ms step_avg:31.48ms
+step:99/1490 train_time:3112ms step_avg:31.44ms
+step:100/1490 train_time:3147ms step_avg:31.47ms
+step:101/1490 train_time:3175ms step_avg:31.44ms
+step:102/1490 train_time:3211ms step_avg:31.48ms
+step:103/1490 train_time:3238ms step_avg:31.43ms
+step:104/1490 train_time:3272ms step_avg:31.46ms
+step:105/1490 train_time:3300ms step_avg:31.43ms
+step:106/1490 train_time:3334ms step_avg:31.46ms
+step:107/1490 train_time:3364ms step_avg:31.44ms
+step:108/1490 train_time:3397ms step_avg:31.45ms
+step:109/1490 train_time:3425ms step_avg:31.42ms
+step:110/1490 train_time:3460ms step_avg:31.45ms
+step:111/1490 train_time:3488ms step_avg:31.42ms
+step:112/1490 train_time:3523ms step_avg:31.45ms
+step:113/1490 train_time:3550ms step_avg:31.42ms
+step:114/1490 train_time:3585ms step_avg:31.45ms
+step:115/1490 train_time:3613ms step_avg:31.42ms
+step:116/1490 train_time:3648ms step_avg:31.45ms
+step:117/1490 train_time:3675ms step_avg:31.41ms
+step:118/1490 train_time:3710ms step_avg:31.44ms
+step:119/1490 train_time:3738ms step_avg:31.41ms
+step:120/1490 train_time:3772ms step_avg:31.44ms
+step:121/1490 train_time:3800ms step_avg:31.41ms
+step:122/1490 train_time:3834ms step_avg:31.43ms
+step:123/1490 train_time:3862ms step_avg:31.40ms
+step:124/1490 train_time:3896ms step_avg:31.42ms
+step:125/1490 train_time:3925ms step_avg:31.40ms
+step:126/1490 train_time:3960ms step_avg:31.43ms
+step:127/1490 train_time:3987ms step_avg:31.40ms
+step:128/1490 train_time:4022ms step_avg:31.42ms
+step:129/1490 train_time:4049ms step_avg:31.39ms
+step:130/1490 train_time:4086ms step_avg:31.43ms
+step:131/1490 train_time:4113ms step_avg:31.40ms
+step:132/1490 train_time:4148ms step_avg:31.42ms
+step:133/1490 train_time:4176ms step_avg:31.40ms
+step:134/1490 train_time:4211ms step_avg:31.42ms
+step:135/1490 train_time:4238ms step_avg:31.39ms
+step:136/1490 train_time:4273ms step_avg:31.42ms
+step:137/1490 train_time:4301ms step_avg:31.39ms
+step:138/1490 train_time:4335ms step_avg:31.41ms
+step:139/1490 train_time:4363ms step_avg:31.39ms
+step:140/1490 train_time:4397ms step_avg:31.41ms
+step:141/1490 train_time:4425ms step_avg:31.38ms
+step:142/1490 train_time:4461ms step_avg:31.41ms
+step:143/1490 train_time:4488ms step_avg:31.38ms
+step:144/1490 train_time:4523ms step_avg:31.41ms
+step:145/1490 train_time:4550ms step_avg:31.38ms
+step:146/1490 train_time:4585ms step_avg:31.41ms
+step:147/1490 train_time:4613ms step_avg:31.38ms
+step:148/1490 train_time:4648ms step_avg:31.40ms
+step:149/1490 train_time:4676ms step_avg:31.38ms
+step:150/1490 train_time:4710ms step_avg:31.40ms
+step:151/1490 train_time:4738ms step_avg:31.38ms
+step:152/1490 train_time:4772ms step_avg:31.40ms
+step:153/1490 train_time:4800ms step_avg:31.37ms
+step:154/1490 train_time:4834ms step_avg:31.39ms
+step:155/1490 train_time:4862ms step_avg:31.37ms
+step:156/1490 train_time:4897ms step_avg:31.39ms
+step:157/1490 train_time:4925ms step_avg:31.37ms
+step:158/1490 train_time:4960ms step_avg:31.39ms
+step:159/1490 train_time:4987ms step_avg:31.37ms
+step:160/1490 train_time:5022ms step_avg:31.39ms
+step:161/1490 train_time:5050ms step_avg:31.37ms
+step:162/1490 train_time:5085ms step_avg:31.39ms
+step:163/1490 train_time:5112ms step_avg:31.36ms
+step:164/1490 train_time:5148ms step_avg:31.39ms
+step:165/1490 train_time:5175ms step_avg:31.37ms
+step:166/1490 train_time:5210ms step_avg:31.39ms
+step:167/1490 train_time:5238ms step_avg:31.37ms
+step:168/1490 train_time:5273ms step_avg:31.38ms
+step:169/1490 train_time:5300ms step_avg:31.36ms
+step:170/1490 train_time:5335ms step_avg:31.38ms
+step:171/1490 train_time:5363ms step_avg:31.36ms
+step:172/1490 train_time:5397ms step_avg:31.38ms
+step:173/1490 train_time:5425ms step_avg:31.36ms
+step:174/1490 train_time:5460ms step_avg:31.38ms
+step:175/1490 train_time:5487ms step_avg:31.36ms
+step:176/1490 train_time:5523ms step_avg:31.38ms
+step:177/1490 train_time:5550ms step_avg:31.36ms
+step:178/1490 train_time:5585ms step_avg:31.38ms
+step:179/1490 train_time:5613ms step_avg:31.36ms
+step:180/1490 train_time:5648ms step_avg:31.38ms
+step:181/1490 train_time:5676ms step_avg:31.36ms
+step:182/1490 train_time:5710ms step_avg:31.37ms
+step:183/1490 train_time:5738ms step_avg:31.35ms
+step:184/1490 train_time:5772ms step_avg:31.37ms
+step:185/1490 train_time:5800ms step_avg:31.35ms
+step:186/1490 train_time:5835ms step_avg:31.37ms
+step:187/1490 train_time:5863ms step_avg:31.35ms
+step:188/1490 train_time:5897ms step_avg:31.37ms
+step:189/1490 train_time:5925ms step_avg:31.35ms
+step:190/1490 train_time:5959ms step_avg:31.37ms
+step:191/1490 train_time:5987ms step_avg:31.35ms
+step:192/1490 train_time:6022ms step_avg:31.37ms
+step:193/1490 train_time:6049ms step_avg:31.34ms
+step:194/1490 train_time:6084ms step_avg:31.36ms
+step:195/1490 train_time:6112ms step_avg:31.34ms
+step:196/1490 train_time:6147ms step_avg:31.36ms
+step:197/1490 train_time:6174ms step_avg:31.34ms
+step:198/1490 train_time:6209ms step_avg:31.36ms
+step:199/1490 train_time:6237ms step_avg:31.34ms
+step:200/1490 train_time:6271ms step_avg:31.36ms
+step:201/1490 train_time:6299ms step_avg:31.34ms
+step:202/1490 train_time:6333ms step_avg:31.35ms
+step:203/1490 train_time:6361ms step_avg:31.34ms
+step:204/1490 train_time:6396ms step_avg:31.35ms
+step:205/1490 train_time:6424ms step_avg:31.34ms
+step:206/1490 train_time:6458ms step_avg:31.35ms
+step:207/1490 train_time:6486ms step_avg:31.34ms
+step:208/1490 train_time:6522ms step_avg:31.35ms
+step:209/1490 train_time:6550ms step_avg:31.34ms
+step:210/1490 train_time:6585ms step_avg:31.36ms
+step:211/1490 train_time:6612ms step_avg:31.34ms
+step:212/1490 train_time:6647ms step_avg:31.35ms
+step:213/1490 train_time:6675ms step_avg:31.34ms
+step:214/1490 train_time:6709ms step_avg:31.35ms
+step:215/1490 train_time:6737ms step_avg:31.33ms
+step:216/1490 train_time:6771ms step_avg:31.35ms
+step:217/1490 train_time:6799ms step_avg:31.33ms
+step:218/1490 train_time:6833ms step_avg:31.34ms
+step:219/1490 train_time:6861ms step_avg:31.33ms
+step:220/1490 train_time:6895ms step_avg:31.34ms
+step:221/1490 train_time:6923ms step_avg:31.33ms
+step:222/1490 train_time:6958ms step_avg:31.34ms
+step:223/1490 train_time:6986ms step_avg:31.33ms
+step:224/1490 train_time:7021ms step_avg:31.34ms
+step:225/1490 train_time:7049ms step_avg:31.33ms
+step:226/1490 train_time:7084ms step_avg:31.35ms
+step:227/1490 train_time:7111ms step_avg:31.33ms
+step:228/1490 train_time:7146ms step_avg:31.34ms
+step:229/1490 train_time:7174ms step_avg:31.33ms
+step:230/1490 train_time:7209ms step_avg:31.34ms
+step:231/1490 train_time:7237ms step_avg:31.33ms
+step:232/1490 train_time:7271ms step_avg:31.34ms
+step:233/1490 train_time:7299ms step_avg:31.33ms
+step:234/1490 train_time:7333ms step_avg:31.34ms
+step:235/1490 train_time:7362ms step_avg:31.33ms
+step:236/1490 train_time:7395ms step_avg:31.33ms
+step:237/1490 train_time:7423ms step_avg:31.32ms
+step:238/1490 train_time:7458ms step_avg:31.34ms
+step:239/1490 train_time:7485ms step_avg:31.32ms
+step:240/1490 train_time:7520ms step_avg:31.33ms
+step:241/1490 train_time:7548ms step_avg:31.32ms
+step:242/1490 train_time:7583ms step_avg:31.33ms
+step:243/1490 train_time:7610ms step_avg:31.32ms
+step:244/1490 train_time:7645ms step_avg:31.33ms
+step:245/1490 train_time:7673ms step_avg:31.32ms
+step:246/1490 train_time:7708ms step_avg:31.33ms
+step:247/1490 train_time:7736ms step_avg:31.32ms
+step:248/1490 train_time:7771ms step_avg:31.33ms
+step:249/1490 train_time:7798ms step_avg:31.32ms
+step:250/1490 train_time:7833ms step_avg:31.33ms
+step:250/1490 val_loss:4.5127 train_time:7875ms step_avg:31.50ms
+step:251/1490 train_time:7897ms step_avg:31.46ms
+step:252/1490 train_time:7917ms step_avg:31.42ms
+step:253/1490 train_time:7933ms step_avg:31.36ms
+step:254/1490 train_time:7962ms step_avg:31.35ms
+step:255/1490 train_time:7992ms step_avg:31.34ms
+step:256/1490 train_time:8029ms step_avg:31.36ms
+step:257/1490 train_time:8057ms step_avg:31.35ms
+step:258/1490 train_time:8091ms step_avg:31.36ms
+step:259/1490 train_time:8119ms step_avg:31.35ms
+step:260/1490 train_time:8154ms step_avg:31.36ms
+step:261/1490 train_time:8181ms step_avg:31.35ms
+step:262/1490 train_time:8216ms step_avg:31.36ms
+step:263/1490 train_time:8243ms step_avg:31.34ms
+step:264/1490 train_time:8277ms step_avg:31.35ms
+step:265/1490 train_time:8305ms step_avg:31.34ms
+step:266/1490 train_time:8340ms step_avg:31.35ms
+step:267/1490 train_time:8368ms step_avg:31.34ms
+step:268/1490 train_time:8403ms step_avg:31.35ms
+step:269/1490 train_time:8430ms step_avg:31.34ms
+step:270/1490 train_time:8464ms step_avg:31.35ms
+step:271/1490 train_time:8492ms step_avg:31.33ms
+step:272/1490 train_time:8526ms step_avg:31.35ms
+step:273/1490 train_time:8553ms step_avg:31.33ms
+step:274/1490 train_time:8588ms step_avg:31.34ms
+step:275/1490 train_time:8615ms step_avg:31.33ms
+step:276/1490 train_time:8649ms step_avg:31.34ms
+step:277/1490 train_time:8677ms step_avg:31.33ms
+step:278/1490 train_time:8711ms step_avg:31.34ms
+step:279/1490 train_time:8739ms step_avg:31.32ms
+step:280/1490 train_time:8773ms step_avg:31.33ms
+step:281/1490 train_time:8801ms step_avg:31.32ms
+step:282/1490 train_time:8835ms step_avg:31.33ms
+step:283/1490 train_time:8863ms step_avg:31.32ms
+step:284/1490 train_time:8898ms step_avg:31.33ms
+step:285/1490 train_time:8927ms step_avg:31.32ms
+step:286/1490 train_time:8962ms step_avg:31.34ms
+step:287/1490 train_time:8990ms step_avg:31.32ms
+step:288/1490 train_time:9025ms step_avg:31.34ms
+step:289/1490 train_time:9053ms step_avg:31.33ms
+step:290/1490 train_time:9088ms step_avg:31.34ms
+step:291/1490 train_time:9115ms step_avg:31.32ms
+step:292/1490 train_time:9150ms step_avg:31.33ms
+step:293/1490 train_time:9178ms step_avg:31.32ms
+step:294/1490 train_time:9212ms step_avg:31.33ms
+step:295/1490 train_time:9240ms step_avg:31.32ms
+step:296/1490 train_time:9274ms step_avg:31.33ms
+step:297/1490 train_time:9303ms step_avg:31.32ms
+step:298/1490 train_time:9337ms step_avg:31.33ms
+step:299/1490 train_time:9365ms step_avg:31.32ms
+step:300/1490 train_time:9400ms step_avg:31.33ms
+step:301/1490 train_time:9428ms step_avg:31.32ms
+step:302/1490 train_time:9462ms step_avg:31.33ms
+step:303/1490 train_time:9489ms step_avg:31.32ms
+step:304/1490 train_time:9524ms step_avg:31.33ms
+step:305/1490 train_time:9552ms step_avg:31.32ms
+step:306/1490 train_time:9587ms step_avg:31.33ms
+step:307/1490 train_time:9615ms step_avg:31.32ms
+step:308/1490 train_time:9649ms step_avg:31.33ms
+step:309/1490 train_time:9677ms step_avg:31.32ms
+step:310/1490 train_time:9711ms step_avg:31.33ms
+step:311/1490 train_time:9739ms step_avg:31.31ms
+step:312/1490 train_time:9773ms step_avg:31.32ms
+step:313/1490 train_time:9801ms step_avg:31.31ms
+step:314/1490 train_time:9835ms step_avg:31.32ms
+step:315/1490 train_time:9863ms step_avg:31.31ms
+step:316/1490 train_time:9897ms step_avg:31.32ms
+step:317/1490 train_time:9925ms step_avg:31.31ms
+step:318/1490 train_time:9960ms step_avg:31.32ms
+step:319/1490 train_time:9988ms step_avg:31.31ms
+step:320/1490 train_time:10023ms step_avg:31.32ms
+step:321/1490 train_time:10051ms step_avg:31.31ms
+step:322/1490 train_time:10086ms step_avg:31.32ms
+step:323/1490 train_time:10114ms step_avg:31.31ms
+step:324/1490 train_time:10148ms step_avg:31.32ms
+step:325/1490 train_time:10176ms step_avg:31.31ms
+step:326/1490 train_time:10210ms step_avg:31.32ms
+step:327/1490 train_time:10238ms step_avg:31.31ms
+step:328/1490 train_time:10272ms step_avg:31.32ms
+step:329/1490 train_time:10300ms step_avg:31.31ms
+step:330/1490 train_time:10334ms step_avg:31.31ms
+step:331/1490 train_time:10362ms step_avg:31.31ms
+step:332/1490 train_time:10397ms step_avg:31.31ms
+step:333/1490 train_time:10424ms step_avg:31.30ms
+step:334/1490 train_time:10459ms step_avg:31.31ms
+step:335/1490 train_time:10487ms step_avg:31.31ms
+step:336/1490 train_time:10522ms step_avg:31.32ms
+step:337/1490 train_time:10549ms step_avg:31.30ms
+step:338/1490 train_time:10584ms step_avg:31.31ms
+step:339/1490 train_time:10611ms step_avg:31.30ms
+step:340/1490 train_time:10646ms step_avg:31.31ms
+step:341/1490 train_time:10673ms step_avg:31.30ms
+step:342/1490 train_time:10708ms step_avg:31.31ms
+step:343/1490 train_time:10735ms step_avg:31.30ms
+step:344/1490 train_time:10770ms step_avg:31.31ms
+step:345/1490 train_time:10798ms step_avg:31.30ms
+step:346/1490 train_time:10832ms step_avg:31.31ms
+step:347/1490 train_time:10860ms step_avg:31.30ms
+step:348/1490 train_time:10894ms step_avg:31.30ms
+step:349/1490 train_time:10922ms step_avg:31.30ms
+step:350/1490 train_time:10957ms step_avg:31.30ms
+step:351/1490 train_time:10984ms step_avg:31.29ms
+step:352/1490 train_time:11019ms step_avg:31.30ms
+step:353/1490 train_time:11047ms step_avg:31.29ms
+step:354/1490 train_time:11081ms step_avg:31.30ms
+step:355/1490 train_time:11110ms step_avg:31.29ms
+step:356/1490 train_time:11145ms step_avg:31.30ms
+step:357/1490 train_time:11172ms step_avg:31.29ms
+step:358/1490 train_time:11208ms step_avg:31.31ms
+step:359/1490 train_time:11235ms step_avg:31.30ms
+step:360/1490 train_time:11269ms step_avg:31.30ms
+step:361/1490 train_time:11297ms step_avg:31.29ms
+step:362/1490 train_time:11332ms step_avg:31.30ms
+step:363/1490 train_time:11360ms step_avg:31.29ms
+step:364/1490 train_time:11394ms step_avg:31.30ms
+step:365/1490 train_time:11422ms step_avg:31.29ms
+step:366/1490 train_time:11456ms step_avg:31.30ms
+step:367/1490 train_time:11484ms step_avg:31.29ms
+step:368/1490 train_time:11518ms step_avg:31.30ms
+step:369/1490 train_time:11547ms step_avg:31.29ms
+step:370/1490 train_time:11581ms step_avg:31.30ms
+step:371/1490 train_time:11609ms step_avg:31.29ms
+step:372/1490 train_time:11644ms step_avg:31.30ms
+step:373/1490 train_time:11672ms step_avg:31.29ms
+step:374/1490 train_time:11707ms step_avg:31.30ms
+step:375/1490 train_time:11735ms step_avg:31.29ms
+step:376/1490 train_time:11769ms step_avg:31.30ms
+step:377/1490 train_time:11797ms step_avg:31.29ms
+step:378/1490 train_time:11831ms step_avg:31.30ms
+step:379/1490 train_time:11859ms step_avg:31.29ms
+step:380/1490 train_time:11894ms step_avg:31.30ms
+step:381/1490 train_time:11921ms step_avg:31.29ms
+step:382/1490 train_time:11955ms step_avg:31.30ms
+step:383/1490 train_time:11983ms step_avg:31.29ms
+step:384/1490 train_time:12018ms step_avg:31.30ms
+step:385/1490 train_time:12045ms step_avg:31.29ms
+step:386/1490 train_time:12080ms step_avg:31.29ms
+step:387/1490 train_time:12107ms step_avg:31.29ms
+step:388/1490 train_time:12142ms step_avg:31.29ms
+step:389/1490 train_time:12170ms step_avg:31.29ms
+step:390/1490 train_time:12205ms step_avg:31.30ms
+step:391/1490 train_time:12233ms step_avg:31.29ms
+step:392/1490 train_time:12267ms step_avg:31.29ms
+step:393/1490 train_time:12295ms step_avg:31.29ms
+step:394/1490 train_time:12331ms step_avg:31.30ms
+step:395/1490 train_time:12358ms step_avg:31.29ms
+step:396/1490 train_time:12393ms step_avg:31.30ms
+step:397/1490 train_time:12420ms step_avg:31.28ms
+step:398/1490 train_time:12455ms step_avg:31.29ms
+step:399/1490 train_time:12482ms step_avg:31.28ms
+step:400/1490 train_time:12517ms step_avg:31.29ms
+step:401/1490 train_time:12545ms step_avg:31.28ms
+step:402/1490 train_time:12581ms step_avg:31.30ms
+step:403/1490 train_time:12607ms step_avg:31.28ms
+step:404/1490 train_time:12641ms step_avg:31.29ms
+step:405/1490 train_time:12669ms step_avg:31.28ms
+step:406/1490 train_time:12704ms step_avg:31.29ms
+step:407/1490 train_time:12732ms step_avg:31.28ms
+step:408/1490 train_time:12767ms step_avg:31.29ms
+step:409/1490 train_time:12794ms step_avg:31.28ms
+step:410/1490 train_time:12829ms step_avg:31.29ms
+step:411/1490 train_time:12856ms step_avg:31.28ms
+step:412/1490 train_time:12891ms step_avg:31.29ms
+step:413/1490 train_time:12919ms step_avg:31.28ms
+step:414/1490 train_time:12953ms step_avg:31.29ms
+step:415/1490 train_time:12981ms step_avg:31.28ms
+step:416/1490 train_time:13015ms step_avg:31.29ms
+step:417/1490 train_time:13043ms step_avg:31.28ms
+step:418/1490 train_time:13077ms step_avg:31.29ms
+step:419/1490 train_time:13105ms step_avg:31.28ms
+step:420/1490 train_time:13140ms step_avg:31.29ms
+step:421/1490 train_time:13167ms step_avg:31.28ms
+step:422/1490 train_time:13203ms step_avg:31.29ms
+step:423/1490 train_time:13230ms step_avg:31.28ms
+step:424/1490 train_time:13266ms step_avg:31.29ms
+step:425/1490 train_time:13293ms step_avg:31.28ms
+step:426/1490 train_time:13328ms step_avg:31.29ms
+step:427/1490 train_time:13355ms step_avg:31.28ms
+step:428/1490 train_time:13390ms step_avg:31.28ms
+step:429/1490 train_time:13417ms step_avg:31.28ms
+step:430/1490 train_time:13452ms step_avg:31.28ms
+step:431/1490 train_time:13480ms step_avg:31.28ms
+step:432/1490 train_time:13514ms step_avg:31.28ms
+step:433/1490 train_time:13542ms step_avg:31.28ms
+step:434/1490 train_time:13576ms step_avg:31.28ms
+step:435/1490 train_time:13604ms step_avg:31.27ms
+step:436/1490 train_time:13639ms step_avg:31.28ms
+step:437/1490 train_time:13667ms step_avg:31.28ms
+step:438/1490 train_time:13702ms step_avg:31.28ms
+step:439/1490 train_time:13730ms step_avg:31.28ms
+step:440/1490 train_time:13765ms step_avg:31.28ms
+step:441/1490 train_time:13793ms step_avg:31.28ms
+step:442/1490 train_time:13828ms step_avg:31.28ms
+step:443/1490 train_time:13855ms step_avg:31.28ms
+step:444/1490 train_time:13890ms step_avg:31.28ms
+step:445/1490 train_time:13917ms step_avg:31.27ms
+step:446/1490 train_time:13952ms step_avg:31.28ms
+step:447/1490 train_time:13980ms step_avg:31.28ms
+step:448/1490 train_time:14014ms step_avg:31.28ms
+step:449/1490 train_time:14042ms step_avg:31.27ms
+step:450/1490 train_time:14077ms step_avg:31.28ms
+step:451/1490 train_time:14105ms step_avg:31.27ms
+step:452/1490 train_time:14140ms step_avg:31.28ms
+step:453/1490 train_time:14167ms step_avg:31.27ms
+step:454/1490 train_time:14202ms step_avg:31.28ms
+step:455/1490 train_time:14229ms step_avg:31.27ms
+step:456/1490 train_time:14264ms step_avg:31.28ms
+step:457/1490 train_time:14292ms step_avg:31.27ms
+step:458/1490 train_time:14327ms step_avg:31.28ms
+step:459/1490 train_time:14355ms step_avg:31.27ms
+step:460/1490 train_time:14390ms step_avg:31.28ms
+step:461/1490 train_time:14418ms step_avg:31.27ms
+step:462/1490 train_time:14452ms step_avg:31.28ms
+step:463/1490 train_time:14480ms step_avg:31.27ms
+step:464/1490 train_time:14514ms step_avg:31.28ms
+step:465/1490 train_time:14542ms step_avg:31.27ms
+step:466/1490 train_time:14576ms step_avg:31.28ms
+step:467/1490 train_time:14604ms step_avg:31.27ms
+step:468/1490 train_time:14639ms step_avg:31.28ms
+step:469/1490 train_time:14667ms step_avg:31.27ms
+step:470/1490 train_time:14702ms step_avg:31.28ms
+step:471/1490 train_time:14729ms step_avg:31.27ms
+step:472/1490 train_time:14764ms step_avg:31.28ms
+step:473/1490 train_time:14792ms step_avg:31.27ms
+step:474/1490 train_time:14827ms step_avg:31.28ms
+step:475/1490 train_time:14855ms step_avg:31.27ms
+step:476/1490 train_time:14890ms step_avg:31.28ms
+step:477/1490 train_time:14917ms step_avg:31.27ms
+step:478/1490 train_time:14952ms step_avg:31.28ms
+step:479/1490 train_time:14979ms step_avg:31.27ms
+step:480/1490 train_time:15014ms step_avg:31.28ms
+step:481/1490 train_time:15041ms step_avg:31.27ms
+step:482/1490 train_time:15076ms step_avg:31.28ms
+step:483/1490 train_time:15103ms step_avg:31.27ms
+step:484/1490 train_time:15141ms step_avg:31.28ms
+step:485/1490 train_time:15192ms step_avg:31.32ms
+step:486/1490 train_time:15251ms step_avg:31.38ms
+step:487/1490 train_time:15304ms step_avg:31.42ms
+step:488/1490 train_time:15363ms step_avg:31.48ms
+step:489/1490 train_time:15417ms step_avg:31.53ms
+step:490/1490 train_time:15476ms step_avg:31.58ms
+step:491/1490 train_time:15530ms step_avg:31.63ms
+step:492/1490 train_time:15590ms step_avg:31.69ms
+step:493/1490 train_time:15643ms step_avg:31.73ms
+step:494/1490 train_time:15703ms step_avg:31.79ms
+step:495/1490 train_time:15758ms step_avg:31.83ms
+step:496/1490 train_time:15817ms step_avg:31.89ms
+step:497/1490 train_time:15871ms step_avg:31.93ms
+step:498/1490 train_time:15930ms step_avg:31.99ms
+step:499/1490 train_time:15985ms step_avg:32.03ms
+step:500/1490 train_time:16044ms step_avg:32.09ms
+step:500/1490 val_loss:4.2166 train_time:16116ms step_avg:32.23ms
+step:501/1490 train_time:16137ms step_avg:32.21ms
+step:502/1490 train_time:16159ms step_avg:32.19ms
+step:503/1490 train_time:16219ms step_avg:32.24ms
+step:504/1490 train_time:16281ms step_avg:32.30ms
+step:505/1490 train_time:16335ms step_avg:32.35ms
+step:506/1490 train_time:16394ms step_avg:32.40ms
+step:507/1490 train_time:16449ms step_avg:32.44ms
+step:508/1490 train_time:16508ms step_avg:32.50ms
+step:509/1490 train_time:16561ms step_avg:32.54ms
+step:510/1490 train_time:16621ms step_avg:32.59ms
+step:511/1490 train_time:16674ms step_avg:32.63ms
+step:512/1490 train_time:16732ms step_avg:32.68ms
+step:513/1490 train_time:16786ms step_avg:32.72ms
+step:514/1490 train_time:16845ms step_avg:32.77ms
+step:515/1490 train_time:16898ms step_avg:32.81ms
+step:516/1490 train_time:16958ms step_avg:32.86ms
+step:517/1490 train_time:17012ms step_avg:32.90ms
+step:518/1490 train_time:17071ms step_avg:32.96ms
+step:519/1490 train_time:17126ms step_avg:33.00ms
+step:520/1490 train_time:17188ms step_avg:33.05ms
+step:521/1490 train_time:17243ms step_avg:33.10ms
+step:522/1490 train_time:17302ms step_avg:33.15ms
+step:523/1490 train_time:17357ms step_avg:33.19ms
+step:524/1490 train_time:17416ms step_avg:33.24ms
+step:525/1490 train_time:17470ms step_avg:33.28ms
+step:526/1490 train_time:17529ms step_avg:33.32ms
+step:527/1490 train_time:17583ms step_avg:33.36ms
+step:528/1490 train_time:17641ms step_avg:33.41ms
+step:529/1490 train_time:17695ms step_avg:33.45ms
+step:530/1490 train_time:17754ms step_avg:33.50ms
+step:531/1490 train_time:17807ms step_avg:33.53ms
+step:532/1490 train_time:17865ms step_avg:33.58ms
+step:533/1490 train_time:17918ms step_avg:33.62ms
+step:534/1490 train_time:17978ms step_avg:33.67ms
+step:535/1490 train_time:18032ms step_avg:33.70ms
+step:536/1490 train_time:18092ms step_avg:33.75ms
+step:537/1490 train_time:18146ms step_avg:33.79ms
+step:538/1490 train_time:18206ms step_avg:33.84ms
+step:539/1490 train_time:18260ms step_avg:33.88ms
+step:540/1490 train_time:18320ms step_avg:33.93ms
+step:541/1490 train_time:18375ms step_avg:33.96ms
+step:542/1490 train_time:18434ms step_avg:34.01ms
+step:543/1490 train_time:18488ms step_avg:34.05ms
+step:544/1490 train_time:18547ms step_avg:34.09ms
+step:545/1490 train_time:18600ms step_avg:34.13ms
+step:546/1490 train_time:18660ms step_avg:34.18ms
+step:547/1490 train_time:18713ms step_avg:34.21ms
+step:548/1490 train_time:18773ms step_avg:34.26ms
+step:549/1490 train_time:18826ms step_avg:34.29ms
+step:550/1490 train_time:18885ms step_avg:34.34ms
+step:551/1490 train_time:18938ms step_avg:34.37ms
+step:552/1490 train_time:18997ms step_avg:34.42ms
+step:553/1490 train_time:19051ms step_avg:34.45ms
+step:554/1490 train_time:19111ms step_avg:34.50ms
+step:555/1490 train_time:19165ms step_avg:34.53ms
+step:556/1490 train_time:19225ms step_avg:34.58ms
+step:557/1490 train_time:19279ms step_avg:34.61ms
+step:558/1490 train_time:19338ms step_avg:34.66ms
+step:559/1490 train_time:19393ms step_avg:34.69ms
+step:560/1490 train_time:19453ms step_avg:34.74ms
+step:561/1490 train_time:19507ms step_avg:34.77ms
+step:562/1490 train_time:19566ms step_avg:34.82ms
+step:563/1490 train_time:19619ms step_avg:34.85ms
+step:564/1490 train_time:19679ms step_avg:34.89ms
+step:565/1490 train_time:19733ms step_avg:34.92ms
+step:566/1490 train_time:19791ms step_avg:34.97ms
+step:567/1490 train_time:19845ms step_avg:35.00ms
+step:568/1490 train_time:19904ms step_avg:35.04ms
+step:569/1490 train_time:19957ms step_avg:35.07ms
+step:570/1490 train_time:20017ms step_avg:35.12ms
+step:571/1490 train_time:20070ms step_avg:35.15ms
+step:572/1490 train_time:20129ms step_avg:35.19ms
+step:573/1490 train_time:20183ms step_avg:35.22ms
+step:574/1490 train_time:20243ms step_avg:35.27ms
+step:575/1490 train_time:20298ms step_avg:35.30ms
+step:576/1490 train_time:20357ms step_avg:35.34ms
+step:577/1490 train_time:20411ms step_avg:35.37ms
+step:578/1490 train_time:20471ms step_avg:35.42ms
+step:579/1490 train_time:20524ms step_avg:35.45ms
+step:580/1490 train_time:20584ms step_avg:35.49ms
+step:581/1490 train_time:20637ms step_avg:35.52ms
+step:582/1490 train_time:20696ms step_avg:35.56ms
+step:583/1490 train_time:20750ms step_avg:35.59ms
+step:584/1490 train_time:20809ms step_avg:35.63ms
+step:585/1490 train_time:20862ms step_avg:35.66ms
+step:586/1490 train_time:20921ms step_avg:35.70ms
+step:587/1490 train_time:20975ms step_avg:35.73ms
+step:588/1490 train_time:21034ms step_avg:35.77ms
+step:589/1490 train_time:21088ms step_avg:35.80ms
+step:590/1490 train_time:21148ms step_avg:35.84ms
+step:591/1490 train_time:21202ms step_avg:35.87ms
+step:592/1490 train_time:21261ms step_avg:35.91ms
+step:593/1490 train_time:21315ms step_avg:35.94ms
+step:594/1490 train_time:21375ms step_avg:35.98ms
+step:595/1490 train_time:21428ms step_avg:36.01ms
+step:596/1490 train_time:21487ms step_avg:36.05ms
+step:597/1490 train_time:21541ms step_avg:36.08ms
+step:598/1490 train_time:21600ms step_avg:36.12ms
+step:599/1490 train_time:21654ms step_avg:36.15ms
+step:600/1490 train_time:21713ms step_avg:36.19ms
+step:601/1490 train_time:21767ms step_avg:36.22ms
+step:602/1490 train_time:21825ms step_avg:36.25ms
+step:603/1490 train_time:21879ms step_avg:36.28ms
+step:604/1490 train_time:21937ms step_avg:36.32ms
+step:605/1490 train_time:21991ms step_avg:36.35ms
+step:606/1490 train_time:22050ms step_avg:36.39ms
+step:607/1490 train_time:22105ms step_avg:36.42ms
+step:608/1490 train_time:22164ms step_avg:36.45ms
+step:609/1490 train_time:22217ms step_avg:36.48ms
+step:610/1490 train_time:22277ms step_avg:36.52ms
+step:611/1490 train_time:22330ms step_avg:36.55ms
+step:612/1490 train_time:22389ms step_avg:36.58ms
+step:613/1490 train_time:22444ms step_avg:36.61ms
+step:614/1490 train_time:22503ms step_avg:36.65ms
+step:615/1490 train_time:22557ms step_avg:36.68ms
+step:616/1490 train_time:22616ms step_avg:36.71ms
+step:617/1490 train_time:22671ms step_avg:36.74ms
+step:618/1490 train_time:22730ms step_avg:36.78ms
+step:619/1490 train_time:22784ms step_avg:36.81ms
+step:620/1490 train_time:22842ms step_avg:36.84ms
+step:621/1490 train_time:22896ms step_avg:36.87ms
+step:622/1490 train_time:22955ms step_avg:36.91ms
+step:623/1490 train_time:23008ms step_avg:36.93ms
+step:624/1490 train_time:23069ms step_avg:36.97ms
+step:625/1490 train_time:23124ms step_avg:37.00ms
+step:626/1490 train_time:23182ms step_avg:37.03ms
+step:627/1490 train_time:23236ms step_avg:37.06ms
+step:628/1490 train_time:23295ms step_avg:37.09ms
+step:629/1490 train_time:23349ms step_avg:37.12ms
+step:630/1490 train_time:23408ms step_avg:37.16ms
+step:631/1490 train_time:23462ms step_avg:37.18ms
+step:632/1490 train_time:23521ms step_avg:37.22ms
+step:633/1490 train_time:23576ms step_avg:37.24ms
+step:634/1490 train_time:23635ms step_avg:37.28ms
+step:635/1490 train_time:23688ms step_avg:37.30ms
+step:636/1490 train_time:23748ms step_avg:37.34ms
+step:637/1490 train_time:23801ms step_avg:37.36ms
+step:638/1490 train_time:23861ms step_avg:37.40ms
+step:639/1490 train_time:23915ms step_avg:37.43ms
+step:640/1490 train_time:23974ms step_avg:37.46ms
+step:641/1490 train_time:24027ms step_avg:37.48ms
+step:642/1490 train_time:24087ms step_avg:37.52ms
+step:643/1490 train_time:24141ms step_avg:37.54ms
+step:644/1490 train_time:24200ms step_avg:37.58ms
+step:645/1490 train_time:24254ms step_avg:37.60ms
+step:646/1490 train_time:24313ms step_avg:37.64ms
+step:647/1490 train_time:24367ms step_avg:37.66ms
+step:648/1490 train_time:24426ms step_avg:37.70ms
+step:649/1490 train_time:24480ms step_avg:37.72ms
+step:650/1490 train_time:24539ms step_avg:37.75ms
+step:651/1490 train_time:24593ms step_avg:37.78ms
+step:652/1490 train_time:24652ms step_avg:37.81ms
+step:653/1490 train_time:24706ms step_avg:37.84ms
+step:654/1490 train_time:24766ms step_avg:37.87ms
+step:655/1490 train_time:24819ms step_avg:37.89ms
+step:656/1490 train_time:24878ms step_avg:37.92ms
+step:657/1490 train_time:24933ms step_avg:37.95ms
+step:658/1490 train_time:24992ms step_avg:37.98ms
+step:659/1490 train_time:25046ms step_avg:38.01ms
+step:660/1490 train_time:25105ms step_avg:38.04ms
+step:661/1490 train_time:25158ms step_avg:38.06ms
+step:662/1490 train_time:25218ms step_avg:38.09ms
+step:663/1490 train_time:25272ms step_avg:38.12ms
+step:664/1490 train_time:25331ms step_avg:38.15ms
+step:665/1490 train_time:25385ms step_avg:38.17ms
+step:666/1490 train_time:25444ms step_avg:38.20ms
+step:667/1490 train_time:25498ms step_avg:38.23ms
+step:668/1490 train_time:25556ms step_avg:38.26ms
+step:669/1490 train_time:25610ms step_avg:38.28ms
+step:670/1490 train_time:25669ms step_avg:38.31ms
+step:671/1490 train_time:25723ms step_avg:38.34ms
+step:672/1490 train_time:25782ms step_avg:38.37ms
+step:673/1490 train_time:25836ms step_avg:38.39ms
+step:674/1490 train_time:25896ms step_avg:38.42ms
+step:675/1490 train_time:25949ms step_avg:38.44ms
+step:676/1490 train_time:26009ms step_avg:38.48ms
+step:677/1490 train_time:26063ms step_avg:38.50ms
+step:678/1490 train_time:26122ms step_avg:38.53ms
+step:679/1490 train_time:26175ms step_avg:38.55ms
+step:680/1490 train_time:26234ms step_avg:38.58ms
+step:681/1490 train_time:26287ms step_avg:38.60ms
+step:682/1490 train_time:26347ms step_avg:38.63ms
+step:683/1490 train_time:26400ms step_avg:38.65ms
+step:684/1490 train_time:26460ms step_avg:38.68ms
+step:685/1490 train_time:26514ms step_avg:38.71ms
+step:686/1490 train_time:26574ms step_avg:38.74ms
+step:687/1490 train_time:26628ms step_avg:38.76ms
+step:688/1490 train_time:26688ms step_avg:38.79ms
+step:689/1490 train_time:26741ms step_avg:38.81ms
+step:690/1490 train_time:26800ms step_avg:38.84ms
+step:691/1490 train_time:26854ms step_avg:38.86ms
+step:692/1490 train_time:26913ms step_avg:38.89ms
+step:693/1490 train_time:26967ms step_avg:38.91ms
+step:694/1490 train_time:27027ms step_avg:38.94ms
+step:695/1490 train_time:27081ms step_avg:38.97ms
+step:696/1490 train_time:27139ms step_avg:38.99ms
+step:697/1490 train_time:27193ms step_avg:39.01ms
+step:698/1490 train_time:27253ms step_avg:39.04ms
+step:699/1490 train_time:27306ms step_avg:39.06ms
+step:700/1490 train_time:27366ms step_avg:39.09ms
+step:701/1490 train_time:27420ms step_avg:39.12ms
+step:702/1490 train_time:27479ms step_avg:39.14ms
+step:703/1490 train_time:27533ms step_avg:39.16ms
+step:704/1490 train_time:27593ms step_avg:39.19ms
+step:705/1490 train_time:27647ms step_avg:39.22ms
+step:706/1490 train_time:27706ms step_avg:39.24ms
+step:707/1490 train_time:27761ms step_avg:39.27ms
+step:708/1490 train_time:27819ms step_avg:39.29ms
+step:709/1490 train_time:27874ms step_avg:39.31ms
+step:710/1490 train_time:27932ms step_avg:39.34ms
+step:711/1490 train_time:27986ms step_avg:39.36ms
+step:712/1490 train_time:28045ms step_avg:39.39ms
+step:713/1490 train_time:28099ms step_avg:39.41ms
+step:714/1490 train_time:28158ms step_avg:39.44ms
+step:715/1490 train_time:28212ms step_avg:39.46ms
+step:716/1490 train_time:28272ms step_avg:39.49ms
+step:717/1490 train_time:28326ms step_avg:39.51ms
+step:718/1490 train_time:28385ms step_avg:39.53ms
+step:719/1490 train_time:28438ms step_avg:39.55ms
+step:720/1490 train_time:28497ms step_avg:39.58ms
+step:721/1490 train_time:28551ms step_avg:39.60ms
+step:722/1490 train_time:28610ms step_avg:39.63ms
+step:723/1490 train_time:28666ms step_avg:39.65ms
+step:724/1490 train_time:28724ms step_avg:39.67ms
+step:725/1490 train_time:28778ms step_avg:39.69ms
+step:726/1490 train_time:28837ms step_avg:39.72ms
+step:727/1490 train_time:28890ms step_avg:39.74ms
+step:728/1490 train_time:28950ms step_avg:39.77ms
+step:729/1490 train_time:29005ms step_avg:39.79ms
+step:730/1490 train_time:29064ms step_avg:39.81ms
+step:731/1490 train_time:29117ms step_avg:39.83ms
+step:732/1490 train_time:29176ms step_avg:39.86ms
+step:733/1490 train_time:29229ms step_avg:39.88ms
+step:734/1490 train_time:29290ms step_avg:39.90ms
+step:735/1490 train_time:29344ms step_avg:39.92ms
+step:736/1490 train_time:29403ms step_avg:39.95ms
+step:737/1490 train_time:29457ms step_avg:39.97ms
+step:738/1490 train_time:29516ms step_avg:39.99ms
+step:739/1490 train_time:29570ms step_avg:40.01ms
+step:740/1490 train_time:29629ms step_avg:40.04ms
+step:741/1490 train_time:29683ms step_avg:40.06ms
+step:742/1490 train_time:29742ms step_avg:40.08ms
+step:743/1490 train_time:29795ms step_avg:40.10ms
+step:744/1490 train_time:29856ms step_avg:40.13ms
+step:745/1490 train_time:29909ms step_avg:40.15ms
+step:746/1490 train_time:29969ms step_avg:40.17ms
+step:747/1490 train_time:30022ms step_avg:40.19ms
+step:748/1490 train_time:30082ms step_avg:40.22ms
+step:749/1490 train_time:30136ms step_avg:40.24ms
+step:750/1490 train_time:30195ms step_avg:40.26ms
+step:750/1490 val_loss:3.8072 train_time:30267ms step_avg:40.36ms
+step:751/1490 train_time:30285ms step_avg:40.33ms
+step:752/1490 train_time:30311ms step_avg:40.31ms
+step:753/1490 train_time:30369ms step_avg:40.33ms
+step:754/1490 train_time:30431ms step_avg:40.36ms
+step:755/1490 train_time:30487ms step_avg:40.38ms
+step:756/1490 train_time:30546ms step_avg:40.40ms
+step:757/1490 train_time:30599ms step_avg:40.42ms
+step:758/1490 train_time:30659ms step_avg:40.45ms
+step:759/1490 train_time:30712ms step_avg:40.46ms
+step:760/1490 train_time:30771ms step_avg:40.49ms
+step:761/1490 train_time:30825ms step_avg:40.51ms
+step:762/1490 train_time:30883ms step_avg:40.53ms
+step:763/1490 train_time:30937ms step_avg:40.55ms
+step:764/1490 train_time:30996ms step_avg:40.57ms
+step:765/1490 train_time:31048ms step_avg:40.59ms
+step:766/1490 train_time:31106ms step_avg:40.61ms
+step:767/1490 train_time:31160ms step_avg:40.63ms
+step:768/1490 train_time:31219ms step_avg:40.65ms
+step:769/1490 train_time:31273ms step_avg:40.67ms
+step:770/1490 train_time:31336ms step_avg:40.70ms
+step:771/1490 train_time:31390ms step_avg:40.71ms
+step:772/1490 train_time:31450ms step_avg:40.74ms
+step:773/1490 train_time:31504ms step_avg:40.76ms
+step:774/1490 train_time:31563ms step_avg:40.78ms
+step:775/1490 train_time:31618ms step_avg:40.80ms
+step:776/1490 train_time:31676ms step_avg:40.82ms
+step:777/1490 train_time:31730ms step_avg:40.84ms
+step:778/1490 train_time:31790ms step_avg:40.86ms
+step:779/1490 train_time:31843ms step_avg:40.88ms
+step:780/1490 train_time:31901ms step_avg:40.90ms
+step:781/1490 train_time:31955ms step_avg:40.92ms
+step:782/1490 train_time:32013ms step_avg:40.94ms
+step:783/1490 train_time:32066ms step_avg:40.95ms
+step:784/1490 train_time:32125ms step_avg:40.98ms
+step:785/1490 train_time:32179ms step_avg:40.99ms
+step:786/1490 train_time:32238ms step_avg:41.02ms
+step:787/1490 train_time:32293ms step_avg:41.03ms
+step:788/1490 train_time:32353ms step_avg:41.06ms
+step:789/1490 train_time:32407ms step_avg:41.07ms
+step:790/1490 train_time:32467ms step_avg:41.10ms
+step:791/1490 train_time:32520ms step_avg:41.11ms
+step:792/1490 train_time:32579ms step_avg:41.14ms
+step:793/1490 train_time:32633ms step_avg:41.15ms
+step:794/1490 train_time:32693ms step_avg:41.17ms
+step:795/1490 train_time:32746ms step_avg:41.19ms
+step:796/1490 train_time:32805ms step_avg:41.21ms
+step:797/1490 train_time:32858ms step_avg:41.23ms
+step:798/1490 train_time:32917ms step_avg:41.25ms
+step:799/1490 train_time:32971ms step_avg:41.26ms
+step:800/1490 train_time:33030ms step_avg:41.29ms
+step:801/1490 train_time:33083ms step_avg:41.30ms
+step:802/1490 train_time:33142ms step_avg:41.32ms
+step:803/1490 train_time:33196ms step_avg:41.34ms
+step:804/1490 train_time:33255ms step_avg:41.36ms
+step:805/1490 train_time:33309ms step_avg:41.38ms
+step:806/1490 train_time:33368ms step_avg:41.40ms
+step:807/1490 train_time:33422ms step_avg:41.42ms
+step:808/1490 train_time:33482ms step_avg:41.44ms
+step:809/1490 train_time:33536ms step_avg:41.45ms
+step:810/1490 train_time:33596ms step_avg:41.48ms
+step:811/1490 train_time:33650ms step_avg:41.49ms
+step:812/1490 train_time:33709ms step_avg:41.51ms
+step:813/1490 train_time:33763ms step_avg:41.53ms
+step:814/1490 train_time:33821ms step_avg:41.55ms
+step:815/1490 train_time:33874ms step_avg:41.56ms
+step:816/1490 train_time:33934ms step_avg:41.59ms
+step:817/1490 train_time:33987ms step_avg:41.60ms
+step:818/1490 train_time:34046ms step_avg:41.62ms
+step:819/1490 train_time:34100ms step_avg:41.64ms
+step:820/1490 train_time:34158ms step_avg:41.66ms
+step:821/1490 train_time:34212ms step_avg:41.67ms
+step:822/1490 train_time:34271ms step_avg:41.69ms
+step:823/1490 train_time:34327ms step_avg:41.71ms
+step:824/1490 train_time:34386ms step_avg:41.73ms
+step:825/1490 train_time:34440ms step_avg:41.75ms
+step:826/1490 train_time:34499ms step_avg:41.77ms
+step:827/1490 train_time:34552ms step_avg:41.78ms
+step:828/1490 train_time:34612ms step_avg:41.80ms
+step:829/1490 train_time:34666ms step_avg:41.82ms
+step:830/1490 train_time:34725ms step_avg:41.84ms
+step:831/1490 train_time:34779ms step_avg:41.85ms
+step:832/1490 train_time:34838ms step_avg:41.87ms
+step:833/1490 train_time:34891ms step_avg:41.89ms
+step:834/1490 train_time:34950ms step_avg:41.91ms
+step:835/1490 train_time:35004ms step_avg:41.92ms
+step:836/1490 train_time:35063ms step_avg:41.94ms
+step:837/1490 train_time:35116ms step_avg:41.95ms
+step:838/1490 train_time:35175ms step_avg:41.98ms
+step:839/1490 train_time:35229ms step_avg:41.99ms
+step:840/1490 train_time:35289ms step_avg:42.01ms
+step:841/1490 train_time:35344ms step_avg:42.03ms
+step:842/1490 train_time:35404ms step_avg:42.05ms
+step:843/1490 train_time:35457ms step_avg:42.06ms
+step:844/1490 train_time:35517ms step_avg:42.08ms
+step:845/1490 train_time:35570ms step_avg:42.09ms
+step:846/1490 train_time:35629ms step_avg:42.12ms
+step:847/1490 train_time:35683ms step_avg:42.13ms
+step:848/1490 train_time:35742ms step_avg:42.15ms
+step:849/1490 train_time:35796ms step_avg:42.16ms
+step:850/1490 train_time:35855ms step_avg:42.18ms
+step:851/1490 train_time:35908ms step_avg:42.20ms
+step:852/1490 train_time:35967ms step_avg:42.22ms
+step:853/1490 train_time:36021ms step_avg:42.23ms
+step:854/1490 train_time:36081ms step_avg:42.25ms
+step:855/1490 train_time:36135ms step_avg:42.26ms
+step:856/1490 train_time:36194ms step_avg:42.28ms
+step:857/1490 train_time:36248ms step_avg:42.30ms
+step:858/1490 train_time:36307ms step_avg:42.32ms
+step:859/1490 train_time:36360ms step_avg:42.33ms
+step:860/1490 train_time:36419ms step_avg:42.35ms
+step:861/1490 train_time:36473ms step_avg:42.36ms
+step:862/1490 train_time:36533ms step_avg:42.38ms
+step:863/1490 train_time:36586ms step_avg:42.39ms
+step:864/1490 train_time:36646ms step_avg:42.41ms
+step:865/1490 train_time:36699ms step_avg:42.43ms
+step:866/1490 train_time:36758ms step_avg:42.45ms
+step:867/1490 train_time:36811ms step_avg:42.46ms
+step:868/1490 train_time:36871ms step_avg:42.48ms
+step:869/1490 train_time:36925ms step_avg:42.49ms
+step:870/1490 train_time:36983ms step_avg:42.51ms
+step:871/1490 train_time:37038ms step_avg:42.52ms
+step:872/1490 train_time:37097ms step_avg:42.54ms
+step:873/1490 train_time:37149ms step_avg:42.55ms
+step:874/1490 train_time:37209ms step_avg:42.57ms
+step:875/1490 train_time:37263ms step_avg:42.59ms
+step:876/1490 train_time:37322ms step_avg:42.61ms
+step:877/1490 train_time:37376ms step_avg:42.62ms
+step:878/1490 train_time:37436ms step_avg:42.64ms
+step:879/1490 train_time:37490ms step_avg:42.65ms
+step:880/1490 train_time:37549ms step_avg:42.67ms
+step:881/1490 train_time:37603ms step_avg:42.68ms
+step:882/1490 train_time:37662ms step_avg:42.70ms
+step:883/1490 train_time:37716ms step_avg:42.71ms
+step:884/1490 train_time:37775ms step_avg:42.73ms
+step:885/1490 train_time:37829ms step_avg:42.74ms
+step:886/1490 train_time:37889ms step_avg:42.76ms
+step:887/1490 train_time:37942ms step_avg:42.78ms
+step:888/1490 train_time:38001ms step_avg:42.79ms
+step:889/1490 train_time:38055ms step_avg:42.81ms
+step:890/1490 train_time:38113ms step_avg:42.82ms
+step:891/1490 train_time:38167ms step_avg:42.84ms
+step:892/1490 train_time:38226ms step_avg:42.85ms
+step:893/1490 train_time:38280ms step_avg:42.87ms
+step:894/1490 train_time:38340ms step_avg:42.89ms
+step:895/1490 train_time:38393ms step_avg:42.90ms
+step:896/1490 train_time:38452ms step_avg:42.92ms
+step:897/1490 train_time:38506ms step_avg:42.93ms
+step:898/1490 train_time:38565ms step_avg:42.94ms
+step:899/1490 train_time:38619ms step_avg:42.96ms
+step:900/1490 train_time:38677ms step_avg:42.97ms
+step:901/1490 train_time:38732ms step_avg:42.99ms
+step:902/1490 train_time:38791ms step_avg:43.01ms
+step:903/1490 train_time:38845ms step_avg:43.02ms
+step:904/1490 train_time:38905ms step_avg:43.04ms
+step:905/1490 train_time:38958ms step_avg:43.05ms
+step:906/1490 train_time:39018ms step_avg:43.07ms
+step:907/1490 train_time:39071ms step_avg:43.08ms
+step:908/1490 train_time:39131ms step_avg:43.10ms
+step:909/1490 train_time:39185ms step_avg:43.11ms
+step:910/1490 train_time:39244ms step_avg:43.12ms
+step:911/1490 train_time:39297ms step_avg:43.14ms
+step:912/1490 train_time:39356ms step_avg:43.15ms
+step:913/1490 train_time:39411ms step_avg:43.17ms
+step:914/1490 train_time:39469ms step_avg:43.18ms
+step:915/1490 train_time:39523ms step_avg:43.19ms
+step:916/1490 train_time:39582ms step_avg:43.21ms
+step:917/1490 train_time:39636ms step_avg:43.22ms
+step:918/1490 train_time:39696ms step_avg:43.24ms
+step:919/1490 train_time:39749ms step_avg:43.25ms
+step:920/1490 train_time:39808ms step_avg:43.27ms
+step:921/1490 train_time:39862ms step_avg:43.28ms
+step:922/1490 train_time:39921ms step_avg:43.30ms
+step:923/1490 train_time:39975ms step_avg:43.31ms
+step:924/1490 train_time:40036ms step_avg:43.33ms
+step:925/1490 train_time:40088ms step_avg:43.34ms
+step:926/1490 train_time:40147ms step_avg:43.36ms
+step:927/1490 train_time:40202ms step_avg:43.37ms
+step:928/1490 train_time:40259ms step_avg:43.38ms
+step:929/1490 train_time:40313ms step_avg:43.39ms
+step:930/1490 train_time:40373ms step_avg:43.41ms
+step:931/1490 train_time:40428ms step_avg:43.42ms
+step:932/1490 train_time:40487ms step_avg:43.44ms
+step:933/1490 train_time:40540ms step_avg:43.45ms
+step:934/1490 train_time:40600ms step_avg:43.47ms
+step:935/1490 train_time:40653ms step_avg:43.48ms
+step:936/1490 train_time:40713ms step_avg:43.50ms
+step:937/1490 train_time:40767ms step_avg:43.51ms
+step:938/1490 train_time:40827ms step_avg:43.53ms
+step:939/1490 train_time:40880ms step_avg:43.54ms
+step:940/1490 train_time:40939ms step_avg:43.55ms
+step:941/1490 train_time:40993ms step_avg:43.56ms
+step:942/1490 train_time:41053ms step_avg:43.58ms
+step:943/1490 train_time:41106ms step_avg:43.59ms
+step:944/1490 train_time:41165ms step_avg:43.61ms
+step:945/1490 train_time:41219ms step_avg:43.62ms
+step:946/1490 train_time:41278ms step_avg:43.63ms
+step:947/1490 train_time:41332ms step_avg:43.65ms
+step:948/1490 train_time:41391ms step_avg:43.66ms
+step:949/1490 train_time:41445ms step_avg:43.67ms
+step:950/1490 train_time:41504ms step_avg:43.69ms
+step:951/1490 train_time:41557ms step_avg:43.70ms
+step:952/1490 train_time:41616ms step_avg:43.71ms
+step:953/1490 train_time:41669ms step_avg:43.72ms
+step:954/1490 train_time:41728ms step_avg:43.74ms
+step:955/1490 train_time:41782ms step_avg:43.75ms
+step:956/1490 train_time:41842ms step_avg:43.77ms
+step:957/1490 train_time:41896ms step_avg:43.78ms
+step:958/1490 train_time:41957ms step_avg:43.80ms
+step:959/1490 train_time:42009ms step_avg:43.80ms
+step:960/1490 train_time:42068ms step_avg:43.82ms
+step:961/1490 train_time:42121ms step_avg:43.83ms
+step:962/1490 train_time:42181ms step_avg:43.85ms
+step:963/1490 train_time:42234ms step_avg:43.86ms
+step:964/1490 train_time:42294ms step_avg:43.87ms
+step:965/1490 train_time:42347ms step_avg:43.88ms
+step:966/1490 train_time:42406ms step_avg:43.90ms
+step:967/1490 train_time:42460ms step_avg:43.91ms
+step:968/1490 train_time:42521ms step_avg:43.93ms
+step:969/1490 train_time:42599ms step_avg:43.96ms
+step:970/1490 train_time:42684ms step_avg:44.00ms
+step:971/1490 train_time:42765ms step_avg:44.04ms
+step:972/1490 train_time:42850ms step_avg:44.08ms
+step:973/1490 train_time:42930ms step_avg:44.12ms
+step:974/1490 train_time:43015ms step_avg:44.16ms
+step:975/1490 train_time:43095ms step_avg:44.20ms
+step:976/1490 train_time:43180ms step_avg:44.24ms
+step:977/1490 train_time:43260ms step_avg:44.28ms
+step:978/1490 train_time:43345ms step_avg:44.32ms
+step:979/1490 train_time:43425ms step_avg:44.36ms
+step:980/1490 train_time:43511ms step_avg:44.40ms
+step:981/1490 train_time:43591ms step_avg:44.44ms
+step:982/1490 train_time:43675ms step_avg:44.48ms
+step:983/1490 train_time:43755ms step_avg:44.51ms
+step:984/1490 train_time:43840ms step_avg:44.55ms
+step:985/1490 train_time:43920ms step_avg:44.59ms
+step:986/1490 train_time:44004ms step_avg:44.63ms
+step:987/1490 train_time:44084ms step_avg:44.66ms
+step:988/1490 train_time:44169ms step_avg:44.71ms
+step:989/1490 train_time:44250ms step_avg:44.74ms
+step:990/1490 train_time:44334ms step_avg:44.78ms
+step:991/1490 train_time:44414ms step_avg:44.82ms
+step:992/1490 train_time:44499ms step_avg:44.86ms
+step:993/1490 train_time:44578ms step_avg:44.89ms
+step:994/1490 train_time:44662ms step_avg:44.93ms
+step:995/1490 train_time:44742ms step_avg:44.97ms
+step:996/1490 train_time:44827ms step_avg:45.01ms
+step:997/1490 train_time:44907ms step_avg:45.04ms
+step:998/1490 train_time:44991ms step_avg:45.08ms
+step:999/1490 train_time:45072ms step_avg:45.12ms
+step:1000/1490 train_time:45157ms step_avg:45.16ms
+step:1000/1490 val_loss:3.5162 train_time:45259ms step_avg:45.26ms
+step:1001/1490 train_time:45284ms step_avg:45.24ms
+step:1002/1490 train_time:45327ms step_avg:45.24ms
+step:1003/1490 train_time:45410ms step_avg:45.27ms
+step:1004/1490 train_time:45495ms step_avg:45.31ms
+step:1005/1490 train_time:45574ms step_avg:45.35ms
+step:1006/1490 train_time:45657ms step_avg:45.39ms
+step:1007/1490 train_time:45737ms step_avg:45.42ms
+step:1008/1490 train_time:45820ms step_avg:45.46ms
+step:1009/1490 train_time:45900ms step_avg:45.49ms
+step:1010/1490 train_time:45984ms step_avg:45.53ms
+step:1011/1490 train_time:46063ms step_avg:45.56ms
+step:1012/1490 train_time:46145ms step_avg:45.60ms
+step:1013/1490 train_time:46226ms step_avg:45.63ms
+step:1014/1490 train_time:46313ms step_avg:45.67ms
+step:1015/1490 train_time:46394ms step_avg:45.71ms
+step:1016/1490 train_time:46481ms step_avg:45.75ms
+step:1017/1490 train_time:46563ms step_avg:45.78ms
+step:1018/1490 train_time:46649ms step_avg:45.82ms
+step:1019/1490 train_time:46729ms step_avg:45.86ms
+step:1020/1490 train_time:46813ms step_avg:45.89ms
+step:1021/1490 train_time:46891ms step_avg:45.93ms
+step:1022/1490 train_time:46975ms step_avg:45.96ms
+step:1023/1490 train_time:47053ms step_avg:46.00ms
+step:1024/1490 train_time:47138ms step_avg:46.03ms
+step:1025/1490 train_time:47217ms step_avg:46.07ms
+step:1026/1490 train_time:47303ms step_avg:46.10ms
+step:1027/1490 train_time:47385ms step_avg:46.14ms
+step:1028/1490 train_time:47472ms step_avg:46.18ms
+step:1029/1490 train_time:47553ms step_avg:46.21ms
+step:1030/1490 train_time:47637ms step_avg:46.25ms
+step:1031/1490 train_time:47717ms step_avg:46.28ms
+step:1032/1490 train_time:47801ms step_avg:46.32ms
+step:1033/1490 train_time:47880ms step_avg:46.35ms
+step:1034/1490 train_time:47965ms step_avg:46.39ms
+step:1035/1490 train_time:48044ms step_avg:46.42ms
+step:1036/1490 train_time:48128ms step_avg:46.46ms
+step:1037/1490 train_time:48206ms step_avg:46.49ms
+step:1038/1490 train_time:48293ms step_avg:46.53ms
+step:1039/1490 train_time:48374ms step_avg:46.56ms
+step:1040/1490 train_time:48459ms step_avg:46.60ms
+step:1041/1490 train_time:48540ms step_avg:46.63ms
+step:1042/1490 train_time:48626ms step_avg:46.67ms
+step:1043/1490 train_time:48705ms step_avg:46.70ms
+step:1044/1490 train_time:48790ms step_avg:46.73ms
+step:1045/1490 train_time:48869ms step_avg:46.76ms
+step:1046/1490 train_time:48954ms step_avg:46.80ms
+step:1047/1490 train_time:49033ms step_avg:46.83ms
+step:1048/1490 train_time:49117ms step_avg:46.87ms
+step:1049/1490 train_time:49196ms step_avg:46.90ms
+step:1050/1490 train_time:49281ms step_avg:46.93ms
+step:1051/1490 train_time:49363ms step_avg:46.97ms
+step:1052/1490 train_time:49449ms step_avg:47.00ms
+step:1053/1490 train_time:49529ms step_avg:47.04ms
+step:1054/1490 train_time:49614ms step_avg:47.07ms
+step:1055/1490 train_time:49693ms step_avg:47.10ms
+step:1056/1490 train_time:49777ms step_avg:47.14ms
+step:1057/1490 train_time:49856ms step_avg:47.17ms
+step:1058/1490 train_time:49941ms step_avg:47.20ms
+step:1059/1490 train_time:50021ms step_avg:47.23ms
+step:1060/1490 train_time:50106ms step_avg:47.27ms
+step:1061/1490 train_time:50186ms step_avg:47.30ms
+step:1062/1490 train_time:50270ms step_avg:47.33ms
+step:1063/1490 train_time:50349ms step_avg:47.37ms
+step:1064/1490 train_time:50435ms step_avg:47.40ms
+step:1065/1490 train_time:50515ms step_avg:47.43ms
+step:1066/1490 train_time:50601ms step_avg:47.47ms
+step:1067/1490 train_time:50682ms step_avg:47.50ms
+step:1068/1490 train_time:50766ms step_avg:47.53ms
+step:1069/1490 train_time:50845ms step_avg:47.56ms
+step:1070/1490 train_time:50929ms step_avg:47.60ms
+step:1071/1490 train_time:51009ms step_avg:47.63ms
+step:1072/1490 train_time:51094ms step_avg:47.66ms
+step:1073/1490 train_time:51172ms step_avg:47.69ms
+step:1074/1490 train_time:51257ms step_avg:47.73ms
+step:1075/1490 train_time:51337ms step_avg:47.76ms
+step:1076/1490 train_time:51423ms step_avg:47.79ms
+step:1077/1490 train_time:51502ms step_avg:47.82ms
+step:1078/1490 train_time:51588ms step_avg:47.86ms
+step:1079/1490 train_time:51667ms step_avg:47.88ms
+step:1080/1490 train_time:51753ms step_avg:47.92ms
+step:1081/1490 train_time:51831ms step_avg:47.95ms
+step:1082/1490 train_time:51915ms step_avg:47.98ms
+step:1083/1490 train_time:51995ms step_avg:48.01ms
+step:1084/1490 train_time:52080ms step_avg:48.04ms
+step:1085/1490 train_time:52160ms step_avg:48.07ms
+step:1086/1490 train_time:52245ms step_avg:48.11ms
+step:1087/1490 train_time:52324ms step_avg:48.14ms
+step:1088/1490 train_time:52409ms step_avg:48.17ms
+step:1089/1490 train_time:52488ms step_avg:48.20ms
+step:1090/1490 train_time:52573ms step_avg:48.23ms
+step:1091/1490 train_time:52652ms step_avg:48.26ms
+step:1092/1490 train_time:52737ms step_avg:48.29ms
+step:1093/1490 train_time:52817ms step_avg:48.32ms
+step:1094/1490 train_time:52902ms step_avg:48.36ms
+step:1095/1490 train_time:52983ms step_avg:48.39ms
+step:1096/1490 train_time:53067ms step_avg:48.42ms
+step:1097/1490 train_time:53147ms step_avg:48.45ms
+step:1098/1490 train_time:53232ms step_avg:48.48ms
+step:1099/1490 train_time:53311ms step_avg:48.51ms
+step:1100/1490 train_time:53395ms step_avg:48.54ms
+step:1101/1490 train_time:53474ms step_avg:48.57ms
+step:1102/1490 train_time:53558ms step_avg:48.60ms
+step:1103/1490 train_time:53639ms step_avg:48.63ms
+step:1104/1490 train_time:53725ms step_avg:48.66ms
+step:1105/1490 train_time:53804ms step_avg:48.69ms
+step:1106/1490 train_time:53889ms step_avg:48.72ms
+step:1107/1490 train_time:53968ms step_avg:48.75ms
+step:1108/1490 train_time:54053ms step_avg:48.78ms
+step:1109/1490 train_time:54133ms step_avg:48.81ms
+step:1110/1490 train_time:54218ms step_avg:48.84ms
+step:1111/1490 train_time:54297ms step_avg:48.87ms
+step:1112/1490 train_time:54382ms step_avg:48.90ms
+step:1113/1490 train_time:54461ms step_avg:48.93ms
+step:1114/1490 train_time:54547ms step_avg:48.97ms
+step:1115/1490 train_time:54626ms step_avg:48.99ms
+step:1116/1490 train_time:54711ms step_avg:49.02ms
+step:1117/1490 train_time:54790ms step_avg:49.05ms
+step:1118/1490 train_time:54875ms step_avg:49.08ms
+step:1119/1490 train_time:54954ms step_avg:49.11ms
+step:1120/1490 train_time:55039ms step_avg:49.14ms
+step:1121/1490 train_time:55119ms step_avg:49.17ms
+step:1122/1490 train_time:55203ms step_avg:49.20ms
+step:1123/1490 train_time:55284ms step_avg:49.23ms
+step:1124/1490 train_time:55368ms step_avg:49.26ms
+step:1125/1490 train_time:55447ms step_avg:49.29ms
+step:1126/1490 train_time:55534ms step_avg:49.32ms
+step:1127/1490 train_time:55613ms step_avg:49.35ms
+step:1128/1490 train_time:55696ms step_avg:49.38ms
+step:1129/1490 train_time:55777ms step_avg:49.40ms
+step:1130/1490 train_time:55861ms step_avg:49.43ms
+step:1131/1490 train_time:55941ms step_avg:49.46ms
+step:1132/1490 train_time:56025ms step_avg:49.49ms
+step:1133/1490 train_time:56104ms step_avg:49.52ms
+step:1134/1490 train_time:56190ms step_avg:49.55ms
+step:1135/1490 train_time:56269ms step_avg:49.58ms
+step:1136/1490 train_time:56355ms step_avg:49.61ms
+step:1137/1490 train_time:56435ms step_avg:49.63ms
+step:1138/1490 train_time:56520ms step_avg:49.67ms
+step:1139/1490 train_time:56600ms step_avg:49.69ms
+step:1140/1490 train_time:56685ms step_avg:49.72ms
+step:1141/1490 train_time:56765ms step_avg:49.75ms
+step:1142/1490 train_time:56850ms step_avg:49.78ms
+step:1143/1490 train_time:56929ms step_avg:49.81ms
+step:1144/1490 train_time:57014ms step_avg:49.84ms
+step:1145/1490 train_time:57093ms step_avg:49.86ms
+step:1146/1490 train_time:57178ms step_avg:49.89ms
+step:1147/1490 train_time:57258ms step_avg:49.92ms
+step:1148/1490 train_time:57343ms step_avg:49.95ms
+step:1149/1490 train_time:57424ms step_avg:49.98ms
+step:1150/1490 train_time:57508ms step_avg:50.01ms
+step:1151/1490 train_time:57588ms step_avg:50.03ms
+step:1152/1490 train_time:57673ms step_avg:50.06ms
+step:1153/1490 train_time:57752ms step_avg:50.09ms
+step:1154/1490 train_time:57837ms step_avg:50.12ms
+step:1155/1490 train_time:57916ms step_avg:50.14ms
+step:1156/1490 train_time:58002ms step_avg:50.17ms
+step:1157/1490 train_time:58083ms step_avg:50.20ms
+step:1158/1490 train_time:58169ms step_avg:50.23ms
+step:1159/1490 train_time:58249ms step_avg:50.26ms
+step:1160/1490 train_time:58333ms step_avg:50.29ms
+step:1161/1490 train_time:58412ms step_avg:50.31ms
+step:1162/1490 train_time:58497ms step_avg:50.34ms
+step:1163/1490 train_time:58576ms step_avg:50.37ms
+step:1164/1490 train_time:58660ms step_avg:50.40ms
+step:1165/1490 train_time:58740ms step_avg:50.42ms
+step:1166/1490 train_time:58826ms step_avg:50.45ms
+step:1167/1490 train_time:58905ms step_avg:50.48ms
+step:1168/1490 train_time:58991ms step_avg:50.51ms
+step:1169/1490 train_time:59069ms step_avg:50.53ms
+step:1170/1490 train_time:59154ms step_avg:50.56ms
+step:1171/1490 train_time:59234ms step_avg:50.58ms
+step:1172/1490 train_time:59319ms step_avg:50.61ms
+step:1173/1490 train_time:59399ms step_avg:50.64ms
+step:1174/1490 train_time:59484ms step_avg:50.67ms
+step:1175/1490 train_time:59564ms step_avg:50.69ms
+step:1176/1490 train_time:59648ms step_avg:50.72ms
+step:1177/1490 train_time:59728ms step_avg:50.75ms
+step:1178/1490 train_time:59813ms step_avg:50.78ms
+step:1179/1490 train_time:59893ms step_avg:50.80ms
+step:1180/1490 train_time:59979ms step_avg:50.83ms
+step:1181/1490 train_time:60059ms step_avg:50.85ms
+step:1182/1490 train_time:60145ms step_avg:50.88ms
+step:1183/1490 train_time:60224ms step_avg:50.91ms
+step:1184/1490 train_time:60309ms step_avg:50.94ms
+step:1185/1490 train_time:60389ms step_avg:50.96ms
+step:1186/1490 train_time:60473ms step_avg:50.99ms
+step:1187/1490 train_time:60553ms step_avg:51.01ms
+step:1188/1490 train_time:60639ms step_avg:51.04ms
+step:1189/1490 train_time:60718ms step_avg:51.07ms
+step:1190/1490 train_time:60802ms step_avg:51.09ms
+step:1191/1490 train_time:60883ms step_avg:51.12ms
+step:1192/1490 train_time:60967ms step_avg:51.15ms
+step:1193/1490 train_time:61047ms step_avg:51.17ms
+step:1194/1490 train_time:61133ms step_avg:51.20ms
+step:1195/1490 train_time:61212ms step_avg:51.22ms
+step:1196/1490 train_time:61296ms step_avg:51.25ms
+step:1197/1490 train_time:61376ms step_avg:51.27ms
+step:1198/1490 train_time:61459ms step_avg:51.30ms
+step:1199/1490 train_time:61539ms step_avg:51.32ms
+step:1200/1490 train_time:61624ms step_avg:51.35ms
+step:1201/1490 train_time:61703ms step_avg:51.38ms
+step:1202/1490 train_time:61788ms step_avg:51.40ms
+step:1203/1490 train_time:61867ms step_avg:51.43ms
+step:1204/1490 train_time:61952ms step_avg:51.46ms
+step:1205/1490 train_time:62032ms step_avg:51.48ms
+step:1206/1490 train_time:62117ms step_avg:51.51ms
+step:1207/1490 train_time:62196ms step_avg:51.53ms
+step:1208/1490 train_time:62281ms step_avg:51.56ms
+step:1209/1490 train_time:62362ms step_avg:51.58ms
+step:1210/1490 train_time:62448ms step_avg:51.61ms
+step:1211/1490 train_time:62528ms step_avg:51.63ms
+step:1212/1490 train_time:62613ms step_avg:51.66ms
+step:1213/1490 train_time:62691ms step_avg:51.68ms
+step:1214/1490 train_time:62777ms step_avg:51.71ms
+step:1215/1490 train_time:62856ms step_avg:51.73ms
+step:1216/1490 train_time:62941ms step_avg:51.76ms
+step:1217/1490 train_time:63021ms step_avg:51.78ms
+step:1218/1490 train_time:63105ms step_avg:51.81ms
+step:1219/1490 train_time:63184ms step_avg:51.83ms
+step:1220/1490 train_time:63268ms step_avg:51.86ms
+step:1221/1490 train_time:63347ms step_avg:51.88ms
+step:1222/1490 train_time:63432ms step_avg:51.91ms
+step:1223/1490 train_time:63512ms step_avg:51.93ms
+step:1224/1490 train_time:63597ms step_avg:51.96ms
+step:1225/1490 train_time:63677ms step_avg:51.98ms
+step:1226/1490 train_time:63763ms step_avg:52.01ms
+step:1227/1490 train_time:63843ms step_avg:52.03ms
+step:1228/1490 train_time:63927ms step_avg:52.06ms
+step:1229/1490 train_time:64007ms step_avg:52.08ms
+step:1230/1490 train_time:64091ms step_avg:52.11ms
+step:1231/1490 train_time:64172ms step_avg:52.13ms
+step:1232/1490 train_time:64256ms step_avg:52.16ms
+step:1233/1490 train_time:64336ms step_avg:52.18ms
+step:1234/1490 train_time:64420ms step_avg:52.20ms
+step:1235/1490 train_time:64500ms step_avg:52.23ms
+step:1236/1490 train_time:64584ms step_avg:52.25ms
+step:1237/1490 train_time:64664ms step_avg:52.28ms
+step:1238/1490 train_time:64749ms step_avg:52.30ms
+step:1239/1490 train_time:64828ms step_avg:52.32ms
+step:1240/1490 train_time:64913ms step_avg:52.35ms
+step:1241/1490 train_time:64992ms step_avg:52.37ms
+step:1242/1490 train_time:65077ms step_avg:52.40ms
+step:1243/1490 train_time:65156ms step_avg:52.42ms
+step:1244/1490 train_time:65242ms step_avg:52.45ms
+step:1245/1490 train_time:65321ms step_avg:52.47ms
+step:1246/1490 train_time:65407ms step_avg:52.49ms
+step:1247/1490 train_time:65487ms step_avg:52.52ms
+step:1248/1490 train_time:65573ms step_avg:52.54ms
+step:1249/1490 train_time:65652ms step_avg:52.56ms
+step:1250/1490 train_time:65738ms step_avg:52.59ms
+step:1250/1490 val_loss:3.3718 train_time:65839ms step_avg:52.67ms
+step:1251/1490 train_time:65865ms step_avg:52.65ms
+step:1252/1490 train_time:65908ms step_avg:52.64ms
+step:1253/1490 train_time:65991ms step_avg:52.67ms
+step:1254/1490 train_time:66078ms step_avg:52.69ms
+step:1255/1490 train_time:66158ms step_avg:52.72ms
+step:1256/1490 train_time:66243ms step_avg:52.74ms
+step:1257/1490 train_time:66323ms step_avg:52.76ms
+step:1258/1490 train_time:66407ms step_avg:52.79ms
+step:1259/1490 train_time:66485ms step_avg:52.81ms
+step:1260/1490 train_time:66569ms step_avg:52.83ms
+step:1261/1490 train_time:66647ms step_avg:52.85ms
+step:1262/1490 train_time:66731ms step_avg:52.88ms
+step:1263/1490 train_time:66811ms step_avg:52.90ms
+step:1264/1490 train_time:66898ms step_avg:52.93ms
+step:1265/1490 train_time:66980ms step_avg:52.95ms
+step:1266/1490 train_time:67067ms step_avg:52.98ms
+step:1267/1490 train_time:67148ms step_avg:53.00ms
+step:1268/1490 train_time:67234ms step_avg:53.02ms
+step:1269/1490 train_time:67314ms step_avg:53.04ms
+step:1270/1490 train_time:67398ms step_avg:53.07ms
+step:1271/1490 train_time:67477ms step_avg:53.09ms
+step:1272/1490 train_time:67561ms step_avg:53.11ms
+step:1273/1490 train_time:67640ms step_avg:53.13ms
+step:1274/1490 train_time:67722ms step_avg:53.16ms
+step:1275/1490 train_time:67800ms step_avg:53.18ms
+step:1276/1490 train_time:67888ms step_avg:53.20ms
+step:1277/1490 train_time:67968ms step_avg:53.22ms
+step:1278/1490 train_time:68054ms step_avg:53.25ms
+step:1279/1490 train_time:68135ms step_avg:53.27ms
+step:1280/1490 train_time:68220ms step_avg:53.30ms
+step:1281/1490 train_time:68299ms step_avg:53.32ms
+step:1282/1490 train_time:68387ms step_avg:53.34ms
+step:1283/1490 train_time:68465ms step_avg:53.36ms
+step:1284/1490 train_time:68549ms step_avg:53.39ms
+step:1285/1490 train_time:68626ms step_avg:53.41ms
+step:1286/1490 train_time:68711ms step_avg:53.43ms
+step:1287/1490 train_time:68791ms step_avg:53.45ms
+step:1288/1490 train_time:68877ms step_avg:53.48ms
+step:1289/1490 train_time:68957ms step_avg:53.50ms
+step:1290/1490 train_time:69043ms step_avg:53.52ms
+step:1291/1490 train_time:69122ms step_avg:53.54ms
+step:1292/1490 train_time:69208ms step_avg:53.57ms
+step:1293/1490 train_time:69287ms step_avg:53.59ms
+step:1294/1490 train_time:69372ms step_avg:53.61ms
+step:1295/1490 train_time:69452ms step_avg:53.63ms
+step:1296/1490 train_time:69536ms step_avg:53.65ms
+step:1297/1490 train_time:69615ms step_avg:53.67ms
+step:1298/1490 train_time:69699ms step_avg:53.70ms
+step:1299/1490 train_time:69778ms step_avg:53.72ms
+step:1300/1490 train_time:69864ms step_avg:53.74ms
+step:1301/1490 train_time:69944ms step_avg:53.76ms
+step:1302/1490 train_time:70029ms step_avg:53.79ms
+step:1303/1490 train_time:70109ms step_avg:53.81ms
+step:1304/1490 train_time:70195ms step_avg:53.83ms
+step:1305/1490 train_time:70274ms step_avg:53.85ms
+step:1306/1490 train_time:70360ms step_avg:53.87ms
+step:1307/1490 train_time:70439ms step_avg:53.89ms
+step:1308/1490 train_time:70522ms step_avg:53.92ms
+step:1309/1490 train_time:70602ms step_avg:53.94ms
+step:1310/1490 train_time:70685ms step_avg:53.96ms
+step:1311/1490 train_time:70765ms step_avg:53.98ms
+step:1312/1490 train_time:70851ms step_avg:54.00ms
+step:1313/1490 train_time:70929ms step_avg:54.02ms
+step:1314/1490 train_time:71013ms step_avg:54.04ms
+step:1315/1490 train_time:71093ms step_avg:54.06ms
+step:1316/1490 train_time:71178ms step_avg:54.09ms
+step:1317/1490 train_time:71258ms step_avg:54.11ms
+step:1318/1490 train_time:71344ms step_avg:54.13ms
+step:1319/1490 train_time:71424ms step_avg:54.15ms
+step:1320/1490 train_time:71508ms step_avg:54.17ms
+step:1321/1490 train_time:71587ms step_avg:54.19ms
+step:1322/1490 train_time:71671ms step_avg:54.21ms
+step:1323/1490 train_time:71750ms step_avg:54.23ms
+step:1324/1490 train_time:71835ms step_avg:54.26ms
+step:1325/1490 train_time:71916ms step_avg:54.28ms
+step:1326/1490 train_time:72000ms step_avg:54.30ms
+step:1327/1490 train_time:72080ms step_avg:54.32ms
+step:1328/1490 train_time:72164ms step_avg:54.34ms
+step:1329/1490 train_time:72244ms step_avg:54.36ms
+step:1330/1490 train_time:72329ms step_avg:54.38ms
+step:1331/1490 train_time:72409ms step_avg:54.40ms
+step:1332/1490 train_time:72494ms step_avg:54.43ms
+step:1333/1490 train_time:72574ms step_avg:54.44ms
+step:1334/1490 train_time:72658ms step_avg:54.47ms
+step:1335/1490 train_time:72738ms step_avg:54.49ms
+step:1336/1490 train_time:72822ms step_avg:54.51ms
+step:1337/1490 train_time:72902ms step_avg:54.53ms
+step:1338/1490 train_time:72989ms step_avg:54.55ms
+step:1339/1490 train_time:73067ms step_avg:54.57ms
+step:1340/1490 train_time:73153ms step_avg:54.59ms
+step:1341/1490 train_time:73233ms step_avg:54.61ms
+step:1342/1490 train_time:73317ms step_avg:54.63ms
+step:1343/1490 train_time:73397ms step_avg:54.65ms
+step:1344/1490 train_time:73484ms step_avg:54.68ms
+step:1345/1490 train_time:73564ms step_avg:54.69ms
+step:1346/1490 train_time:73650ms step_avg:54.72ms
+step:1347/1490 train_time:73728ms step_avg:54.74ms
+step:1348/1490 train_time:73812ms step_avg:54.76ms
+step:1349/1490 train_time:73893ms step_avg:54.78ms
+step:1350/1490 train_time:73979ms step_avg:54.80ms
+step:1351/1490 train_time:74058ms step_avg:54.82ms
+step:1352/1490 train_time:74144ms step_avg:54.84ms
+step:1353/1490 train_time:74224ms step_avg:54.86ms
+step:1354/1490 train_time:74309ms step_avg:54.88ms
+step:1355/1490 train_time:74389ms step_avg:54.90ms
+step:1356/1490 train_time:74474ms step_avg:54.92ms
+step:1357/1490 train_time:74555ms step_avg:54.94ms
+step:1358/1490 train_time:74640ms step_avg:54.96ms
+step:1359/1490 train_time:74719ms step_avg:54.98ms
+step:1360/1490 train_time:74804ms step_avg:55.00ms
+step:1361/1490 train_time:74883ms step_avg:55.02ms
+step:1362/1490 train_time:74968ms step_avg:55.04ms
+step:1363/1490 train_time:75047ms step_avg:55.06ms
+step:1364/1490 train_time:75132ms step_avg:55.08ms
+step:1365/1490 train_time:75212ms step_avg:55.10ms
+step:1366/1490 train_time:75297ms step_avg:55.12ms
+step:1367/1490 train_time:75376ms step_avg:55.14ms
+step:1368/1490 train_time:75460ms step_avg:55.16ms
+step:1369/1490 train_time:75540ms step_avg:55.18ms
+step:1370/1490 train_time:75625ms step_avg:55.20ms
+step:1371/1490 train_time:75704ms step_avg:55.22ms
+step:1372/1490 train_time:75790ms step_avg:55.24ms
+step:1373/1490 train_time:75868ms step_avg:55.26ms
+step:1374/1490 train_time:75953ms step_avg:55.28ms
+step:1375/1490 train_time:76032ms step_avg:55.30ms
+step:1376/1490 train_time:76118ms step_avg:55.32ms
+step:1377/1490 train_time:76198ms step_avg:55.34ms
+step:1378/1490 train_time:76283ms step_avg:55.36ms
+step:1379/1490 train_time:76362ms step_avg:55.37ms
+step:1380/1490 train_time:76448ms step_avg:55.40ms
+step:1381/1490 train_time:76527ms step_avg:55.41ms
+step:1382/1490 train_time:76612ms step_avg:55.44ms
+step:1383/1490 train_time:76691ms step_avg:55.45ms
+step:1384/1490 train_time:76776ms step_avg:55.47ms
+step:1385/1490 train_time:76857ms step_avg:55.49ms
+step:1386/1490 train_time:76942ms step_avg:55.51ms
+step:1387/1490 train_time:77020ms step_avg:55.53ms
+step:1388/1490 train_time:77106ms step_avg:55.55ms
+step:1389/1490 train_time:77186ms step_avg:55.57ms
+step:1390/1490 train_time:77271ms step_avg:55.59ms
+step:1391/1490 train_time:77351ms step_avg:55.61ms
+step:1392/1490 train_time:77436ms step_avg:55.63ms
+step:1393/1490 train_time:77516ms step_avg:55.65ms
+step:1394/1490 train_time:77601ms step_avg:55.67ms
+step:1395/1490 train_time:77679ms step_avg:55.68ms
+step:1396/1490 train_time:77763ms step_avg:55.70ms
+step:1397/1490 train_time:77843ms step_avg:55.72ms
+step:1398/1490 train_time:77929ms step_avg:55.74ms
+step:1399/1490 train_time:78007ms step_avg:55.76ms
+step:1400/1490 train_time:78092ms step_avg:55.78ms
+step:1401/1490 train_time:78172ms step_avg:55.80ms
+step:1402/1490 train_time:78258ms step_avg:55.82ms
+step:1403/1490 train_time:78339ms step_avg:55.84ms
+step:1404/1490 train_time:78423ms step_avg:55.86ms
+step:1405/1490 train_time:78504ms step_avg:55.87ms
+step:1406/1490 train_time:78588ms step_avg:55.89ms
+step:1407/1490 train_time:78666ms step_avg:55.91ms
+step:1408/1490 train_time:78752ms step_avg:55.93ms
+step:1409/1490 train_time:78831ms step_avg:55.95ms
+step:1410/1490 train_time:78917ms step_avg:55.97ms
+step:1411/1490 train_time:78996ms step_avg:55.99ms
+step:1412/1490 train_time:79081ms step_avg:56.01ms
+step:1413/1490 train_time:79160ms step_avg:56.02ms
+step:1414/1490 train_time:79246ms step_avg:56.04ms
+step:1415/1490 train_time:79324ms step_avg:56.06ms
+step:1416/1490 train_time:79409ms step_avg:56.08ms
+step:1417/1490 train_time:79489ms step_avg:56.10ms
+step:1418/1490 train_time:79573ms step_avg:56.12ms
+step:1419/1490 train_time:79653ms step_avg:56.13ms
+step:1420/1490 train_time:79739ms step_avg:56.15ms
+step:1421/1490 train_time:79818ms step_avg:56.17ms
+step:1422/1490 train_time:79903ms step_avg:56.19ms
+step:1423/1490 train_time:79983ms step_avg:56.21ms
+step:1424/1490 train_time:80068ms step_avg:56.23ms
+step:1425/1490 train_time:80148ms step_avg:56.24ms
+step:1426/1490 train_time:80232ms step_avg:56.26ms
+step:1427/1490 train_time:80311ms step_avg:56.28ms
+step:1428/1490 train_time:80397ms step_avg:56.30ms
+step:1429/1490 train_time:80477ms step_avg:56.32ms
+step:1430/1490 train_time:80563ms step_avg:56.34ms
+step:1431/1490 train_time:80641ms step_avg:56.35ms
+step:1432/1490 train_time:80726ms step_avg:56.37ms
+step:1433/1490 train_time:80805ms step_avg:56.39ms
+step:1434/1490 train_time:80891ms step_avg:56.41ms
+step:1435/1490 train_time:80971ms step_avg:56.43ms
+step:1436/1490 train_time:81056ms step_avg:56.45ms
+step:1437/1490 train_time:81135ms step_avg:56.46ms
+step:1438/1490 train_time:81220ms step_avg:56.48ms
+step:1439/1490 train_time:81300ms step_avg:56.50ms
+step:1440/1490 train_time:81385ms step_avg:56.52ms
+step:1441/1490 train_time:81465ms step_avg:56.53ms
+step:1442/1490 train_time:81551ms step_avg:56.55ms
+step:1443/1490 train_time:81630ms step_avg:56.57ms
+step:1444/1490 train_time:81715ms step_avg:56.59ms
+step:1445/1490 train_time:81795ms step_avg:56.61ms
+step:1446/1490 train_time:81882ms step_avg:56.63ms
+step:1447/1490 train_time:81961ms step_avg:56.64ms
+step:1448/1490 train_time:82047ms step_avg:56.66ms
+step:1449/1490 train_time:82126ms step_avg:56.68ms
+step:1450/1490 train_time:82209ms step_avg:56.70ms
+step:1451/1490 train_time:82293ms step_avg:56.71ms
+step:1452/1490 train_time:82379ms step_avg:56.73ms
+step:1453/1490 train_time:82459ms step_avg:56.75ms
+step:1454/1490 train_time:82545ms step_avg:56.77ms
+step:1455/1490 train_time:82624ms step_avg:56.79ms
+step:1456/1490 train_time:82709ms step_avg:56.81ms
+step:1457/1490 train_time:82790ms step_avg:56.82ms
+step:1458/1490 train_time:82876ms step_avg:56.84ms
+step:1459/1490 train_time:82956ms step_avg:56.86ms
+step:1460/1490 train_time:83044ms step_avg:56.88ms
+step:1461/1490 train_time:83122ms step_avg:56.89ms
+step:1462/1490 train_time:83207ms step_avg:56.91ms
+step:1463/1490 train_time:83287ms step_avg:56.93ms
+step:1464/1490 train_time:83373ms step_avg:56.95ms
+step:1465/1490 train_time:83454ms step_avg:56.97ms
+step:1466/1490 train_time:83539ms step_avg:56.98ms
+step:1467/1490 train_time:83619ms step_avg:57.00ms
+step:1468/1490 train_time:83703ms step_avg:57.02ms
+step:1469/1490 train_time:83782ms step_avg:57.03ms
+step:1470/1490 train_time:83869ms step_avg:57.05ms
+step:1471/1490 train_time:83949ms step_avg:57.07ms
+step:1472/1490 train_time:84033ms step_avg:57.09ms
+step:1473/1490 train_time:84114ms step_avg:57.10ms
+step:1474/1490 train_time:84198ms step_avg:57.12ms
+step:1475/1490 train_time:84279ms step_avg:57.14ms
+step:1476/1490 train_time:84365ms step_avg:57.16ms
+step:1477/1490 train_time:84444ms step_avg:57.17ms
+step:1478/1490 train_time:84530ms step_avg:57.19ms
+step:1479/1490 train_time:84609ms step_avg:57.21ms
+step:1480/1490 train_time:84694ms step_avg:57.23ms
+step:1481/1490 train_time:84774ms step_avg:57.24ms
+step:1482/1490 train_time:84859ms step_avg:57.26ms
+step:1483/1490 train_time:84941ms step_avg:57.28ms
+step:1484/1490 train_time:85026ms step_avg:57.30ms
+step:1485/1490 train_time:85106ms step_avg:57.31ms
+step:1486/1490 train_time:85191ms step_avg:57.33ms
+step:1487/1490 train_time:85271ms step_avg:57.34ms
+step:1488/1490 train_time:85357ms step_avg:57.36ms
+step:1489/1490 train_time:85438ms step_avg:57.38ms
+step:1490/1490 train_time:85521ms step_avg:57.40ms
+step:1490/1490 val_loss:3.2786 train_time:85624ms step_avg:57.47ms
+peak memory allocated: 31296 MiB reserved: 47042 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/a8aecac8-4f80-437b-b565-f64841b0763b.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/a8aecac8-4f80-437b-b565-f64841b0763b.txt
@@ -1,0 +1,4449 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 00:34:00 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1539MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8294 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:88ms step_avg:87.92ms
+step:2/1490 train_time:122ms step_avg:60.82ms
+step:3/1490 train_time:140ms step_avg:46.61ms
+step:4/1490 train_time:165ms step_avg:41.21ms
+step:5/1490 train_time:189ms step_avg:37.80ms
+step:6/1490 train_time:223ms step_avg:37.25ms
+step:7/1490 train_time:251ms step_avg:35.88ms
+step:8/1490 train_time:286ms step_avg:35.78ms
+step:9/1490 train_time:314ms step_avg:34.86ms
+step:10/1490 train_time:349ms step_avg:34.88ms
+step:11/1490 train_time:376ms step_avg:34.22ms
+step:12/1490 train_time:411ms step_avg:34.26ms
+step:13/1490 train_time:439ms step_avg:33.76ms
+step:14/1490 train_time:473ms step_avg:33.80ms
+step:15/1490 train_time:501ms step_avg:33.39ms
+step:16/1490 train_time:535ms step_avg:33.46ms
+step:17/1490 train_time:563ms step_avg:33.14ms
+step:18/1490 train_time:598ms step_avg:33.21ms
+step:19/1490 train_time:626ms step_avg:32.93ms
+step:20/1490 train_time:660ms step_avg:32.99ms
+step:21/1490 train_time:688ms step_avg:32.76ms
+step:22/1490 train_time:722ms step_avg:32.82ms
+step:23/1490 train_time:750ms step_avg:32.61ms
+step:24/1490 train_time:784ms step_avg:32.67ms
+step:25/1490 train_time:812ms step_avg:32.48ms
+step:26/1490 train_time:846ms step_avg:32.54ms
+step:27/1490 train_time:874ms step_avg:32.37ms
+step:28/1490 train_time:909ms step_avg:32.45ms
+step:29/1490 train_time:936ms step_avg:32.29ms
+step:30/1490 train_time:971ms step_avg:32.37ms
+step:31/1490 train_time:999ms step_avg:32.24ms
+step:32/1490 train_time:1035ms step_avg:32.35ms
+step:33/1490 train_time:1064ms step_avg:32.25ms
+step:34/1490 train_time:1100ms step_avg:32.35ms
+step:35/1490 train_time:1128ms step_avg:32.23ms
+step:36/1490 train_time:1163ms step_avg:32.29ms
+step:37/1490 train_time:1191ms step_avg:32.19ms
+step:38/1490 train_time:1225ms step_avg:32.25ms
+step:39/1490 train_time:1253ms step_avg:32.14ms
+step:40/1490 train_time:1288ms step_avg:32.20ms
+step:41/1490 train_time:1315ms step_avg:32.08ms
+step:42/1490 train_time:1351ms step_avg:32.16ms
+step:43/1490 train_time:1378ms step_avg:32.06ms
+step:44/1490 train_time:1413ms step_avg:32.11ms
+step:45/1490 train_time:1441ms step_avg:32.02ms
+step:46/1490 train_time:1475ms step_avg:32.07ms
+step:47/1490 train_time:1503ms step_avg:31.98ms
+step:48/1490 train_time:1538ms step_avg:32.04ms
+step:49/1490 train_time:1566ms step_avg:31.95ms
+step:50/1490 train_time:1600ms step_avg:32.00ms
+step:51/1490 train_time:1628ms step_avg:31.92ms
+step:52/1490 train_time:1662ms step_avg:31.97ms
+step:53/1490 train_time:1690ms step_avg:31.89ms
+step:54/1490 train_time:1724ms step_avg:31.93ms
+step:55/1490 train_time:1753ms step_avg:31.87ms
+step:56/1490 train_time:1787ms step_avg:31.91ms
+step:57/1490 train_time:1814ms step_avg:31.83ms
+step:58/1490 train_time:1849ms step_avg:31.88ms
+step:59/1490 train_time:1877ms step_avg:31.81ms
+step:60/1490 train_time:1912ms step_avg:31.86ms
+step:61/1490 train_time:1940ms step_avg:31.80ms
+step:62/1490 train_time:1974ms step_avg:31.85ms
+step:63/1490 train_time:2002ms step_avg:31.78ms
+step:64/1490 train_time:2037ms step_avg:31.83ms
+step:65/1490 train_time:2066ms step_avg:31.78ms
+step:66/1490 train_time:2100ms step_avg:31.83ms
+step:67/1490 train_time:2128ms step_avg:31.77ms
+step:68/1490 train_time:2163ms step_avg:31.80ms
+step:69/1490 train_time:2191ms step_avg:31.76ms
+step:70/1490 train_time:2225ms step_avg:31.79ms
+step:71/1490 train_time:2254ms step_avg:31.74ms
+step:72/1490 train_time:2288ms step_avg:31.78ms
+step:73/1490 train_time:2316ms step_avg:31.73ms
+step:74/1490 train_time:2351ms step_avg:31.77ms
+step:75/1490 train_time:2379ms step_avg:31.72ms
+step:76/1490 train_time:2414ms step_avg:31.76ms
+step:77/1490 train_time:2442ms step_avg:31.71ms
+step:78/1490 train_time:2476ms step_avg:31.75ms
+step:79/1490 train_time:2504ms step_avg:31.70ms
+step:80/1490 train_time:2539ms step_avg:31.74ms
+step:81/1490 train_time:2567ms step_avg:31.69ms
+step:82/1490 train_time:2601ms step_avg:31.72ms
+step:83/1490 train_time:2629ms step_avg:31.68ms
+step:84/1490 train_time:2663ms step_avg:31.71ms
+step:85/1490 train_time:2692ms step_avg:31.67ms
+step:86/1490 train_time:2726ms step_avg:31.70ms
+step:87/1490 train_time:2754ms step_avg:31.66ms
+step:88/1490 train_time:2789ms step_avg:31.69ms
+step:89/1490 train_time:2817ms step_avg:31.65ms
+step:90/1490 train_time:2851ms step_avg:31.68ms
+step:91/1490 train_time:2879ms step_avg:31.64ms
+step:92/1490 train_time:2914ms step_avg:31.67ms
+step:93/1490 train_time:2942ms step_avg:31.63ms
+step:94/1490 train_time:2976ms step_avg:31.66ms
+step:95/1490 train_time:3004ms step_avg:31.62ms
+step:96/1490 train_time:3038ms step_avg:31.65ms
+step:97/1490 train_time:3067ms step_avg:31.61ms
+step:98/1490 train_time:3101ms step_avg:31.64ms
+step:99/1490 train_time:3129ms step_avg:31.60ms
+step:100/1490 train_time:3164ms step_avg:31.64ms
+step:101/1490 train_time:3191ms step_avg:31.60ms
+step:102/1490 train_time:3225ms step_avg:31.62ms
+step:103/1490 train_time:3254ms step_avg:31.59ms
+step:104/1490 train_time:3289ms step_avg:31.62ms
+step:105/1490 train_time:3317ms step_avg:31.59ms
+step:106/1490 train_time:3351ms step_avg:31.61ms
+step:107/1490 train_time:3379ms step_avg:31.58ms
+step:108/1490 train_time:3414ms step_avg:31.61ms
+step:109/1490 train_time:3442ms step_avg:31.58ms
+step:110/1490 train_time:3477ms step_avg:31.61ms
+step:111/1490 train_time:3505ms step_avg:31.58ms
+step:112/1490 train_time:3540ms step_avg:31.61ms
+step:113/1490 train_time:3567ms step_avg:31.57ms
+step:114/1490 train_time:3602ms step_avg:31.60ms
+step:115/1490 train_time:3629ms step_avg:31.56ms
+step:116/1490 train_time:3663ms step_avg:31.58ms
+step:117/1490 train_time:3692ms step_avg:31.55ms
+step:118/1490 train_time:3726ms step_avg:31.57ms
+step:119/1490 train_time:3754ms step_avg:31.55ms
+step:120/1490 train_time:3789ms step_avg:31.58ms
+step:121/1490 train_time:3817ms step_avg:31.55ms
+step:122/1490 train_time:3852ms step_avg:31.57ms
+step:123/1490 train_time:3879ms step_avg:31.54ms
+step:124/1490 train_time:3914ms step_avg:31.56ms
+step:125/1490 train_time:3942ms step_avg:31.54ms
+step:126/1490 train_time:3977ms step_avg:31.57ms
+step:127/1490 train_time:4005ms step_avg:31.53ms
+step:128/1490 train_time:4039ms step_avg:31.56ms
+step:129/1490 train_time:4067ms step_avg:31.53ms
+step:130/1490 train_time:4101ms step_avg:31.55ms
+step:131/1490 train_time:4129ms step_avg:31.52ms
+step:132/1490 train_time:4164ms step_avg:31.54ms
+step:133/1490 train_time:4192ms step_avg:31.52ms
+step:134/1490 train_time:4226ms step_avg:31.54ms
+step:135/1490 train_time:4254ms step_avg:31.51ms
+step:136/1490 train_time:4289ms step_avg:31.53ms
+step:137/1490 train_time:4316ms step_avg:31.51ms
+step:138/1490 train_time:4351ms step_avg:31.53ms
+step:139/1490 train_time:4379ms step_avg:31.50ms
+step:140/1490 train_time:4414ms step_avg:31.53ms
+step:141/1490 train_time:4442ms step_avg:31.50ms
+step:142/1490 train_time:4476ms step_avg:31.52ms
+step:143/1490 train_time:4504ms step_avg:31.50ms
+step:144/1490 train_time:4538ms step_avg:31.52ms
+step:145/1490 train_time:4567ms step_avg:31.49ms
+step:146/1490 train_time:4601ms step_avg:31.51ms
+step:147/1490 train_time:4629ms step_avg:31.49ms
+step:148/1490 train_time:4663ms step_avg:31.50ms
+step:149/1490 train_time:4691ms step_avg:31.48ms
+step:150/1490 train_time:4725ms step_avg:31.50ms
+step:151/1490 train_time:4754ms step_avg:31.48ms
+step:152/1490 train_time:4792ms step_avg:31.53ms
+step:153/1490 train_time:4817ms step_avg:31.48ms
+step:154/1490 train_time:4851ms step_avg:31.50ms
+step:155/1490 train_time:4879ms step_avg:31.48ms
+step:156/1490 train_time:4914ms step_avg:31.50ms
+step:157/1490 train_time:4942ms step_avg:31.47ms
+step:158/1490 train_time:4976ms step_avg:31.49ms
+step:159/1490 train_time:5004ms step_avg:31.47ms
+step:160/1490 train_time:5039ms step_avg:31.49ms
+step:161/1490 train_time:5067ms step_avg:31.47ms
+step:162/1490 train_time:5101ms step_avg:31.49ms
+step:163/1490 train_time:5129ms step_avg:31.47ms
+step:164/1490 train_time:5163ms step_avg:31.48ms
+step:165/1490 train_time:5191ms step_avg:31.46ms
+step:166/1490 train_time:5226ms step_avg:31.48ms
+step:167/1490 train_time:5254ms step_avg:31.46ms
+step:168/1490 train_time:5289ms step_avg:31.48ms
+step:169/1490 train_time:5317ms step_avg:31.46ms
+step:170/1490 train_time:5352ms step_avg:31.48ms
+step:171/1490 train_time:5380ms step_avg:31.46ms
+step:172/1490 train_time:5415ms step_avg:31.48ms
+step:173/1490 train_time:5443ms step_avg:31.46ms
+step:174/1490 train_time:5477ms step_avg:31.48ms
+step:175/1490 train_time:5505ms step_avg:31.46ms
+step:176/1490 train_time:5539ms step_avg:31.47ms
+step:177/1490 train_time:5567ms step_avg:31.45ms
+step:178/1490 train_time:5602ms step_avg:31.47ms
+step:179/1490 train_time:5629ms step_avg:31.45ms
+step:180/1490 train_time:5663ms step_avg:31.46ms
+step:181/1490 train_time:5692ms step_avg:31.45ms
+step:182/1490 train_time:5726ms step_avg:31.46ms
+step:183/1490 train_time:5754ms step_avg:31.44ms
+step:184/1490 train_time:5788ms step_avg:31.46ms
+step:185/1490 train_time:5816ms step_avg:31.44ms
+step:186/1490 train_time:5851ms step_avg:31.46ms
+step:187/1490 train_time:5879ms step_avg:31.44ms
+step:188/1490 train_time:5915ms step_avg:31.46ms
+step:189/1490 train_time:5943ms step_avg:31.44ms
+step:190/1490 train_time:5978ms step_avg:31.46ms
+step:191/1490 train_time:6005ms step_avg:31.44ms
+step:192/1490 train_time:6039ms step_avg:31.46ms
+step:193/1490 train_time:6067ms step_avg:31.44ms
+step:194/1490 train_time:6101ms step_avg:31.45ms
+step:195/1490 train_time:6129ms step_avg:31.43ms
+step:196/1490 train_time:6163ms step_avg:31.45ms
+step:197/1490 train_time:6191ms step_avg:31.43ms
+step:198/1490 train_time:6226ms step_avg:31.44ms
+step:199/1490 train_time:6254ms step_avg:31.42ms
+step:200/1490 train_time:6288ms step_avg:31.44ms
+step:201/1490 train_time:6316ms step_avg:31.42ms
+step:202/1490 train_time:6351ms step_avg:31.44ms
+step:203/1490 train_time:6379ms step_avg:31.42ms
+step:204/1490 train_time:6413ms step_avg:31.44ms
+step:205/1490 train_time:6441ms step_avg:31.42ms
+step:206/1490 train_time:6476ms step_avg:31.43ms
+step:207/1490 train_time:6504ms step_avg:31.42ms
+step:208/1490 train_time:6538ms step_avg:31.43ms
+step:209/1490 train_time:6566ms step_avg:31.42ms
+step:210/1490 train_time:6600ms step_avg:31.43ms
+step:211/1490 train_time:6628ms step_avg:31.41ms
+step:212/1490 train_time:6662ms step_avg:31.43ms
+step:213/1490 train_time:6690ms step_avg:31.41ms
+step:214/1490 train_time:6725ms step_avg:31.42ms
+step:215/1490 train_time:6753ms step_avg:31.41ms
+step:216/1490 train_time:6788ms step_avg:31.43ms
+step:217/1490 train_time:6816ms step_avg:31.41ms
+step:218/1490 train_time:6851ms step_avg:31.43ms
+step:219/1490 train_time:6879ms step_avg:31.41ms
+step:220/1490 train_time:6913ms step_avg:31.42ms
+step:221/1490 train_time:6941ms step_avg:31.41ms
+step:222/1490 train_time:6975ms step_avg:31.42ms
+step:223/1490 train_time:7003ms step_avg:31.40ms
+step:224/1490 train_time:7037ms step_avg:31.42ms
+step:225/1490 train_time:7065ms step_avg:31.40ms
+step:226/1490 train_time:7099ms step_avg:31.41ms
+step:227/1490 train_time:7127ms step_avg:31.40ms
+step:228/1490 train_time:7162ms step_avg:31.41ms
+step:229/1490 train_time:7190ms step_avg:31.40ms
+step:230/1490 train_time:7224ms step_avg:31.41ms
+step:231/1490 train_time:7252ms step_avg:31.39ms
+step:232/1490 train_time:7286ms step_avg:31.41ms
+step:233/1490 train_time:7314ms step_avg:31.39ms
+step:234/1490 train_time:7349ms step_avg:31.41ms
+step:235/1490 train_time:7377ms step_avg:31.39ms
+step:236/1490 train_time:7412ms step_avg:31.40ms
+step:237/1490 train_time:7439ms step_avg:31.39ms
+step:238/1490 train_time:7474ms step_avg:31.40ms
+step:239/1490 train_time:7502ms step_avg:31.39ms
+step:240/1490 train_time:7536ms step_avg:31.40ms
+step:241/1490 train_time:7564ms step_avg:31.39ms
+step:242/1490 train_time:7598ms step_avg:31.40ms
+step:243/1490 train_time:7626ms step_avg:31.38ms
+step:244/1490 train_time:7660ms step_avg:31.39ms
+step:245/1490 train_time:7688ms step_avg:31.38ms
+step:246/1490 train_time:7722ms step_avg:31.39ms
+step:247/1490 train_time:7751ms step_avg:31.38ms
+step:248/1490 train_time:7786ms step_avg:31.39ms
+step:249/1490 train_time:7814ms step_avg:31.38ms
+step:250/1490 train_time:7849ms step_avg:31.39ms
+step:250/1490 val_loss:4.5094 train_time:7891ms step_avg:31.56ms
+step:251/1490 train_time:7908ms step_avg:31.51ms
+step:252/1490 train_time:7927ms step_avg:31.46ms
+step:253/1490 train_time:7942ms step_avg:31.39ms
+step:254/1490 train_time:7976ms step_avg:31.40ms
+step:255/1490 train_time:8007ms step_avg:31.40ms
+step:256/1490 train_time:8042ms step_avg:31.42ms
+step:257/1490 train_time:8071ms step_avg:31.40ms
+step:258/1490 train_time:8106ms step_avg:31.42ms
+step:259/1490 train_time:8134ms step_avg:31.40ms
+step:260/1490 train_time:8169ms step_avg:31.42ms
+step:261/1490 train_time:8196ms step_avg:31.40ms
+step:262/1490 train_time:8231ms step_avg:31.42ms
+step:263/1490 train_time:8258ms step_avg:31.40ms
+step:264/1490 train_time:8292ms step_avg:31.41ms
+step:265/1490 train_time:8321ms step_avg:31.40ms
+step:266/1490 train_time:8355ms step_avg:31.41ms
+step:267/1490 train_time:8382ms step_avg:31.39ms
+step:268/1490 train_time:8416ms step_avg:31.40ms
+step:269/1490 train_time:8444ms step_avg:31.39ms
+step:270/1490 train_time:8478ms step_avg:31.40ms
+step:271/1490 train_time:8506ms step_avg:31.39ms
+step:272/1490 train_time:8540ms step_avg:31.40ms
+step:273/1490 train_time:8567ms step_avg:31.38ms
+step:274/1490 train_time:8602ms step_avg:31.39ms
+step:275/1490 train_time:8630ms step_avg:31.38ms
+step:276/1490 train_time:8664ms step_avg:31.39ms
+step:277/1490 train_time:8692ms step_avg:31.38ms
+step:278/1490 train_time:8726ms step_avg:31.39ms
+step:279/1490 train_time:8754ms step_avg:31.37ms
+step:280/1490 train_time:8788ms step_avg:31.39ms
+step:281/1490 train_time:8815ms step_avg:31.37ms
+step:282/1490 train_time:8850ms step_avg:31.38ms
+step:283/1490 train_time:8878ms step_avg:31.37ms
+step:284/1490 train_time:8912ms step_avg:31.38ms
+step:285/1490 train_time:8942ms step_avg:31.37ms
+step:286/1490 train_time:8976ms step_avg:31.38ms
+step:287/1490 train_time:9004ms step_avg:31.37ms
+step:288/1490 train_time:9039ms step_avg:31.39ms
+step:289/1490 train_time:9067ms step_avg:31.37ms
+step:290/1490 train_time:9101ms step_avg:31.38ms
+step:291/1490 train_time:9129ms step_avg:31.37ms
+step:292/1490 train_time:9164ms step_avg:31.38ms
+step:293/1490 train_time:9192ms step_avg:31.37ms
+step:294/1490 train_time:9227ms step_avg:31.38ms
+step:295/1490 train_time:9255ms step_avg:31.37ms
+step:296/1490 train_time:9290ms step_avg:31.38ms
+step:297/1490 train_time:9318ms step_avg:31.37ms
+step:298/1490 train_time:9352ms step_avg:31.38ms
+step:299/1490 train_time:9380ms step_avg:31.37ms
+step:300/1490 train_time:9414ms step_avg:31.38ms
+step:301/1490 train_time:9442ms step_avg:31.37ms
+step:302/1490 train_time:9476ms step_avg:31.38ms
+step:303/1490 train_time:9504ms step_avg:31.37ms
+step:304/1490 train_time:9538ms step_avg:31.37ms
+step:305/1490 train_time:9566ms step_avg:31.36ms
+step:306/1490 train_time:9600ms step_avg:31.37ms
+step:307/1490 train_time:9628ms step_avg:31.36ms
+step:308/1490 train_time:9663ms step_avg:31.37ms
+step:309/1490 train_time:9691ms step_avg:31.36ms
+step:310/1490 train_time:9725ms step_avg:31.37ms
+step:311/1490 train_time:9753ms step_avg:31.36ms
+step:312/1490 train_time:9787ms step_avg:31.37ms
+step:313/1490 train_time:9815ms step_avg:31.36ms
+step:314/1490 train_time:9850ms step_avg:31.37ms
+step:315/1490 train_time:9877ms step_avg:31.36ms
+step:316/1490 train_time:9912ms step_avg:31.37ms
+step:317/1490 train_time:9940ms step_avg:31.36ms
+step:318/1490 train_time:9976ms step_avg:31.37ms
+step:319/1490 train_time:10002ms step_avg:31.35ms
+step:320/1490 train_time:10037ms step_avg:31.36ms
+step:321/1490 train_time:10064ms step_avg:31.35ms
+step:322/1490 train_time:10098ms step_avg:31.36ms
+step:323/1490 train_time:10127ms step_avg:31.35ms
+step:324/1490 train_time:10161ms step_avg:31.36ms
+step:325/1490 train_time:10189ms step_avg:31.35ms
+step:326/1490 train_time:10224ms step_avg:31.36ms
+step:327/1490 train_time:10252ms step_avg:31.35ms
+step:328/1490 train_time:10287ms step_avg:31.36ms
+step:329/1490 train_time:10314ms step_avg:31.35ms
+step:330/1490 train_time:10349ms step_avg:31.36ms
+step:331/1490 train_time:10377ms step_avg:31.35ms
+step:332/1490 train_time:10412ms step_avg:31.36ms
+step:333/1490 train_time:10440ms step_avg:31.35ms
+step:334/1490 train_time:10474ms step_avg:31.36ms
+step:335/1490 train_time:10502ms step_avg:31.35ms
+step:336/1490 train_time:10536ms step_avg:31.36ms
+step:337/1490 train_time:10563ms step_avg:31.35ms
+step:338/1490 train_time:10597ms step_avg:31.35ms
+step:339/1490 train_time:10625ms step_avg:31.34ms
+step:340/1490 train_time:10660ms step_avg:31.35ms
+step:341/1490 train_time:10688ms step_avg:31.34ms
+step:342/1490 train_time:10722ms step_avg:31.35ms
+step:343/1490 train_time:10750ms step_avg:31.34ms
+step:344/1490 train_time:10785ms step_avg:31.35ms
+step:345/1490 train_time:10812ms step_avg:31.34ms
+step:346/1490 train_time:10847ms step_avg:31.35ms
+step:347/1490 train_time:10874ms step_avg:31.34ms
+step:348/1490 train_time:10909ms step_avg:31.35ms
+step:349/1490 train_time:10937ms step_avg:31.34ms
+step:350/1490 train_time:10972ms step_avg:31.35ms
+step:351/1490 train_time:10999ms step_avg:31.34ms
+step:352/1490 train_time:11033ms step_avg:31.34ms
+step:353/1490 train_time:11061ms step_avg:31.33ms
+step:354/1490 train_time:11095ms step_avg:31.34ms
+step:355/1490 train_time:11124ms step_avg:31.33ms
+step:356/1490 train_time:11158ms step_avg:31.34ms
+step:357/1490 train_time:11186ms step_avg:31.33ms
+step:358/1490 train_time:11221ms step_avg:31.34ms
+step:359/1490 train_time:11249ms step_avg:31.33ms
+step:360/1490 train_time:11284ms step_avg:31.34ms
+step:361/1490 train_time:11312ms step_avg:31.34ms
+step:362/1490 train_time:11347ms step_avg:31.34ms
+step:363/1490 train_time:11374ms step_avg:31.33ms
+step:364/1490 train_time:11409ms step_avg:31.34ms
+step:365/1490 train_time:11437ms step_avg:31.33ms
+step:366/1490 train_time:11471ms step_avg:31.34ms
+step:367/1490 train_time:11499ms step_avg:31.33ms
+step:368/1490 train_time:11533ms step_avg:31.34ms
+step:369/1490 train_time:11561ms step_avg:31.33ms
+step:370/1490 train_time:11595ms step_avg:31.34ms
+step:371/1490 train_time:11623ms step_avg:31.33ms
+step:372/1490 train_time:11658ms step_avg:31.34ms
+step:373/1490 train_time:11685ms step_avg:31.33ms
+step:374/1490 train_time:11720ms step_avg:31.34ms
+step:375/1490 train_time:11748ms step_avg:31.33ms
+step:376/1490 train_time:11782ms step_avg:31.34ms
+step:377/1490 train_time:11810ms step_avg:31.33ms
+step:378/1490 train_time:11845ms step_avg:31.34ms
+step:379/1490 train_time:11873ms step_avg:31.33ms
+step:380/1490 train_time:11907ms step_avg:31.33ms
+step:381/1490 train_time:11934ms step_avg:31.32ms
+step:382/1490 train_time:11969ms step_avg:31.33ms
+step:383/1490 train_time:11997ms step_avg:31.32ms
+step:384/1490 train_time:12031ms step_avg:31.33ms
+step:385/1490 train_time:12060ms step_avg:31.32ms
+step:386/1490 train_time:12093ms step_avg:31.33ms
+step:387/1490 train_time:12121ms step_avg:31.32ms
+step:388/1490 train_time:12155ms step_avg:31.33ms
+step:389/1490 train_time:12183ms step_avg:31.32ms
+step:390/1490 train_time:12217ms step_avg:31.33ms
+step:391/1490 train_time:12246ms step_avg:31.32ms
+step:392/1490 train_time:12279ms step_avg:31.33ms
+step:393/1490 train_time:12308ms step_avg:31.32ms
+step:394/1490 train_time:12342ms step_avg:31.33ms
+step:395/1490 train_time:12370ms step_avg:31.32ms
+step:396/1490 train_time:12404ms step_avg:31.32ms
+step:397/1490 train_time:12432ms step_avg:31.32ms
+step:398/1490 train_time:12467ms step_avg:31.32ms
+step:399/1490 train_time:12495ms step_avg:31.32ms
+step:400/1490 train_time:12529ms step_avg:31.32ms
+step:401/1490 train_time:12557ms step_avg:31.31ms
+step:402/1490 train_time:12591ms step_avg:31.32ms
+step:403/1490 train_time:12619ms step_avg:31.31ms
+step:404/1490 train_time:12654ms step_avg:31.32ms
+step:405/1490 train_time:12682ms step_avg:31.31ms
+step:406/1490 train_time:12716ms step_avg:31.32ms
+step:407/1490 train_time:12744ms step_avg:31.31ms
+step:408/1490 train_time:12778ms step_avg:31.32ms
+step:409/1490 train_time:12806ms step_avg:31.31ms
+step:410/1490 train_time:12840ms step_avg:31.32ms
+step:411/1490 train_time:12868ms step_avg:31.31ms
+step:412/1490 train_time:12903ms step_avg:31.32ms
+step:413/1490 train_time:12931ms step_avg:31.31ms
+step:414/1490 train_time:12965ms step_avg:31.32ms
+step:415/1490 train_time:12993ms step_avg:31.31ms
+step:416/1490 train_time:13027ms step_avg:31.32ms
+step:417/1490 train_time:13055ms step_avg:31.31ms
+step:418/1490 train_time:13090ms step_avg:31.31ms
+step:419/1490 train_time:13118ms step_avg:31.31ms
+step:420/1490 train_time:13152ms step_avg:31.32ms
+step:421/1490 train_time:13181ms step_avg:31.31ms
+step:422/1490 train_time:13215ms step_avg:31.32ms
+step:423/1490 train_time:13243ms step_avg:31.31ms
+step:424/1490 train_time:13277ms step_avg:31.31ms
+step:425/1490 train_time:13306ms step_avg:31.31ms
+step:426/1490 train_time:13340ms step_avg:31.31ms
+step:427/1490 train_time:13368ms step_avg:31.31ms
+step:428/1490 train_time:13402ms step_avg:31.31ms
+step:429/1490 train_time:13430ms step_avg:31.31ms
+step:430/1490 train_time:13466ms step_avg:31.32ms
+step:431/1490 train_time:13493ms step_avg:31.31ms
+step:432/1490 train_time:13528ms step_avg:31.32ms
+step:433/1490 train_time:13557ms step_avg:31.31ms
+step:434/1490 train_time:13591ms step_avg:31.32ms
+step:435/1490 train_time:13619ms step_avg:31.31ms
+step:436/1490 train_time:13653ms step_avg:31.32ms
+step:437/1490 train_time:13681ms step_avg:31.31ms
+step:438/1490 train_time:13715ms step_avg:31.31ms
+step:439/1490 train_time:13743ms step_avg:31.31ms
+step:440/1490 train_time:13777ms step_avg:31.31ms
+step:441/1490 train_time:13805ms step_avg:31.30ms
+step:442/1490 train_time:13839ms step_avg:31.31ms
+step:443/1490 train_time:13867ms step_avg:31.30ms
+step:444/1490 train_time:13901ms step_avg:31.31ms
+step:445/1490 train_time:13929ms step_avg:31.30ms
+step:446/1490 train_time:13964ms step_avg:31.31ms
+step:447/1490 train_time:13992ms step_avg:31.30ms
+step:448/1490 train_time:14026ms step_avg:31.31ms
+step:449/1490 train_time:14054ms step_avg:31.30ms
+step:450/1490 train_time:14088ms step_avg:31.31ms
+step:451/1490 train_time:14116ms step_avg:31.30ms
+step:452/1490 train_time:14151ms step_avg:31.31ms
+step:453/1490 train_time:14179ms step_avg:31.30ms
+step:454/1490 train_time:14213ms step_avg:31.31ms
+step:455/1490 train_time:14241ms step_avg:31.30ms
+step:456/1490 train_time:14274ms step_avg:31.30ms
+step:457/1490 train_time:14303ms step_avg:31.30ms
+step:458/1490 train_time:14337ms step_avg:31.30ms
+step:459/1490 train_time:14365ms step_avg:31.30ms
+step:460/1490 train_time:14399ms step_avg:31.30ms
+step:461/1490 train_time:14428ms step_avg:31.30ms
+step:462/1490 train_time:14462ms step_avg:31.30ms
+step:463/1490 train_time:14490ms step_avg:31.30ms
+step:464/1490 train_time:14524ms step_avg:31.30ms
+step:465/1490 train_time:14553ms step_avg:31.30ms
+step:466/1490 train_time:14587ms step_avg:31.30ms
+step:467/1490 train_time:14615ms step_avg:31.30ms
+step:468/1490 train_time:14650ms step_avg:31.30ms
+step:469/1490 train_time:14678ms step_avg:31.30ms
+step:470/1490 train_time:14711ms step_avg:31.30ms
+step:471/1490 train_time:14740ms step_avg:31.29ms
+step:472/1490 train_time:14774ms step_avg:31.30ms
+step:473/1490 train_time:14802ms step_avg:31.29ms
+step:474/1490 train_time:14836ms step_avg:31.30ms
+step:475/1490 train_time:14864ms step_avg:31.29ms
+step:476/1490 train_time:14898ms step_avg:31.30ms
+step:477/1490 train_time:14927ms step_avg:31.29ms
+step:478/1490 train_time:14961ms step_avg:31.30ms
+step:479/1490 train_time:14989ms step_avg:31.29ms
+step:480/1490 train_time:15024ms step_avg:31.30ms
+step:481/1490 train_time:15052ms step_avg:31.29ms
+step:482/1490 train_time:15086ms step_avg:31.30ms
+step:483/1490 train_time:15114ms step_avg:31.29ms
+step:484/1490 train_time:15152ms step_avg:31.31ms
+step:485/1490 train_time:15204ms step_avg:31.35ms
+step:486/1490 train_time:15263ms step_avg:31.40ms
+step:487/1490 train_time:15316ms step_avg:31.45ms
+step:488/1490 train_time:15375ms step_avg:31.51ms
+step:489/1490 train_time:15429ms step_avg:31.55ms
+step:490/1490 train_time:15488ms step_avg:31.61ms
+step:491/1490 train_time:15542ms step_avg:31.65ms
+step:492/1490 train_time:15602ms step_avg:31.71ms
+step:493/1490 train_time:15656ms step_avg:31.76ms
+step:494/1490 train_time:15715ms step_avg:31.81ms
+step:495/1490 train_time:15770ms step_avg:31.86ms
+step:496/1490 train_time:15829ms step_avg:31.91ms
+step:497/1490 train_time:15883ms step_avg:31.96ms
+step:498/1490 train_time:15942ms step_avg:32.01ms
+step:499/1490 train_time:15996ms step_avg:32.06ms
+step:500/1490 train_time:16056ms step_avg:32.11ms
+step:500/1490 val_loss:4.2254 train_time:16128ms step_avg:32.26ms
+step:501/1490 train_time:16152ms step_avg:32.24ms
+step:502/1490 train_time:16173ms step_avg:32.22ms
+step:503/1490 train_time:16232ms step_avg:32.27ms
+step:504/1490 train_time:16297ms step_avg:32.33ms
+step:505/1490 train_time:16351ms step_avg:32.38ms
+step:506/1490 train_time:16411ms step_avg:32.43ms
+step:507/1490 train_time:16464ms step_avg:32.47ms
+step:508/1490 train_time:16522ms step_avg:32.52ms
+step:509/1490 train_time:16575ms step_avg:32.56ms
+step:510/1490 train_time:16635ms step_avg:32.62ms
+step:511/1490 train_time:16688ms step_avg:32.66ms
+step:512/1490 train_time:16747ms step_avg:32.71ms
+step:513/1490 train_time:16801ms step_avg:32.75ms
+step:514/1490 train_time:16859ms step_avg:32.80ms
+step:515/1490 train_time:16911ms step_avg:32.84ms
+step:516/1490 train_time:16971ms step_avg:32.89ms
+step:517/1490 train_time:17025ms step_avg:32.93ms
+step:518/1490 train_time:17084ms step_avg:32.98ms
+step:519/1490 train_time:17139ms step_avg:33.02ms
+step:520/1490 train_time:17200ms step_avg:33.08ms
+step:521/1490 train_time:17255ms step_avg:33.12ms
+step:522/1490 train_time:17316ms step_avg:33.17ms
+step:523/1490 train_time:17372ms step_avg:33.22ms
+step:524/1490 train_time:17431ms step_avg:33.27ms
+step:525/1490 train_time:17484ms step_avg:33.30ms
+step:526/1490 train_time:17543ms step_avg:33.35ms
+step:527/1490 train_time:17597ms step_avg:33.39ms
+step:528/1490 train_time:17655ms step_avg:33.44ms
+step:529/1490 train_time:17709ms step_avg:33.48ms
+step:530/1490 train_time:17767ms step_avg:33.52ms
+step:531/1490 train_time:17821ms step_avg:33.56ms
+step:532/1490 train_time:17879ms step_avg:33.61ms
+step:533/1490 train_time:17932ms step_avg:33.64ms
+step:534/1490 train_time:17991ms step_avg:33.69ms
+step:535/1490 train_time:18045ms step_avg:33.73ms
+step:536/1490 train_time:18104ms step_avg:33.78ms
+step:537/1490 train_time:18159ms step_avg:33.82ms
+step:538/1490 train_time:18219ms step_avg:33.86ms
+step:539/1490 train_time:18274ms step_avg:33.90ms
+step:540/1490 train_time:18334ms step_avg:33.95ms
+step:541/1490 train_time:18389ms step_avg:33.99ms
+step:542/1490 train_time:18448ms step_avg:34.04ms
+step:543/1490 train_time:18502ms step_avg:34.07ms
+step:544/1490 train_time:18561ms step_avg:34.12ms
+step:545/1490 train_time:18614ms step_avg:34.15ms
+step:546/1490 train_time:18674ms step_avg:34.20ms
+step:547/1490 train_time:18727ms step_avg:34.24ms
+step:548/1490 train_time:18786ms step_avg:34.28ms
+step:549/1490 train_time:18839ms step_avg:34.32ms
+step:550/1490 train_time:18898ms step_avg:34.36ms
+step:551/1490 train_time:18951ms step_avg:34.39ms
+step:552/1490 train_time:19010ms step_avg:34.44ms
+step:553/1490 train_time:19064ms step_avg:34.47ms
+step:554/1490 train_time:19123ms step_avg:34.52ms
+step:555/1490 train_time:19177ms step_avg:34.55ms
+step:556/1490 train_time:19236ms step_avg:34.60ms
+step:557/1490 train_time:19291ms step_avg:34.63ms
+step:558/1490 train_time:19351ms step_avg:34.68ms
+step:559/1490 train_time:19405ms step_avg:34.71ms
+step:560/1490 train_time:19465ms step_avg:34.76ms
+step:561/1490 train_time:19519ms step_avg:34.79ms
+step:562/1490 train_time:19578ms step_avg:34.84ms
+step:563/1490 train_time:19631ms step_avg:34.87ms
+step:564/1490 train_time:19691ms step_avg:34.91ms
+step:565/1490 train_time:19744ms step_avg:34.95ms
+step:566/1490 train_time:19803ms step_avg:34.99ms
+step:567/1490 train_time:19856ms step_avg:35.02ms
+step:568/1490 train_time:19915ms step_avg:35.06ms
+step:569/1490 train_time:19968ms step_avg:35.09ms
+step:570/1490 train_time:20028ms step_avg:35.14ms
+step:571/1490 train_time:20082ms step_avg:35.17ms
+step:572/1490 train_time:20142ms step_avg:35.21ms
+step:573/1490 train_time:20196ms step_avg:35.25ms
+step:574/1490 train_time:20255ms step_avg:35.29ms
+step:575/1490 train_time:20309ms step_avg:35.32ms
+step:576/1490 train_time:20369ms step_avg:35.36ms
+step:577/1490 train_time:20423ms step_avg:35.40ms
+step:578/1490 train_time:20483ms step_avg:35.44ms
+step:579/1490 train_time:20536ms step_avg:35.47ms
+step:580/1490 train_time:20596ms step_avg:35.51ms
+step:581/1490 train_time:20649ms step_avg:35.54ms
+step:582/1490 train_time:20708ms step_avg:35.58ms
+step:583/1490 train_time:20764ms step_avg:35.61ms
+step:584/1490 train_time:20822ms step_avg:35.65ms
+step:585/1490 train_time:20875ms step_avg:35.68ms
+step:586/1490 train_time:20934ms step_avg:35.72ms
+step:587/1490 train_time:20987ms step_avg:35.75ms
+step:588/1490 train_time:21047ms step_avg:35.79ms
+step:589/1490 train_time:21101ms step_avg:35.82ms
+step:590/1490 train_time:21159ms step_avg:35.86ms
+step:591/1490 train_time:21213ms step_avg:35.89ms
+step:592/1490 train_time:21272ms step_avg:35.93ms
+step:593/1490 train_time:21327ms step_avg:35.96ms
+step:594/1490 train_time:21387ms step_avg:36.00ms
+step:595/1490 train_time:21441ms step_avg:36.03ms
+step:596/1490 train_time:21500ms step_avg:36.07ms
+step:597/1490 train_time:21554ms step_avg:36.10ms
+step:598/1490 train_time:21613ms step_avg:36.14ms
+step:599/1490 train_time:21668ms step_avg:36.17ms
+step:600/1490 train_time:21727ms step_avg:36.21ms
+step:601/1490 train_time:21781ms step_avg:36.24ms
+step:602/1490 train_time:21839ms step_avg:36.28ms
+step:603/1490 train_time:21893ms step_avg:36.31ms
+step:604/1490 train_time:21952ms step_avg:36.35ms
+step:605/1490 train_time:22007ms step_avg:36.37ms
+step:606/1490 train_time:22066ms step_avg:36.41ms
+step:607/1490 train_time:22121ms step_avg:36.44ms
+step:608/1490 train_time:22180ms step_avg:36.48ms
+step:609/1490 train_time:22233ms step_avg:36.51ms
+step:610/1490 train_time:22293ms step_avg:36.55ms
+step:611/1490 train_time:22346ms step_avg:36.57ms
+step:612/1490 train_time:22406ms step_avg:36.61ms
+step:613/1490 train_time:22460ms step_avg:36.64ms
+step:614/1490 train_time:22519ms step_avg:36.68ms
+step:615/1490 train_time:22573ms step_avg:36.70ms
+step:616/1490 train_time:22633ms step_avg:36.74ms
+step:617/1490 train_time:22687ms step_avg:36.77ms
+step:618/1490 train_time:22747ms step_avg:36.81ms
+step:619/1490 train_time:22801ms step_avg:36.83ms
+step:620/1490 train_time:22859ms step_avg:36.87ms
+step:621/1490 train_time:22913ms step_avg:36.90ms
+step:622/1490 train_time:22972ms step_avg:36.93ms
+step:623/1490 train_time:23026ms step_avg:36.96ms
+step:624/1490 train_time:23086ms step_avg:37.00ms
+step:625/1490 train_time:23140ms step_avg:37.02ms
+step:626/1490 train_time:23199ms step_avg:37.06ms
+step:627/1490 train_time:23253ms step_avg:37.09ms
+step:628/1490 train_time:23312ms step_avg:37.12ms
+step:629/1490 train_time:23366ms step_avg:37.15ms
+step:630/1490 train_time:23426ms step_avg:37.18ms
+step:631/1490 train_time:23479ms step_avg:37.21ms
+step:632/1490 train_time:23538ms step_avg:37.24ms
+step:633/1490 train_time:23592ms step_avg:37.27ms
+step:634/1490 train_time:23652ms step_avg:37.31ms
+step:635/1490 train_time:23706ms step_avg:37.33ms
+step:636/1490 train_time:23765ms step_avg:37.37ms
+step:637/1490 train_time:23819ms step_avg:37.39ms
+step:638/1490 train_time:23878ms step_avg:37.43ms
+step:639/1490 train_time:23931ms step_avg:37.45ms
+step:640/1490 train_time:23992ms step_avg:37.49ms
+step:641/1490 train_time:24045ms step_avg:37.51ms
+step:642/1490 train_time:24105ms step_avg:37.55ms
+step:643/1490 train_time:24158ms step_avg:37.57ms
+step:644/1490 train_time:24217ms step_avg:37.60ms
+step:645/1490 train_time:24270ms step_avg:37.63ms
+step:646/1490 train_time:24331ms step_avg:37.66ms
+step:647/1490 train_time:24385ms step_avg:37.69ms
+step:648/1490 train_time:24445ms step_avg:37.72ms
+step:649/1490 train_time:24500ms step_avg:37.75ms
+step:650/1490 train_time:24558ms step_avg:37.78ms
+step:651/1490 train_time:24612ms step_avg:37.81ms
+step:652/1490 train_time:24671ms step_avg:37.84ms
+step:653/1490 train_time:24725ms step_avg:37.86ms
+step:654/1490 train_time:24784ms step_avg:37.90ms
+step:655/1490 train_time:24838ms step_avg:37.92ms
+step:656/1490 train_time:24898ms step_avg:37.95ms
+step:657/1490 train_time:24952ms step_avg:37.98ms
+step:658/1490 train_time:25012ms step_avg:38.01ms
+step:659/1490 train_time:25065ms step_avg:38.03ms
+step:660/1490 train_time:25125ms step_avg:38.07ms
+step:661/1490 train_time:25179ms step_avg:38.09ms
+step:662/1490 train_time:25238ms step_avg:38.12ms
+step:663/1490 train_time:25293ms step_avg:38.15ms
+step:664/1490 train_time:25352ms step_avg:38.18ms
+step:665/1490 train_time:25406ms step_avg:38.20ms
+step:666/1490 train_time:25465ms step_avg:38.24ms
+step:667/1490 train_time:25520ms step_avg:38.26ms
+step:668/1490 train_time:25577ms step_avg:38.29ms
+step:669/1490 train_time:25630ms step_avg:38.31ms
+step:670/1490 train_time:25691ms step_avg:38.34ms
+step:671/1490 train_time:25744ms step_avg:38.37ms
+step:672/1490 train_time:25804ms step_avg:38.40ms
+step:673/1490 train_time:25857ms step_avg:38.42ms
+step:674/1490 train_time:25916ms step_avg:38.45ms
+step:675/1490 train_time:25970ms step_avg:38.47ms
+step:676/1490 train_time:26029ms step_avg:38.50ms
+step:677/1490 train_time:26083ms step_avg:38.53ms
+step:678/1490 train_time:26142ms step_avg:38.56ms
+step:679/1490 train_time:26196ms step_avg:38.58ms
+step:680/1490 train_time:26254ms step_avg:38.61ms
+step:681/1490 train_time:26309ms step_avg:38.63ms
+step:682/1490 train_time:26369ms step_avg:38.66ms
+step:683/1490 train_time:26422ms step_avg:38.69ms
+step:684/1490 train_time:26482ms step_avg:38.72ms
+step:685/1490 train_time:26536ms step_avg:38.74ms
+step:686/1490 train_time:26596ms step_avg:38.77ms
+step:687/1490 train_time:26648ms step_avg:38.79ms
+step:688/1490 train_time:26708ms step_avg:38.82ms
+step:689/1490 train_time:26762ms step_avg:38.84ms
+step:690/1490 train_time:26821ms step_avg:38.87ms
+step:691/1490 train_time:26875ms step_avg:38.89ms
+step:692/1490 train_time:26935ms step_avg:38.92ms
+step:693/1490 train_time:26988ms step_avg:38.94ms
+step:694/1490 train_time:27048ms step_avg:38.97ms
+step:695/1490 train_time:27101ms step_avg:38.99ms
+step:696/1490 train_time:27161ms step_avg:39.02ms
+step:697/1490 train_time:27215ms step_avg:39.05ms
+step:698/1490 train_time:27275ms step_avg:39.08ms
+step:699/1490 train_time:27328ms step_avg:39.10ms
+step:700/1490 train_time:27388ms step_avg:39.13ms
+step:701/1490 train_time:27443ms step_avg:39.15ms
+step:702/1490 train_time:27502ms step_avg:39.18ms
+step:703/1490 train_time:27555ms step_avg:39.20ms
+step:704/1490 train_time:27614ms step_avg:39.23ms
+step:705/1490 train_time:27668ms step_avg:39.25ms
+step:706/1490 train_time:27728ms step_avg:39.27ms
+step:707/1490 train_time:27781ms step_avg:39.29ms
+step:708/1490 train_time:27840ms step_avg:39.32ms
+step:709/1490 train_time:27894ms step_avg:39.34ms
+step:710/1490 train_time:27953ms step_avg:39.37ms
+step:711/1490 train_time:28007ms step_avg:39.39ms
+step:712/1490 train_time:28067ms step_avg:39.42ms
+step:713/1490 train_time:28120ms step_avg:39.44ms
+step:714/1490 train_time:28180ms step_avg:39.47ms
+step:715/1490 train_time:28234ms step_avg:39.49ms
+step:716/1490 train_time:28294ms step_avg:39.52ms
+step:717/1490 train_time:28348ms step_avg:39.54ms
+step:718/1490 train_time:28408ms step_avg:39.56ms
+step:719/1490 train_time:28461ms step_avg:39.58ms
+step:720/1490 train_time:28521ms step_avg:39.61ms
+step:721/1490 train_time:28574ms step_avg:39.63ms
+step:722/1490 train_time:28634ms step_avg:39.66ms
+step:723/1490 train_time:28688ms step_avg:39.68ms
+step:724/1490 train_time:28748ms step_avg:39.71ms
+step:725/1490 train_time:28802ms step_avg:39.73ms
+step:726/1490 train_time:28861ms step_avg:39.75ms
+step:727/1490 train_time:28914ms step_avg:39.77ms
+step:728/1490 train_time:28973ms step_avg:39.80ms
+step:729/1490 train_time:29028ms step_avg:39.82ms
+step:730/1490 train_time:29087ms step_avg:39.85ms
+step:731/1490 train_time:29141ms step_avg:39.86ms
+step:732/1490 train_time:29200ms step_avg:39.89ms
+step:733/1490 train_time:29254ms step_avg:39.91ms
+step:734/1490 train_time:29314ms step_avg:39.94ms
+step:735/1490 train_time:29368ms step_avg:39.96ms
+step:736/1490 train_time:29427ms step_avg:39.98ms
+step:737/1490 train_time:29480ms step_avg:40.00ms
+step:738/1490 train_time:29539ms step_avg:40.03ms
+step:739/1490 train_time:29593ms step_avg:40.04ms
+step:740/1490 train_time:29652ms step_avg:40.07ms
+step:741/1490 train_time:29706ms step_avg:40.09ms
+step:742/1490 train_time:29767ms step_avg:40.12ms
+step:743/1490 train_time:29821ms step_avg:40.14ms
+step:744/1490 train_time:29880ms step_avg:40.16ms
+step:745/1490 train_time:29933ms step_avg:40.18ms
+step:746/1490 train_time:29995ms step_avg:40.21ms
+step:747/1490 train_time:30046ms step_avg:40.22ms
+step:748/1490 train_time:30106ms step_avg:40.25ms
+step:749/1490 train_time:30160ms step_avg:40.27ms
+step:750/1490 train_time:30219ms step_avg:40.29ms
+step:750/1490 val_loss:3.8073 train_time:30292ms step_avg:40.39ms
+step:751/1490 train_time:30312ms step_avg:40.36ms
+step:752/1490 train_time:30335ms step_avg:40.34ms
+step:753/1490 train_time:30391ms step_avg:40.36ms
+step:754/1490 train_time:30454ms step_avg:40.39ms
+step:755/1490 train_time:30509ms step_avg:40.41ms
+step:756/1490 train_time:30569ms step_avg:40.44ms
+step:757/1490 train_time:30624ms step_avg:40.45ms
+step:758/1490 train_time:30682ms step_avg:40.48ms
+step:759/1490 train_time:30736ms step_avg:40.49ms
+step:760/1490 train_time:30795ms step_avg:40.52ms
+step:761/1490 train_time:30848ms step_avg:40.54ms
+step:762/1490 train_time:30908ms step_avg:40.56ms
+step:763/1490 train_time:30961ms step_avg:40.58ms
+step:764/1490 train_time:31019ms step_avg:40.60ms
+step:765/1490 train_time:31072ms step_avg:40.62ms
+step:766/1490 train_time:31131ms step_avg:40.64ms
+step:767/1490 train_time:31184ms step_avg:40.66ms
+step:768/1490 train_time:31243ms step_avg:40.68ms
+step:769/1490 train_time:31297ms step_avg:40.70ms
+step:770/1490 train_time:31357ms step_avg:40.72ms
+step:771/1490 train_time:31413ms step_avg:40.74ms
+step:772/1490 train_time:31474ms step_avg:40.77ms
+step:773/1490 train_time:31528ms step_avg:40.79ms
+step:774/1490 train_time:31587ms step_avg:40.81ms
+step:775/1490 train_time:31642ms step_avg:40.83ms
+step:776/1490 train_time:31700ms step_avg:40.85ms
+step:777/1490 train_time:31754ms step_avg:40.87ms
+step:778/1490 train_time:31814ms step_avg:40.89ms
+step:779/1490 train_time:31867ms step_avg:40.91ms
+step:780/1490 train_time:31925ms step_avg:40.93ms
+step:781/1490 train_time:31978ms step_avg:40.94ms
+step:782/1490 train_time:32037ms step_avg:40.97ms
+step:783/1490 train_time:32090ms step_avg:40.98ms
+step:784/1490 train_time:32149ms step_avg:41.01ms
+step:785/1490 train_time:32203ms step_avg:41.02ms
+step:786/1490 train_time:32262ms step_avg:41.05ms
+step:787/1490 train_time:32317ms step_avg:41.06ms
+step:788/1490 train_time:32376ms step_avg:41.09ms
+step:789/1490 train_time:32431ms step_avg:41.10ms
+step:790/1490 train_time:32492ms step_avg:41.13ms
+step:791/1490 train_time:32546ms step_avg:41.15ms
+step:792/1490 train_time:32605ms step_avg:41.17ms
+step:793/1490 train_time:32658ms step_avg:41.18ms
+step:794/1490 train_time:32718ms step_avg:41.21ms
+step:795/1490 train_time:32771ms step_avg:41.22ms
+step:796/1490 train_time:32830ms step_avg:41.24ms
+step:797/1490 train_time:32884ms step_avg:41.26ms
+step:798/1490 train_time:32942ms step_avg:41.28ms
+step:799/1490 train_time:32996ms step_avg:41.30ms
+step:800/1490 train_time:33055ms step_avg:41.32ms
+step:801/1490 train_time:33109ms step_avg:41.33ms
+step:802/1490 train_time:33169ms step_avg:41.36ms
+step:803/1490 train_time:33223ms step_avg:41.37ms
+step:804/1490 train_time:33282ms step_avg:41.39ms
+step:805/1490 train_time:33336ms step_avg:41.41ms
+step:806/1490 train_time:33396ms step_avg:41.43ms
+step:807/1490 train_time:33450ms step_avg:41.45ms
+step:808/1490 train_time:33509ms step_avg:41.47ms
+step:809/1490 train_time:33563ms step_avg:41.49ms
+step:810/1490 train_time:33623ms step_avg:41.51ms
+step:811/1490 train_time:33677ms step_avg:41.53ms
+step:812/1490 train_time:33737ms step_avg:41.55ms
+step:813/1490 train_time:33790ms step_avg:41.56ms
+step:814/1490 train_time:33849ms step_avg:41.58ms
+step:815/1490 train_time:33903ms step_avg:41.60ms
+step:816/1490 train_time:33962ms step_avg:41.62ms
+step:817/1490 train_time:34015ms step_avg:41.63ms
+step:818/1490 train_time:34074ms step_avg:41.66ms
+step:819/1490 train_time:34128ms step_avg:41.67ms
+step:820/1490 train_time:34187ms step_avg:41.69ms
+step:821/1490 train_time:34241ms step_avg:41.71ms
+step:822/1490 train_time:34301ms step_avg:41.73ms
+step:823/1490 train_time:34355ms step_avg:41.74ms
+step:824/1490 train_time:34415ms step_avg:41.77ms
+step:825/1490 train_time:34468ms step_avg:41.78ms
+step:826/1490 train_time:34528ms step_avg:41.80ms
+step:827/1490 train_time:34582ms step_avg:41.82ms
+step:828/1490 train_time:34641ms step_avg:41.84ms
+step:829/1490 train_time:34694ms step_avg:41.85ms
+step:830/1490 train_time:34754ms step_avg:41.87ms
+step:831/1490 train_time:34808ms step_avg:41.89ms
+step:832/1490 train_time:34867ms step_avg:41.91ms
+step:833/1490 train_time:34921ms step_avg:41.92ms
+step:834/1490 train_time:34979ms step_avg:41.94ms
+step:835/1490 train_time:35034ms step_avg:41.96ms
+step:836/1490 train_time:35093ms step_avg:41.98ms
+step:837/1490 train_time:35147ms step_avg:41.99ms
+step:838/1490 train_time:35206ms step_avg:42.01ms
+step:839/1490 train_time:35260ms step_avg:42.03ms
+step:840/1490 train_time:35319ms step_avg:42.05ms
+step:841/1490 train_time:35373ms step_avg:42.06ms
+step:842/1490 train_time:35433ms step_avg:42.08ms
+step:843/1490 train_time:35487ms step_avg:42.10ms
+step:844/1490 train_time:35546ms step_avg:42.12ms
+step:845/1490 train_time:35600ms step_avg:42.13ms
+step:846/1490 train_time:35658ms step_avg:42.15ms
+step:847/1490 train_time:35712ms step_avg:42.16ms
+step:848/1490 train_time:35771ms step_avg:42.18ms
+step:849/1490 train_time:35825ms step_avg:42.20ms
+step:850/1490 train_time:35884ms step_avg:42.22ms
+step:851/1490 train_time:35937ms step_avg:42.23ms
+step:852/1490 train_time:35996ms step_avg:42.25ms
+step:853/1490 train_time:36050ms step_avg:42.26ms
+step:854/1490 train_time:36109ms step_avg:42.28ms
+step:855/1490 train_time:36164ms step_avg:42.30ms
+step:856/1490 train_time:36223ms step_avg:42.32ms
+step:857/1490 train_time:36276ms step_avg:42.33ms
+step:858/1490 train_time:36336ms step_avg:42.35ms
+step:859/1490 train_time:36389ms step_avg:42.36ms
+step:860/1490 train_time:36450ms step_avg:42.38ms
+step:861/1490 train_time:36504ms step_avg:42.40ms
+step:862/1490 train_time:36562ms step_avg:42.42ms
+step:863/1490 train_time:36616ms step_avg:42.43ms
+step:864/1490 train_time:36675ms step_avg:42.45ms
+step:865/1490 train_time:36728ms step_avg:42.46ms
+step:866/1490 train_time:36788ms step_avg:42.48ms
+step:867/1490 train_time:36842ms step_avg:42.49ms
+step:868/1490 train_time:36901ms step_avg:42.51ms
+step:869/1490 train_time:36955ms step_avg:42.53ms
+step:870/1490 train_time:37014ms step_avg:42.54ms
+step:871/1490 train_time:37066ms step_avg:42.56ms
+step:872/1490 train_time:37126ms step_avg:42.58ms
+step:873/1490 train_time:37180ms step_avg:42.59ms
+step:874/1490 train_time:37240ms step_avg:42.61ms
+step:875/1490 train_time:37294ms step_avg:42.62ms
+step:876/1490 train_time:37353ms step_avg:42.64ms
+step:877/1490 train_time:37407ms step_avg:42.65ms
+step:878/1490 train_time:37466ms step_avg:42.67ms
+step:879/1490 train_time:37520ms step_avg:42.68ms
+step:880/1490 train_time:37579ms step_avg:42.70ms
+step:881/1490 train_time:37633ms step_avg:42.72ms
+step:882/1490 train_time:37692ms step_avg:42.73ms
+step:883/1490 train_time:37745ms step_avg:42.75ms
+step:884/1490 train_time:37805ms step_avg:42.77ms
+step:885/1490 train_time:37858ms step_avg:42.78ms
+step:886/1490 train_time:37918ms step_avg:42.80ms
+step:887/1490 train_time:37971ms step_avg:42.81ms
+step:888/1490 train_time:38030ms step_avg:42.83ms
+step:889/1490 train_time:38083ms step_avg:42.84ms
+step:890/1490 train_time:38143ms step_avg:42.86ms
+step:891/1490 train_time:38196ms step_avg:42.87ms
+step:892/1490 train_time:38256ms step_avg:42.89ms
+step:893/1490 train_time:38310ms step_avg:42.90ms
+step:894/1490 train_time:38369ms step_avg:42.92ms
+step:895/1490 train_time:38423ms step_avg:42.93ms
+step:896/1490 train_time:38483ms step_avg:42.95ms
+step:897/1490 train_time:38536ms step_avg:42.96ms
+step:898/1490 train_time:38596ms step_avg:42.98ms
+step:899/1490 train_time:38650ms step_avg:42.99ms
+step:900/1490 train_time:38710ms step_avg:43.01ms
+step:901/1490 train_time:38763ms step_avg:43.02ms
+step:902/1490 train_time:38822ms step_avg:43.04ms
+step:903/1490 train_time:38875ms step_avg:43.05ms
+step:904/1490 train_time:38935ms step_avg:43.07ms
+step:905/1490 train_time:38989ms step_avg:43.08ms
+step:906/1490 train_time:39048ms step_avg:43.10ms
+step:907/1490 train_time:39102ms step_avg:43.11ms
+step:908/1490 train_time:39161ms step_avg:43.13ms
+step:909/1490 train_time:39215ms step_avg:43.14ms
+step:910/1490 train_time:39274ms step_avg:43.16ms
+step:911/1490 train_time:39327ms step_avg:43.17ms
+step:912/1490 train_time:39386ms step_avg:43.19ms
+step:913/1490 train_time:39440ms step_avg:43.20ms
+step:914/1490 train_time:39499ms step_avg:43.22ms
+step:915/1490 train_time:39553ms step_avg:43.23ms
+step:916/1490 train_time:39612ms step_avg:43.24ms
+step:917/1490 train_time:39666ms step_avg:43.26ms
+step:918/1490 train_time:39726ms step_avg:43.27ms
+step:919/1490 train_time:39780ms step_avg:43.29ms
+step:920/1490 train_time:39838ms step_avg:43.30ms
+step:921/1490 train_time:39892ms step_avg:43.31ms
+step:922/1490 train_time:39951ms step_avg:43.33ms
+step:923/1490 train_time:40004ms step_avg:43.34ms
+step:924/1490 train_time:40064ms step_avg:43.36ms
+step:925/1490 train_time:40117ms step_avg:43.37ms
+step:926/1490 train_time:40176ms step_avg:43.39ms
+step:927/1490 train_time:40229ms step_avg:43.40ms
+step:928/1490 train_time:40289ms step_avg:43.41ms
+step:929/1490 train_time:40344ms step_avg:43.43ms
+step:930/1490 train_time:40402ms step_avg:43.44ms
+step:931/1490 train_time:40456ms step_avg:43.45ms
+step:932/1490 train_time:40515ms step_avg:43.47ms
+step:933/1490 train_time:40569ms step_avg:43.48ms
+step:934/1490 train_time:40629ms step_avg:43.50ms
+step:935/1490 train_time:40683ms step_avg:43.51ms
+step:936/1490 train_time:40742ms step_avg:43.53ms
+step:937/1490 train_time:40796ms step_avg:43.54ms
+step:938/1490 train_time:40855ms step_avg:43.56ms
+step:939/1490 train_time:40909ms step_avg:43.57ms
+step:940/1490 train_time:40968ms step_avg:43.58ms
+step:941/1490 train_time:41022ms step_avg:43.59ms
+step:942/1490 train_time:41080ms step_avg:43.61ms
+step:943/1490 train_time:41134ms step_avg:43.62ms
+step:944/1490 train_time:41193ms step_avg:43.64ms
+step:945/1490 train_time:41248ms step_avg:43.65ms
+step:946/1490 train_time:41307ms step_avg:43.67ms
+step:947/1490 train_time:41361ms step_avg:43.68ms
+step:948/1490 train_time:41420ms step_avg:43.69ms
+step:949/1490 train_time:41474ms step_avg:43.70ms
+step:950/1490 train_time:41534ms step_avg:43.72ms
+step:951/1490 train_time:41588ms step_avg:43.73ms
+step:952/1490 train_time:41648ms step_avg:43.75ms
+step:953/1490 train_time:41702ms step_avg:43.76ms
+step:954/1490 train_time:41761ms step_avg:43.77ms
+step:955/1490 train_time:41815ms step_avg:43.79ms
+step:956/1490 train_time:41874ms step_avg:43.80ms
+step:957/1490 train_time:41928ms step_avg:43.81ms
+step:958/1490 train_time:41987ms step_avg:43.83ms
+step:959/1490 train_time:42041ms step_avg:43.84ms
+step:960/1490 train_time:42100ms step_avg:43.85ms
+step:961/1490 train_time:42153ms step_avg:43.86ms
+step:962/1490 train_time:42213ms step_avg:43.88ms
+step:963/1490 train_time:42266ms step_avg:43.89ms
+step:964/1490 train_time:42326ms step_avg:43.91ms
+step:965/1490 train_time:42380ms step_avg:43.92ms
+step:966/1490 train_time:42438ms step_avg:43.93ms
+step:967/1490 train_time:42492ms step_avg:43.94ms
+step:968/1490 train_time:42555ms step_avg:43.96ms
+step:969/1490 train_time:42632ms step_avg:44.00ms
+step:970/1490 train_time:42718ms step_avg:44.04ms
+step:971/1490 train_time:42797ms step_avg:44.08ms
+step:972/1490 train_time:42882ms step_avg:44.12ms
+step:973/1490 train_time:42961ms step_avg:44.15ms
+step:974/1490 train_time:43047ms step_avg:44.20ms
+step:975/1490 train_time:43127ms step_avg:44.23ms
+step:976/1490 train_time:43211ms step_avg:44.27ms
+step:977/1490 train_time:43290ms step_avg:44.31ms
+step:978/1490 train_time:43376ms step_avg:44.35ms
+step:979/1490 train_time:43455ms step_avg:44.39ms
+step:980/1490 train_time:43540ms step_avg:44.43ms
+step:981/1490 train_time:43619ms step_avg:44.46ms
+step:982/1490 train_time:43703ms step_avg:44.50ms
+step:983/1490 train_time:43784ms step_avg:44.54ms
+step:984/1490 train_time:43869ms step_avg:44.58ms
+step:985/1490 train_time:43949ms step_avg:44.62ms
+step:986/1490 train_time:44034ms step_avg:44.66ms
+step:987/1490 train_time:44113ms step_avg:44.69ms
+step:988/1490 train_time:44198ms step_avg:44.74ms
+step:989/1490 train_time:44277ms step_avg:44.77ms
+step:990/1490 train_time:44361ms step_avg:44.81ms
+step:991/1490 train_time:44442ms step_avg:44.85ms
+step:992/1490 train_time:44528ms step_avg:44.89ms
+step:993/1490 train_time:44607ms step_avg:44.92ms
+step:994/1490 train_time:44691ms step_avg:44.96ms
+step:995/1490 train_time:44770ms step_avg:45.00ms
+step:996/1490 train_time:44855ms step_avg:45.04ms
+step:997/1490 train_time:44935ms step_avg:45.07ms
+step:998/1490 train_time:45018ms step_avg:45.11ms
+step:999/1490 train_time:45097ms step_avg:45.14ms
+step:1000/1490 train_time:45183ms step_avg:45.18ms
+step:1000/1490 val_loss:3.5175 train_time:45285ms step_avg:45.29ms
+step:1001/1490 train_time:45302ms step_avg:45.26ms
+step:1002/1490 train_time:45353ms step_avg:45.26ms
+step:1003/1490 train_time:45435ms step_avg:45.30ms
+step:1004/1490 train_time:45528ms step_avg:45.35ms
+step:1005/1490 train_time:45607ms step_avg:45.38ms
+step:1006/1490 train_time:45692ms step_avg:45.42ms
+step:1007/1490 train_time:45772ms step_avg:45.45ms
+step:1008/1490 train_time:45855ms step_avg:45.49ms
+step:1009/1490 train_time:45933ms step_avg:45.52ms
+step:1010/1490 train_time:46017ms step_avg:45.56ms
+step:1011/1490 train_time:46096ms step_avg:45.59ms
+step:1012/1490 train_time:46181ms step_avg:45.63ms
+step:1013/1490 train_time:46260ms step_avg:45.67ms
+step:1014/1490 train_time:46348ms step_avg:45.71ms
+step:1015/1490 train_time:46430ms step_avg:45.74ms
+step:1016/1490 train_time:46516ms step_avg:45.78ms
+step:1017/1490 train_time:46597ms step_avg:45.82ms
+step:1018/1490 train_time:46683ms step_avg:45.86ms
+step:1019/1490 train_time:46763ms step_avg:45.89ms
+step:1020/1490 train_time:46848ms step_avg:45.93ms
+step:1021/1490 train_time:46925ms step_avg:45.96ms
+step:1022/1490 train_time:47009ms step_avg:46.00ms
+step:1023/1490 train_time:47087ms step_avg:46.03ms
+step:1024/1490 train_time:47170ms step_avg:46.06ms
+step:1025/1490 train_time:47251ms step_avg:46.10ms
+step:1026/1490 train_time:47338ms step_avg:46.14ms
+step:1027/1490 train_time:47420ms step_avg:46.17ms
+step:1028/1490 train_time:47506ms step_avg:46.21ms
+step:1029/1490 train_time:47586ms step_avg:46.24ms
+step:1030/1490 train_time:47671ms step_avg:46.28ms
+step:1031/1490 train_time:47752ms step_avg:46.32ms
+step:1032/1490 train_time:47837ms step_avg:46.35ms
+step:1033/1490 train_time:47916ms step_avg:46.39ms
+step:1034/1490 train_time:48000ms step_avg:46.42ms
+step:1035/1490 train_time:48080ms step_avg:46.45ms
+step:1036/1490 train_time:48164ms step_avg:46.49ms
+step:1037/1490 train_time:48243ms step_avg:46.52ms
+step:1038/1490 train_time:48330ms step_avg:46.56ms
+step:1039/1490 train_time:48411ms step_avg:46.59ms
+step:1040/1490 train_time:48498ms step_avg:46.63ms
+step:1041/1490 train_time:48579ms step_avg:46.67ms
+step:1042/1490 train_time:48665ms step_avg:46.70ms
+step:1043/1490 train_time:48745ms step_avg:46.74ms
+step:1044/1490 train_time:48829ms step_avg:46.77ms
+step:1045/1490 train_time:48907ms step_avg:46.80ms
+step:1046/1490 train_time:48991ms step_avg:46.84ms
+step:1047/1490 train_time:49070ms step_avg:46.87ms
+step:1048/1490 train_time:49155ms step_avg:46.90ms
+step:1049/1490 train_time:49234ms step_avg:46.93ms
+step:1050/1490 train_time:49319ms step_avg:46.97ms
+step:1051/1490 train_time:49399ms step_avg:47.00ms
+step:1052/1490 train_time:49485ms step_avg:47.04ms
+step:1053/1490 train_time:49566ms step_avg:47.07ms
+step:1054/1490 train_time:49652ms step_avg:47.11ms
+step:1055/1490 train_time:49732ms step_avg:47.14ms
+step:1056/1490 train_time:49816ms step_avg:47.17ms
+step:1057/1490 train_time:49895ms step_avg:47.20ms
+step:1058/1490 train_time:49981ms step_avg:47.24ms
+step:1059/1490 train_time:50061ms step_avg:47.27ms
+step:1060/1490 train_time:50147ms step_avg:47.31ms
+step:1061/1490 train_time:50226ms step_avg:47.34ms
+step:1062/1490 train_time:50310ms step_avg:47.37ms
+step:1063/1490 train_time:50391ms step_avg:47.40ms
+step:1064/1490 train_time:50477ms step_avg:47.44ms
+step:1065/1490 train_time:50559ms step_avg:47.47ms
+step:1066/1490 train_time:50644ms step_avg:47.51ms
+step:1067/1490 train_time:50723ms step_avg:47.54ms
+step:1068/1490 train_time:50807ms step_avg:47.57ms
+step:1069/1490 train_time:50886ms step_avg:47.60ms
+step:1070/1490 train_time:50970ms step_avg:47.64ms
+step:1071/1490 train_time:51049ms step_avg:47.66ms
+step:1072/1490 train_time:51133ms step_avg:47.70ms
+step:1073/1490 train_time:51213ms step_avg:47.73ms
+step:1074/1490 train_time:51298ms step_avg:47.76ms
+step:1075/1490 train_time:51377ms step_avg:47.79ms
+step:1076/1490 train_time:51462ms step_avg:47.83ms
+step:1077/1490 train_time:51542ms step_avg:47.86ms
+step:1078/1490 train_time:51627ms step_avg:47.89ms
+step:1079/1490 train_time:51705ms step_avg:47.92ms
+step:1080/1490 train_time:51791ms step_avg:47.95ms
+step:1081/1490 train_time:51870ms step_avg:47.98ms
+step:1082/1490 train_time:51954ms step_avg:48.02ms
+step:1083/1490 train_time:52033ms step_avg:48.05ms
+step:1084/1490 train_time:52119ms step_avg:48.08ms
+step:1085/1490 train_time:52199ms step_avg:48.11ms
+step:1086/1490 train_time:52283ms step_avg:48.14ms
+step:1087/1490 train_time:52363ms step_avg:48.17ms
+step:1088/1490 train_time:52448ms step_avg:48.21ms
+step:1089/1490 train_time:52526ms step_avg:48.23ms
+step:1090/1490 train_time:52611ms step_avg:48.27ms
+step:1091/1490 train_time:52692ms step_avg:48.30ms
+step:1092/1490 train_time:52777ms step_avg:48.33ms
+step:1093/1490 train_time:52856ms step_avg:48.36ms
+step:1094/1490 train_time:52941ms step_avg:48.39ms
+step:1095/1490 train_time:53020ms step_avg:48.42ms
+step:1096/1490 train_time:53105ms step_avg:48.45ms
+step:1097/1490 train_time:53184ms step_avg:48.48ms
+step:1098/1490 train_time:53269ms step_avg:48.51ms
+step:1099/1490 train_time:53349ms step_avg:48.54ms
+step:1100/1490 train_time:53433ms step_avg:48.58ms
+step:1101/1490 train_time:53512ms step_avg:48.60ms
+step:1102/1490 train_time:53598ms step_avg:48.64ms
+step:1103/1490 train_time:53678ms step_avg:48.67ms
+step:1104/1490 train_time:53764ms step_avg:48.70ms
+step:1105/1490 train_time:53844ms step_avg:48.73ms
+step:1106/1490 train_time:53927ms step_avg:48.76ms
+step:1107/1490 train_time:54007ms step_avg:48.79ms
+step:1108/1490 train_time:54092ms step_avg:48.82ms
+step:1109/1490 train_time:54171ms step_avg:48.85ms
+step:1110/1490 train_time:54256ms step_avg:48.88ms
+step:1111/1490 train_time:54335ms step_avg:48.91ms
+step:1112/1490 train_time:54420ms step_avg:48.94ms
+step:1113/1490 train_time:54499ms step_avg:48.97ms
+step:1114/1490 train_time:54584ms step_avg:49.00ms
+step:1115/1490 train_time:54663ms step_avg:49.03ms
+step:1116/1490 train_time:54750ms step_avg:49.06ms
+step:1117/1490 train_time:54831ms step_avg:49.09ms
+step:1118/1490 train_time:54916ms step_avg:49.12ms
+step:1119/1490 train_time:54995ms step_avg:49.15ms
+step:1120/1490 train_time:55080ms step_avg:49.18ms
+step:1121/1490 train_time:55159ms step_avg:49.21ms
+step:1122/1490 train_time:55245ms step_avg:49.24ms
+step:1123/1490 train_time:55323ms step_avg:49.26ms
+step:1124/1490 train_time:55408ms step_avg:49.30ms
+step:1125/1490 train_time:55487ms step_avg:49.32ms
+step:1126/1490 train_time:55573ms step_avg:49.35ms
+step:1127/1490 train_time:55653ms step_avg:49.38ms
+step:1128/1490 train_time:55739ms step_avg:49.41ms
+step:1129/1490 train_time:55819ms step_avg:49.44ms
+step:1130/1490 train_time:55903ms step_avg:49.47ms
+step:1131/1490 train_time:55983ms step_avg:49.50ms
+step:1132/1490 train_time:56067ms step_avg:49.53ms
+step:1133/1490 train_time:56147ms step_avg:49.56ms
+step:1134/1490 train_time:56232ms step_avg:49.59ms
+step:1135/1490 train_time:56310ms step_avg:49.61ms
+step:1136/1490 train_time:56397ms step_avg:49.65ms
+step:1137/1490 train_time:56477ms step_avg:49.67ms
+step:1138/1490 train_time:56563ms step_avg:49.70ms
+step:1139/1490 train_time:56643ms step_avg:49.73ms
+step:1140/1490 train_time:56727ms step_avg:49.76ms
+step:1141/1490 train_time:56806ms step_avg:49.79ms
+step:1142/1490 train_time:56892ms step_avg:49.82ms
+step:1143/1490 train_time:56970ms step_avg:49.84ms
+step:1144/1490 train_time:57056ms step_avg:49.87ms
+step:1145/1490 train_time:57135ms step_avg:49.90ms
+step:1146/1490 train_time:57220ms step_avg:49.93ms
+step:1147/1490 train_time:57300ms step_avg:49.96ms
+step:1148/1490 train_time:57385ms step_avg:49.99ms
+step:1149/1490 train_time:57465ms step_avg:50.01ms
+step:1150/1490 train_time:57549ms step_avg:50.04ms
+step:1151/1490 train_time:57628ms step_avg:50.07ms
+step:1152/1490 train_time:57712ms step_avg:50.10ms
+step:1153/1490 train_time:57793ms step_avg:50.12ms
+step:1154/1490 train_time:57879ms step_avg:50.15ms
+step:1155/1490 train_time:57958ms step_avg:50.18ms
+step:1156/1490 train_time:58043ms step_avg:50.21ms
+step:1157/1490 train_time:58122ms step_avg:50.24ms
+step:1158/1490 train_time:58207ms step_avg:50.27ms
+step:1159/1490 train_time:58287ms step_avg:50.29ms
+step:1160/1490 train_time:58373ms step_avg:50.32ms
+step:1161/1490 train_time:58452ms step_avg:50.35ms
+step:1162/1490 train_time:58536ms step_avg:50.38ms
+step:1163/1490 train_time:58616ms step_avg:50.40ms
+step:1164/1490 train_time:58701ms step_avg:50.43ms
+step:1165/1490 train_time:58781ms step_avg:50.46ms
+step:1166/1490 train_time:58866ms step_avg:50.49ms
+step:1167/1490 train_time:58946ms step_avg:50.51ms
+step:1168/1490 train_time:59031ms step_avg:50.54ms
+step:1169/1490 train_time:59110ms step_avg:50.56ms
+step:1170/1490 train_time:59195ms step_avg:50.59ms
+step:1171/1490 train_time:59275ms step_avg:50.62ms
+step:1172/1490 train_time:59359ms step_avg:50.65ms
+step:1173/1490 train_time:59439ms step_avg:50.67ms
+step:1174/1490 train_time:59523ms step_avg:50.70ms
+step:1175/1490 train_time:59602ms step_avg:50.72ms
+step:1176/1490 train_time:59688ms step_avg:50.76ms
+step:1177/1490 train_time:59768ms step_avg:50.78ms
+step:1178/1490 train_time:59853ms step_avg:50.81ms
+step:1179/1490 train_time:59932ms step_avg:50.83ms
+step:1180/1490 train_time:60017ms step_avg:50.86ms
+step:1181/1490 train_time:60097ms step_avg:50.89ms
+step:1182/1490 train_time:60182ms step_avg:50.92ms
+step:1183/1490 train_time:60261ms step_avg:50.94ms
+step:1184/1490 train_time:60347ms step_avg:50.97ms
+step:1185/1490 train_time:60426ms step_avg:50.99ms
+step:1186/1490 train_time:60512ms step_avg:51.02ms
+step:1187/1490 train_time:60593ms step_avg:51.05ms
+step:1188/1490 train_time:60678ms step_avg:51.08ms
+step:1189/1490 train_time:60757ms step_avg:51.10ms
+step:1190/1490 train_time:60843ms step_avg:51.13ms
+step:1191/1490 train_time:60921ms step_avg:51.15ms
+step:1192/1490 train_time:61007ms step_avg:51.18ms
+step:1193/1490 train_time:61086ms step_avg:51.20ms
+step:1194/1490 train_time:61171ms step_avg:51.23ms
+step:1195/1490 train_time:61251ms step_avg:51.26ms
+step:1196/1490 train_time:61336ms step_avg:51.28ms
+step:1197/1490 train_time:61417ms step_avg:51.31ms
+step:1198/1490 train_time:61501ms step_avg:51.34ms
+step:1199/1490 train_time:61582ms step_avg:51.36ms
+step:1200/1490 train_time:61668ms step_avg:51.39ms
+step:1201/1490 train_time:61747ms step_avg:51.41ms
+step:1202/1490 train_time:61831ms step_avg:51.44ms
+step:1203/1490 train_time:61910ms step_avg:51.46ms
+step:1204/1490 train_time:61995ms step_avg:51.49ms
+step:1205/1490 train_time:62075ms step_avg:51.51ms
+step:1206/1490 train_time:62160ms step_avg:51.54ms
+step:1207/1490 train_time:62240ms step_avg:51.57ms
+step:1208/1490 train_time:62325ms step_avg:51.59ms
+step:1209/1490 train_time:62405ms step_avg:51.62ms
+step:1210/1490 train_time:62488ms step_avg:51.64ms
+step:1211/1490 train_time:62568ms step_avg:51.67ms
+step:1212/1490 train_time:62653ms step_avg:51.69ms
+step:1213/1490 train_time:62733ms step_avg:51.72ms
+step:1214/1490 train_time:62817ms step_avg:51.74ms
+step:1215/1490 train_time:62897ms step_avg:51.77ms
+step:1216/1490 train_time:62982ms step_avg:51.79ms
+step:1217/1490 train_time:63061ms step_avg:51.82ms
+step:1218/1490 train_time:63146ms step_avg:51.84ms
+step:1219/1490 train_time:63226ms step_avg:51.87ms
+step:1220/1490 train_time:63311ms step_avg:51.89ms
+step:1221/1490 train_time:63390ms step_avg:51.92ms
+step:1222/1490 train_time:63475ms step_avg:51.94ms
+step:1223/1490 train_time:63555ms step_avg:51.97ms
+step:1224/1490 train_time:63640ms step_avg:51.99ms
+step:1225/1490 train_time:63719ms step_avg:52.02ms
+step:1226/1490 train_time:63803ms step_avg:52.04ms
+step:1227/1490 train_time:63882ms step_avg:52.06ms
+step:1228/1490 train_time:63966ms step_avg:52.09ms
+step:1229/1490 train_time:64046ms step_avg:52.11ms
+step:1230/1490 train_time:64131ms step_avg:52.14ms
+step:1231/1490 train_time:64211ms step_avg:52.16ms
+step:1232/1490 train_time:64298ms step_avg:52.19ms
+step:1233/1490 train_time:64378ms step_avg:52.21ms
+step:1234/1490 train_time:64463ms step_avg:52.24ms
+step:1235/1490 train_time:64542ms step_avg:52.26ms
+step:1236/1490 train_time:64627ms step_avg:52.29ms
+step:1237/1490 train_time:64706ms step_avg:52.31ms
+step:1238/1490 train_time:64791ms step_avg:52.34ms
+step:1239/1490 train_time:64872ms step_avg:52.36ms
+step:1240/1490 train_time:64958ms step_avg:52.39ms
+step:1241/1490 train_time:65038ms step_avg:52.41ms
+step:1242/1490 train_time:65123ms step_avg:52.43ms
+step:1243/1490 train_time:65202ms step_avg:52.46ms
+step:1244/1490 train_time:65287ms step_avg:52.48ms
+step:1245/1490 train_time:65367ms step_avg:52.50ms
+step:1246/1490 train_time:65452ms step_avg:52.53ms
+step:1247/1490 train_time:65531ms step_avg:52.55ms
+step:1248/1490 train_time:65616ms step_avg:52.58ms
+step:1249/1490 train_time:65698ms step_avg:52.60ms
+step:1250/1490 train_time:65782ms step_avg:52.63ms
+step:1250/1490 val_loss:3.3708 train_time:65883ms step_avg:52.71ms
+step:1251/1490 train_time:65908ms step_avg:52.68ms
+step:1252/1490 train_time:65953ms step_avg:52.68ms
+step:1253/1490 train_time:66035ms step_avg:52.70ms
+step:1254/1490 train_time:66121ms step_avg:52.73ms
+step:1255/1490 train_time:66201ms step_avg:52.75ms
+step:1256/1490 train_time:66285ms step_avg:52.77ms
+step:1257/1490 train_time:66365ms step_avg:52.80ms
+step:1258/1490 train_time:66449ms step_avg:52.82ms
+step:1259/1490 train_time:66527ms step_avg:52.84ms
+step:1260/1490 train_time:66611ms step_avg:52.87ms
+step:1261/1490 train_time:66689ms step_avg:52.89ms
+step:1262/1490 train_time:66774ms step_avg:52.91ms
+step:1263/1490 train_time:66853ms step_avg:52.93ms
+step:1264/1490 train_time:66941ms step_avg:52.96ms
+step:1265/1490 train_time:67025ms step_avg:52.98ms
+step:1266/1490 train_time:67111ms step_avg:53.01ms
+step:1267/1490 train_time:67192ms step_avg:53.03ms
+step:1268/1490 train_time:67277ms step_avg:53.06ms
+step:1269/1490 train_time:67356ms step_avg:53.08ms
+step:1270/1490 train_time:67440ms step_avg:53.10ms
+step:1271/1490 train_time:67518ms step_avg:53.12ms
+step:1272/1490 train_time:67602ms step_avg:53.15ms
+step:1273/1490 train_time:67681ms step_avg:53.17ms
+step:1274/1490 train_time:67766ms step_avg:53.19ms
+step:1275/1490 train_time:67845ms step_avg:53.21ms
+step:1276/1490 train_time:67932ms step_avg:53.24ms
+step:1277/1490 train_time:68013ms step_avg:53.26ms
+step:1278/1490 train_time:68100ms step_avg:53.29ms
+step:1279/1490 train_time:68180ms step_avg:53.31ms
+step:1280/1490 train_time:68266ms step_avg:53.33ms
+step:1281/1490 train_time:68346ms step_avg:53.35ms
+step:1282/1490 train_time:68429ms step_avg:53.38ms
+step:1283/1490 train_time:68508ms step_avg:53.40ms
+step:1284/1490 train_time:68592ms step_avg:53.42ms
+step:1285/1490 train_time:68671ms step_avg:53.44ms
+step:1286/1490 train_time:68756ms step_avg:53.47ms
+step:1287/1490 train_time:68836ms step_avg:53.49ms
+step:1288/1490 train_time:68921ms step_avg:53.51ms
+step:1289/1490 train_time:69003ms step_avg:53.53ms
+step:1290/1490 train_time:69088ms step_avg:53.56ms
+step:1291/1490 train_time:69168ms step_avg:53.58ms
+step:1292/1490 train_time:69253ms step_avg:53.60ms
+step:1293/1490 train_time:69332ms step_avg:53.62ms
+step:1294/1490 train_time:69418ms step_avg:53.65ms
+step:1295/1490 train_time:69496ms step_avg:53.66ms
+step:1296/1490 train_time:69580ms step_avg:53.69ms
+step:1297/1490 train_time:69661ms step_avg:53.71ms
+step:1298/1490 train_time:69746ms step_avg:53.73ms
+step:1299/1490 train_time:69825ms step_avg:53.75ms
+step:1300/1490 train_time:69911ms step_avg:53.78ms
+step:1301/1490 train_time:69991ms step_avg:53.80ms
+step:1302/1490 train_time:70077ms step_avg:53.82ms
+step:1303/1490 train_time:70157ms step_avg:53.84ms
+step:1304/1490 train_time:70242ms step_avg:53.87ms
+step:1305/1490 train_time:70322ms step_avg:53.89ms
+step:1306/1490 train_time:70407ms step_avg:53.91ms
+step:1307/1490 train_time:70487ms step_avg:53.93ms
+step:1308/1490 train_time:70571ms step_avg:53.95ms
+step:1309/1490 train_time:70650ms step_avg:53.97ms
+step:1310/1490 train_time:70734ms step_avg:54.00ms
+step:1311/1490 train_time:70813ms step_avg:54.01ms
+step:1312/1490 train_time:70898ms step_avg:54.04ms
+step:1313/1490 train_time:70978ms step_avg:54.06ms
+step:1314/1490 train_time:71063ms step_avg:54.08ms
+step:1315/1490 train_time:71144ms step_avg:54.10ms
+step:1316/1490 train_time:71229ms step_avg:54.13ms
+step:1317/1490 train_time:71309ms step_avg:54.14ms
+step:1318/1490 train_time:71394ms step_avg:54.17ms
+step:1319/1490 train_time:71473ms step_avg:54.19ms
+step:1320/1490 train_time:71558ms step_avg:54.21ms
+step:1321/1490 train_time:71636ms step_avg:54.23ms
+step:1322/1490 train_time:71721ms step_avg:54.25ms
+step:1323/1490 train_time:71801ms step_avg:54.27ms
+step:1324/1490 train_time:71886ms step_avg:54.29ms
+step:1325/1490 train_time:71967ms step_avg:54.31ms
+step:1326/1490 train_time:72050ms step_avg:54.34ms
+step:1327/1490 train_time:72131ms step_avg:54.36ms
+step:1328/1490 train_time:72217ms step_avg:54.38ms
+step:1329/1490 train_time:72297ms step_avg:54.40ms
+step:1330/1490 train_time:72382ms step_avg:54.42ms
+step:1331/1490 train_time:72462ms step_avg:54.44ms
+step:1332/1490 train_time:72546ms step_avg:54.46ms
+step:1333/1490 train_time:72625ms step_avg:54.48ms
+step:1334/1490 train_time:72709ms step_avg:54.50ms
+step:1335/1490 train_time:72789ms step_avg:54.52ms
+step:1336/1490 train_time:72874ms step_avg:54.55ms
+step:1337/1490 train_time:72954ms step_avg:54.57ms
+step:1338/1490 train_time:73038ms step_avg:54.59ms
+step:1339/1490 train_time:73118ms step_avg:54.61ms
+step:1340/1490 train_time:73202ms step_avg:54.63ms
+step:1341/1490 train_time:73283ms step_avg:54.65ms
+step:1342/1490 train_time:73368ms step_avg:54.67ms
+step:1343/1490 train_time:73447ms step_avg:54.69ms
+step:1344/1490 train_time:73533ms step_avg:54.71ms
+step:1345/1490 train_time:73613ms step_avg:54.73ms
+step:1346/1490 train_time:73697ms step_avg:54.75ms
+step:1347/1490 train_time:73777ms step_avg:54.77ms
+step:1348/1490 train_time:73862ms step_avg:54.79ms
+step:1349/1490 train_time:73942ms step_avg:54.81ms
+step:1350/1490 train_time:74028ms step_avg:54.84ms
+step:1351/1490 train_time:74108ms step_avg:54.85ms
+step:1352/1490 train_time:74193ms step_avg:54.88ms
+step:1353/1490 train_time:74272ms step_avg:54.89ms
+step:1354/1490 train_time:74357ms step_avg:54.92ms
+step:1355/1490 train_time:74435ms step_avg:54.93ms
+step:1356/1490 train_time:74522ms step_avg:54.96ms
+step:1357/1490 train_time:74602ms step_avg:54.98ms
+step:1358/1490 train_time:74688ms step_avg:55.00ms
+step:1359/1490 train_time:74767ms step_avg:55.02ms
+step:1360/1490 train_time:74853ms step_avg:55.04ms
+step:1361/1490 train_time:74932ms step_avg:55.06ms
+step:1362/1490 train_time:75017ms step_avg:55.08ms
+step:1363/1490 train_time:75099ms step_avg:55.10ms
+step:1364/1490 train_time:75183ms step_avg:55.12ms
+step:1365/1490 train_time:75263ms step_avg:55.14ms
+step:1366/1490 train_time:75348ms step_avg:55.16ms
+step:1367/1490 train_time:75427ms step_avg:55.18ms
+step:1368/1490 train_time:75512ms step_avg:55.20ms
+step:1369/1490 train_time:75591ms step_avg:55.22ms
+step:1370/1490 train_time:75676ms step_avg:55.24ms
+step:1371/1490 train_time:75756ms step_avg:55.26ms
+step:1372/1490 train_time:75841ms step_avg:55.28ms
+step:1373/1490 train_time:75921ms step_avg:55.30ms
+step:1374/1490 train_time:76006ms step_avg:55.32ms
+step:1375/1490 train_time:76086ms step_avg:55.34ms
+step:1376/1490 train_time:76171ms step_avg:55.36ms
+step:1377/1490 train_time:76250ms step_avg:55.37ms
+step:1378/1490 train_time:76334ms step_avg:55.40ms
+step:1379/1490 train_time:76413ms step_avg:55.41ms
+step:1380/1490 train_time:76500ms step_avg:55.43ms
+step:1381/1490 train_time:76579ms step_avg:55.45ms
+step:1382/1490 train_time:76665ms step_avg:55.47ms
+step:1383/1490 train_time:76745ms step_avg:55.49ms
+step:1384/1490 train_time:76830ms step_avg:55.51ms
+step:1385/1490 train_time:76909ms step_avg:55.53ms
+step:1386/1490 train_time:76995ms step_avg:55.55ms
+step:1387/1490 train_time:77074ms step_avg:55.57ms
+step:1388/1490 train_time:77159ms step_avg:55.59ms
+step:1389/1490 train_time:77239ms step_avg:55.61ms
+step:1390/1490 train_time:77323ms step_avg:55.63ms
+step:1391/1490 train_time:77402ms step_avg:55.65ms
+step:1392/1490 train_time:77489ms step_avg:55.67ms
+step:1393/1490 train_time:77569ms step_avg:55.69ms
+step:1394/1490 train_time:77654ms step_avg:55.71ms
+step:1395/1490 train_time:77733ms step_avg:55.72ms
+step:1396/1490 train_time:77816ms step_avg:55.74ms
+step:1397/1490 train_time:77897ms step_avg:55.76ms
+step:1398/1490 train_time:77982ms step_avg:55.78ms
+step:1399/1490 train_time:78062ms step_avg:55.80ms
+step:1400/1490 train_time:78147ms step_avg:55.82ms
+step:1401/1490 train_time:78227ms step_avg:55.84ms
+step:1402/1490 train_time:78310ms step_avg:55.86ms
+step:1403/1490 train_time:78390ms step_avg:55.87ms
+step:1404/1490 train_time:78475ms step_avg:55.89ms
+step:1405/1490 train_time:78554ms step_avg:55.91ms
+step:1406/1490 train_time:78639ms step_avg:55.93ms
+step:1407/1490 train_time:78719ms step_avg:55.95ms
+step:1408/1490 train_time:78805ms step_avg:55.97ms
+step:1409/1490 train_time:78883ms step_avg:55.99ms
+step:1410/1490 train_time:78969ms step_avg:56.01ms
+step:1411/1490 train_time:79049ms step_avg:56.02ms
+step:1412/1490 train_time:79134ms step_avg:56.04ms
+step:1413/1490 train_time:79214ms step_avg:56.06ms
+step:1414/1490 train_time:79300ms step_avg:56.08ms
+step:1415/1490 train_time:79379ms step_avg:56.10ms
+step:1416/1490 train_time:79464ms step_avg:56.12ms
+step:1417/1490 train_time:79545ms step_avg:56.14ms
+step:1418/1490 train_time:79628ms step_avg:56.16ms
+step:1419/1490 train_time:79708ms step_avg:56.17ms
+step:1420/1490 train_time:79792ms step_avg:56.19ms
+step:1421/1490 train_time:79873ms step_avg:56.21ms
+step:1422/1490 train_time:79958ms step_avg:56.23ms
+step:1423/1490 train_time:80038ms step_avg:56.25ms
+step:1424/1490 train_time:80123ms step_avg:56.27ms
+step:1425/1490 train_time:80202ms step_avg:56.28ms
+step:1426/1490 train_time:80288ms step_avg:56.30ms
+step:1427/1490 train_time:80367ms step_avg:56.32ms
+step:1428/1490 train_time:80454ms step_avg:56.34ms
+step:1429/1490 train_time:80533ms step_avg:56.36ms
+step:1430/1490 train_time:80617ms step_avg:56.38ms
+step:1431/1490 train_time:80696ms step_avg:56.39ms
+step:1432/1490 train_time:80781ms step_avg:56.41ms
+step:1433/1490 train_time:80860ms step_avg:56.43ms
+step:1434/1490 train_time:80946ms step_avg:56.45ms
+step:1435/1490 train_time:81025ms step_avg:56.46ms
+step:1436/1490 train_time:81110ms step_avg:56.48ms
+step:1437/1490 train_time:81189ms step_avg:56.50ms
+step:1438/1490 train_time:81275ms step_avg:56.52ms
+step:1439/1490 train_time:81354ms step_avg:56.54ms
+step:1440/1490 train_time:81437ms step_avg:56.55ms
+step:1441/1490 train_time:81517ms step_avg:56.57ms
+step:1442/1490 train_time:81603ms step_avg:56.59ms
+step:1443/1490 train_time:81683ms step_avg:56.61ms
+step:1444/1490 train_time:81767ms step_avg:56.63ms
+step:1445/1490 train_time:81846ms step_avg:56.64ms
+step:1446/1490 train_time:81932ms step_avg:56.66ms
+step:1447/1490 train_time:82012ms step_avg:56.68ms
+step:1448/1490 train_time:82097ms step_avg:56.70ms
+step:1449/1490 train_time:82177ms step_avg:56.71ms
+step:1450/1490 train_time:82261ms step_avg:56.73ms
+step:1451/1490 train_time:82346ms step_avg:56.75ms
+step:1452/1490 train_time:82433ms step_avg:56.77ms
+step:1453/1490 train_time:82512ms step_avg:56.79ms
+step:1454/1490 train_time:82597ms step_avg:56.81ms
+step:1455/1490 train_time:82676ms step_avg:56.82ms
+step:1456/1490 train_time:82761ms step_avg:56.84ms
+step:1457/1490 train_time:82842ms step_avg:56.86ms
+step:1458/1490 train_time:82928ms step_avg:56.88ms
+step:1459/1490 train_time:83008ms step_avg:56.89ms
+step:1460/1490 train_time:83095ms step_avg:56.91ms
+step:1461/1490 train_time:83175ms step_avg:56.93ms
+step:1462/1490 train_time:83261ms step_avg:56.95ms
+step:1463/1490 train_time:83342ms step_avg:56.97ms
+step:1464/1490 train_time:83427ms step_avg:56.99ms
+step:1465/1490 train_time:83506ms step_avg:57.00ms
+step:1466/1490 train_time:83591ms step_avg:57.02ms
+step:1467/1490 train_time:83669ms step_avg:57.03ms
+step:1468/1490 train_time:83754ms step_avg:57.05ms
+step:1469/1490 train_time:83834ms step_avg:57.07ms
+step:1470/1490 train_time:83919ms step_avg:57.09ms
+step:1471/1490 train_time:83999ms step_avg:57.10ms
+step:1472/1490 train_time:84084ms step_avg:57.12ms
+step:1473/1490 train_time:84165ms step_avg:57.14ms
+step:1474/1490 train_time:84251ms step_avg:57.16ms
+step:1475/1490 train_time:84329ms step_avg:57.17ms
+step:1476/1490 train_time:84416ms step_avg:57.19ms
+step:1477/1490 train_time:84495ms step_avg:57.21ms
+step:1478/1490 train_time:84581ms step_avg:57.23ms
+step:1479/1490 train_time:84662ms step_avg:57.24ms
+step:1480/1490 train_time:84748ms step_avg:57.26ms
+step:1481/1490 train_time:84828ms step_avg:57.28ms
+step:1482/1490 train_time:84914ms step_avg:57.30ms
+step:1483/1490 train_time:84992ms step_avg:57.31ms
+step:1484/1490 train_time:85078ms step_avg:57.33ms
+step:1485/1490 train_time:85159ms step_avg:57.35ms
+step:1486/1490 train_time:85245ms step_avg:57.37ms
+step:1487/1490 train_time:85326ms step_avg:57.38ms
+step:1488/1490 train_time:85411ms step_avg:57.40ms
+step:1489/1490 train_time:85490ms step_avg:57.41ms
+step:1490/1490 train_time:85575ms step_avg:57.43ms
+step:1490/1490 val_loss:3.2781 train_time:85678ms step_avg:57.50ms
+peak memory allocated: 31296 MiB reserved: 47022 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/b2bf2a70-f6d4-46c7-82b2-7fa6265757c8.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/b2bf2a70-f6d4-46c7-82b2-7fa6265757c8.txt
@@ -1,0 +1,4449 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 00:17:58 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   32C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   35C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   31C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8329 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:81ms step_avg:80.57ms
+step:2/1490 train_time:109ms step_avg:54.58ms
+step:3/1490 train_time:131ms step_avg:43.56ms
+step:4/1490 train_time:153ms step_avg:38.34ms
+step:5/1490 train_time:174ms step_avg:34.71ms
+step:6/1490 train_time:208ms step_avg:34.69ms
+step:7/1490 train_time:235ms step_avg:33.60ms
+step:8/1490 train_time:270ms step_avg:33.73ms
+step:9/1490 train_time:297ms step_avg:33.01ms
+step:10/1490 train_time:332ms step_avg:33.22ms
+step:11/1490 train_time:360ms step_avg:32.69ms
+step:12/1490 train_time:396ms step_avg:32.97ms
+step:13/1490 train_time:422ms step_avg:32.46ms
+step:14/1490 train_time:457ms step_avg:32.64ms
+step:15/1490 train_time:484ms step_avg:32.28ms
+step:16/1490 train_time:519ms step_avg:32.42ms
+step:17/1490 train_time:547ms step_avg:32.15ms
+step:18/1490 train_time:581ms step_avg:32.28ms
+step:19/1490 train_time:608ms step_avg:32.03ms
+step:20/1490 train_time:643ms step_avg:32.15ms
+step:21/1490 train_time:671ms step_avg:31.96ms
+step:22/1490 train_time:706ms step_avg:32.08ms
+step:23/1490 train_time:733ms step_avg:31.88ms
+step:24/1490 train_time:768ms step_avg:31.99ms
+step:25/1490 train_time:795ms step_avg:31.82ms
+step:26/1490 train_time:830ms step_avg:31.92ms
+step:27/1490 train_time:858ms step_avg:31.76ms
+step:28/1490 train_time:893ms step_avg:31.88ms
+step:29/1490 train_time:920ms step_avg:31.72ms
+step:30/1490 train_time:955ms step_avg:31.85ms
+step:31/1490 train_time:984ms step_avg:31.76ms
+step:32/1490 train_time:1020ms step_avg:31.87ms
+step:33/1490 train_time:1048ms step_avg:31.77ms
+step:34/1490 train_time:1084ms step_avg:31.89ms
+step:35/1490 train_time:1112ms step_avg:31.78ms
+step:36/1490 train_time:1147ms step_avg:31.86ms
+step:37/1490 train_time:1175ms step_avg:31.75ms
+step:38/1490 train_time:1209ms step_avg:31.83ms
+step:39/1490 train_time:1238ms step_avg:31.74ms
+step:40/1490 train_time:1273ms step_avg:31.82ms
+step:41/1490 train_time:1301ms step_avg:31.73ms
+step:42/1490 train_time:1337ms step_avg:31.84ms
+step:43/1490 train_time:1364ms step_avg:31.71ms
+step:44/1490 train_time:1399ms step_avg:31.79ms
+step:45/1490 train_time:1427ms step_avg:31.70ms
+step:46/1490 train_time:1461ms step_avg:31.76ms
+step:47/1490 train_time:1492ms step_avg:31.75ms
+step:48/1490 train_time:1523ms step_avg:31.74ms
+step:49/1490 train_time:1551ms step_avg:31.65ms
+step:50/1490 train_time:1585ms step_avg:31.71ms
+step:51/1490 train_time:1613ms step_avg:31.63ms
+step:52/1490 train_time:1648ms step_avg:31.69ms
+step:53/1490 train_time:1675ms step_avg:31.61ms
+step:54/1490 train_time:1710ms step_avg:31.66ms
+step:55/1490 train_time:1738ms step_avg:31.60ms
+step:56/1490 train_time:1774ms step_avg:31.68ms
+step:57/1490 train_time:1801ms step_avg:31.59ms
+step:58/1490 train_time:1835ms step_avg:31.64ms
+step:59/1490 train_time:1863ms step_avg:31.58ms
+step:60/1490 train_time:1898ms step_avg:31.63ms
+step:61/1490 train_time:1925ms step_avg:31.56ms
+step:62/1490 train_time:1962ms step_avg:31.65ms
+step:63/1490 train_time:1988ms step_avg:31.56ms
+step:64/1490 train_time:2023ms step_avg:31.61ms
+step:65/1490 train_time:2051ms step_avg:31.56ms
+step:66/1490 train_time:2086ms step_avg:31.60ms
+step:67/1490 train_time:2114ms step_avg:31.55ms
+step:68/1490 train_time:2149ms step_avg:31.61ms
+step:69/1490 train_time:2177ms step_avg:31.55ms
+step:70/1490 train_time:2212ms step_avg:31.60ms
+step:71/1490 train_time:2240ms step_avg:31.54ms
+step:72/1490 train_time:2275ms step_avg:31.60ms
+step:73/1490 train_time:2303ms step_avg:31.54ms
+step:74/1490 train_time:2337ms step_avg:31.59ms
+step:75/1490 train_time:2365ms step_avg:31.54ms
+step:76/1490 train_time:2400ms step_avg:31.57ms
+step:77/1490 train_time:2428ms step_avg:31.53ms
+step:78/1490 train_time:2463ms step_avg:31.58ms
+step:79/1490 train_time:2491ms step_avg:31.53ms
+step:80/1490 train_time:2524ms step_avg:31.56ms
+step:81/1490 train_time:2552ms step_avg:31.51ms
+step:82/1490 train_time:2587ms step_avg:31.54ms
+step:83/1490 train_time:2614ms step_avg:31.50ms
+step:84/1490 train_time:2649ms step_avg:31.53ms
+step:85/1490 train_time:2677ms step_avg:31.49ms
+step:86/1490 train_time:2712ms step_avg:31.53ms
+step:87/1490 train_time:2739ms step_avg:31.49ms
+step:88/1490 train_time:2775ms step_avg:31.53ms
+step:89/1490 train_time:2803ms step_avg:31.49ms
+step:90/1490 train_time:2837ms step_avg:31.53ms
+step:91/1490 train_time:2865ms step_avg:31.48ms
+step:92/1490 train_time:2900ms step_avg:31.52ms
+step:93/1490 train_time:2928ms step_avg:31.48ms
+step:94/1490 train_time:2962ms step_avg:31.51ms
+step:95/1490 train_time:2990ms step_avg:31.47ms
+step:96/1490 train_time:3024ms step_avg:31.50ms
+step:97/1490 train_time:3052ms step_avg:31.47ms
+step:98/1490 train_time:3087ms step_avg:31.50ms
+step:99/1490 train_time:3115ms step_avg:31.46ms
+step:100/1490 train_time:3149ms step_avg:31.49ms
+step:101/1490 train_time:3177ms step_avg:31.45ms
+step:102/1490 train_time:3212ms step_avg:31.49ms
+step:103/1490 train_time:3240ms step_avg:31.46ms
+step:104/1490 train_time:3275ms step_avg:31.49ms
+step:105/1490 train_time:3303ms step_avg:31.46ms
+step:106/1490 train_time:3338ms step_avg:31.49ms
+step:107/1490 train_time:3366ms step_avg:31.46ms
+step:108/1490 train_time:3401ms step_avg:31.49ms
+step:109/1490 train_time:3429ms step_avg:31.46ms
+step:110/1490 train_time:3463ms step_avg:31.48ms
+step:111/1490 train_time:3491ms step_avg:31.45ms
+step:112/1490 train_time:3526ms step_avg:31.48ms
+step:113/1490 train_time:3553ms step_avg:31.44ms
+step:114/1490 train_time:3591ms step_avg:31.50ms
+step:115/1490 train_time:3616ms step_avg:31.44ms
+step:116/1490 train_time:3650ms step_avg:31.47ms
+step:117/1490 train_time:3678ms step_avg:31.44ms
+step:118/1490 train_time:3713ms step_avg:31.47ms
+step:119/1490 train_time:3741ms step_avg:31.44ms
+step:120/1490 train_time:3776ms step_avg:31.47ms
+step:121/1490 train_time:3804ms step_avg:31.44ms
+step:122/1490 train_time:3838ms step_avg:31.46ms
+step:123/1490 train_time:3866ms step_avg:31.43ms
+step:124/1490 train_time:3901ms step_avg:31.46ms
+step:125/1490 train_time:3929ms step_avg:31.43ms
+step:126/1490 train_time:3963ms step_avg:31.45ms
+step:127/1490 train_time:3991ms step_avg:31.42ms
+step:128/1490 train_time:4025ms step_avg:31.45ms
+step:129/1490 train_time:4053ms step_avg:31.42ms
+step:130/1490 train_time:4088ms step_avg:31.44ms
+step:131/1490 train_time:4115ms step_avg:31.41ms
+step:132/1490 train_time:4150ms step_avg:31.44ms
+step:133/1490 train_time:4178ms step_avg:31.41ms
+step:134/1490 train_time:4213ms step_avg:31.44ms
+step:135/1490 train_time:4240ms step_avg:31.41ms
+step:136/1490 train_time:4276ms step_avg:31.44ms
+step:137/1490 train_time:4305ms step_avg:31.43ms
+step:138/1490 train_time:4338ms step_avg:31.44ms
+step:139/1490 train_time:4367ms step_avg:31.42ms
+step:140/1490 train_time:4402ms step_avg:31.44ms
+step:141/1490 train_time:4429ms step_avg:31.41ms
+step:142/1490 train_time:4464ms step_avg:31.43ms
+step:143/1490 train_time:4492ms step_avg:31.41ms
+step:144/1490 train_time:4526ms step_avg:31.43ms
+step:145/1490 train_time:4554ms step_avg:31.41ms
+step:146/1490 train_time:4588ms step_avg:31.43ms
+step:147/1490 train_time:4616ms step_avg:31.40ms
+step:148/1490 train_time:4650ms step_avg:31.42ms
+step:149/1490 train_time:4678ms step_avg:31.40ms
+step:150/1490 train_time:4714ms step_avg:31.42ms
+step:151/1490 train_time:4741ms step_avg:31.40ms
+step:152/1490 train_time:4777ms step_avg:31.42ms
+step:153/1490 train_time:4804ms step_avg:31.40ms
+step:154/1490 train_time:4839ms step_avg:31.42ms
+step:155/1490 train_time:4867ms step_avg:31.40ms
+step:156/1490 train_time:4902ms step_avg:31.42ms
+step:157/1490 train_time:4930ms step_avg:31.40ms
+step:158/1490 train_time:4964ms step_avg:31.42ms
+step:159/1490 train_time:4992ms step_avg:31.40ms
+step:160/1490 train_time:5026ms step_avg:31.41ms
+step:161/1490 train_time:5054ms step_avg:31.39ms
+step:162/1490 train_time:5089ms step_avg:31.41ms
+step:163/1490 train_time:5116ms step_avg:31.39ms
+step:164/1490 train_time:5152ms step_avg:31.41ms
+step:165/1490 train_time:5179ms step_avg:31.39ms
+step:166/1490 train_time:5213ms step_avg:31.41ms
+step:167/1490 train_time:5241ms step_avg:31.38ms
+step:168/1490 train_time:5276ms step_avg:31.41ms
+step:169/1490 train_time:5304ms step_avg:31.39ms
+step:170/1490 train_time:5339ms step_avg:31.40ms
+step:171/1490 train_time:5367ms step_avg:31.39ms
+step:172/1490 train_time:5402ms step_avg:31.41ms
+step:173/1490 train_time:5430ms step_avg:31.39ms
+step:174/1490 train_time:5464ms step_avg:31.40ms
+step:175/1490 train_time:5492ms step_avg:31.38ms
+step:176/1490 train_time:5526ms step_avg:31.40ms
+step:177/1490 train_time:5554ms step_avg:31.38ms
+step:178/1490 train_time:5589ms step_avg:31.40ms
+step:179/1490 train_time:5617ms step_avg:31.38ms
+step:180/1490 train_time:5652ms step_avg:31.40ms
+step:181/1490 train_time:5679ms step_avg:31.38ms
+step:182/1490 train_time:5714ms step_avg:31.39ms
+step:183/1490 train_time:5742ms step_avg:31.37ms
+step:184/1490 train_time:5777ms step_avg:31.40ms
+step:185/1490 train_time:5805ms step_avg:31.38ms
+step:186/1490 train_time:5839ms step_avg:31.39ms
+step:187/1490 train_time:5868ms step_avg:31.38ms
+step:188/1490 train_time:5902ms step_avg:31.39ms
+step:189/1490 train_time:5930ms step_avg:31.38ms
+step:190/1490 train_time:5964ms step_avg:31.39ms
+step:191/1490 train_time:5992ms step_avg:31.37ms
+step:192/1490 train_time:6027ms step_avg:31.39ms
+step:193/1490 train_time:6055ms step_avg:31.37ms
+step:194/1490 train_time:6093ms step_avg:31.41ms
+step:195/1490 train_time:6117ms step_avg:31.37ms
+step:196/1490 train_time:6152ms step_avg:31.39ms
+step:197/1490 train_time:6180ms step_avg:31.37ms
+step:198/1490 train_time:6214ms step_avg:31.39ms
+step:199/1490 train_time:6242ms step_avg:31.37ms
+step:200/1490 train_time:6277ms step_avg:31.38ms
+step:201/1490 train_time:6305ms step_avg:31.37ms
+step:202/1490 train_time:6340ms step_avg:31.39ms
+step:203/1490 train_time:6367ms step_avg:31.37ms
+step:204/1490 train_time:6402ms step_avg:31.38ms
+step:205/1490 train_time:6430ms step_avg:31.36ms
+step:206/1490 train_time:6465ms step_avg:31.39ms
+step:207/1490 train_time:6492ms step_avg:31.36ms
+step:208/1490 train_time:6526ms step_avg:31.38ms
+step:209/1490 train_time:6554ms step_avg:31.36ms
+step:210/1490 train_time:6589ms step_avg:31.38ms
+step:211/1490 train_time:6618ms step_avg:31.37ms
+step:212/1490 train_time:6651ms step_avg:31.37ms
+step:213/1490 train_time:6679ms step_avg:31.36ms
+step:214/1490 train_time:6714ms step_avg:31.37ms
+step:215/1490 train_time:6741ms step_avg:31.36ms
+step:216/1490 train_time:6778ms step_avg:31.38ms
+step:217/1490 train_time:6804ms step_avg:31.35ms
+step:218/1490 train_time:6839ms step_avg:31.37ms
+step:219/1490 train_time:6870ms step_avg:31.37ms
+step:220/1490 train_time:6905ms step_avg:31.39ms
+step:221/1490 train_time:6929ms step_avg:31.35ms
+step:222/1490 train_time:6963ms step_avg:31.37ms
+step:223/1490 train_time:6991ms step_avg:31.35ms
+step:224/1490 train_time:7026ms step_avg:31.37ms
+step:225/1490 train_time:7054ms step_avg:31.35ms
+step:226/1490 train_time:7088ms step_avg:31.36ms
+step:227/1490 train_time:7116ms step_avg:31.35ms
+step:228/1490 train_time:7151ms step_avg:31.36ms
+step:229/1490 train_time:7179ms step_avg:31.35ms
+step:230/1490 train_time:7213ms step_avg:31.36ms
+step:231/1490 train_time:7241ms step_avg:31.34ms
+step:232/1490 train_time:7276ms step_avg:31.36ms
+step:233/1490 train_time:7303ms step_avg:31.34ms
+step:234/1490 train_time:7338ms step_avg:31.36ms
+step:235/1490 train_time:7366ms step_avg:31.34ms
+step:236/1490 train_time:7400ms step_avg:31.36ms
+step:237/1490 train_time:7428ms step_avg:31.34ms
+step:238/1490 train_time:7463ms step_avg:31.36ms
+step:239/1490 train_time:7491ms step_avg:31.34ms
+step:240/1490 train_time:7526ms step_avg:31.36ms
+step:241/1490 train_time:7553ms step_avg:31.34ms
+step:242/1490 train_time:7588ms step_avg:31.35ms
+step:243/1490 train_time:7615ms step_avg:31.34ms
+step:244/1490 train_time:7650ms step_avg:31.35ms
+step:245/1490 train_time:7677ms step_avg:31.34ms
+step:246/1490 train_time:7712ms step_avg:31.35ms
+step:247/1490 train_time:7740ms step_avg:31.33ms
+step:248/1490 train_time:7774ms step_avg:31.35ms
+step:249/1490 train_time:7802ms step_avg:31.33ms
+step:250/1490 train_time:7841ms step_avg:31.36ms
+step:250/1490 val_loss:4.4998 train_time:7878ms step_avg:31.51ms
+step:251/1490 train_time:7905ms step_avg:31.49ms
+step:252/1490 train_time:7927ms step_avg:31.46ms
+step:253/1490 train_time:7943ms step_avg:31.40ms
+step:254/1490 train_time:7966ms step_avg:31.36ms
+step:255/1490 train_time:7995ms step_avg:31.35ms
+step:256/1490 train_time:8031ms step_avg:31.37ms
+step:257/1490 train_time:8059ms step_avg:31.36ms
+step:258/1490 train_time:8096ms step_avg:31.38ms
+step:259/1490 train_time:8121ms step_avg:31.36ms
+step:260/1490 train_time:8156ms step_avg:31.37ms
+step:261/1490 train_time:8184ms step_avg:31.36ms
+step:262/1490 train_time:8219ms step_avg:31.37ms
+step:263/1490 train_time:8246ms step_avg:31.35ms
+step:264/1490 train_time:8283ms step_avg:31.37ms
+step:265/1490 train_time:8308ms step_avg:31.35ms
+step:266/1490 train_time:8342ms step_avg:31.36ms
+step:267/1490 train_time:8370ms step_avg:31.35ms
+step:268/1490 train_time:8404ms step_avg:31.36ms
+step:269/1490 train_time:8432ms step_avg:31.35ms
+step:270/1490 train_time:8466ms step_avg:31.36ms
+step:271/1490 train_time:8494ms step_avg:31.34ms
+step:272/1490 train_time:8528ms step_avg:31.35ms
+step:273/1490 train_time:8556ms step_avg:31.34ms
+step:274/1490 train_time:8590ms step_avg:31.35ms
+step:275/1490 train_time:8617ms step_avg:31.34ms
+step:276/1490 train_time:8652ms step_avg:31.35ms
+step:277/1490 train_time:8679ms step_avg:31.33ms
+step:278/1490 train_time:8713ms step_avg:31.34ms
+step:279/1490 train_time:8741ms step_avg:31.33ms
+step:280/1490 train_time:8776ms step_avg:31.34ms
+step:281/1490 train_time:8803ms step_avg:31.33ms
+step:282/1490 train_time:8837ms step_avg:31.34ms
+step:283/1490 train_time:8866ms step_avg:31.33ms
+step:284/1490 train_time:8900ms step_avg:31.34ms
+step:285/1490 train_time:8929ms step_avg:31.33ms
+step:286/1490 train_time:8963ms step_avg:31.34ms
+step:287/1490 train_time:8992ms step_avg:31.33ms
+step:288/1490 train_time:9026ms step_avg:31.34ms
+step:289/1490 train_time:9054ms step_avg:31.33ms
+step:290/1490 train_time:9089ms step_avg:31.34ms
+step:291/1490 train_time:9117ms step_avg:31.33ms
+step:292/1490 train_time:9152ms step_avg:31.34ms
+step:293/1490 train_time:9180ms step_avg:31.33ms
+step:294/1490 train_time:9214ms step_avg:31.34ms
+step:295/1490 train_time:9242ms step_avg:31.33ms
+step:296/1490 train_time:9276ms step_avg:31.34ms
+step:297/1490 train_time:9304ms step_avg:31.33ms
+step:298/1490 train_time:9339ms step_avg:31.34ms
+step:299/1490 train_time:9366ms step_avg:31.33ms
+step:300/1490 train_time:9401ms step_avg:31.34ms
+step:301/1490 train_time:9429ms step_avg:31.33ms
+step:302/1490 train_time:9463ms step_avg:31.33ms
+step:303/1490 train_time:9491ms step_avg:31.32ms
+step:304/1490 train_time:9525ms step_avg:31.33ms
+step:305/1490 train_time:9553ms step_avg:31.32ms
+step:306/1490 train_time:9588ms step_avg:31.33ms
+step:307/1490 train_time:9615ms step_avg:31.32ms
+step:308/1490 train_time:9649ms step_avg:31.33ms
+step:309/1490 train_time:9677ms step_avg:31.32ms
+step:310/1490 train_time:9712ms step_avg:31.33ms
+step:311/1490 train_time:9739ms step_avg:31.32ms
+step:312/1490 train_time:9775ms step_avg:31.33ms
+step:313/1490 train_time:9801ms step_avg:31.31ms
+step:314/1490 train_time:9836ms step_avg:31.32ms
+step:315/1490 train_time:9864ms step_avg:31.31ms
+step:316/1490 train_time:9898ms step_avg:31.32ms
+step:317/1490 train_time:9926ms step_avg:31.31ms
+step:318/1490 train_time:9961ms step_avg:31.32ms
+step:319/1490 train_time:9988ms step_avg:31.31ms
+step:320/1490 train_time:10023ms step_avg:31.32ms
+step:321/1490 train_time:10051ms step_avg:31.31ms
+step:322/1490 train_time:10086ms step_avg:31.32ms
+step:323/1490 train_time:10113ms step_avg:31.31ms
+step:324/1490 train_time:10149ms step_avg:31.32ms
+step:325/1490 train_time:10176ms step_avg:31.31ms
+step:326/1490 train_time:10211ms step_avg:31.32ms
+step:327/1490 train_time:10239ms step_avg:31.31ms
+step:328/1490 train_time:10274ms step_avg:31.32ms
+step:329/1490 train_time:10302ms step_avg:31.31ms
+step:330/1490 train_time:10339ms step_avg:31.33ms
+step:331/1490 train_time:10365ms step_avg:31.31ms
+step:332/1490 train_time:10399ms step_avg:31.32ms
+step:333/1490 train_time:10427ms step_avg:31.31ms
+step:334/1490 train_time:10461ms step_avg:31.32ms
+step:335/1490 train_time:10489ms step_avg:31.31ms
+step:336/1490 train_time:10526ms step_avg:31.33ms
+step:337/1490 train_time:10552ms step_avg:31.31ms
+step:338/1490 train_time:10586ms step_avg:31.32ms
+step:339/1490 train_time:10614ms step_avg:31.31ms
+step:340/1490 train_time:10649ms step_avg:31.32ms
+step:341/1490 train_time:10677ms step_avg:31.31ms
+step:342/1490 train_time:10712ms step_avg:31.32ms
+step:343/1490 train_time:10739ms step_avg:31.31ms
+step:344/1490 train_time:10774ms step_avg:31.32ms
+step:345/1490 train_time:10801ms step_avg:31.31ms
+step:346/1490 train_time:10836ms step_avg:31.32ms
+step:347/1490 train_time:10864ms step_avg:31.31ms
+step:348/1490 train_time:10906ms step_avg:31.34ms
+step:349/1490 train_time:10926ms step_avg:31.31ms
+step:350/1490 train_time:10960ms step_avg:31.31ms
+step:351/1490 train_time:10988ms step_avg:31.30ms
+step:352/1490 train_time:11022ms step_avg:31.31ms
+step:353/1490 train_time:11050ms step_avg:31.30ms
+step:354/1490 train_time:11085ms step_avg:31.31ms
+step:355/1490 train_time:11113ms step_avg:31.30ms
+step:356/1490 train_time:11147ms step_avg:31.31ms
+step:357/1490 train_time:11175ms step_avg:31.30ms
+step:358/1490 train_time:11210ms step_avg:31.31ms
+step:359/1490 train_time:11238ms step_avg:31.30ms
+step:360/1490 train_time:11273ms step_avg:31.31ms
+step:361/1490 train_time:11301ms step_avg:31.30ms
+step:362/1490 train_time:11335ms step_avg:31.31ms
+step:363/1490 train_time:11363ms step_avg:31.30ms
+step:364/1490 train_time:11397ms step_avg:31.31ms
+step:365/1490 train_time:11426ms step_avg:31.30ms
+step:366/1490 train_time:11460ms step_avg:31.31ms
+step:367/1490 train_time:11488ms step_avg:31.30ms
+step:368/1490 train_time:11523ms step_avg:31.31ms
+step:369/1490 train_time:11551ms step_avg:31.30ms
+step:370/1490 train_time:11585ms step_avg:31.31ms
+step:371/1490 train_time:11613ms step_avg:31.30ms
+step:372/1490 train_time:11648ms step_avg:31.31ms
+step:373/1490 train_time:11676ms step_avg:31.30ms
+step:374/1490 train_time:11710ms step_avg:31.31ms
+step:375/1490 train_time:11738ms step_avg:31.30ms
+step:376/1490 train_time:11774ms step_avg:31.31ms
+step:377/1490 train_time:11800ms step_avg:31.30ms
+step:378/1490 train_time:11835ms step_avg:31.31ms
+step:379/1490 train_time:11863ms step_avg:31.30ms
+step:380/1490 train_time:11897ms step_avg:31.31ms
+step:381/1490 train_time:11924ms step_avg:31.30ms
+step:382/1490 train_time:11959ms step_avg:31.31ms
+step:383/1490 train_time:11989ms step_avg:31.30ms
+step:384/1490 train_time:12022ms step_avg:31.31ms
+step:385/1490 train_time:12050ms step_avg:31.30ms
+step:386/1490 train_time:12084ms step_avg:31.31ms
+step:387/1490 train_time:12112ms step_avg:31.30ms
+step:388/1490 train_time:12146ms step_avg:31.31ms
+step:389/1490 train_time:12174ms step_avg:31.30ms
+step:390/1490 train_time:12209ms step_avg:31.31ms
+step:391/1490 train_time:12237ms step_avg:31.30ms
+step:392/1490 train_time:12272ms step_avg:31.31ms
+step:393/1490 train_time:12299ms step_avg:31.30ms
+step:394/1490 train_time:12334ms step_avg:31.30ms
+step:395/1490 train_time:12362ms step_avg:31.30ms
+step:396/1490 train_time:12397ms step_avg:31.30ms
+step:397/1490 train_time:12424ms step_avg:31.29ms
+step:398/1490 train_time:12459ms step_avg:31.30ms
+step:399/1490 train_time:12486ms step_avg:31.29ms
+step:400/1490 train_time:12521ms step_avg:31.30ms
+step:401/1490 train_time:12548ms step_avg:31.29ms
+step:402/1490 train_time:12583ms step_avg:31.30ms
+step:403/1490 train_time:12615ms step_avg:31.30ms
+step:404/1490 train_time:12646ms step_avg:31.30ms
+step:405/1490 train_time:12673ms step_avg:31.29ms
+step:406/1490 train_time:12708ms step_avg:31.30ms
+step:407/1490 train_time:12736ms step_avg:31.29ms
+step:408/1490 train_time:12771ms step_avg:31.30ms
+step:409/1490 train_time:12798ms step_avg:31.29ms
+step:410/1490 train_time:12834ms step_avg:31.30ms
+step:411/1490 train_time:12861ms step_avg:31.29ms
+step:412/1490 train_time:12896ms step_avg:31.30ms
+step:413/1490 train_time:12924ms step_avg:31.29ms
+step:414/1490 train_time:12958ms step_avg:31.30ms
+step:415/1490 train_time:12986ms step_avg:31.29ms
+step:416/1490 train_time:13021ms step_avg:31.30ms
+step:417/1490 train_time:13048ms step_avg:31.29ms
+step:418/1490 train_time:13083ms step_avg:31.30ms
+step:419/1490 train_time:13111ms step_avg:31.29ms
+step:420/1490 train_time:13146ms step_avg:31.30ms
+step:421/1490 train_time:13174ms step_avg:31.29ms
+step:422/1490 train_time:13208ms step_avg:31.30ms
+step:423/1490 train_time:13236ms step_avg:31.29ms
+step:424/1490 train_time:13271ms step_avg:31.30ms
+step:425/1490 train_time:13299ms step_avg:31.29ms
+step:426/1490 train_time:13335ms step_avg:31.30ms
+step:427/1490 train_time:13361ms step_avg:31.29ms
+step:428/1490 train_time:13396ms step_avg:31.30ms
+step:429/1490 train_time:13424ms step_avg:31.29ms
+step:430/1490 train_time:13458ms step_avg:31.30ms
+step:431/1490 train_time:13486ms step_avg:31.29ms
+step:432/1490 train_time:13521ms step_avg:31.30ms
+step:433/1490 train_time:13549ms step_avg:31.29ms
+step:434/1490 train_time:13583ms step_avg:31.30ms
+step:435/1490 train_time:13611ms step_avg:31.29ms
+step:436/1490 train_time:13645ms step_avg:31.30ms
+step:437/1490 train_time:13673ms step_avg:31.29ms
+step:438/1490 train_time:13708ms step_avg:31.30ms
+step:439/1490 train_time:13736ms step_avg:31.29ms
+step:440/1490 train_time:13771ms step_avg:31.30ms
+step:441/1490 train_time:13797ms step_avg:31.29ms
+step:442/1490 train_time:13833ms step_avg:31.30ms
+step:443/1490 train_time:13861ms step_avg:31.29ms
+step:444/1490 train_time:13895ms step_avg:31.29ms
+step:445/1490 train_time:13923ms step_avg:31.29ms
+step:446/1490 train_time:13957ms step_avg:31.29ms
+step:447/1490 train_time:13985ms step_avg:31.29ms
+step:448/1490 train_time:14019ms step_avg:31.29ms
+step:449/1490 train_time:14049ms step_avg:31.29ms
+step:450/1490 train_time:14081ms step_avg:31.29ms
+step:451/1490 train_time:14109ms step_avg:31.28ms
+step:452/1490 train_time:14143ms step_avg:31.29ms
+step:453/1490 train_time:14171ms step_avg:31.28ms
+step:454/1490 train_time:14205ms step_avg:31.29ms
+step:455/1490 train_time:14233ms step_avg:31.28ms
+step:456/1490 train_time:14268ms step_avg:31.29ms
+step:457/1490 train_time:14295ms step_avg:31.28ms
+step:458/1490 train_time:14331ms step_avg:31.29ms
+step:459/1490 train_time:14359ms step_avg:31.28ms
+step:460/1490 train_time:14393ms step_avg:31.29ms
+step:461/1490 train_time:14421ms step_avg:31.28ms
+step:462/1490 train_time:14456ms step_avg:31.29ms
+step:463/1490 train_time:14484ms step_avg:31.28ms
+step:464/1490 train_time:14519ms step_avg:31.29ms
+step:465/1490 train_time:14546ms step_avg:31.28ms
+step:466/1490 train_time:14581ms step_avg:31.29ms
+step:467/1490 train_time:14608ms step_avg:31.28ms
+step:468/1490 train_time:14643ms step_avg:31.29ms
+step:469/1490 train_time:14670ms step_avg:31.28ms
+step:470/1490 train_time:14705ms step_avg:31.29ms
+step:471/1490 train_time:14733ms step_avg:31.28ms
+step:472/1490 train_time:14768ms step_avg:31.29ms
+step:473/1490 train_time:14795ms step_avg:31.28ms
+step:474/1490 train_time:14830ms step_avg:31.29ms
+step:475/1490 train_time:14857ms step_avg:31.28ms
+step:476/1490 train_time:14892ms step_avg:31.29ms
+step:477/1490 train_time:14921ms step_avg:31.28ms
+step:478/1490 train_time:14955ms step_avg:31.29ms
+step:479/1490 train_time:14982ms step_avg:31.28ms
+step:480/1490 train_time:15017ms step_avg:31.28ms
+step:481/1490 train_time:15045ms step_avg:31.28ms
+step:482/1490 train_time:15079ms step_avg:31.28ms
+step:483/1490 train_time:15107ms step_avg:31.28ms
+step:484/1490 train_time:15144ms step_avg:31.29ms
+step:485/1490 train_time:15195ms step_avg:31.33ms
+step:486/1490 train_time:15254ms step_avg:31.39ms
+step:487/1490 train_time:15307ms step_avg:31.43ms
+step:488/1490 train_time:15366ms step_avg:31.49ms
+step:489/1490 train_time:15420ms step_avg:31.53ms
+step:490/1490 train_time:15480ms step_avg:31.59ms
+step:491/1490 train_time:15534ms step_avg:31.64ms
+step:492/1490 train_time:15593ms step_avg:31.69ms
+step:493/1490 train_time:15648ms step_avg:31.74ms
+step:494/1490 train_time:15707ms step_avg:31.80ms
+step:495/1490 train_time:15761ms step_avg:31.84ms
+step:496/1490 train_time:15820ms step_avg:31.89ms
+step:497/1490 train_time:15874ms step_avg:31.94ms
+step:498/1490 train_time:15933ms step_avg:31.99ms
+step:499/1490 train_time:15988ms step_avg:32.04ms
+step:500/1490 train_time:16051ms step_avg:32.10ms
+step:500/1490 val_loss:4.2126 train_time:16120ms step_avg:32.24ms
+step:501/1490 train_time:16141ms step_avg:32.22ms
+step:502/1490 train_time:16164ms step_avg:32.20ms
+step:503/1490 train_time:16222ms step_avg:32.25ms
+step:504/1490 train_time:16285ms step_avg:32.31ms
+step:505/1490 train_time:16341ms step_avg:32.36ms
+step:506/1490 train_time:16399ms step_avg:32.41ms
+step:507/1490 train_time:16454ms step_avg:32.45ms
+step:508/1490 train_time:16514ms step_avg:32.51ms
+step:509/1490 train_time:16568ms step_avg:32.55ms
+step:510/1490 train_time:16627ms step_avg:32.60ms
+step:511/1490 train_time:16681ms step_avg:32.64ms
+step:512/1490 train_time:16740ms step_avg:32.69ms
+step:513/1490 train_time:16793ms step_avg:32.74ms
+step:514/1490 train_time:16851ms step_avg:32.78ms
+step:515/1490 train_time:16906ms step_avg:32.83ms
+step:516/1490 train_time:16965ms step_avg:32.88ms
+step:517/1490 train_time:17018ms step_avg:32.92ms
+step:518/1490 train_time:17077ms step_avg:32.97ms
+step:519/1490 train_time:17132ms step_avg:33.01ms
+step:520/1490 train_time:17193ms step_avg:33.06ms
+step:521/1490 train_time:17248ms step_avg:33.11ms
+step:522/1490 train_time:17308ms step_avg:33.16ms
+step:523/1490 train_time:17363ms step_avg:33.20ms
+step:524/1490 train_time:17422ms step_avg:33.25ms
+step:525/1490 train_time:17477ms step_avg:33.29ms
+step:526/1490 train_time:17535ms step_avg:33.34ms
+step:527/1490 train_time:17589ms step_avg:33.38ms
+step:528/1490 train_time:17648ms step_avg:33.42ms
+step:529/1490 train_time:17702ms step_avg:33.46ms
+step:530/1490 train_time:17760ms step_avg:33.51ms
+step:531/1490 train_time:17813ms step_avg:33.55ms
+step:532/1490 train_time:17875ms step_avg:33.60ms
+step:533/1490 train_time:17925ms step_avg:33.63ms
+step:534/1490 train_time:17984ms step_avg:33.68ms
+step:535/1490 train_time:18038ms step_avg:33.72ms
+step:536/1490 train_time:18098ms step_avg:33.76ms
+step:537/1490 train_time:18153ms step_avg:33.80ms
+step:538/1490 train_time:18213ms step_avg:33.85ms
+step:539/1490 train_time:18267ms step_avg:33.89ms
+step:540/1490 train_time:18327ms step_avg:33.94ms
+step:541/1490 train_time:18382ms step_avg:33.98ms
+step:542/1490 train_time:18441ms step_avg:34.02ms
+step:543/1490 train_time:18495ms step_avg:34.06ms
+step:544/1490 train_time:18555ms step_avg:34.11ms
+step:545/1490 train_time:18608ms step_avg:34.14ms
+step:546/1490 train_time:18668ms step_avg:34.19ms
+step:547/1490 train_time:18721ms step_avg:34.23ms
+step:548/1490 train_time:18780ms step_avg:34.27ms
+step:549/1490 train_time:18834ms step_avg:34.31ms
+step:550/1490 train_time:18893ms step_avg:34.35ms
+step:551/1490 train_time:18946ms step_avg:34.39ms
+step:552/1490 train_time:19007ms step_avg:34.43ms
+step:553/1490 train_time:19061ms step_avg:34.47ms
+step:554/1490 train_time:19120ms step_avg:34.51ms
+step:555/1490 train_time:19174ms step_avg:34.55ms
+step:556/1490 train_time:19234ms step_avg:34.59ms
+step:557/1490 train_time:19288ms step_avg:34.63ms
+step:558/1490 train_time:19348ms step_avg:34.67ms
+step:559/1490 train_time:19403ms step_avg:34.71ms
+step:560/1490 train_time:19462ms step_avg:34.75ms
+step:561/1490 train_time:19516ms step_avg:34.79ms
+step:562/1490 train_time:19577ms step_avg:34.83ms
+step:563/1490 train_time:19630ms step_avg:34.87ms
+step:564/1490 train_time:19690ms step_avg:34.91ms
+step:565/1490 train_time:19743ms step_avg:34.94ms
+step:566/1490 train_time:19801ms step_avg:34.98ms
+step:567/1490 train_time:19854ms step_avg:35.02ms
+step:568/1490 train_time:19913ms step_avg:35.06ms
+step:569/1490 train_time:19967ms step_avg:35.09ms
+step:570/1490 train_time:20028ms step_avg:35.14ms
+step:571/1490 train_time:20083ms step_avg:35.17ms
+step:572/1490 train_time:20142ms step_avg:35.21ms
+step:573/1490 train_time:20196ms step_avg:35.25ms
+step:574/1490 train_time:20256ms step_avg:35.29ms
+step:575/1490 train_time:20311ms step_avg:35.32ms
+step:576/1490 train_time:20371ms step_avg:35.37ms
+step:577/1490 train_time:20425ms step_avg:35.40ms
+step:578/1490 train_time:20485ms step_avg:35.44ms
+step:579/1490 train_time:20538ms step_avg:35.47ms
+step:580/1490 train_time:20598ms step_avg:35.51ms
+step:581/1490 train_time:20652ms step_avg:35.55ms
+step:582/1490 train_time:20711ms step_avg:35.59ms
+step:583/1490 train_time:20764ms step_avg:35.62ms
+step:584/1490 train_time:20823ms step_avg:35.66ms
+step:585/1490 train_time:20877ms step_avg:35.69ms
+step:586/1490 train_time:20935ms step_avg:35.73ms
+step:587/1490 train_time:20989ms step_avg:35.76ms
+step:588/1490 train_time:21049ms step_avg:35.80ms
+step:589/1490 train_time:21103ms step_avg:35.83ms
+step:590/1490 train_time:21162ms step_avg:35.87ms
+step:591/1490 train_time:21216ms step_avg:35.90ms
+step:592/1490 train_time:21276ms step_avg:35.94ms
+step:593/1490 train_time:21330ms step_avg:35.97ms
+step:594/1490 train_time:21390ms step_avg:36.01ms
+step:595/1490 train_time:21444ms step_avg:36.04ms
+step:596/1490 train_time:21503ms step_avg:36.08ms
+step:597/1490 train_time:21557ms step_avg:36.11ms
+step:598/1490 train_time:21616ms step_avg:36.15ms
+step:599/1490 train_time:21670ms step_avg:36.18ms
+step:600/1490 train_time:21729ms step_avg:36.22ms
+step:601/1490 train_time:21783ms step_avg:36.24ms
+step:602/1490 train_time:21841ms step_avg:36.28ms
+step:603/1490 train_time:21895ms step_avg:36.31ms
+step:604/1490 train_time:21955ms step_avg:36.35ms
+step:605/1490 train_time:22009ms step_avg:36.38ms
+step:606/1490 train_time:22069ms step_avg:36.42ms
+step:607/1490 train_time:22123ms step_avg:36.45ms
+step:608/1490 train_time:22182ms step_avg:36.48ms
+step:609/1490 train_time:22235ms step_avg:36.51ms
+step:610/1490 train_time:22295ms step_avg:36.55ms
+step:611/1490 train_time:22349ms step_avg:36.58ms
+step:612/1490 train_time:22409ms step_avg:36.62ms
+step:613/1490 train_time:22463ms step_avg:36.64ms
+step:614/1490 train_time:22523ms step_avg:36.68ms
+step:615/1490 train_time:22576ms step_avg:36.71ms
+step:616/1490 train_time:22635ms step_avg:36.75ms
+step:617/1490 train_time:22690ms step_avg:36.77ms
+step:618/1490 train_time:22748ms step_avg:36.81ms
+step:619/1490 train_time:22803ms step_avg:36.84ms
+step:620/1490 train_time:22862ms step_avg:36.87ms
+step:621/1490 train_time:22915ms step_avg:36.90ms
+step:622/1490 train_time:22975ms step_avg:36.94ms
+step:623/1490 train_time:23029ms step_avg:36.97ms
+step:624/1490 train_time:23089ms step_avg:37.00ms
+step:625/1490 train_time:23143ms step_avg:37.03ms
+step:626/1490 train_time:23202ms step_avg:37.06ms
+step:627/1490 train_time:23255ms step_avg:37.09ms
+step:628/1490 train_time:23314ms step_avg:37.12ms
+step:629/1490 train_time:23369ms step_avg:37.15ms
+step:630/1490 train_time:23428ms step_avg:37.19ms
+step:631/1490 train_time:23482ms step_avg:37.21ms
+step:632/1490 train_time:23542ms step_avg:37.25ms
+step:633/1490 train_time:23596ms step_avg:37.28ms
+step:634/1490 train_time:23656ms step_avg:37.31ms
+step:635/1490 train_time:23710ms step_avg:37.34ms
+step:636/1490 train_time:23769ms step_avg:37.37ms
+step:637/1490 train_time:23823ms step_avg:37.40ms
+step:638/1490 train_time:23883ms step_avg:37.43ms
+step:639/1490 train_time:23936ms step_avg:37.46ms
+step:640/1490 train_time:23994ms step_avg:37.49ms
+step:641/1490 train_time:24048ms step_avg:37.52ms
+step:642/1490 train_time:24108ms step_avg:37.55ms
+step:643/1490 train_time:24162ms step_avg:37.58ms
+step:644/1490 train_time:24221ms step_avg:37.61ms
+step:645/1490 train_time:24275ms step_avg:37.64ms
+step:646/1490 train_time:24335ms step_avg:37.67ms
+step:647/1490 train_time:24389ms step_avg:37.69ms
+step:648/1490 train_time:24449ms step_avg:37.73ms
+step:649/1490 train_time:24503ms step_avg:37.76ms
+step:650/1490 train_time:24563ms step_avg:37.79ms
+step:651/1490 train_time:24616ms step_avg:37.81ms
+step:652/1490 train_time:24676ms step_avg:37.85ms
+step:653/1490 train_time:24730ms step_avg:37.87ms
+step:654/1490 train_time:24791ms step_avg:37.91ms
+step:655/1490 train_time:24844ms step_avg:37.93ms
+step:656/1490 train_time:24903ms step_avg:37.96ms
+step:657/1490 train_time:24956ms step_avg:37.98ms
+step:658/1490 train_time:25016ms step_avg:38.02ms
+step:659/1490 train_time:25071ms step_avg:38.04ms
+step:660/1490 train_time:25130ms step_avg:38.08ms
+step:661/1490 train_time:25183ms step_avg:38.10ms
+step:662/1490 train_time:25243ms step_avg:38.13ms
+step:663/1490 train_time:25296ms step_avg:38.15ms
+step:664/1490 train_time:25356ms step_avg:38.19ms
+step:665/1490 train_time:25410ms step_avg:38.21ms
+step:666/1490 train_time:25470ms step_avg:38.24ms
+step:667/1490 train_time:25523ms step_avg:38.27ms
+step:668/1490 train_time:25584ms step_avg:38.30ms
+step:669/1490 train_time:25638ms step_avg:38.32ms
+step:670/1490 train_time:25697ms step_avg:38.35ms
+step:671/1490 train_time:25750ms step_avg:38.38ms
+step:672/1490 train_time:25810ms step_avg:38.41ms
+step:673/1490 train_time:25865ms step_avg:38.43ms
+step:674/1490 train_time:25924ms step_avg:38.46ms
+step:675/1490 train_time:25978ms step_avg:38.49ms
+step:676/1490 train_time:26036ms step_avg:38.52ms
+step:677/1490 train_time:26090ms step_avg:38.54ms
+step:678/1490 train_time:26150ms step_avg:38.57ms
+step:679/1490 train_time:26204ms step_avg:38.59ms
+step:680/1490 train_time:26262ms step_avg:38.62ms
+step:681/1490 train_time:26316ms step_avg:38.64ms
+step:682/1490 train_time:26376ms step_avg:38.68ms
+step:683/1490 train_time:26430ms step_avg:38.70ms
+step:684/1490 train_time:26490ms step_avg:38.73ms
+step:685/1490 train_time:26544ms step_avg:38.75ms
+step:686/1490 train_time:26603ms step_avg:38.78ms
+step:687/1490 train_time:26658ms step_avg:38.80ms
+step:688/1490 train_time:26717ms step_avg:38.83ms
+step:689/1490 train_time:26771ms step_avg:38.86ms
+step:690/1490 train_time:26830ms step_avg:38.88ms
+step:691/1490 train_time:26885ms step_avg:38.91ms
+step:692/1490 train_time:26944ms step_avg:38.94ms
+step:693/1490 train_time:26998ms step_avg:38.96ms
+step:694/1490 train_time:27057ms step_avg:38.99ms
+step:695/1490 train_time:27111ms step_avg:39.01ms
+step:696/1490 train_time:27171ms step_avg:39.04ms
+step:697/1490 train_time:27225ms step_avg:39.06ms
+step:698/1490 train_time:27284ms step_avg:39.09ms
+step:699/1490 train_time:27338ms step_avg:39.11ms
+step:700/1490 train_time:27398ms step_avg:39.14ms
+step:701/1490 train_time:27452ms step_avg:39.16ms
+step:702/1490 train_time:27511ms step_avg:39.19ms
+step:703/1490 train_time:27565ms step_avg:39.21ms
+step:704/1490 train_time:27624ms step_avg:39.24ms
+step:705/1490 train_time:27677ms step_avg:39.26ms
+step:706/1490 train_time:27736ms step_avg:39.29ms
+step:707/1490 train_time:27790ms step_avg:39.31ms
+step:708/1490 train_time:27851ms step_avg:39.34ms
+step:709/1490 train_time:27904ms step_avg:39.36ms
+step:710/1490 train_time:27964ms step_avg:39.39ms
+step:711/1490 train_time:28016ms step_avg:39.40ms
+step:712/1490 train_time:28076ms step_avg:39.43ms
+step:713/1490 train_time:28130ms step_avg:39.45ms
+step:714/1490 train_time:28190ms step_avg:39.48ms
+step:715/1490 train_time:28243ms step_avg:39.50ms
+step:716/1490 train_time:28301ms step_avg:39.53ms
+step:717/1490 train_time:28355ms step_avg:39.55ms
+step:718/1490 train_time:28416ms step_avg:39.58ms
+step:719/1490 train_time:28469ms step_avg:39.60ms
+step:720/1490 train_time:28529ms step_avg:39.62ms
+step:721/1490 train_time:28583ms step_avg:39.64ms
+step:722/1490 train_time:28642ms step_avg:39.67ms
+step:723/1490 train_time:28696ms step_avg:39.69ms
+step:724/1490 train_time:28756ms step_avg:39.72ms
+step:725/1490 train_time:28809ms step_avg:39.74ms
+step:726/1490 train_time:28869ms step_avg:39.76ms
+step:727/1490 train_time:28923ms step_avg:39.78ms
+step:728/1490 train_time:28982ms step_avg:39.81ms
+step:729/1490 train_time:29036ms step_avg:39.83ms
+step:730/1490 train_time:29095ms step_avg:39.86ms
+step:731/1490 train_time:29149ms step_avg:39.88ms
+step:732/1490 train_time:29209ms step_avg:39.90ms
+step:733/1490 train_time:29263ms step_avg:39.92ms
+step:734/1490 train_time:29322ms step_avg:39.95ms
+step:735/1490 train_time:29376ms step_avg:39.97ms
+step:736/1490 train_time:29435ms step_avg:39.99ms
+step:737/1490 train_time:29489ms step_avg:40.01ms
+step:738/1490 train_time:29549ms step_avg:40.04ms
+step:739/1490 train_time:29603ms step_avg:40.06ms
+step:740/1490 train_time:29662ms step_avg:40.08ms
+step:741/1490 train_time:29716ms step_avg:40.10ms
+step:742/1490 train_time:29776ms step_avg:40.13ms
+step:743/1490 train_time:29829ms step_avg:40.15ms
+step:744/1490 train_time:29889ms step_avg:40.17ms
+step:745/1490 train_time:29942ms step_avg:40.19ms
+step:746/1490 train_time:30002ms step_avg:40.22ms
+step:747/1490 train_time:30055ms step_avg:40.23ms
+step:748/1490 train_time:30115ms step_avg:40.26ms
+step:749/1490 train_time:30169ms step_avg:40.28ms
+step:750/1490 train_time:30229ms step_avg:40.31ms
+step:750/1490 val_loss:3.7970 train_time:30301ms step_avg:40.40ms
+step:751/1490 train_time:30325ms step_avg:40.38ms
+step:752/1490 train_time:30347ms step_avg:40.35ms
+step:753/1490 train_time:30405ms step_avg:40.38ms
+step:754/1490 train_time:30467ms step_avg:40.41ms
+step:755/1490 train_time:30522ms step_avg:40.43ms
+step:756/1490 train_time:30582ms step_avg:40.45ms
+step:757/1490 train_time:30635ms step_avg:40.47ms
+step:758/1490 train_time:30695ms step_avg:40.49ms
+step:759/1490 train_time:30748ms step_avg:40.51ms
+step:760/1490 train_time:30807ms step_avg:40.54ms
+step:761/1490 train_time:30860ms step_avg:40.55ms
+step:762/1490 train_time:30919ms step_avg:40.58ms
+step:763/1490 train_time:30971ms step_avg:40.59ms
+step:764/1490 train_time:31030ms step_avg:40.62ms
+step:765/1490 train_time:31084ms step_avg:40.63ms
+step:766/1490 train_time:31141ms step_avg:40.65ms
+step:767/1490 train_time:31194ms step_avg:40.67ms
+step:768/1490 train_time:31254ms step_avg:40.69ms
+step:769/1490 train_time:31309ms step_avg:40.71ms
+step:770/1490 train_time:31370ms step_avg:40.74ms
+step:771/1490 train_time:31427ms step_avg:40.76ms
+step:772/1490 train_time:31488ms step_avg:40.79ms
+step:773/1490 train_time:31543ms step_avg:40.81ms
+step:774/1490 train_time:31603ms step_avg:40.83ms
+step:775/1490 train_time:31656ms step_avg:40.85ms
+step:776/1490 train_time:31715ms step_avg:40.87ms
+step:777/1490 train_time:31769ms step_avg:40.89ms
+step:778/1490 train_time:31828ms step_avg:40.91ms
+step:779/1490 train_time:31881ms step_avg:40.93ms
+step:780/1490 train_time:31940ms step_avg:40.95ms
+step:781/1490 train_time:31993ms step_avg:40.96ms
+step:782/1490 train_time:32052ms step_avg:40.99ms
+step:783/1490 train_time:32105ms step_avg:41.00ms
+step:784/1490 train_time:32164ms step_avg:41.03ms
+step:785/1490 train_time:32217ms step_avg:41.04ms
+step:786/1490 train_time:32276ms step_avg:41.06ms
+step:787/1490 train_time:32330ms step_avg:41.08ms
+step:788/1490 train_time:32391ms step_avg:41.11ms
+step:789/1490 train_time:32445ms step_avg:41.12ms
+step:790/1490 train_time:32506ms step_avg:41.15ms
+step:791/1490 train_time:32559ms step_avg:41.16ms
+step:792/1490 train_time:32620ms step_avg:41.19ms
+step:793/1490 train_time:32673ms step_avg:41.20ms
+step:794/1490 train_time:32733ms step_avg:41.23ms
+step:795/1490 train_time:32786ms step_avg:41.24ms
+step:796/1490 train_time:32846ms step_avg:41.26ms
+step:797/1490 train_time:32901ms step_avg:41.28ms
+step:798/1490 train_time:32960ms step_avg:41.30ms
+step:799/1490 train_time:33013ms step_avg:41.32ms
+step:800/1490 train_time:33072ms step_avg:41.34ms
+step:801/1490 train_time:33126ms step_avg:41.36ms
+step:802/1490 train_time:33185ms step_avg:41.38ms
+step:803/1490 train_time:33237ms step_avg:41.39ms
+step:804/1490 train_time:33297ms step_avg:41.41ms
+step:805/1490 train_time:33353ms step_avg:41.43ms
+step:806/1490 train_time:33412ms step_avg:41.45ms
+step:807/1490 train_time:33467ms step_avg:41.47ms
+step:808/1490 train_time:33527ms step_avg:41.49ms
+step:809/1490 train_time:33581ms step_avg:41.51ms
+step:810/1490 train_time:33640ms step_avg:41.53ms
+step:811/1490 train_time:33695ms step_avg:41.55ms
+step:812/1490 train_time:33753ms step_avg:41.57ms
+step:813/1490 train_time:33808ms step_avg:41.58ms
+step:814/1490 train_time:33867ms step_avg:41.61ms
+step:815/1490 train_time:33921ms step_avg:41.62ms
+step:816/1490 train_time:33980ms step_avg:41.64ms
+step:817/1490 train_time:34033ms step_avg:41.66ms
+step:818/1490 train_time:34093ms step_avg:41.68ms
+step:819/1490 train_time:34146ms step_avg:41.69ms
+step:820/1490 train_time:34205ms step_avg:41.71ms
+step:821/1490 train_time:34259ms step_avg:41.73ms
+step:822/1490 train_time:34319ms step_avg:41.75ms
+step:823/1490 train_time:34373ms step_avg:41.77ms
+step:824/1490 train_time:34434ms step_avg:41.79ms
+step:825/1490 train_time:34488ms step_avg:41.80ms
+step:826/1490 train_time:34549ms step_avg:41.83ms
+step:827/1490 train_time:34604ms step_avg:41.84ms
+step:828/1490 train_time:34663ms step_avg:41.86ms
+step:829/1490 train_time:34717ms step_avg:41.88ms
+step:830/1490 train_time:34776ms step_avg:41.90ms
+step:831/1490 train_time:34829ms step_avg:41.91ms
+step:832/1490 train_time:34889ms step_avg:41.93ms
+step:833/1490 train_time:34943ms step_avg:41.95ms
+step:834/1490 train_time:35002ms step_avg:41.97ms
+step:835/1490 train_time:35055ms step_avg:41.98ms
+step:836/1490 train_time:35114ms step_avg:42.00ms
+step:837/1490 train_time:35168ms step_avg:42.02ms
+step:838/1490 train_time:35228ms step_avg:42.04ms
+step:839/1490 train_time:35281ms step_avg:42.05ms
+step:840/1490 train_time:35341ms step_avg:42.07ms
+step:841/1490 train_time:35395ms step_avg:42.09ms
+step:842/1490 train_time:35455ms step_avg:42.11ms
+step:843/1490 train_time:35509ms step_avg:42.12ms
+step:844/1490 train_time:35570ms step_avg:42.14ms
+step:845/1490 train_time:35624ms step_avg:42.16ms
+step:846/1490 train_time:35683ms step_avg:42.18ms
+step:847/1490 train_time:35736ms step_avg:42.19ms
+step:848/1490 train_time:35797ms step_avg:42.21ms
+step:849/1490 train_time:35851ms step_avg:42.23ms
+step:850/1490 train_time:35911ms step_avg:42.25ms
+step:851/1490 train_time:35964ms step_avg:42.26ms
+step:852/1490 train_time:36023ms step_avg:42.28ms
+step:853/1490 train_time:36077ms step_avg:42.29ms
+step:854/1490 train_time:36136ms step_avg:42.31ms
+step:855/1490 train_time:36190ms step_avg:42.33ms
+step:856/1490 train_time:36250ms step_avg:42.35ms
+step:857/1490 train_time:36303ms step_avg:42.36ms
+step:858/1490 train_time:36363ms step_avg:42.38ms
+step:859/1490 train_time:36416ms step_avg:42.39ms
+step:860/1490 train_time:36476ms step_avg:42.41ms
+step:861/1490 train_time:36531ms step_avg:42.43ms
+step:862/1490 train_time:36591ms step_avg:42.45ms
+step:863/1490 train_time:36645ms step_avg:42.46ms
+step:864/1490 train_time:36704ms step_avg:42.48ms
+step:865/1490 train_time:36758ms step_avg:42.49ms
+step:866/1490 train_time:36817ms step_avg:42.51ms
+step:867/1490 train_time:36871ms step_avg:42.53ms
+step:868/1490 train_time:36930ms step_avg:42.55ms
+step:869/1490 train_time:36984ms step_avg:42.56ms
+step:870/1490 train_time:37043ms step_avg:42.58ms
+step:871/1490 train_time:37098ms step_avg:42.59ms
+step:872/1490 train_time:37157ms step_avg:42.61ms
+step:873/1490 train_time:37211ms step_avg:42.62ms
+step:874/1490 train_time:37270ms step_avg:42.64ms
+step:875/1490 train_time:37324ms step_avg:42.66ms
+step:876/1490 train_time:37384ms step_avg:42.68ms
+step:877/1490 train_time:37437ms step_avg:42.69ms
+step:878/1490 train_time:37498ms step_avg:42.71ms
+step:879/1490 train_time:37551ms step_avg:42.72ms
+step:880/1490 train_time:37611ms step_avg:42.74ms
+step:881/1490 train_time:37665ms step_avg:42.75ms
+step:882/1490 train_time:37725ms step_avg:42.77ms
+step:883/1490 train_time:37779ms step_avg:42.79ms
+step:884/1490 train_time:37839ms step_avg:42.80ms
+step:885/1490 train_time:37893ms step_avg:42.82ms
+step:886/1490 train_time:37952ms step_avg:42.83ms
+step:887/1490 train_time:38006ms step_avg:42.85ms
+step:888/1490 train_time:38065ms step_avg:42.87ms
+step:889/1490 train_time:38118ms step_avg:42.88ms
+step:890/1490 train_time:38178ms step_avg:42.90ms
+step:891/1490 train_time:38232ms step_avg:42.91ms
+step:892/1490 train_time:38291ms step_avg:42.93ms
+step:893/1490 train_time:38345ms step_avg:42.94ms
+step:894/1490 train_time:38405ms step_avg:42.96ms
+step:895/1490 train_time:38458ms step_avg:42.97ms
+step:896/1490 train_time:38518ms step_avg:42.99ms
+step:897/1490 train_time:38572ms step_avg:43.00ms
+step:898/1490 train_time:38630ms step_avg:43.02ms
+step:899/1490 train_time:38684ms step_avg:43.03ms
+step:900/1490 train_time:38744ms step_avg:43.05ms
+step:901/1490 train_time:38798ms step_avg:43.06ms
+step:902/1490 train_time:38858ms step_avg:43.08ms
+step:903/1490 train_time:38911ms step_avg:43.09ms
+step:904/1490 train_time:38970ms step_avg:43.11ms
+step:905/1490 train_time:39024ms step_avg:43.12ms
+step:906/1490 train_time:39084ms step_avg:43.14ms
+step:907/1490 train_time:39138ms step_avg:43.15ms
+step:908/1490 train_time:39198ms step_avg:43.17ms
+step:909/1490 train_time:39252ms step_avg:43.18ms
+step:910/1490 train_time:39311ms step_avg:43.20ms
+step:911/1490 train_time:39364ms step_avg:43.21ms
+step:912/1490 train_time:39424ms step_avg:43.23ms
+step:913/1490 train_time:39477ms step_avg:43.24ms
+step:914/1490 train_time:39536ms step_avg:43.26ms
+step:915/1490 train_time:39590ms step_avg:43.27ms
+step:916/1490 train_time:39650ms step_avg:43.29ms
+step:917/1490 train_time:39704ms step_avg:43.30ms
+step:918/1490 train_time:39763ms step_avg:43.31ms
+step:919/1490 train_time:39817ms step_avg:43.33ms
+step:920/1490 train_time:39876ms step_avg:43.34ms
+step:921/1490 train_time:39930ms step_avg:43.35ms
+step:922/1490 train_time:39989ms step_avg:43.37ms
+step:923/1490 train_time:40043ms step_avg:43.38ms
+step:924/1490 train_time:40103ms step_avg:43.40ms
+step:925/1490 train_time:40156ms step_avg:43.41ms
+step:926/1490 train_time:40215ms step_avg:43.43ms
+step:927/1490 train_time:40269ms step_avg:43.44ms
+step:928/1490 train_time:40329ms step_avg:43.46ms
+step:929/1490 train_time:40383ms step_avg:43.47ms
+step:930/1490 train_time:40442ms step_avg:43.49ms
+step:931/1490 train_time:40496ms step_avg:43.50ms
+step:932/1490 train_time:40555ms step_avg:43.51ms
+step:933/1490 train_time:40609ms step_avg:43.52ms
+step:934/1490 train_time:40669ms step_avg:43.54ms
+step:935/1490 train_time:40723ms step_avg:43.55ms
+step:936/1490 train_time:40782ms step_avg:43.57ms
+step:937/1490 train_time:40835ms step_avg:43.58ms
+step:938/1490 train_time:40894ms step_avg:43.60ms
+step:939/1490 train_time:40948ms step_avg:43.61ms
+step:940/1490 train_time:41008ms step_avg:43.63ms
+step:941/1490 train_time:41062ms step_avg:43.64ms
+step:942/1490 train_time:41121ms step_avg:43.65ms
+step:943/1490 train_time:41175ms step_avg:43.66ms
+step:944/1490 train_time:41235ms step_avg:43.68ms
+step:945/1490 train_time:41289ms step_avg:43.69ms
+step:946/1490 train_time:41348ms step_avg:43.71ms
+step:947/1490 train_time:41401ms step_avg:43.72ms
+step:948/1490 train_time:41460ms step_avg:43.73ms
+step:949/1490 train_time:41514ms step_avg:43.74ms
+step:950/1490 train_time:41574ms step_avg:43.76ms
+step:951/1490 train_time:41628ms step_avg:43.77ms
+step:952/1490 train_time:41688ms step_avg:43.79ms
+step:953/1490 train_time:41741ms step_avg:43.80ms
+step:954/1490 train_time:41801ms step_avg:43.82ms
+step:955/1490 train_time:41855ms step_avg:43.83ms
+step:956/1490 train_time:41914ms step_avg:43.84ms
+step:957/1490 train_time:41967ms step_avg:43.85ms
+step:958/1490 train_time:42027ms step_avg:43.87ms
+step:959/1490 train_time:42080ms step_avg:43.88ms
+step:960/1490 train_time:42140ms step_avg:43.90ms
+step:961/1490 train_time:42194ms step_avg:43.91ms
+step:962/1490 train_time:42253ms step_avg:43.92ms
+step:963/1490 train_time:42306ms step_avg:43.93ms
+step:964/1490 train_time:42366ms step_avg:43.95ms
+step:965/1490 train_time:42419ms step_avg:43.96ms
+step:966/1490 train_time:42479ms step_avg:43.97ms
+step:967/1490 train_time:42532ms step_avg:43.98ms
+step:968/1490 train_time:42596ms step_avg:44.00ms
+step:969/1490 train_time:42674ms step_avg:44.04ms
+step:970/1490 train_time:42760ms step_avg:44.08ms
+step:971/1490 train_time:42839ms step_avg:44.12ms
+step:972/1490 train_time:42924ms step_avg:44.16ms
+step:973/1490 train_time:43003ms step_avg:44.20ms
+step:974/1490 train_time:43088ms step_avg:44.24ms
+step:975/1490 train_time:43168ms step_avg:44.27ms
+step:976/1490 train_time:43255ms step_avg:44.32ms
+step:977/1490 train_time:43335ms step_avg:44.35ms
+step:978/1490 train_time:43421ms step_avg:44.40ms
+step:979/1490 train_time:43500ms step_avg:44.43ms
+step:980/1490 train_time:43585ms step_avg:44.47ms
+step:981/1490 train_time:43666ms step_avg:44.51ms
+step:982/1490 train_time:43750ms step_avg:44.55ms
+step:983/1490 train_time:43829ms step_avg:44.59ms
+step:984/1490 train_time:43913ms step_avg:44.63ms
+step:985/1490 train_time:43993ms step_avg:44.66ms
+step:986/1490 train_time:44079ms step_avg:44.70ms
+step:987/1490 train_time:44157ms step_avg:44.74ms
+step:988/1490 train_time:44244ms step_avg:44.78ms
+step:989/1490 train_time:44323ms step_avg:44.82ms
+step:990/1490 train_time:44409ms step_avg:44.86ms
+step:991/1490 train_time:44490ms step_avg:44.89ms
+step:992/1490 train_time:44574ms step_avg:44.93ms
+step:993/1490 train_time:44654ms step_avg:44.97ms
+step:994/1490 train_time:44740ms step_avg:45.01ms
+step:995/1490 train_time:44819ms step_avg:45.04ms
+step:996/1490 train_time:44904ms step_avg:45.08ms
+step:997/1490 train_time:44984ms step_avg:45.12ms
+step:998/1490 train_time:45069ms step_avg:45.16ms
+step:999/1490 train_time:45149ms step_avg:45.19ms
+step:1000/1490 train_time:45233ms step_avg:45.23ms
+step:1000/1490 val_loss:3.5139 train_time:45337ms step_avg:45.34ms
+step:1001/1490 train_time:45364ms step_avg:45.32ms
+step:1002/1490 train_time:45405ms step_avg:45.31ms
+step:1003/1490 train_time:45489ms step_avg:45.35ms
+step:1004/1490 train_time:45576ms step_avg:45.39ms
+step:1005/1490 train_time:45656ms step_avg:45.43ms
+step:1006/1490 train_time:45741ms step_avg:45.47ms
+step:1007/1490 train_time:45820ms step_avg:45.50ms
+step:1008/1490 train_time:45903ms step_avg:45.54ms
+step:1009/1490 train_time:45981ms step_avg:45.57ms
+step:1010/1490 train_time:46065ms step_avg:45.61ms
+step:1011/1490 train_time:46143ms step_avg:45.64ms
+step:1012/1490 train_time:46226ms step_avg:45.68ms
+step:1013/1490 train_time:46305ms step_avg:45.71ms
+step:1014/1490 train_time:46391ms step_avg:45.75ms
+step:1015/1490 train_time:46474ms step_avg:45.79ms
+step:1016/1490 train_time:46560ms step_avg:45.83ms
+step:1017/1490 train_time:46641ms step_avg:45.86ms
+step:1018/1490 train_time:46726ms step_avg:45.90ms
+step:1019/1490 train_time:46804ms step_avg:45.93ms
+step:1020/1490 train_time:46889ms step_avg:45.97ms
+step:1021/1490 train_time:46969ms step_avg:46.00ms
+step:1022/1490 train_time:47053ms step_avg:46.04ms
+step:1023/1490 train_time:47132ms step_avg:46.07ms
+step:1024/1490 train_time:47216ms step_avg:46.11ms
+step:1025/1490 train_time:47295ms step_avg:46.14ms
+step:1026/1490 train_time:47381ms step_avg:46.18ms
+step:1027/1490 train_time:47461ms step_avg:46.21ms
+step:1028/1490 train_time:47547ms step_avg:46.25ms
+step:1029/1490 train_time:47627ms step_avg:46.29ms
+step:1030/1490 train_time:47713ms step_avg:46.32ms
+step:1031/1490 train_time:47794ms step_avg:46.36ms
+step:1032/1490 train_time:47878ms step_avg:46.39ms
+step:1033/1490 train_time:47956ms step_avg:46.42ms
+step:1034/1490 train_time:48040ms step_avg:46.46ms
+step:1035/1490 train_time:48119ms step_avg:46.49ms
+step:1036/1490 train_time:48203ms step_avg:46.53ms
+step:1037/1490 train_time:48283ms step_avg:46.56ms
+step:1038/1490 train_time:48368ms step_avg:46.60ms
+step:1039/1490 train_time:48448ms step_avg:46.63ms
+step:1040/1490 train_time:48535ms step_avg:46.67ms
+step:1041/1490 train_time:48615ms step_avg:46.70ms
+step:1042/1490 train_time:48700ms step_avg:46.74ms
+step:1043/1490 train_time:48779ms step_avg:46.77ms
+step:1044/1490 train_time:48866ms step_avg:46.81ms
+step:1045/1490 train_time:48944ms step_avg:46.84ms
+step:1046/1490 train_time:49029ms step_avg:46.87ms
+step:1047/1490 train_time:49107ms step_avg:46.90ms
+step:1048/1490 train_time:49192ms step_avg:46.94ms
+step:1049/1490 train_time:49272ms step_avg:46.97ms
+step:1050/1490 train_time:49357ms step_avg:47.01ms
+step:1051/1490 train_time:49437ms step_avg:47.04ms
+step:1052/1490 train_time:49524ms step_avg:47.08ms
+step:1053/1490 train_time:49603ms step_avg:47.11ms
+step:1054/1490 train_time:49687ms step_avg:47.14ms
+step:1055/1490 train_time:49767ms step_avg:47.17ms
+step:1056/1490 train_time:49853ms step_avg:47.21ms
+step:1057/1490 train_time:49933ms step_avg:47.24ms
+step:1058/1490 train_time:50018ms step_avg:47.28ms
+step:1059/1490 train_time:50097ms step_avg:47.31ms
+step:1060/1490 train_time:50180ms step_avg:47.34ms
+step:1061/1490 train_time:50260ms step_avg:47.37ms
+step:1062/1490 train_time:50346ms step_avg:47.41ms
+step:1063/1490 train_time:50425ms step_avg:47.44ms
+step:1064/1490 train_time:50510ms step_avg:47.47ms
+step:1065/1490 train_time:50589ms step_avg:47.50ms
+step:1066/1490 train_time:50674ms step_avg:47.54ms
+step:1067/1490 train_time:50755ms step_avg:47.57ms
+step:1068/1490 train_time:50840ms step_avg:47.60ms
+step:1069/1490 train_time:50920ms step_avg:47.63ms
+step:1070/1490 train_time:51005ms step_avg:47.67ms
+step:1071/1490 train_time:51084ms step_avg:47.70ms
+step:1072/1490 train_time:51169ms step_avg:47.73ms
+step:1073/1490 train_time:51247ms step_avg:47.76ms
+step:1074/1490 train_time:51333ms step_avg:47.80ms
+step:1075/1490 train_time:51414ms step_avg:47.83ms
+step:1076/1490 train_time:51499ms step_avg:47.86ms
+step:1077/1490 train_time:51577ms step_avg:47.89ms
+step:1078/1490 train_time:51662ms step_avg:47.92ms
+step:1079/1490 train_time:51742ms step_avg:47.95ms
+step:1080/1490 train_time:51827ms step_avg:47.99ms
+step:1081/1490 train_time:51905ms step_avg:48.02ms
+step:1082/1490 train_time:51990ms step_avg:48.05ms
+step:1083/1490 train_time:52069ms step_avg:48.08ms
+step:1084/1490 train_time:52154ms step_avg:48.11ms
+step:1085/1490 train_time:52234ms step_avg:48.14ms
+step:1086/1490 train_time:52320ms step_avg:48.18ms
+step:1087/1490 train_time:52399ms step_avg:48.21ms
+step:1088/1490 train_time:52483ms step_avg:48.24ms
+step:1089/1490 train_time:52563ms step_avg:48.27ms
+step:1090/1490 train_time:52648ms step_avg:48.30ms
+step:1091/1490 train_time:52729ms step_avg:48.33ms
+step:1092/1490 train_time:52815ms step_avg:48.37ms
+step:1093/1490 train_time:52894ms step_avg:48.39ms
+step:1094/1490 train_time:52978ms step_avg:48.43ms
+step:1095/1490 train_time:53058ms step_avg:48.45ms
+step:1096/1490 train_time:53144ms step_avg:48.49ms
+step:1097/1490 train_time:53223ms step_avg:48.52ms
+step:1098/1490 train_time:53308ms step_avg:48.55ms
+step:1099/1490 train_time:53386ms step_avg:48.58ms
+step:1100/1490 train_time:53472ms step_avg:48.61ms
+step:1101/1490 train_time:53553ms step_avg:48.64ms
+step:1102/1490 train_time:53640ms step_avg:48.67ms
+step:1103/1490 train_time:53719ms step_avg:48.70ms
+step:1104/1490 train_time:53804ms step_avg:48.74ms
+step:1105/1490 train_time:53883ms step_avg:48.76ms
+step:1106/1490 train_time:53967ms step_avg:48.79ms
+step:1107/1490 train_time:54047ms step_avg:48.82ms
+step:1108/1490 train_time:54132ms step_avg:48.86ms
+step:1109/1490 train_time:54214ms step_avg:48.89ms
+step:1110/1490 train_time:54298ms step_avg:48.92ms
+step:1111/1490 train_time:54377ms step_avg:48.94ms
+step:1112/1490 train_time:54462ms step_avg:48.98ms
+step:1113/1490 train_time:54542ms step_avg:49.00ms
+step:1114/1490 train_time:54627ms step_avg:49.04ms
+step:1115/1490 train_time:54706ms step_avg:49.06ms
+step:1116/1490 train_time:54791ms step_avg:49.10ms
+step:1117/1490 train_time:54872ms step_avg:49.12ms
+step:1118/1490 train_time:54957ms step_avg:49.16ms
+step:1119/1490 train_time:55036ms step_avg:49.18ms
+step:1120/1490 train_time:55121ms step_avg:49.22ms
+step:1121/1490 train_time:55201ms step_avg:49.24ms
+step:1122/1490 train_time:55286ms step_avg:49.27ms
+step:1123/1490 train_time:55366ms step_avg:49.30ms
+step:1124/1490 train_time:55450ms step_avg:49.33ms
+step:1125/1490 train_time:55531ms step_avg:49.36ms
+step:1126/1490 train_time:55617ms step_avg:49.39ms
+step:1127/1490 train_time:55696ms step_avg:49.42ms
+step:1128/1490 train_time:55780ms step_avg:49.45ms
+step:1129/1490 train_time:55860ms step_avg:49.48ms
+step:1130/1490 train_time:55945ms step_avg:49.51ms
+step:1131/1490 train_time:56024ms step_avg:49.53ms
+step:1132/1490 train_time:56109ms step_avg:49.57ms
+step:1133/1490 train_time:56187ms step_avg:49.59ms
+step:1134/1490 train_time:56273ms step_avg:49.62ms
+step:1135/1490 train_time:56353ms step_avg:49.65ms
+step:1136/1490 train_time:56437ms step_avg:49.68ms
+step:1137/1490 train_time:56517ms step_avg:49.71ms
+step:1138/1490 train_time:56602ms step_avg:49.74ms
+step:1139/1490 train_time:56682ms step_avg:49.76ms
+step:1140/1490 train_time:56767ms step_avg:49.80ms
+step:1141/1490 train_time:56847ms step_avg:49.82ms
+step:1142/1490 train_time:56932ms step_avg:49.85ms
+step:1143/1490 train_time:57011ms step_avg:49.88ms
+step:1144/1490 train_time:57096ms step_avg:49.91ms
+step:1145/1490 train_time:57176ms step_avg:49.94ms
+step:1146/1490 train_time:57260ms step_avg:49.97ms
+step:1147/1490 train_time:57340ms step_avg:49.99ms
+step:1148/1490 train_time:57425ms step_avg:50.02ms
+step:1149/1490 train_time:57504ms step_avg:50.05ms
+step:1150/1490 train_time:57588ms step_avg:50.08ms
+step:1151/1490 train_time:57669ms step_avg:50.10ms
+step:1152/1490 train_time:57754ms step_avg:50.13ms
+step:1153/1490 train_time:57833ms step_avg:50.16ms
+step:1154/1490 train_time:57918ms step_avg:50.19ms
+step:1155/1490 train_time:57997ms step_avg:50.21ms
+step:1156/1490 train_time:58083ms step_avg:50.24ms
+step:1157/1490 train_time:58162ms step_avg:50.27ms
+step:1158/1490 train_time:58247ms step_avg:50.30ms
+step:1159/1490 train_time:58328ms step_avg:50.33ms
+step:1160/1490 train_time:58412ms step_avg:50.36ms
+step:1161/1490 train_time:58492ms step_avg:50.38ms
+step:1162/1490 train_time:58577ms step_avg:50.41ms
+step:1163/1490 train_time:58656ms step_avg:50.44ms
+step:1164/1490 train_time:58742ms step_avg:50.47ms
+step:1165/1490 train_time:58822ms step_avg:50.49ms
+step:1166/1490 train_time:58906ms step_avg:50.52ms
+step:1167/1490 train_time:58985ms step_avg:50.54ms
+step:1168/1490 train_time:59071ms step_avg:50.57ms
+step:1169/1490 train_time:59150ms step_avg:50.60ms
+step:1170/1490 train_time:59236ms step_avg:50.63ms
+step:1171/1490 train_time:59316ms step_avg:50.65ms
+step:1172/1490 train_time:59400ms step_avg:50.68ms
+step:1173/1490 train_time:59482ms step_avg:50.71ms
+step:1174/1490 train_time:59567ms step_avg:50.74ms
+step:1175/1490 train_time:59646ms step_avg:50.76ms
+step:1176/1490 train_time:59731ms step_avg:50.79ms
+step:1177/1490 train_time:59811ms step_avg:50.82ms
+step:1178/1490 train_time:59896ms step_avg:50.85ms
+step:1179/1490 train_time:59976ms step_avg:50.87ms
+step:1180/1490 train_time:60063ms step_avg:50.90ms
+step:1181/1490 train_time:60141ms step_avg:50.92ms
+step:1182/1490 train_time:60226ms step_avg:50.95ms
+step:1183/1490 train_time:60304ms step_avg:50.98ms
+step:1184/1490 train_time:60391ms step_avg:51.01ms
+step:1185/1490 train_time:60470ms step_avg:51.03ms
+step:1186/1490 train_time:60556ms step_avg:51.06ms
+step:1187/1490 train_time:60637ms step_avg:51.08ms
+step:1188/1490 train_time:60723ms step_avg:51.11ms
+step:1189/1490 train_time:60803ms step_avg:51.14ms
+step:1190/1490 train_time:60887ms step_avg:51.17ms
+step:1191/1490 train_time:60968ms step_avg:51.19ms
+step:1192/1490 train_time:61053ms step_avg:51.22ms
+step:1193/1490 train_time:61133ms step_avg:51.24ms
+step:1194/1490 train_time:61218ms step_avg:51.27ms
+step:1195/1490 train_time:61297ms step_avg:51.29ms
+step:1196/1490 train_time:61383ms step_avg:51.32ms
+step:1197/1490 train_time:61463ms step_avg:51.35ms
+step:1198/1490 train_time:61548ms step_avg:51.38ms
+step:1199/1490 train_time:61628ms step_avg:51.40ms
+step:1200/1490 train_time:61713ms step_avg:51.43ms
+step:1201/1490 train_time:61793ms step_avg:51.45ms
+step:1202/1490 train_time:61877ms step_avg:51.48ms
+step:1203/1490 train_time:61958ms step_avg:51.50ms
+step:1204/1490 train_time:62044ms step_avg:51.53ms
+step:1205/1490 train_time:62124ms step_avg:51.56ms
+step:1206/1490 train_time:62209ms step_avg:51.58ms
+step:1207/1490 train_time:62288ms step_avg:51.61ms
+step:1208/1490 train_time:62373ms step_avg:51.63ms
+step:1209/1490 train_time:62452ms step_avg:51.66ms
+step:1210/1490 train_time:62537ms step_avg:51.68ms
+step:1211/1490 train_time:62618ms step_avg:51.71ms
+step:1212/1490 train_time:62702ms step_avg:51.73ms
+step:1213/1490 train_time:62784ms step_avg:51.76ms
+step:1214/1490 train_time:62868ms step_avg:51.79ms
+step:1215/1490 train_time:62947ms step_avg:51.81ms
+step:1216/1490 train_time:63033ms step_avg:51.84ms
+step:1217/1490 train_time:63113ms step_avg:51.86ms
+step:1218/1490 train_time:63199ms step_avg:51.89ms
+step:1219/1490 train_time:63277ms step_avg:51.91ms
+step:1220/1490 train_time:63362ms step_avg:51.94ms
+step:1221/1490 train_time:63442ms step_avg:51.96ms
+step:1222/1490 train_time:63528ms step_avg:51.99ms
+step:1223/1490 train_time:63607ms step_avg:52.01ms
+step:1224/1490 train_time:63691ms step_avg:52.04ms
+step:1225/1490 train_time:63772ms step_avg:52.06ms
+step:1226/1490 train_time:63857ms step_avg:52.09ms
+step:1227/1490 train_time:63937ms step_avg:52.11ms
+step:1228/1490 train_time:64021ms step_avg:52.13ms
+step:1229/1490 train_time:64101ms step_avg:52.16ms
+step:1230/1490 train_time:64184ms step_avg:52.18ms
+step:1231/1490 train_time:64265ms step_avg:52.21ms
+step:1232/1490 train_time:64349ms step_avg:52.23ms
+step:1233/1490 train_time:64431ms step_avg:52.26ms
+step:1234/1490 train_time:64517ms step_avg:52.28ms
+step:1235/1490 train_time:64595ms step_avg:52.30ms
+step:1236/1490 train_time:64680ms step_avg:52.33ms
+step:1237/1490 train_time:64761ms step_avg:52.35ms
+step:1238/1490 train_time:64845ms step_avg:52.38ms
+step:1239/1490 train_time:64924ms step_avg:52.40ms
+step:1240/1490 train_time:65010ms step_avg:52.43ms
+step:1241/1490 train_time:65089ms step_avg:52.45ms
+step:1242/1490 train_time:65173ms step_avg:52.47ms
+step:1243/1490 train_time:65253ms step_avg:52.50ms
+step:1244/1490 train_time:65337ms step_avg:52.52ms
+step:1245/1490 train_time:65417ms step_avg:52.54ms
+step:1246/1490 train_time:65502ms step_avg:52.57ms
+step:1247/1490 train_time:65581ms step_avg:52.59ms
+step:1248/1490 train_time:65667ms step_avg:52.62ms
+step:1249/1490 train_time:65747ms step_avg:52.64ms
+step:1250/1490 train_time:65833ms step_avg:52.67ms
+step:1250/1490 val_loss:3.3700 train_time:65934ms step_avg:52.75ms
+step:1251/1490 train_time:65957ms step_avg:52.72ms
+step:1252/1490 train_time:66001ms step_avg:52.72ms
+step:1253/1490 train_time:66088ms step_avg:52.74ms
+step:1254/1490 train_time:66175ms step_avg:52.77ms
+step:1255/1490 train_time:66255ms step_avg:52.79ms
+step:1256/1490 train_time:66339ms step_avg:52.82ms
+step:1257/1490 train_time:66418ms step_avg:52.84ms
+step:1258/1490 train_time:66502ms step_avg:52.86ms
+step:1259/1490 train_time:66581ms step_avg:52.88ms
+step:1260/1490 train_time:66664ms step_avg:52.91ms
+step:1261/1490 train_time:66742ms step_avg:52.93ms
+step:1262/1490 train_time:66825ms step_avg:52.95ms
+step:1263/1490 train_time:66904ms step_avg:52.97ms
+step:1264/1490 train_time:66993ms step_avg:53.00ms
+step:1265/1490 train_time:67077ms step_avg:53.03ms
+step:1266/1490 train_time:67165ms step_avg:53.05ms
+step:1267/1490 train_time:67246ms step_avg:53.08ms
+step:1268/1490 train_time:67332ms step_avg:53.10ms
+step:1269/1490 train_time:67411ms step_avg:53.12ms
+step:1270/1490 train_time:67494ms step_avg:53.15ms
+step:1271/1490 train_time:67573ms step_avg:53.17ms
+step:1272/1490 train_time:67657ms step_avg:53.19ms
+step:1273/1490 train_time:67735ms step_avg:53.21ms
+step:1274/1490 train_time:67819ms step_avg:53.23ms
+step:1275/1490 train_time:67899ms step_avg:53.25ms
+step:1276/1490 train_time:67986ms step_avg:53.28ms
+step:1277/1490 train_time:68069ms step_avg:53.30ms
+step:1278/1490 train_time:68154ms step_avg:53.33ms
+step:1279/1490 train_time:68237ms step_avg:53.35ms
+step:1280/1490 train_time:68322ms step_avg:53.38ms
+step:1281/1490 train_time:68402ms step_avg:53.40ms
+step:1282/1490 train_time:68485ms step_avg:53.42ms
+step:1283/1490 train_time:68566ms step_avg:53.44ms
+step:1284/1490 train_time:68651ms step_avg:53.47ms
+step:1285/1490 train_time:68729ms step_avg:53.49ms
+step:1286/1490 train_time:68813ms step_avg:53.51ms
+step:1287/1490 train_time:68892ms step_avg:53.53ms
+step:1288/1490 train_time:68978ms step_avg:53.55ms
+step:1289/1490 train_time:69058ms step_avg:53.58ms
+step:1290/1490 train_time:69145ms step_avg:53.60ms
+step:1291/1490 train_time:69224ms step_avg:53.62ms
+step:1292/1490 train_time:69309ms step_avg:53.64ms
+step:1293/1490 train_time:69389ms step_avg:53.66ms
+step:1294/1490 train_time:69476ms step_avg:53.69ms
+step:1295/1490 train_time:69555ms step_avg:53.71ms
+step:1296/1490 train_time:69639ms step_avg:53.73ms
+step:1297/1490 train_time:69718ms step_avg:53.75ms
+step:1298/1490 train_time:69802ms step_avg:53.78ms
+step:1299/1490 train_time:69883ms step_avg:53.80ms
+step:1300/1490 train_time:69967ms step_avg:53.82ms
+step:1301/1490 train_time:70047ms step_avg:53.84ms
+step:1302/1490 train_time:70134ms step_avg:53.87ms
+step:1303/1490 train_time:70214ms step_avg:53.89ms
+step:1304/1490 train_time:70299ms step_avg:53.91ms
+step:1305/1490 train_time:70380ms step_avg:53.93ms
+step:1306/1490 train_time:70464ms step_avg:53.95ms
+step:1307/1490 train_time:70543ms step_avg:53.97ms
+step:1308/1490 train_time:70627ms step_avg:54.00ms
+step:1309/1490 train_time:70705ms step_avg:54.01ms
+step:1310/1490 train_time:70790ms step_avg:54.04ms
+step:1311/1490 train_time:70870ms step_avg:54.06ms
+step:1312/1490 train_time:70955ms step_avg:54.08ms
+step:1313/1490 train_time:71035ms step_avg:54.10ms
+step:1314/1490 train_time:71120ms step_avg:54.12ms
+step:1315/1490 train_time:71200ms step_avg:54.14ms
+step:1316/1490 train_time:71284ms step_avg:54.17ms
+step:1317/1490 train_time:71366ms step_avg:54.19ms
+step:1318/1490 train_time:71451ms step_avg:54.21ms
+step:1319/1490 train_time:71531ms step_avg:54.23ms
+step:1320/1490 train_time:71615ms step_avg:54.25ms
+step:1321/1490 train_time:71693ms step_avg:54.27ms
+step:1322/1490 train_time:71778ms step_avg:54.30ms
+step:1323/1490 train_time:71857ms step_avg:54.31ms
+step:1324/1490 train_time:71942ms step_avg:54.34ms
+step:1325/1490 train_time:72022ms step_avg:54.36ms
+step:1326/1490 train_time:72107ms step_avg:54.38ms
+step:1327/1490 train_time:72187ms step_avg:54.40ms
+step:1328/1490 train_time:72272ms step_avg:54.42ms
+step:1329/1490 train_time:72352ms step_avg:54.44ms
+step:1330/1490 train_time:72437ms step_avg:54.46ms
+step:1331/1490 train_time:72516ms step_avg:54.48ms
+step:1332/1490 train_time:72600ms step_avg:54.50ms
+step:1333/1490 train_time:72680ms step_avg:54.52ms
+step:1334/1490 train_time:72766ms step_avg:54.55ms
+step:1335/1490 train_time:72845ms step_avg:54.57ms
+step:1336/1490 train_time:72932ms step_avg:54.59ms
+step:1337/1490 train_time:73011ms step_avg:54.61ms
+step:1338/1490 train_time:73096ms step_avg:54.63ms
+step:1339/1490 train_time:73176ms step_avg:54.65ms
+step:1340/1490 train_time:73261ms step_avg:54.67ms
+step:1341/1490 train_time:73342ms step_avg:54.69ms
+step:1342/1490 train_time:73426ms step_avg:54.71ms
+step:1343/1490 train_time:73506ms step_avg:54.73ms
+step:1344/1490 train_time:73592ms step_avg:54.76ms
+step:1345/1490 train_time:73672ms step_avg:54.77ms
+step:1346/1490 train_time:73757ms step_avg:54.80ms
+step:1347/1490 train_time:73837ms step_avg:54.82ms
+step:1348/1490 train_time:73921ms step_avg:54.84ms
+step:1349/1490 train_time:74001ms step_avg:54.86ms
+step:1350/1490 train_time:74085ms step_avg:54.88ms
+step:1351/1490 train_time:74166ms step_avg:54.90ms
+step:1352/1490 train_time:74251ms step_avg:54.92ms
+step:1353/1490 train_time:74331ms step_avg:54.94ms
+step:1354/1490 train_time:74416ms step_avg:54.96ms
+step:1355/1490 train_time:74495ms step_avg:54.98ms
+step:1356/1490 train_time:74580ms step_avg:55.00ms
+step:1357/1490 train_time:74659ms step_avg:55.02ms
+step:1358/1490 train_time:74744ms step_avg:55.04ms
+step:1359/1490 train_time:74824ms step_avg:55.06ms
+step:1360/1490 train_time:74910ms step_avg:55.08ms
+step:1361/1490 train_time:74991ms step_avg:55.10ms
+step:1362/1490 train_time:75075ms step_avg:55.12ms
+step:1363/1490 train_time:75154ms step_avg:55.14ms
+step:1364/1490 train_time:75240ms step_avg:55.16ms
+step:1365/1490 train_time:75319ms step_avg:55.18ms
+step:1366/1490 train_time:75404ms step_avg:55.20ms
+step:1367/1490 train_time:75484ms step_avg:55.22ms
+step:1368/1490 train_time:75570ms step_avg:55.24ms
+step:1369/1490 train_time:75650ms step_avg:55.26ms
+step:1370/1490 train_time:75735ms step_avg:55.28ms
+step:1371/1490 train_time:75813ms step_avg:55.30ms
+step:1372/1490 train_time:75899ms step_avg:55.32ms
+step:1373/1490 train_time:75980ms step_avg:55.34ms
+step:1374/1490 train_time:76065ms step_avg:55.36ms
+step:1375/1490 train_time:76145ms step_avg:55.38ms
+step:1376/1490 train_time:76231ms step_avg:55.40ms
+step:1377/1490 train_time:76312ms step_avg:55.42ms
+step:1378/1490 train_time:76395ms step_avg:55.44ms
+step:1379/1490 train_time:76475ms step_avg:55.46ms
+step:1380/1490 train_time:76560ms step_avg:55.48ms
+step:1381/1490 train_time:76641ms step_avg:55.50ms
+step:1382/1490 train_time:76726ms step_avg:55.52ms
+step:1383/1490 train_time:76806ms step_avg:55.54ms
+step:1384/1490 train_time:76889ms step_avg:55.56ms
+step:1385/1490 train_time:76968ms step_avg:55.57ms
+step:1386/1490 train_time:77054ms step_avg:55.59ms
+step:1387/1490 train_time:77134ms step_avg:55.61ms
+step:1388/1490 train_time:77219ms step_avg:55.63ms
+step:1389/1490 train_time:77299ms step_avg:55.65ms
+step:1390/1490 train_time:77389ms step_avg:55.68ms
+step:1391/1490 train_time:77463ms step_avg:55.69ms
+step:1392/1490 train_time:77549ms step_avg:55.71ms
+step:1393/1490 train_time:77630ms step_avg:55.73ms
+step:1394/1490 train_time:77714ms step_avg:55.75ms
+step:1395/1490 train_time:77793ms step_avg:55.77ms
+step:1396/1490 train_time:77878ms step_avg:55.79ms
+step:1397/1490 train_time:77958ms step_avg:55.80ms
+step:1398/1490 train_time:78044ms step_avg:55.83ms
+step:1399/1490 train_time:78123ms step_avg:55.84ms
+step:1400/1490 train_time:78208ms step_avg:55.86ms
+step:1401/1490 train_time:78288ms step_avg:55.88ms
+step:1402/1490 train_time:78373ms step_avg:55.90ms
+step:1403/1490 train_time:78451ms step_avg:55.92ms
+step:1404/1490 train_time:78538ms step_avg:55.94ms
+step:1405/1490 train_time:78619ms step_avg:55.96ms
+step:1406/1490 train_time:78703ms step_avg:55.98ms
+step:1407/1490 train_time:78782ms step_avg:55.99ms
+step:1408/1490 train_time:78866ms step_avg:56.01ms
+step:1409/1490 train_time:78945ms step_avg:56.03ms
+step:1410/1490 train_time:79032ms step_avg:56.05ms
+step:1411/1490 train_time:79110ms step_avg:56.07ms
+step:1412/1490 train_time:79195ms step_avg:56.09ms
+step:1413/1490 train_time:79276ms step_avg:56.10ms
+step:1414/1490 train_time:79361ms step_avg:56.13ms
+step:1415/1490 train_time:79443ms step_avg:56.14ms
+step:1416/1490 train_time:79529ms step_avg:56.16ms
+step:1417/1490 train_time:79609ms step_avg:56.18ms
+step:1418/1490 train_time:79693ms step_avg:56.20ms
+step:1419/1490 train_time:79772ms step_avg:56.22ms
+step:1420/1490 train_time:79857ms step_avg:56.24ms
+step:1421/1490 train_time:79936ms step_avg:56.25ms
+step:1422/1490 train_time:80020ms step_avg:56.27ms
+step:1423/1490 train_time:80100ms step_avg:56.29ms
+step:1424/1490 train_time:80185ms step_avg:56.31ms
+step:1425/1490 train_time:80266ms step_avg:56.33ms
+step:1426/1490 train_time:80352ms step_avg:56.35ms
+step:1427/1490 train_time:80431ms step_avg:56.36ms
+step:1428/1490 train_time:80516ms step_avg:56.38ms
+step:1429/1490 train_time:80594ms step_avg:56.40ms
+step:1430/1490 train_time:80679ms step_avg:56.42ms
+step:1431/1490 train_time:80761ms step_avg:56.44ms
+step:1432/1490 train_time:80846ms step_avg:56.46ms
+step:1433/1490 train_time:80925ms step_avg:56.47ms
+step:1434/1490 train_time:81011ms step_avg:56.49ms
+step:1435/1490 train_time:81091ms step_avg:56.51ms
+step:1436/1490 train_time:81177ms step_avg:56.53ms
+step:1437/1490 train_time:81256ms step_avg:56.55ms
+step:1438/1490 train_time:81342ms step_avg:56.57ms
+step:1439/1490 train_time:81422ms step_avg:56.58ms
+step:1440/1490 train_time:81507ms step_avg:56.60ms
+step:1441/1490 train_time:81586ms step_avg:56.62ms
+step:1442/1490 train_time:81671ms step_avg:56.64ms
+step:1443/1490 train_time:81750ms step_avg:56.65ms
+step:1444/1490 train_time:81835ms step_avg:56.67ms
+step:1445/1490 train_time:81914ms step_avg:56.69ms
+step:1446/1490 train_time:81998ms step_avg:56.71ms
+step:1447/1490 train_time:82080ms step_avg:56.72ms
+step:1448/1490 train_time:82165ms step_avg:56.74ms
+step:1449/1490 train_time:82244ms step_avg:56.76ms
+step:1450/1490 train_time:82330ms step_avg:56.78ms
+step:1451/1490 train_time:82414ms step_avg:56.80ms
+step:1452/1490 train_time:82501ms step_avg:56.82ms
+step:1453/1490 train_time:82581ms step_avg:56.83ms
+step:1454/1490 train_time:82667ms step_avg:56.85ms
+step:1455/1490 train_time:82746ms step_avg:56.87ms
+step:1456/1490 train_time:82832ms step_avg:56.89ms
+step:1457/1490 train_time:82912ms step_avg:56.91ms
+step:1458/1490 train_time:82996ms step_avg:56.92ms
+step:1459/1490 train_time:83076ms step_avg:56.94ms
+step:1460/1490 train_time:83162ms step_avg:56.96ms
+step:1461/1490 train_time:83242ms step_avg:56.98ms
+step:1462/1490 train_time:83329ms step_avg:57.00ms
+step:1463/1490 train_time:83411ms step_avg:57.01ms
+step:1464/1490 train_time:83496ms step_avg:57.03ms
+step:1465/1490 train_time:83575ms step_avg:57.05ms
+step:1466/1490 train_time:83660ms step_avg:57.07ms
+step:1467/1490 train_time:83741ms step_avg:57.08ms
+step:1468/1490 train_time:83827ms step_avg:57.10ms
+step:1469/1490 train_time:83908ms step_avg:57.12ms
+step:1470/1490 train_time:83993ms step_avg:57.14ms
+step:1471/1490 train_time:84073ms step_avg:57.15ms
+step:1472/1490 train_time:84157ms step_avg:57.17ms
+step:1473/1490 train_time:84239ms step_avg:57.19ms
+step:1474/1490 train_time:84324ms step_avg:57.21ms
+step:1475/1490 train_time:84405ms step_avg:57.22ms
+step:1476/1490 train_time:84491ms step_avg:57.24ms
+step:1477/1490 train_time:84571ms step_avg:57.26ms
+step:1478/1490 train_time:84656ms step_avg:57.28ms
+step:1479/1490 train_time:84737ms step_avg:57.29ms
+step:1480/1490 train_time:84823ms step_avg:57.31ms
+step:1481/1490 train_time:84903ms step_avg:57.33ms
+step:1482/1490 train_time:84988ms step_avg:57.35ms
+step:1483/1490 train_time:85069ms step_avg:57.36ms
+step:1484/1490 train_time:85153ms step_avg:57.38ms
+step:1485/1490 train_time:85235ms step_avg:57.40ms
+step:1486/1490 train_time:85320ms step_avg:57.42ms
+step:1487/1490 train_time:85400ms step_avg:57.43ms
+step:1488/1490 train_time:85485ms step_avg:57.45ms
+step:1489/1490 train_time:85566ms step_avg:57.47ms
+step:1490/1490 train_time:85651ms step_avg:57.48ms
+step:1490/1490 val_loss:3.2773 train_time:85754ms step_avg:57.55ms
+peak memory allocated: 31277 MiB reserved: 47202 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/train_gpt.py
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/train_gpt.py
@@ -1,0 +1,2006 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/triton_kernels.py
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline/triton_kernels.py
@@ -1,0 +1,882 @@
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/46c3e2a4-0e67-41a8-9dd7-a7e1d5ec57aa.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/46c3e2a4-0e67-41a8-9dd7-a7e1d5ec57aa.txt
@@ -1,0 +1,4681 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 21:21:04 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   30C    P0            119W /  700W |    2045MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   32C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   29C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   29C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   30C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8325 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:83ms step_avg:83.06ms
+step:2/1490 train_time:106ms step_avg:53.09ms
+step:3/1490 train_time:124ms step_avg:41.31ms
+step:4/1490 train_time:144ms step_avg:36.12ms
+step:5/1490 train_time:170ms step_avg:33.94ms
+step:6/1490 train_time:204ms step_avg:33.99ms
+step:7/1490 train_time:231ms step_avg:33.01ms
+step:8/1490 train_time:265ms step_avg:33.16ms
+step:9/1490 train_time:292ms step_avg:32.50ms
+step:10/1490 train_time:327ms step_avg:32.72ms
+step:11/1490 train_time:354ms step_avg:32.21ms
+step:12/1490 train_time:390ms step_avg:32.51ms
+step:13/1490 train_time:416ms step_avg:32.00ms
+step:14/1490 train_time:450ms step_avg:32.15ms
+step:15/1490 train_time:477ms step_avg:31.81ms
+step:16/1490 train_time:511ms step_avg:31.96ms
+step:17/1490 train_time:539ms step_avg:31.68ms
+step:18/1490 train_time:573ms step_avg:31.82ms
+step:19/1490 train_time:600ms step_avg:31.57ms
+step:20/1490 train_time:634ms step_avg:31.70ms
+step:21/1490 train_time:661ms step_avg:31.48ms
+step:22/1490 train_time:695ms step_avg:31.59ms
+step:23/1490 train_time:722ms step_avg:31.41ms
+step:24/1490 train_time:756ms step_avg:31.50ms
+step:25/1490 train_time:783ms step_avg:31.34ms
+step:26/1490 train_time:817ms step_avg:31.44ms
+step:27/1490 train_time:845ms step_avg:31.28ms
+step:28/1490 train_time:878ms step_avg:31.37ms
+step:29/1490 train_time:906ms step_avg:31.24ms
+step:30/1490 train_time:940ms step_avg:31.32ms
+step:31/1490 train_time:968ms step_avg:31.22ms
+step:32/1490 train_time:1003ms step_avg:31.34ms
+step:33/1490 train_time:1031ms step_avg:31.24ms
+step:34/1490 train_time:1066ms step_avg:31.34ms
+step:35/1490 train_time:1094ms step_avg:31.25ms
+step:36/1490 train_time:1128ms step_avg:31.33ms
+step:37/1490 train_time:1155ms step_avg:31.22ms
+step:38/1490 train_time:1190ms step_avg:31.31ms
+step:39/1490 train_time:1217ms step_avg:31.20ms
+step:40/1490 train_time:1252ms step_avg:31.29ms
+step:41/1490 train_time:1279ms step_avg:31.19ms
+step:42/1490 train_time:1313ms step_avg:31.25ms
+step:43/1490 train_time:1340ms step_avg:31.16ms
+step:44/1490 train_time:1374ms step_avg:31.23ms
+step:45/1490 train_time:1401ms step_avg:31.14ms
+step:46/1490 train_time:1436ms step_avg:31.21ms
+step:47/1490 train_time:1463ms step_avg:31.13ms
+step:48/1490 train_time:1497ms step_avg:31.19ms
+step:49/1490 train_time:1525ms step_avg:31.12ms
+step:50/1490 train_time:1559ms step_avg:31.18ms
+step:51/1490 train_time:1586ms step_avg:31.10ms
+step:52/1490 train_time:1620ms step_avg:31.15ms
+step:53/1490 train_time:1647ms step_avg:31.08ms
+step:54/1490 train_time:1681ms step_avg:31.13ms
+step:55/1490 train_time:1709ms step_avg:31.07ms
+step:56/1490 train_time:1742ms step_avg:31.11ms
+step:57/1490 train_time:1770ms step_avg:31.05ms
+step:58/1490 train_time:1804ms step_avg:31.10ms
+step:59/1490 train_time:1831ms step_avg:31.04ms
+step:60/1490 train_time:1865ms step_avg:31.08ms
+step:61/1490 train_time:1892ms step_avg:31.02ms
+step:62/1490 train_time:1926ms step_avg:31.07ms
+step:63/1490 train_time:1954ms step_avg:31.01ms
+step:64/1490 train_time:1988ms step_avg:31.06ms
+step:65/1490 train_time:2015ms step_avg:31.00ms
+step:66/1490 train_time:2050ms step_avg:31.06ms
+step:67/1490 train_time:2077ms step_avg:31.00ms
+step:68/1490 train_time:2112ms step_avg:31.05ms
+step:69/1490 train_time:2139ms step_avg:31.00ms
+step:70/1490 train_time:2174ms step_avg:31.05ms
+step:71/1490 train_time:2201ms step_avg:31.01ms
+step:72/1490 train_time:2235ms step_avg:31.05ms
+step:73/1490 train_time:2263ms step_avg:31.00ms
+step:74/1490 train_time:2297ms step_avg:31.04ms
+step:75/1490 train_time:2324ms step_avg:30.99ms
+step:76/1490 train_time:2358ms step_avg:31.02ms
+step:77/1490 train_time:2385ms step_avg:30.98ms
+step:78/1490 train_time:2419ms step_avg:31.01ms
+step:79/1490 train_time:2446ms step_avg:30.97ms
+step:80/1490 train_time:2480ms step_avg:31.00ms
+step:81/1490 train_time:2508ms step_avg:30.96ms
+step:82/1490 train_time:2541ms step_avg:30.99ms
+step:83/1490 train_time:2569ms step_avg:30.95ms
+step:84/1490 train_time:2603ms step_avg:30.98ms
+step:85/1490 train_time:2630ms step_avg:30.94ms
+step:86/1490 train_time:2664ms step_avg:30.98ms
+step:87/1490 train_time:2691ms step_avg:30.93ms
+step:88/1490 train_time:2725ms step_avg:30.96ms
+step:89/1490 train_time:2752ms step_avg:30.92ms
+step:90/1490 train_time:2786ms step_avg:30.95ms
+step:91/1490 train_time:2813ms step_avg:30.91ms
+step:92/1490 train_time:2847ms step_avg:30.95ms
+step:93/1490 train_time:2874ms step_avg:30.91ms
+step:94/1490 train_time:2908ms step_avg:30.94ms
+step:95/1490 train_time:2935ms step_avg:30.90ms
+step:96/1490 train_time:2970ms step_avg:30.94ms
+step:97/1490 train_time:2997ms step_avg:30.90ms
+step:98/1490 train_time:3031ms step_avg:30.93ms
+step:99/1490 train_time:3059ms step_avg:30.90ms
+step:100/1490 train_time:3092ms step_avg:30.92ms
+step:101/1490 train_time:3120ms step_avg:30.89ms
+step:102/1490 train_time:3154ms step_avg:30.92ms
+step:103/1490 train_time:3182ms step_avg:30.89ms
+step:104/1490 train_time:3215ms step_avg:30.92ms
+step:105/1490 train_time:3243ms step_avg:30.89ms
+step:106/1490 train_time:3277ms step_avg:30.92ms
+step:107/1490 train_time:3305ms step_avg:30.89ms
+step:108/1490 train_time:3339ms step_avg:30.92ms
+step:109/1490 train_time:3367ms step_avg:30.89ms
+step:110/1490 train_time:3401ms step_avg:30.92ms
+step:111/1490 train_time:3428ms step_avg:30.88ms
+step:112/1490 train_time:3462ms step_avg:30.91ms
+step:113/1490 train_time:3489ms step_avg:30.88ms
+step:114/1490 train_time:3523ms step_avg:30.90ms
+step:115/1490 train_time:3550ms step_avg:30.87ms
+step:116/1490 train_time:3584ms step_avg:30.90ms
+step:117/1490 train_time:3611ms step_avg:30.87ms
+step:118/1490 train_time:3645ms step_avg:30.89ms
+step:119/1490 train_time:3673ms step_avg:30.86ms
+step:120/1490 train_time:3706ms step_avg:30.88ms
+step:121/1490 train_time:3733ms step_avg:30.85ms
+step:122/1490 train_time:3768ms step_avg:30.88ms
+step:123/1490 train_time:3795ms step_avg:30.85ms
+step:124/1490 train_time:3829ms step_avg:30.88ms
+step:125/1490 train_time:3856ms step_avg:30.85ms
+step:126/1490 train_time:3890ms step_avg:30.87ms
+step:127/1490 train_time:3917ms step_avg:30.84ms
+step:128/1490 train_time:3951ms step_avg:30.87ms
+step:129/1490 train_time:3979ms step_avg:30.84ms
+step:130/1490 train_time:4014ms step_avg:30.88ms
+step:131/1490 train_time:4040ms step_avg:30.84ms
+step:132/1490 train_time:4074ms step_avg:30.86ms
+step:133/1490 train_time:4101ms step_avg:30.83ms
+step:134/1490 train_time:4135ms step_avg:30.86ms
+step:135/1490 train_time:4162ms step_avg:30.83ms
+step:136/1490 train_time:4196ms step_avg:30.85ms
+step:137/1490 train_time:4224ms step_avg:30.83ms
+step:138/1490 train_time:4258ms step_avg:30.85ms
+step:139/1490 train_time:4286ms step_avg:30.83ms
+step:140/1490 train_time:4320ms step_avg:30.85ms
+step:141/1490 train_time:4348ms step_avg:30.83ms
+step:142/1490 train_time:4381ms step_avg:30.86ms
+step:143/1490 train_time:4409ms step_avg:30.83ms
+step:144/1490 train_time:4443ms step_avg:30.85ms
+step:145/1490 train_time:4470ms step_avg:30.83ms
+step:146/1490 train_time:4504ms step_avg:30.85ms
+step:147/1490 train_time:4532ms step_avg:30.83ms
+step:148/1490 train_time:4566ms step_avg:30.85ms
+step:149/1490 train_time:4593ms step_avg:30.83ms
+step:150/1490 train_time:4627ms step_avg:30.85ms
+step:151/1490 train_time:4654ms step_avg:30.82ms
+step:152/1490 train_time:4689ms step_avg:30.85ms
+step:153/1490 train_time:4716ms step_avg:30.82ms
+step:154/1490 train_time:4749ms step_avg:30.84ms
+step:155/1490 train_time:4777ms step_avg:30.82ms
+step:156/1490 train_time:4811ms step_avg:30.84ms
+step:157/1490 train_time:4838ms step_avg:30.82ms
+step:158/1490 train_time:4872ms step_avg:30.84ms
+step:159/1490 train_time:4900ms step_avg:30.82ms
+step:160/1490 train_time:4934ms step_avg:30.83ms
+step:161/1490 train_time:4961ms step_avg:30.81ms
+step:162/1490 train_time:4994ms step_avg:30.83ms
+step:163/1490 train_time:5022ms step_avg:30.81ms
+step:164/1490 train_time:5056ms step_avg:30.83ms
+step:165/1490 train_time:5083ms step_avg:30.81ms
+step:166/1490 train_time:5117ms step_avg:30.83ms
+step:167/1490 train_time:5145ms step_avg:30.81ms
+step:168/1490 train_time:5179ms step_avg:30.82ms
+step:169/1490 train_time:5206ms step_avg:30.80ms
+step:170/1490 train_time:5240ms step_avg:30.82ms
+step:171/1490 train_time:5268ms step_avg:30.81ms
+step:172/1490 train_time:5302ms step_avg:30.83ms
+step:173/1490 train_time:5329ms step_avg:30.81ms
+step:174/1490 train_time:5364ms step_avg:30.82ms
+step:175/1490 train_time:5391ms step_avg:30.80ms
+step:176/1490 train_time:5425ms step_avg:30.82ms
+step:177/1490 train_time:5452ms step_avg:30.80ms
+step:178/1490 train_time:5487ms step_avg:30.82ms
+step:179/1490 train_time:5514ms step_avg:30.80ms
+step:180/1490 train_time:5548ms step_avg:30.82ms
+step:181/1490 train_time:5576ms step_avg:30.81ms
+step:182/1490 train_time:5611ms step_avg:30.83ms
+step:183/1490 train_time:5637ms step_avg:30.80ms
+step:184/1490 train_time:5671ms step_avg:30.82ms
+step:185/1490 train_time:5698ms step_avg:30.80ms
+step:186/1490 train_time:5732ms step_avg:30.82ms
+step:187/1490 train_time:5760ms step_avg:30.80ms
+step:188/1490 train_time:5794ms step_avg:30.82ms
+step:189/1490 train_time:5821ms step_avg:30.80ms
+step:190/1490 train_time:5855ms step_avg:30.82ms
+step:191/1490 train_time:5883ms step_avg:30.80ms
+step:192/1490 train_time:5917ms step_avg:30.82ms
+step:193/1490 train_time:5944ms step_avg:30.80ms
+step:194/1490 train_time:5978ms step_avg:30.81ms
+step:195/1490 train_time:6005ms step_avg:30.80ms
+step:196/1490 train_time:6039ms step_avg:30.81ms
+step:197/1490 train_time:6066ms step_avg:30.79ms
+step:198/1490 train_time:6100ms step_avg:30.81ms
+step:199/1490 train_time:6128ms step_avg:30.79ms
+step:200/1490 train_time:6162ms step_avg:30.81ms
+step:201/1490 train_time:6189ms step_avg:30.79ms
+step:202/1490 train_time:6223ms step_avg:30.81ms
+step:203/1490 train_time:6251ms step_avg:30.79ms
+step:204/1490 train_time:6285ms step_avg:30.81ms
+step:205/1490 train_time:6312ms step_avg:30.79ms
+step:206/1490 train_time:6346ms step_avg:30.81ms
+step:207/1490 train_time:6374ms step_avg:30.79ms
+step:208/1490 train_time:6408ms step_avg:30.81ms
+step:209/1490 train_time:6435ms step_avg:30.79ms
+step:210/1490 train_time:6471ms step_avg:30.81ms
+step:211/1490 train_time:6497ms step_avg:30.79ms
+step:212/1490 train_time:6532ms step_avg:30.81ms
+step:213/1490 train_time:6558ms step_avg:30.79ms
+step:214/1490 train_time:6592ms step_avg:30.80ms
+step:215/1490 train_time:6619ms step_avg:30.79ms
+step:216/1490 train_time:6653ms step_avg:30.80ms
+step:217/1490 train_time:6681ms step_avg:30.79ms
+step:218/1490 train_time:6715ms step_avg:30.80ms
+step:219/1490 train_time:6743ms step_avg:30.79ms
+step:220/1490 train_time:6777ms step_avg:30.80ms
+step:221/1490 train_time:6804ms step_avg:30.79ms
+step:222/1490 train_time:6838ms step_avg:30.80ms
+step:223/1490 train_time:6866ms step_avg:30.79ms
+step:224/1490 train_time:6899ms step_avg:30.80ms
+step:225/1490 train_time:6927ms step_avg:30.79ms
+step:226/1490 train_time:6961ms step_avg:30.80ms
+step:227/1490 train_time:6988ms step_avg:30.78ms
+step:228/1490 train_time:7022ms step_avg:30.80ms
+step:229/1490 train_time:7049ms step_avg:30.78ms
+step:230/1490 train_time:7083ms step_avg:30.80ms
+step:231/1490 train_time:7110ms step_avg:30.78ms
+step:232/1490 train_time:7144ms step_avg:30.79ms
+step:233/1490 train_time:7172ms step_avg:30.78ms
+step:234/1490 train_time:7206ms step_avg:30.80ms
+step:235/1490 train_time:7234ms step_avg:30.78ms
+step:236/1490 train_time:7268ms step_avg:30.80ms
+step:237/1490 train_time:7295ms step_avg:30.78ms
+step:238/1490 train_time:7329ms step_avg:30.80ms
+step:239/1490 train_time:7357ms step_avg:30.78ms
+step:240/1490 train_time:7391ms step_avg:30.79ms
+step:241/1490 train_time:7418ms step_avg:30.78ms
+step:242/1490 train_time:7452ms step_avg:30.79ms
+step:243/1490 train_time:7479ms step_avg:30.78ms
+step:244/1490 train_time:7513ms step_avg:30.79ms
+step:245/1490 train_time:7541ms step_avg:30.78ms
+step:246/1490 train_time:7575ms step_avg:30.79ms
+step:247/1490 train_time:7602ms step_avg:30.78ms
+step:248/1490 train_time:7636ms step_avg:30.79ms
+step:249/1490 train_time:7664ms step_avg:30.78ms
+step:250/1490 train_time:7698ms step_avg:30.79ms
+step:250/1490 val_loss:4.5174 train_time:7739ms step_avg:30.96ms
+step:251/1490 train_time:7761ms step_avg:30.92ms
+step:252/1490 train_time:7781ms step_avg:30.88ms
+step:253/1490 train_time:7796ms step_avg:30.82ms
+step:254/1490 train_time:7826ms step_avg:30.81ms
+step:255/1490 train_time:7854ms step_avg:30.80ms
+step:256/1490 train_time:7890ms step_avg:30.82ms
+step:257/1490 train_time:7918ms step_avg:30.81ms
+step:258/1490 train_time:7952ms step_avg:30.82ms
+step:259/1490 train_time:7980ms step_avg:30.81ms
+step:260/1490 train_time:8014ms step_avg:30.82ms
+step:261/1490 train_time:8042ms step_avg:30.81ms
+step:262/1490 train_time:8076ms step_avg:30.82ms
+step:263/1490 train_time:8104ms step_avg:30.81ms
+step:264/1490 train_time:8138ms step_avg:30.83ms
+step:265/1490 train_time:8165ms step_avg:30.81ms
+step:266/1490 train_time:8199ms step_avg:30.82ms
+step:267/1490 train_time:8227ms step_avg:30.81ms
+step:268/1490 train_time:8261ms step_avg:30.82ms
+step:269/1490 train_time:8288ms step_avg:30.81ms
+step:270/1490 train_time:8322ms step_avg:30.82ms
+step:271/1490 train_time:8349ms step_avg:30.81ms
+step:272/1490 train_time:8383ms step_avg:30.82ms
+step:273/1490 train_time:8410ms step_avg:30.81ms
+step:274/1490 train_time:8444ms step_avg:30.82ms
+step:275/1490 train_time:8471ms step_avg:30.80ms
+step:276/1490 train_time:8505ms step_avg:30.82ms
+step:277/1490 train_time:8532ms step_avg:30.80ms
+step:278/1490 train_time:8566ms step_avg:30.81ms
+step:279/1490 train_time:8594ms step_avg:30.80ms
+step:280/1490 train_time:8628ms step_avg:30.81ms
+step:281/1490 train_time:8655ms step_avg:30.80ms
+step:282/1490 train_time:8689ms step_avg:30.81ms
+step:283/1490 train_time:8717ms step_avg:30.80ms
+step:284/1490 train_time:8751ms step_avg:30.81ms
+step:285/1490 train_time:8780ms step_avg:30.81ms
+step:286/1490 train_time:8814ms step_avg:30.82ms
+step:287/1490 train_time:8842ms step_avg:30.81ms
+step:288/1490 train_time:8876ms step_avg:30.82ms
+step:289/1490 train_time:8904ms step_avg:30.81ms
+step:290/1490 train_time:8938ms step_avg:30.82ms
+step:291/1490 train_time:8965ms step_avg:30.81ms
+step:292/1490 train_time:8999ms step_avg:30.82ms
+step:293/1490 train_time:9027ms step_avg:30.81ms
+step:294/1490 train_time:9061ms step_avg:30.82ms
+step:295/1490 train_time:9089ms step_avg:30.81ms
+step:296/1490 train_time:9123ms step_avg:30.82ms
+step:297/1490 train_time:9150ms step_avg:30.81ms
+step:298/1490 train_time:9184ms step_avg:30.82ms
+step:299/1490 train_time:9211ms step_avg:30.81ms
+step:300/1490 train_time:9245ms step_avg:30.82ms
+step:301/1490 train_time:9273ms step_avg:30.81ms
+step:302/1490 train_time:9307ms step_avg:30.82ms
+step:303/1490 train_time:9334ms step_avg:30.81ms
+step:304/1490 train_time:9368ms step_avg:30.82ms
+step:305/1490 train_time:9395ms step_avg:30.80ms
+step:306/1490 train_time:9429ms step_avg:30.81ms
+step:307/1490 train_time:9457ms step_avg:30.80ms
+step:308/1490 train_time:9491ms step_avg:30.81ms
+step:309/1490 train_time:9518ms step_avg:30.80ms
+step:310/1490 train_time:9552ms step_avg:30.81ms
+step:311/1490 train_time:9579ms step_avg:30.80ms
+step:312/1490 train_time:9614ms step_avg:30.82ms
+step:313/1490 train_time:9641ms step_avg:30.80ms
+step:314/1490 train_time:9675ms step_avg:30.81ms
+step:315/1490 train_time:9703ms step_avg:30.80ms
+step:316/1490 train_time:9737ms step_avg:30.81ms
+step:317/1490 train_time:9765ms step_avg:30.80ms
+step:318/1490 train_time:9799ms step_avg:30.81ms
+step:319/1490 train_time:9827ms step_avg:30.81ms
+step:320/1490 train_time:9861ms step_avg:30.82ms
+step:321/1490 train_time:9889ms step_avg:30.81ms
+step:322/1490 train_time:9923ms step_avg:30.82ms
+step:323/1490 train_time:9950ms step_avg:30.80ms
+step:324/1490 train_time:9984ms step_avg:30.81ms
+step:325/1490 train_time:10012ms step_avg:30.80ms
+step:326/1490 train_time:10046ms step_avg:30.81ms
+step:327/1490 train_time:10073ms step_avg:30.80ms
+step:328/1490 train_time:10107ms step_avg:30.81ms
+step:329/1490 train_time:10134ms step_avg:30.80ms
+step:330/1490 train_time:10168ms step_avg:30.81ms
+step:331/1490 train_time:10196ms step_avg:30.80ms
+step:332/1490 train_time:10230ms step_avg:30.81ms
+step:333/1490 train_time:10258ms step_avg:30.81ms
+step:334/1490 train_time:10292ms step_avg:30.81ms
+step:335/1490 train_time:10319ms step_avg:30.80ms
+step:336/1490 train_time:10353ms step_avg:30.81ms
+step:337/1490 train_time:10380ms step_avg:30.80ms
+step:338/1490 train_time:10414ms step_avg:30.81ms
+step:339/1490 train_time:10442ms step_avg:30.80ms
+step:340/1490 train_time:10475ms step_avg:30.81ms
+step:341/1490 train_time:10503ms step_avg:30.80ms
+step:342/1490 train_time:10537ms step_avg:30.81ms
+step:343/1490 train_time:10565ms step_avg:30.80ms
+step:344/1490 train_time:10599ms step_avg:30.81ms
+step:345/1490 train_time:10626ms step_avg:30.80ms
+step:346/1490 train_time:10660ms step_avg:30.81ms
+step:347/1490 train_time:10688ms step_avg:30.80ms
+step:348/1490 train_time:10722ms step_avg:30.81ms
+step:349/1490 train_time:10749ms step_avg:30.80ms
+step:350/1490 train_time:10784ms step_avg:30.81ms
+step:351/1490 train_time:10811ms step_avg:30.80ms
+step:352/1490 train_time:10846ms step_avg:30.81ms
+step:353/1490 train_time:10873ms step_avg:30.80ms
+step:354/1490 train_time:10907ms step_avg:30.81ms
+step:355/1490 train_time:10935ms step_avg:30.80ms
+step:356/1490 train_time:10969ms step_avg:30.81ms
+step:357/1490 train_time:10997ms step_avg:30.80ms
+step:358/1490 train_time:11030ms step_avg:30.81ms
+step:359/1490 train_time:11058ms step_avg:30.80ms
+step:360/1490 train_time:11092ms step_avg:30.81ms
+step:361/1490 train_time:11120ms step_avg:30.80ms
+step:362/1490 train_time:11153ms step_avg:30.81ms
+step:363/1490 train_time:11181ms step_avg:30.80ms
+step:364/1490 train_time:11214ms step_avg:30.81ms
+step:365/1490 train_time:11242ms step_avg:30.80ms
+step:366/1490 train_time:11276ms step_avg:30.81ms
+step:367/1490 train_time:11304ms step_avg:30.80ms
+step:368/1490 train_time:11338ms step_avg:30.81ms
+step:369/1490 train_time:11365ms step_avg:30.80ms
+step:370/1490 train_time:11399ms step_avg:30.81ms
+step:371/1490 train_time:11427ms step_avg:30.80ms
+step:372/1490 train_time:11461ms step_avg:30.81ms
+step:373/1490 train_time:11488ms step_avg:30.80ms
+step:374/1490 train_time:11522ms step_avg:30.81ms
+step:375/1490 train_time:11550ms step_avg:30.80ms
+step:376/1490 train_time:11584ms step_avg:30.81ms
+step:377/1490 train_time:11611ms step_avg:30.80ms
+step:378/1490 train_time:11645ms step_avg:30.81ms
+step:379/1490 train_time:11672ms step_avg:30.80ms
+step:380/1490 train_time:11706ms step_avg:30.81ms
+step:381/1490 train_time:11734ms step_avg:30.80ms
+step:382/1490 train_time:11768ms step_avg:30.81ms
+step:383/1490 train_time:11795ms step_avg:30.80ms
+step:384/1490 train_time:11831ms step_avg:30.81ms
+step:385/1490 train_time:11857ms step_avg:30.80ms
+step:386/1490 train_time:11891ms step_avg:30.81ms
+step:387/1490 train_time:11919ms step_avg:30.80ms
+step:388/1490 train_time:11952ms step_avg:30.80ms
+step:389/1490 train_time:11980ms step_avg:30.80ms
+step:390/1490 train_time:12014ms step_avg:30.80ms
+step:391/1490 train_time:12041ms step_avg:30.80ms
+step:392/1490 train_time:12075ms step_avg:30.80ms
+step:393/1490 train_time:12103ms step_avg:30.80ms
+step:394/1490 train_time:12137ms step_avg:30.80ms
+step:395/1490 train_time:12164ms step_avg:30.80ms
+step:396/1490 train_time:12198ms step_avg:30.80ms
+step:397/1490 train_time:12226ms step_avg:30.80ms
+step:398/1490 train_time:12260ms step_avg:30.80ms
+step:399/1490 train_time:12288ms step_avg:30.80ms
+step:400/1490 train_time:12322ms step_avg:30.80ms
+step:401/1490 train_time:12349ms step_avg:30.80ms
+step:402/1490 train_time:12383ms step_avg:30.80ms
+step:403/1490 train_time:12411ms step_avg:30.80ms
+step:404/1490 train_time:12445ms step_avg:30.80ms
+step:405/1490 train_time:12472ms step_avg:30.80ms
+step:406/1490 train_time:12507ms step_avg:30.80ms
+step:407/1490 train_time:12534ms step_avg:30.80ms
+step:408/1490 train_time:12568ms step_avg:30.80ms
+step:409/1490 train_time:12595ms step_avg:30.80ms
+step:410/1490 train_time:12629ms step_avg:30.80ms
+step:411/1490 train_time:12657ms step_avg:30.79ms
+step:412/1490 train_time:12691ms step_avg:30.80ms
+step:413/1490 train_time:12718ms step_avg:30.79ms
+step:414/1490 train_time:12752ms step_avg:30.80ms
+step:415/1490 train_time:12780ms step_avg:30.79ms
+step:416/1490 train_time:12813ms step_avg:30.80ms
+step:417/1490 train_time:12841ms step_avg:30.79ms
+step:418/1490 train_time:12875ms step_avg:30.80ms
+step:419/1490 train_time:12903ms step_avg:30.79ms
+step:420/1490 train_time:12937ms step_avg:30.80ms
+step:421/1490 train_time:12964ms step_avg:30.79ms
+step:422/1490 train_time:12998ms step_avg:30.80ms
+step:423/1490 train_time:13025ms step_avg:30.79ms
+step:424/1490 train_time:13059ms step_avg:30.80ms
+step:425/1490 train_time:13087ms step_avg:30.79ms
+step:426/1490 train_time:13121ms step_avg:30.80ms
+step:427/1490 train_time:13148ms step_avg:30.79ms
+step:428/1490 train_time:13183ms step_avg:30.80ms
+step:429/1490 train_time:13210ms step_avg:30.79ms
+step:430/1490 train_time:13245ms step_avg:30.80ms
+step:431/1490 train_time:13272ms step_avg:30.79ms
+step:432/1490 train_time:13306ms step_avg:30.80ms
+step:433/1490 train_time:13333ms step_avg:30.79ms
+step:434/1490 train_time:13368ms step_avg:30.80ms
+step:435/1490 train_time:13395ms step_avg:30.79ms
+step:436/1490 train_time:13429ms step_avg:30.80ms
+step:437/1490 train_time:13457ms step_avg:30.79ms
+step:438/1490 train_time:13491ms step_avg:30.80ms
+step:439/1490 train_time:13519ms step_avg:30.79ms
+step:440/1490 train_time:13553ms step_avg:30.80ms
+step:441/1490 train_time:13580ms step_avg:30.79ms
+step:442/1490 train_time:13614ms step_avg:30.80ms
+step:443/1490 train_time:13641ms step_avg:30.79ms
+step:444/1490 train_time:13675ms step_avg:30.80ms
+step:445/1490 train_time:13703ms step_avg:30.79ms
+step:446/1490 train_time:13737ms step_avg:30.80ms
+step:447/1490 train_time:13765ms step_avg:30.79ms
+step:448/1490 train_time:13799ms step_avg:30.80ms
+step:449/1490 train_time:13826ms step_avg:30.79ms
+step:450/1490 train_time:13861ms step_avg:30.80ms
+step:451/1490 train_time:13888ms step_avg:30.79ms
+step:452/1490 train_time:13923ms step_avg:30.80ms
+step:453/1490 train_time:13950ms step_avg:30.79ms
+step:454/1490 train_time:13984ms step_avg:30.80ms
+step:455/1490 train_time:14012ms step_avg:30.79ms
+step:456/1490 train_time:14046ms step_avg:30.80ms
+step:457/1490 train_time:14073ms step_avg:30.79ms
+step:458/1490 train_time:14108ms step_avg:30.80ms
+step:459/1490 train_time:14135ms step_avg:30.80ms
+step:460/1490 train_time:14170ms step_avg:30.80ms
+step:461/1490 train_time:14197ms step_avg:30.80ms
+step:462/1490 train_time:14230ms step_avg:30.80ms
+step:463/1490 train_time:14258ms step_avg:30.80ms
+step:464/1490 train_time:14292ms step_avg:30.80ms
+step:465/1490 train_time:14320ms step_avg:30.80ms
+step:466/1490 train_time:14354ms step_avg:30.80ms
+step:467/1490 train_time:14382ms step_avg:30.80ms
+step:468/1490 train_time:14415ms step_avg:30.80ms
+step:469/1490 train_time:14443ms step_avg:30.80ms
+step:470/1490 train_time:14477ms step_avg:30.80ms
+step:471/1490 train_time:14505ms step_avg:30.80ms
+step:472/1490 train_time:14539ms step_avg:30.80ms
+step:473/1490 train_time:14567ms step_avg:30.80ms
+step:474/1490 train_time:14601ms step_avg:30.80ms
+step:475/1490 train_time:14628ms step_avg:30.80ms
+step:476/1490 train_time:14662ms step_avg:30.80ms
+step:477/1490 train_time:14690ms step_avg:30.80ms
+step:478/1490 train_time:14725ms step_avg:30.80ms
+step:479/1490 train_time:14751ms step_avg:30.80ms
+step:480/1490 train_time:14785ms step_avg:30.80ms
+step:481/1490 train_time:14813ms step_avg:30.80ms
+step:482/1490 train_time:14847ms step_avg:30.80ms
+step:483/1490 train_time:14874ms step_avg:30.80ms
+step:484/1490 train_time:14911ms step_avg:30.81ms
+step:485/1490 train_time:14962ms step_avg:30.85ms
+step:486/1490 train_time:15021ms step_avg:30.91ms
+step:487/1490 train_time:15074ms step_avg:30.95ms
+step:488/1490 train_time:15133ms step_avg:31.01ms
+step:489/1490 train_time:15186ms step_avg:31.06ms
+step:490/1490 train_time:15246ms step_avg:31.11ms
+step:491/1490 train_time:15300ms step_avg:31.16ms
+step:492/1490 train_time:15359ms step_avg:31.22ms
+step:493/1490 train_time:15412ms step_avg:31.26ms
+step:494/1490 train_time:15471ms step_avg:31.32ms
+step:495/1490 train_time:15524ms step_avg:31.36ms
+step:496/1490 train_time:15583ms step_avg:31.42ms
+step:497/1490 train_time:15637ms step_avg:31.46ms
+step:498/1490 train_time:15695ms step_avg:31.52ms
+step:499/1490 train_time:15750ms step_avg:31.56ms
+step:500/1490 train_time:15809ms step_avg:31.62ms
+step:500/1490 val_loss:4.2305 train_time:15880ms step_avg:31.76ms
+step:501/1490 train_time:15904ms step_avg:31.74ms
+step:502/1490 train_time:15927ms step_avg:31.73ms
+step:503/1490 train_time:15983ms step_avg:31.78ms
+step:504/1490 train_time:16045ms step_avg:31.84ms
+step:505/1490 train_time:16100ms step_avg:31.88ms
+step:506/1490 train_time:16160ms step_avg:31.94ms
+step:507/1490 train_time:16213ms step_avg:31.98ms
+step:508/1490 train_time:16271ms step_avg:32.03ms
+step:509/1490 train_time:16324ms step_avg:32.07ms
+step:510/1490 train_time:16384ms step_avg:32.13ms
+step:511/1490 train_time:16437ms step_avg:32.17ms
+step:512/1490 train_time:16495ms step_avg:32.22ms
+step:513/1490 train_time:16548ms step_avg:32.26ms
+step:514/1490 train_time:16606ms step_avg:32.31ms
+step:515/1490 train_time:16659ms step_avg:32.35ms
+step:516/1490 train_time:16717ms step_avg:32.40ms
+step:517/1490 train_time:16770ms step_avg:32.44ms
+step:518/1490 train_time:16829ms step_avg:32.49ms
+step:519/1490 train_time:16884ms step_avg:32.53ms
+step:520/1490 train_time:16945ms step_avg:32.59ms
+step:521/1490 train_time:17000ms step_avg:32.63ms
+step:522/1490 train_time:17060ms step_avg:32.68ms
+step:523/1490 train_time:17115ms step_avg:32.72ms
+step:524/1490 train_time:17174ms step_avg:32.77ms
+step:525/1490 train_time:17228ms step_avg:32.81ms
+step:526/1490 train_time:17286ms step_avg:32.86ms
+step:527/1490 train_time:17339ms step_avg:32.90ms
+step:528/1490 train_time:17397ms step_avg:32.95ms
+step:529/1490 train_time:17450ms step_avg:32.99ms
+step:530/1490 train_time:17509ms step_avg:33.04ms
+step:531/1490 train_time:17562ms step_avg:33.07ms
+step:532/1490 train_time:17621ms step_avg:33.12ms
+step:533/1490 train_time:17675ms step_avg:33.16ms
+step:534/1490 train_time:17733ms step_avg:33.21ms
+step:535/1490 train_time:17786ms step_avg:33.25ms
+step:536/1490 train_time:17845ms step_avg:33.29ms
+step:537/1490 train_time:17899ms step_avg:33.33ms
+step:538/1490 train_time:17959ms step_avg:33.38ms
+step:539/1490 train_time:18013ms step_avg:33.42ms
+step:540/1490 train_time:18073ms step_avg:33.47ms
+step:541/1490 train_time:18128ms step_avg:33.51ms
+step:542/1490 train_time:18187ms step_avg:33.56ms
+step:543/1490 train_time:18241ms step_avg:33.59ms
+step:544/1490 train_time:18299ms step_avg:33.64ms
+step:545/1490 train_time:18352ms step_avg:33.67ms
+step:546/1490 train_time:18412ms step_avg:33.72ms
+step:547/1490 train_time:18465ms step_avg:33.76ms
+step:548/1490 train_time:18524ms step_avg:33.80ms
+step:549/1490 train_time:18577ms step_avg:33.84ms
+step:550/1490 train_time:18635ms step_avg:33.88ms
+step:551/1490 train_time:18689ms step_avg:33.92ms
+step:552/1490 train_time:18747ms step_avg:33.96ms
+step:553/1490 train_time:18800ms step_avg:34.00ms
+step:554/1490 train_time:18859ms step_avg:34.04ms
+step:555/1490 train_time:18913ms step_avg:34.08ms
+step:556/1490 train_time:18972ms step_avg:34.12ms
+step:557/1490 train_time:19028ms step_avg:34.16ms
+step:558/1490 train_time:19087ms step_avg:34.21ms
+step:559/1490 train_time:19141ms step_avg:34.24ms
+step:560/1490 train_time:19200ms step_avg:34.29ms
+step:561/1490 train_time:19253ms step_avg:34.32ms
+step:562/1490 train_time:19311ms step_avg:34.36ms
+step:563/1490 train_time:19366ms step_avg:34.40ms
+step:564/1490 train_time:19425ms step_avg:34.44ms
+step:565/1490 train_time:19478ms step_avg:34.47ms
+step:566/1490 train_time:19537ms step_avg:34.52ms
+step:567/1490 train_time:19590ms step_avg:34.55ms
+step:568/1490 train_time:19648ms step_avg:34.59ms
+step:569/1490 train_time:19702ms step_avg:34.63ms
+step:570/1490 train_time:19761ms step_avg:34.67ms
+step:571/1490 train_time:19815ms step_avg:34.70ms
+step:572/1490 train_time:19873ms step_avg:34.74ms
+step:573/1490 train_time:19927ms step_avg:34.78ms
+step:574/1490 train_time:19986ms step_avg:34.82ms
+step:575/1490 train_time:20041ms step_avg:34.85ms
+step:576/1490 train_time:20100ms step_avg:34.90ms
+step:577/1490 train_time:20153ms step_avg:34.93ms
+step:578/1490 train_time:20212ms step_avg:34.97ms
+step:579/1490 train_time:20266ms step_avg:35.00ms
+step:580/1490 train_time:20325ms step_avg:35.04ms
+step:581/1490 train_time:20379ms step_avg:35.08ms
+step:582/1490 train_time:20438ms step_avg:35.12ms
+step:583/1490 train_time:20491ms step_avg:35.15ms
+step:584/1490 train_time:20549ms step_avg:35.19ms
+step:585/1490 train_time:20603ms step_avg:35.22ms
+step:586/1490 train_time:20661ms step_avg:35.26ms
+step:587/1490 train_time:20715ms step_avg:35.29ms
+step:588/1490 train_time:20774ms step_avg:35.33ms
+step:589/1490 train_time:20828ms step_avg:35.36ms
+step:590/1490 train_time:20887ms step_avg:35.40ms
+step:591/1490 train_time:20941ms step_avg:35.43ms
+step:592/1490 train_time:21000ms step_avg:35.47ms
+step:593/1490 train_time:21053ms step_avg:35.50ms
+step:594/1490 train_time:21112ms step_avg:35.54ms
+step:595/1490 train_time:21166ms step_avg:35.57ms
+step:596/1490 train_time:21225ms step_avg:35.61ms
+step:597/1490 train_time:21280ms step_avg:35.64ms
+step:598/1490 train_time:21338ms step_avg:35.68ms
+step:599/1490 train_time:21391ms step_avg:35.71ms
+step:600/1490 train_time:21450ms step_avg:35.75ms
+step:601/1490 train_time:21504ms step_avg:35.78ms
+step:602/1490 train_time:21562ms step_avg:35.82ms
+step:603/1490 train_time:21615ms step_avg:35.85ms
+step:604/1490 train_time:21674ms step_avg:35.88ms
+step:605/1490 train_time:21729ms step_avg:35.92ms
+step:606/1490 train_time:21787ms step_avg:35.95ms
+step:607/1490 train_time:21841ms step_avg:35.98ms
+step:608/1490 train_time:21901ms step_avg:36.02ms
+step:609/1490 train_time:21954ms step_avg:36.05ms
+step:610/1490 train_time:22012ms step_avg:36.09ms
+step:611/1490 train_time:22067ms step_avg:36.12ms
+step:612/1490 train_time:22127ms step_avg:36.15ms
+step:613/1490 train_time:22180ms step_avg:36.18ms
+step:614/1490 train_time:22240ms step_avg:36.22ms
+step:615/1490 train_time:22293ms step_avg:36.25ms
+step:616/1490 train_time:22352ms step_avg:36.29ms
+step:617/1490 train_time:22406ms step_avg:36.31ms
+step:618/1490 train_time:22464ms step_avg:36.35ms
+step:619/1490 train_time:22517ms step_avg:36.38ms
+step:620/1490 train_time:22576ms step_avg:36.41ms
+step:621/1490 train_time:22630ms step_avg:36.44ms
+step:622/1490 train_time:22689ms step_avg:36.48ms
+step:623/1490 train_time:22743ms step_avg:36.51ms
+step:624/1490 train_time:22803ms step_avg:36.54ms
+step:625/1490 train_time:22857ms step_avg:36.57ms
+step:626/1490 train_time:22916ms step_avg:36.61ms
+step:627/1490 train_time:22969ms step_avg:36.63ms
+step:628/1490 train_time:23028ms step_avg:36.67ms
+step:629/1490 train_time:23083ms step_avg:36.70ms
+step:630/1490 train_time:23142ms step_avg:36.73ms
+step:631/1490 train_time:23197ms step_avg:36.76ms
+step:632/1490 train_time:23255ms step_avg:36.80ms
+step:633/1490 train_time:23309ms step_avg:36.82ms
+step:634/1490 train_time:23367ms step_avg:36.86ms
+step:635/1490 train_time:23422ms step_avg:36.88ms
+step:636/1490 train_time:23481ms step_avg:36.92ms
+step:637/1490 train_time:23534ms step_avg:36.95ms
+step:638/1490 train_time:23593ms step_avg:36.98ms
+step:639/1490 train_time:23646ms step_avg:37.01ms
+step:640/1490 train_time:23705ms step_avg:37.04ms
+step:641/1490 train_time:23758ms step_avg:37.06ms
+step:642/1490 train_time:23817ms step_avg:37.10ms
+step:643/1490 train_time:23871ms step_avg:37.12ms
+step:644/1490 train_time:23930ms step_avg:37.16ms
+step:645/1490 train_time:23983ms step_avg:37.18ms
+step:646/1490 train_time:24042ms step_avg:37.22ms
+step:647/1490 train_time:24097ms step_avg:37.24ms
+step:648/1490 train_time:24155ms step_avg:37.28ms
+step:649/1490 train_time:24209ms step_avg:37.30ms
+step:650/1490 train_time:24268ms step_avg:37.34ms
+step:651/1490 train_time:24322ms step_avg:37.36ms
+step:652/1490 train_time:24381ms step_avg:37.39ms
+step:653/1490 train_time:24434ms step_avg:37.42ms
+step:654/1490 train_time:24493ms step_avg:37.45ms
+step:655/1490 train_time:24547ms step_avg:37.48ms
+step:656/1490 train_time:24605ms step_avg:37.51ms
+step:657/1490 train_time:24659ms step_avg:37.53ms
+step:658/1490 train_time:24717ms step_avg:37.56ms
+step:659/1490 train_time:24771ms step_avg:37.59ms
+step:660/1490 train_time:24831ms step_avg:37.62ms
+step:661/1490 train_time:24884ms step_avg:37.65ms
+step:662/1490 train_time:24944ms step_avg:37.68ms
+step:663/1490 train_time:24998ms step_avg:37.70ms
+step:664/1490 train_time:25057ms step_avg:37.74ms
+step:665/1490 train_time:25111ms step_avg:37.76ms
+step:666/1490 train_time:25169ms step_avg:37.79ms
+step:667/1490 train_time:25223ms step_avg:37.82ms
+step:668/1490 train_time:25282ms step_avg:37.85ms
+step:669/1490 train_time:25337ms step_avg:37.87ms
+step:670/1490 train_time:25395ms step_avg:37.90ms
+step:671/1490 train_time:25449ms step_avg:37.93ms
+step:672/1490 train_time:25508ms step_avg:37.96ms
+step:673/1490 train_time:25562ms step_avg:37.98ms
+step:674/1490 train_time:25621ms step_avg:38.01ms
+step:675/1490 train_time:25675ms step_avg:38.04ms
+step:676/1490 train_time:25734ms step_avg:38.07ms
+step:677/1490 train_time:25788ms step_avg:38.09ms
+step:678/1490 train_time:25847ms step_avg:38.12ms
+step:679/1490 train_time:25901ms step_avg:38.15ms
+step:680/1490 train_time:25960ms step_avg:38.18ms
+step:681/1490 train_time:26013ms step_avg:38.20ms
+step:682/1490 train_time:26072ms step_avg:38.23ms
+step:683/1490 train_time:26126ms step_avg:38.25ms
+step:684/1490 train_time:26185ms step_avg:38.28ms
+step:685/1490 train_time:26238ms step_avg:38.30ms
+step:686/1490 train_time:26296ms step_avg:38.33ms
+step:687/1490 train_time:26350ms step_avg:38.36ms
+step:688/1490 train_time:26409ms step_avg:38.38ms
+step:689/1490 train_time:26463ms step_avg:38.41ms
+step:690/1490 train_time:26522ms step_avg:38.44ms
+step:691/1490 train_time:26576ms step_avg:38.46ms
+step:692/1490 train_time:26635ms step_avg:38.49ms
+step:693/1490 train_time:26688ms step_avg:38.51ms
+step:694/1490 train_time:26746ms step_avg:38.54ms
+step:695/1490 train_time:26800ms step_avg:38.56ms
+step:696/1490 train_time:26860ms step_avg:38.59ms
+step:697/1490 train_time:26913ms step_avg:38.61ms
+step:698/1490 train_time:26972ms step_avg:38.64ms
+step:699/1490 train_time:27026ms step_avg:38.66ms
+step:700/1490 train_time:27085ms step_avg:38.69ms
+step:701/1490 train_time:27138ms step_avg:38.71ms
+step:702/1490 train_time:27197ms step_avg:38.74ms
+step:703/1490 train_time:27251ms step_avg:38.76ms
+step:704/1490 train_time:27310ms step_avg:38.79ms
+step:705/1490 train_time:27364ms step_avg:38.81ms
+step:706/1490 train_time:27424ms step_avg:38.84ms
+step:707/1490 train_time:27477ms step_avg:38.86ms
+step:708/1490 train_time:27537ms step_avg:38.89ms
+step:709/1490 train_time:27590ms step_avg:38.91ms
+step:710/1490 train_time:27649ms step_avg:38.94ms
+step:711/1490 train_time:27704ms step_avg:38.96ms
+step:712/1490 train_time:27763ms step_avg:38.99ms
+step:713/1490 train_time:27817ms step_avg:39.01ms
+step:714/1490 train_time:27878ms step_avg:39.05ms
+step:715/1490 train_time:27929ms step_avg:39.06ms
+step:716/1490 train_time:27988ms step_avg:39.09ms
+step:717/1490 train_time:28042ms step_avg:39.11ms
+step:718/1490 train_time:28101ms step_avg:39.14ms
+step:719/1490 train_time:28155ms step_avg:39.16ms
+step:720/1490 train_time:28214ms step_avg:39.19ms
+step:721/1490 train_time:28267ms step_avg:39.21ms
+step:722/1490 train_time:28327ms step_avg:39.23ms
+step:723/1490 train_time:28380ms step_avg:39.25ms
+step:724/1490 train_time:28438ms step_avg:39.28ms
+step:725/1490 train_time:28491ms step_avg:39.30ms
+step:726/1490 train_time:28551ms step_avg:39.33ms
+step:727/1490 train_time:28604ms step_avg:39.35ms
+step:728/1490 train_time:28663ms step_avg:39.37ms
+step:729/1490 train_time:28717ms step_avg:39.39ms
+step:730/1490 train_time:28776ms step_avg:39.42ms
+step:731/1490 train_time:28830ms step_avg:39.44ms
+step:732/1490 train_time:28888ms step_avg:39.46ms
+step:733/1490 train_time:28942ms step_avg:39.48ms
+step:734/1490 train_time:29002ms step_avg:39.51ms
+step:735/1490 train_time:29055ms step_avg:39.53ms
+step:736/1490 train_time:29114ms step_avg:39.56ms
+step:737/1490 train_time:29168ms step_avg:39.58ms
+step:738/1490 train_time:29228ms step_avg:39.60ms
+step:739/1490 train_time:29281ms step_avg:39.62ms
+step:740/1490 train_time:29340ms step_avg:39.65ms
+step:741/1490 train_time:29393ms step_avg:39.67ms
+step:742/1490 train_time:29452ms step_avg:39.69ms
+step:743/1490 train_time:29505ms step_avg:39.71ms
+step:744/1490 train_time:29564ms step_avg:39.74ms
+step:745/1490 train_time:29617ms step_avg:39.75ms
+step:746/1490 train_time:29676ms step_avg:39.78ms
+step:747/1490 train_time:29732ms step_avg:39.80ms
+step:748/1490 train_time:29790ms step_avg:39.83ms
+step:749/1490 train_time:29843ms step_avg:39.84ms
+step:750/1490 train_time:29903ms step_avg:39.87ms
+step:750/1490 val_loss:3.8007 train_time:29973ms step_avg:39.96ms
+step:751/1490 train_time:29997ms step_avg:39.94ms
+step:752/1490 train_time:30019ms step_avg:39.92ms
+step:753/1490 train_time:30072ms step_avg:39.94ms
+step:754/1490 train_time:30138ms step_avg:39.97ms
+step:755/1490 train_time:30192ms step_avg:39.99ms
+step:756/1490 train_time:30251ms step_avg:40.01ms
+step:757/1490 train_time:30306ms step_avg:40.03ms
+step:758/1490 train_time:30365ms step_avg:40.06ms
+step:759/1490 train_time:30419ms step_avg:40.08ms
+step:760/1490 train_time:30476ms step_avg:40.10ms
+step:761/1490 train_time:30530ms step_avg:40.12ms
+step:762/1490 train_time:30588ms step_avg:40.14ms
+step:763/1490 train_time:30641ms step_avg:40.16ms
+step:764/1490 train_time:30698ms step_avg:40.18ms
+step:765/1490 train_time:30751ms step_avg:40.20ms
+step:766/1490 train_time:30809ms step_avg:40.22ms
+step:767/1490 train_time:30862ms step_avg:40.24ms
+step:768/1490 train_time:30921ms step_avg:40.26ms
+step:769/1490 train_time:30975ms step_avg:40.28ms
+step:770/1490 train_time:31035ms step_avg:40.31ms
+step:771/1490 train_time:31092ms step_avg:40.33ms
+step:772/1490 train_time:31152ms step_avg:40.35ms
+step:773/1490 train_time:31207ms step_avg:40.37ms
+step:774/1490 train_time:31266ms step_avg:40.40ms
+step:775/1490 train_time:31319ms step_avg:40.41ms
+step:776/1490 train_time:31378ms step_avg:40.44ms
+step:777/1490 train_time:31431ms step_avg:40.45ms
+step:778/1490 train_time:31490ms step_avg:40.48ms
+step:779/1490 train_time:31543ms step_avg:40.49ms
+step:780/1490 train_time:31601ms step_avg:40.51ms
+step:781/1490 train_time:31654ms step_avg:40.53ms
+step:782/1490 train_time:31712ms step_avg:40.55ms
+step:783/1490 train_time:31765ms step_avg:40.57ms
+step:784/1490 train_time:31824ms step_avg:40.59ms
+step:785/1490 train_time:31878ms step_avg:40.61ms
+step:786/1490 train_time:31936ms step_avg:40.63ms
+step:787/1490 train_time:31991ms step_avg:40.65ms
+step:788/1490 train_time:32050ms step_avg:40.67ms
+step:789/1490 train_time:32105ms step_avg:40.69ms
+step:790/1490 train_time:32164ms step_avg:40.71ms
+step:791/1490 train_time:32218ms step_avg:40.73ms
+step:792/1490 train_time:32280ms step_avg:40.76ms
+step:793/1490 train_time:32331ms step_avg:40.77ms
+step:794/1490 train_time:32391ms step_avg:40.79ms
+step:795/1490 train_time:32445ms step_avg:40.81ms
+step:796/1490 train_time:32504ms step_avg:40.83ms
+step:797/1490 train_time:32557ms step_avg:40.85ms
+step:798/1490 train_time:32615ms step_avg:40.87ms
+step:799/1490 train_time:32669ms step_avg:40.89ms
+step:800/1490 train_time:32727ms step_avg:40.91ms
+step:801/1490 train_time:32781ms step_avg:40.93ms
+step:802/1490 train_time:32839ms step_avg:40.95ms
+step:803/1490 train_time:32893ms step_avg:40.96ms
+step:804/1490 train_time:32953ms step_avg:40.99ms
+step:805/1490 train_time:33007ms step_avg:41.00ms
+step:806/1490 train_time:33066ms step_avg:41.02ms
+step:807/1490 train_time:33119ms step_avg:41.04ms
+step:808/1490 train_time:33179ms step_avg:41.06ms
+step:809/1490 train_time:33231ms step_avg:41.08ms
+step:810/1490 train_time:33292ms step_avg:41.10ms
+step:811/1490 train_time:33346ms step_avg:41.12ms
+step:812/1490 train_time:33404ms step_avg:41.14ms
+step:813/1490 train_time:33457ms step_avg:41.15ms
+step:814/1490 train_time:33515ms step_avg:41.17ms
+step:815/1490 train_time:33570ms step_avg:41.19ms
+step:816/1490 train_time:33628ms step_avg:41.21ms
+step:817/1490 train_time:33682ms step_avg:41.23ms
+step:818/1490 train_time:33740ms step_avg:41.25ms
+step:819/1490 train_time:33794ms step_avg:41.26ms
+step:820/1490 train_time:33853ms step_avg:41.28ms
+step:821/1490 train_time:33907ms step_avg:41.30ms
+step:822/1490 train_time:33966ms step_avg:41.32ms
+step:823/1490 train_time:34020ms step_avg:41.34ms
+step:824/1490 train_time:34078ms step_avg:41.36ms
+step:825/1490 train_time:34131ms step_avg:41.37ms
+step:826/1490 train_time:34191ms step_avg:41.39ms
+step:827/1490 train_time:34246ms step_avg:41.41ms
+step:828/1490 train_time:34305ms step_avg:41.43ms
+step:829/1490 train_time:34359ms step_avg:41.45ms
+step:830/1490 train_time:34417ms step_avg:41.47ms
+step:831/1490 train_time:34470ms step_avg:41.48ms
+step:832/1490 train_time:34529ms step_avg:41.50ms
+step:833/1490 train_time:34583ms step_avg:41.52ms
+step:834/1490 train_time:34641ms step_avg:41.54ms
+step:835/1490 train_time:34734ms step_avg:41.60ms
+step:836/1490 train_time:34753ms step_avg:41.57ms
+step:837/1490 train_time:34807ms step_avg:41.59ms
+step:838/1490 train_time:34866ms step_avg:41.61ms
+step:839/1490 train_time:34920ms step_avg:41.62ms
+step:840/1490 train_time:34977ms step_avg:41.64ms
+step:841/1490 train_time:35031ms step_avg:41.65ms
+step:842/1490 train_time:35091ms step_avg:41.68ms
+step:843/1490 train_time:35146ms step_avg:41.69ms
+step:844/1490 train_time:35205ms step_avg:41.71ms
+step:845/1490 train_time:35259ms step_avg:41.73ms
+step:846/1490 train_time:35320ms step_avg:41.75ms
+step:847/1490 train_time:35372ms step_avg:41.76ms
+step:848/1490 train_time:35430ms step_avg:41.78ms
+step:849/1490 train_time:35483ms step_avg:41.79ms
+step:850/1490 train_time:35543ms step_avg:41.82ms
+step:851/1490 train_time:35597ms step_avg:41.83ms
+step:852/1490 train_time:35655ms step_avg:41.85ms
+step:853/1490 train_time:35708ms step_avg:41.86ms
+step:854/1490 train_time:35767ms step_avg:41.88ms
+step:855/1490 train_time:35821ms step_avg:41.90ms
+step:856/1490 train_time:35880ms step_avg:41.92ms
+step:857/1490 train_time:35933ms step_avg:41.93ms
+step:858/1490 train_time:35992ms step_avg:41.95ms
+step:859/1490 train_time:36046ms step_avg:41.96ms
+step:860/1490 train_time:36105ms step_avg:41.98ms
+step:861/1490 train_time:36159ms step_avg:42.00ms
+step:862/1490 train_time:36217ms step_avg:42.02ms
+step:863/1490 train_time:36271ms step_avg:42.03ms
+step:864/1490 train_time:36330ms step_avg:42.05ms
+step:865/1490 train_time:36385ms step_avg:42.06ms
+step:866/1490 train_time:36444ms step_avg:42.08ms
+step:867/1490 train_time:36497ms step_avg:42.10ms
+step:868/1490 train_time:36556ms step_avg:42.11ms
+step:869/1490 train_time:36609ms step_avg:42.13ms
+step:870/1490 train_time:36668ms step_avg:42.15ms
+step:871/1490 train_time:36721ms step_avg:42.16ms
+step:872/1490 train_time:36780ms step_avg:42.18ms
+step:873/1490 train_time:36832ms step_avg:42.19ms
+step:874/1490 train_time:36893ms step_avg:42.21ms
+step:875/1490 train_time:36946ms step_avg:42.22ms
+step:876/1490 train_time:37004ms step_avg:42.24ms
+step:877/1490 train_time:37058ms step_avg:42.26ms
+step:878/1490 train_time:37116ms step_avg:42.27ms
+step:879/1490 train_time:37170ms step_avg:42.29ms
+step:880/1490 train_time:37230ms step_avg:42.31ms
+step:881/1490 train_time:37285ms step_avg:42.32ms
+step:882/1490 train_time:37344ms step_avg:42.34ms
+step:883/1490 train_time:37397ms step_avg:42.35ms
+step:884/1490 train_time:37456ms step_avg:42.37ms
+step:885/1490 train_time:37509ms step_avg:42.38ms
+step:886/1490 train_time:37568ms step_avg:42.40ms
+step:887/1490 train_time:37621ms step_avg:42.41ms
+step:888/1490 train_time:37680ms step_avg:42.43ms
+step:889/1490 train_time:37733ms step_avg:42.44ms
+step:890/1490 train_time:37792ms step_avg:42.46ms
+step:891/1490 train_time:37848ms step_avg:42.48ms
+step:892/1490 train_time:37906ms step_avg:42.50ms
+step:893/1490 train_time:37959ms step_avg:42.51ms
+step:894/1490 train_time:38018ms step_avg:42.53ms
+step:895/1490 train_time:38071ms step_avg:42.54ms
+step:896/1490 train_time:38130ms step_avg:42.56ms
+step:897/1490 train_time:38184ms step_avg:42.57ms
+step:898/1490 train_time:38243ms step_avg:42.59ms
+step:899/1490 train_time:38297ms step_avg:42.60ms
+step:900/1490 train_time:38355ms step_avg:42.62ms
+step:901/1490 train_time:38409ms step_avg:42.63ms
+step:902/1490 train_time:38469ms step_avg:42.65ms
+step:903/1490 train_time:38522ms step_avg:42.66ms
+step:904/1490 train_time:38581ms step_avg:42.68ms
+step:905/1490 train_time:38634ms step_avg:42.69ms
+step:906/1490 train_time:38694ms step_avg:42.71ms
+step:907/1490 train_time:38748ms step_avg:42.72ms
+step:908/1490 train_time:38807ms step_avg:42.74ms
+step:909/1490 train_time:38860ms step_avg:42.75ms
+step:910/1490 train_time:38918ms step_avg:42.77ms
+step:911/1490 train_time:38972ms step_avg:42.78ms
+step:912/1490 train_time:39030ms step_avg:42.80ms
+step:913/1490 train_time:39084ms step_avg:42.81ms
+step:914/1490 train_time:39142ms step_avg:42.83ms
+step:915/1490 train_time:39196ms step_avg:42.84ms
+step:916/1490 train_time:39255ms step_avg:42.86ms
+step:917/1490 train_time:39309ms step_avg:42.87ms
+step:918/1490 train_time:39368ms step_avg:42.88ms
+step:919/1490 train_time:39421ms step_avg:42.90ms
+step:920/1490 train_time:39480ms step_avg:42.91ms
+step:921/1490 train_time:39532ms step_avg:42.92ms
+step:922/1490 train_time:39591ms step_avg:42.94ms
+step:923/1490 train_time:39645ms step_avg:42.95ms
+step:924/1490 train_time:39704ms step_avg:42.97ms
+step:925/1490 train_time:39758ms step_avg:42.98ms
+step:926/1490 train_time:39818ms step_avg:43.00ms
+step:927/1490 train_time:39870ms step_avg:43.01ms
+step:928/1490 train_time:39929ms step_avg:43.03ms
+step:929/1490 train_time:39983ms step_avg:43.04ms
+step:930/1490 train_time:40041ms step_avg:43.05ms
+step:931/1490 train_time:40095ms step_avg:43.07ms
+step:932/1490 train_time:40154ms step_avg:43.08ms
+step:933/1490 train_time:40208ms step_avg:43.10ms
+step:934/1490 train_time:40267ms step_avg:43.11ms
+step:935/1490 train_time:40321ms step_avg:43.12ms
+step:936/1490 train_time:40379ms step_avg:43.14ms
+step:937/1490 train_time:40433ms step_avg:43.15ms
+step:938/1490 train_time:40492ms step_avg:43.17ms
+step:939/1490 train_time:40545ms step_avg:43.18ms
+step:940/1490 train_time:40605ms step_avg:43.20ms
+step:941/1490 train_time:40658ms step_avg:43.21ms
+step:942/1490 train_time:40716ms step_avg:43.22ms
+step:943/1490 train_time:40770ms step_avg:43.23ms
+step:944/1490 train_time:40830ms step_avg:43.25ms
+step:945/1490 train_time:40883ms step_avg:43.26ms
+step:946/1490 train_time:40957ms step_avg:43.30ms
+step:947/1490 train_time:40996ms step_avg:43.29ms
+step:948/1490 train_time:41055ms step_avg:43.31ms
+step:949/1490 train_time:41108ms step_avg:43.32ms
+step:950/1490 train_time:41168ms step_avg:43.33ms
+step:951/1490 train_time:41222ms step_avg:43.35ms
+step:952/1490 train_time:41281ms step_avg:43.36ms
+step:953/1490 train_time:41334ms step_avg:43.37ms
+step:954/1490 train_time:41393ms step_avg:43.39ms
+step:955/1490 train_time:41447ms step_avg:43.40ms
+step:956/1490 train_time:41505ms step_avg:43.42ms
+step:957/1490 train_time:41559ms step_avg:43.43ms
+step:958/1490 train_time:41617ms step_avg:43.44ms
+step:959/1490 train_time:41671ms step_avg:43.45ms
+step:960/1490 train_time:41730ms step_avg:43.47ms
+step:961/1490 train_time:41784ms step_avg:43.48ms
+step:962/1490 train_time:41843ms step_avg:43.50ms
+step:963/1490 train_time:41897ms step_avg:43.51ms
+step:964/1490 train_time:41956ms step_avg:43.52ms
+step:965/1490 train_time:42009ms step_avg:43.53ms
+step:966/1490 train_time:42068ms step_avg:43.55ms
+step:967/1490 train_time:42122ms step_avg:43.56ms
+step:968/1490 train_time:42183ms step_avg:43.58ms
+step:969/1490 train_time:42262ms step_avg:43.61ms
+step:970/1490 train_time:42347ms step_avg:43.66ms
+step:971/1490 train_time:42427ms step_avg:43.69ms
+step:972/1490 train_time:42511ms step_avg:43.74ms
+step:973/1490 train_time:42591ms step_avg:43.77ms
+step:974/1490 train_time:42676ms step_avg:43.81ms
+step:975/1490 train_time:42755ms step_avg:43.85ms
+step:976/1490 train_time:42839ms step_avg:43.89ms
+step:977/1490 train_time:42920ms step_avg:43.93ms
+step:978/1490 train_time:43004ms step_avg:43.97ms
+step:979/1490 train_time:43083ms step_avg:44.01ms
+step:980/1490 train_time:43169ms step_avg:44.05ms
+step:981/1490 train_time:43248ms step_avg:44.09ms
+step:982/1490 train_time:43332ms step_avg:44.13ms
+step:983/1490 train_time:43413ms step_avg:44.16ms
+step:984/1490 train_time:43497ms step_avg:44.20ms
+step:985/1490 train_time:43576ms step_avg:44.24ms
+step:986/1490 train_time:43660ms step_avg:44.28ms
+step:987/1490 train_time:43740ms step_avg:44.32ms
+step:988/1490 train_time:43826ms step_avg:44.36ms
+step:989/1490 train_time:43906ms step_avg:44.39ms
+step:990/1490 train_time:43992ms step_avg:44.44ms
+step:991/1490 train_time:44072ms step_avg:44.47ms
+step:992/1490 train_time:44156ms step_avg:44.51ms
+step:993/1490 train_time:44235ms step_avg:44.55ms
+step:994/1490 train_time:44320ms step_avg:44.59ms
+step:995/1490 train_time:44400ms step_avg:44.62ms
+step:996/1490 train_time:44486ms step_avg:44.66ms
+step:997/1490 train_time:44565ms step_avg:44.70ms
+step:998/1490 train_time:44648ms step_avg:44.74ms
+step:999/1490 train_time:44728ms step_avg:44.77ms
+step:1000/1490 train_time:44814ms step_avg:44.81ms
+step:1000/1490 val_loss:3.5125 train_time:44914ms step_avg:44.91ms
+step:1001/1490 train_time:44932ms step_avg:44.89ms
+step:1002/1490 train_time:44982ms step_avg:44.89ms
+step:1003/1490 train_time:45065ms step_avg:44.93ms
+step:1004/1490 train_time:45153ms step_avg:44.97ms
+step:1005/1490 train_time:45235ms step_avg:45.01ms
+step:1006/1490 train_time:45319ms step_avg:45.05ms
+step:1007/1490 train_time:45397ms step_avg:45.08ms
+step:1008/1490 train_time:45481ms step_avg:45.12ms
+step:1009/1490 train_time:45559ms step_avg:45.15ms
+step:1010/1490 train_time:45643ms step_avg:45.19ms
+step:1011/1490 train_time:45720ms step_avg:45.22ms
+step:1012/1490 train_time:45804ms step_avg:45.26ms
+step:1013/1490 train_time:45884ms step_avg:45.30ms
+step:1014/1490 train_time:45970ms step_avg:45.34ms
+step:1015/1490 train_time:46052ms step_avg:45.37ms
+step:1016/1490 train_time:46138ms step_avg:45.41ms
+step:1017/1490 train_time:46218ms step_avg:45.45ms
+step:1018/1490 train_time:46303ms step_avg:45.48ms
+step:1019/1490 train_time:46382ms step_avg:45.52ms
+step:1020/1490 train_time:46466ms step_avg:45.56ms
+step:1021/1490 train_time:46545ms step_avg:45.59ms
+step:1022/1490 train_time:46630ms step_avg:45.63ms
+step:1023/1490 train_time:46708ms step_avg:45.66ms
+step:1024/1490 train_time:46792ms step_avg:45.70ms
+step:1025/1490 train_time:46872ms step_avg:45.73ms
+step:1026/1490 train_time:46956ms step_avg:45.77ms
+step:1027/1490 train_time:47037ms step_avg:45.80ms
+step:1028/1490 train_time:47125ms step_avg:45.84ms
+step:1029/1490 train_time:47205ms step_avg:45.87ms
+step:1030/1490 train_time:47290ms step_avg:45.91ms
+step:1031/1490 train_time:47369ms step_avg:45.94ms
+step:1032/1490 train_time:47453ms step_avg:45.98ms
+step:1033/1490 train_time:47532ms step_avg:46.01ms
+step:1034/1490 train_time:47616ms step_avg:46.05ms
+step:1035/1490 train_time:47695ms step_avg:46.08ms
+step:1036/1490 train_time:47779ms step_avg:46.12ms
+step:1037/1490 train_time:47859ms step_avg:46.15ms
+step:1038/1490 train_time:47945ms step_avg:46.19ms
+step:1039/1490 train_time:48025ms step_avg:46.22ms
+step:1040/1490 train_time:48111ms step_avg:46.26ms
+step:1041/1490 train_time:48193ms step_avg:46.29ms
+step:1042/1490 train_time:48278ms step_avg:46.33ms
+step:1043/1490 train_time:48357ms step_avg:46.36ms
+step:1044/1490 train_time:48442ms step_avg:46.40ms
+step:1045/1490 train_time:48523ms step_avg:46.43ms
+step:1046/1490 train_time:48604ms step_avg:46.47ms
+step:1047/1490 train_time:48683ms step_avg:46.50ms
+step:1048/1490 train_time:48768ms step_avg:46.53ms
+step:1049/1490 train_time:48847ms step_avg:46.57ms
+step:1050/1490 train_time:48933ms step_avg:46.60ms
+step:1051/1490 train_time:49012ms step_avg:46.63ms
+step:1052/1490 train_time:49097ms step_avg:46.67ms
+step:1053/1490 train_time:49178ms step_avg:46.70ms
+step:1054/1490 train_time:49263ms step_avg:46.74ms
+step:1055/1490 train_time:49342ms step_avg:46.77ms
+step:1056/1490 train_time:49426ms step_avg:46.80ms
+step:1057/1490 train_time:49505ms step_avg:46.84ms
+step:1058/1490 train_time:49589ms step_avg:46.87ms
+step:1059/1490 train_time:49669ms step_avg:46.90ms
+step:1060/1490 train_time:49753ms step_avg:46.94ms
+step:1061/1490 train_time:49832ms step_avg:46.97ms
+step:1062/1490 train_time:49917ms step_avg:47.00ms
+step:1063/1490 train_time:49996ms step_avg:47.03ms
+step:1064/1490 train_time:50081ms step_avg:47.07ms
+step:1065/1490 train_time:50160ms step_avg:47.10ms
+step:1066/1490 train_time:50244ms step_avg:47.13ms
+step:1067/1490 train_time:50325ms step_avg:47.16ms
+step:1068/1490 train_time:50410ms step_avg:47.20ms
+step:1069/1490 train_time:50490ms step_avg:47.23ms
+step:1070/1490 train_time:50574ms step_avg:47.27ms
+step:1071/1490 train_time:50653ms step_avg:47.30ms
+step:1072/1490 train_time:50737ms step_avg:47.33ms
+step:1073/1490 train_time:50816ms step_avg:47.36ms
+step:1074/1490 train_time:50902ms step_avg:47.39ms
+step:1075/1490 train_time:50980ms step_avg:47.42ms
+step:1076/1490 train_time:51066ms step_avg:47.46ms
+step:1077/1490 train_time:51145ms step_avg:47.49ms
+step:1078/1490 train_time:51231ms step_avg:47.52ms
+step:1079/1490 train_time:51312ms step_avg:47.55ms
+step:1080/1490 train_time:51396ms step_avg:47.59ms
+step:1081/1490 train_time:51475ms step_avg:47.62ms
+step:1082/1490 train_time:51560ms step_avg:47.65ms
+step:1083/1490 train_time:51638ms step_avg:47.68ms
+step:1084/1490 train_time:51724ms step_avg:47.72ms
+step:1085/1490 train_time:51804ms step_avg:47.75ms
+step:1086/1490 train_time:51889ms step_avg:47.78ms
+step:1087/1490 train_time:51970ms step_avg:47.81ms
+step:1088/1490 train_time:52054ms step_avg:47.84ms
+step:1089/1490 train_time:52134ms step_avg:47.87ms
+step:1090/1490 train_time:52219ms step_avg:47.91ms
+step:1091/1490 train_time:52297ms step_avg:47.94ms
+step:1092/1490 train_time:52383ms step_avg:47.97ms
+step:1093/1490 train_time:52462ms step_avg:48.00ms
+step:1094/1490 train_time:52546ms step_avg:48.03ms
+step:1095/1490 train_time:52625ms step_avg:48.06ms
+step:1096/1490 train_time:52709ms step_avg:48.09ms
+step:1097/1490 train_time:52790ms step_avg:48.12ms
+step:1098/1490 train_time:52875ms step_avg:48.16ms
+step:1099/1490 train_time:52953ms step_avg:48.18ms
+step:1100/1490 train_time:53039ms step_avg:48.22ms
+step:1101/1490 train_time:53119ms step_avg:48.25ms
+step:1102/1490 train_time:53204ms step_avg:48.28ms
+step:1103/1490 train_time:53283ms step_avg:48.31ms
+step:1104/1490 train_time:53368ms step_avg:48.34ms
+step:1105/1490 train_time:53448ms step_avg:48.37ms
+step:1106/1490 train_time:53532ms step_avg:48.40ms
+step:1107/1490 train_time:53612ms step_avg:48.43ms
+step:1108/1490 train_time:53696ms step_avg:48.46ms
+step:1109/1490 train_time:53776ms step_avg:48.49ms
+step:1110/1490 train_time:53861ms step_avg:48.52ms
+step:1111/1490 train_time:53940ms step_avg:48.55ms
+step:1112/1490 train_time:54025ms step_avg:48.58ms
+step:1113/1490 train_time:54105ms step_avg:48.61ms
+step:1114/1490 train_time:54191ms step_avg:48.65ms
+step:1115/1490 train_time:54271ms step_avg:48.67ms
+step:1116/1490 train_time:54355ms step_avg:48.70ms
+step:1117/1490 train_time:54434ms step_avg:48.73ms
+step:1118/1490 train_time:54519ms step_avg:48.76ms
+step:1119/1490 train_time:54598ms step_avg:48.79ms
+step:1120/1490 train_time:54683ms step_avg:48.82ms
+step:1121/1490 train_time:54762ms step_avg:48.85ms
+step:1122/1490 train_time:54847ms step_avg:48.88ms
+step:1123/1490 train_time:54926ms step_avg:48.91ms
+step:1124/1490 train_time:55011ms step_avg:48.94ms
+step:1125/1490 train_time:55091ms step_avg:48.97ms
+step:1126/1490 train_time:55176ms step_avg:49.00ms
+step:1127/1490 train_time:55255ms step_avg:49.03ms
+step:1128/1490 train_time:55340ms step_avg:49.06ms
+step:1129/1490 train_time:55419ms step_avg:49.09ms
+step:1130/1490 train_time:55504ms step_avg:49.12ms
+step:1131/1490 train_time:55584ms step_avg:49.15ms
+step:1132/1490 train_time:55668ms step_avg:49.18ms
+step:1133/1490 train_time:55747ms step_avg:49.20ms
+step:1134/1490 train_time:55832ms step_avg:49.23ms
+step:1135/1490 train_time:55912ms step_avg:49.26ms
+step:1136/1490 train_time:55998ms step_avg:49.29ms
+step:1137/1490 train_time:56077ms step_avg:49.32ms
+step:1138/1490 train_time:56162ms step_avg:49.35ms
+step:1139/1490 train_time:56240ms step_avg:49.38ms
+step:1140/1490 train_time:56325ms step_avg:49.41ms
+step:1141/1490 train_time:56404ms step_avg:49.43ms
+step:1142/1490 train_time:56490ms step_avg:49.47ms
+step:1143/1490 train_time:56569ms step_avg:49.49ms
+step:1144/1490 train_time:56654ms step_avg:49.52ms
+step:1145/1490 train_time:56733ms step_avg:49.55ms
+step:1146/1490 train_time:56817ms step_avg:49.58ms
+step:1147/1490 train_time:56896ms step_avg:49.60ms
+step:1148/1490 train_time:56981ms step_avg:49.64ms
+step:1149/1490 train_time:57060ms step_avg:49.66ms
+step:1150/1490 train_time:57145ms step_avg:49.69ms
+step:1151/1490 train_time:57223ms step_avg:49.72ms
+step:1152/1490 train_time:57309ms step_avg:49.75ms
+step:1153/1490 train_time:57390ms step_avg:49.77ms
+step:1154/1490 train_time:57475ms step_avg:49.81ms
+step:1155/1490 train_time:57553ms step_avg:49.83ms
+step:1156/1490 train_time:57638ms step_avg:49.86ms
+step:1157/1490 train_time:57718ms step_avg:49.89ms
+step:1158/1490 train_time:57803ms step_avg:49.92ms
+step:1159/1490 train_time:57882ms step_avg:49.94ms
+step:1160/1490 train_time:57966ms step_avg:49.97ms
+step:1161/1490 train_time:58045ms step_avg:50.00ms
+step:1162/1490 train_time:58131ms step_avg:50.03ms
+step:1163/1490 train_time:58210ms step_avg:50.05ms
+step:1164/1490 train_time:58294ms step_avg:50.08ms
+step:1165/1490 train_time:58374ms step_avg:50.11ms
+step:1166/1490 train_time:58459ms step_avg:50.14ms
+step:1167/1490 train_time:58537ms step_avg:50.16ms
+step:1168/1490 train_time:58623ms step_avg:50.19ms
+step:1169/1490 train_time:58702ms step_avg:50.22ms
+step:1170/1490 train_time:58787ms step_avg:50.24ms
+step:1171/1490 train_time:58865ms step_avg:50.27ms
+step:1172/1490 train_time:58950ms step_avg:50.30ms
+step:1173/1490 train_time:59031ms step_avg:50.32ms
+step:1174/1490 train_time:59116ms step_avg:50.35ms
+step:1175/1490 train_time:59195ms step_avg:50.38ms
+step:1176/1490 train_time:59281ms step_avg:50.41ms
+step:1177/1490 train_time:59360ms step_avg:50.43ms
+step:1178/1490 train_time:59444ms step_avg:50.46ms
+step:1179/1490 train_time:59523ms step_avg:50.49ms
+step:1180/1490 train_time:59608ms step_avg:50.52ms
+step:1181/1490 train_time:59688ms step_avg:50.54ms
+step:1182/1490 train_time:59772ms step_avg:50.57ms
+step:1183/1490 train_time:59851ms step_avg:50.59ms
+step:1184/1490 train_time:59937ms step_avg:50.62ms
+step:1185/1490 train_time:60017ms step_avg:50.65ms
+step:1186/1490 train_time:60102ms step_avg:50.68ms
+step:1187/1490 train_time:60181ms step_avg:50.70ms
+step:1188/1490 train_time:60265ms step_avg:50.73ms
+step:1189/1490 train_time:60345ms step_avg:50.75ms
+step:1190/1490 train_time:60429ms step_avg:50.78ms
+step:1191/1490 train_time:60508ms step_avg:50.80ms
+step:1192/1490 train_time:60594ms step_avg:50.83ms
+step:1193/1490 train_time:60673ms step_avg:50.86ms
+step:1194/1490 train_time:60759ms step_avg:50.89ms
+step:1195/1490 train_time:60839ms step_avg:50.91ms
+step:1196/1490 train_time:60923ms step_avg:50.94ms
+step:1197/1490 train_time:61003ms step_avg:50.96ms
+step:1198/1490 train_time:61088ms step_avg:50.99ms
+step:1199/1490 train_time:61168ms step_avg:51.02ms
+step:1200/1490 train_time:61253ms step_avg:51.04ms
+step:1201/1490 train_time:61331ms step_avg:51.07ms
+step:1202/1490 train_time:61417ms step_avg:51.10ms
+step:1203/1490 train_time:61496ms step_avg:51.12ms
+step:1204/1490 train_time:61581ms step_avg:51.15ms
+step:1205/1490 train_time:61662ms step_avg:51.17ms
+step:1206/1490 train_time:61746ms step_avg:51.20ms
+step:1207/1490 train_time:61825ms step_avg:51.22ms
+step:1208/1490 train_time:61910ms step_avg:51.25ms
+step:1209/1490 train_time:61991ms step_avg:51.27ms
+step:1210/1490 train_time:62076ms step_avg:51.30ms
+step:1211/1490 train_time:62155ms step_avg:51.33ms
+step:1212/1490 train_time:62239ms step_avg:51.35ms
+step:1213/1490 train_time:62319ms step_avg:51.38ms
+step:1214/1490 train_time:62404ms step_avg:51.40ms
+step:1215/1490 train_time:62483ms step_avg:51.43ms
+step:1216/1490 train_time:62568ms step_avg:51.45ms
+step:1217/1490 train_time:62647ms step_avg:51.48ms
+step:1218/1490 train_time:62731ms step_avg:51.50ms
+step:1219/1490 train_time:62810ms step_avg:51.53ms
+step:1220/1490 train_time:62895ms step_avg:51.55ms
+step:1221/1490 train_time:62976ms step_avg:51.58ms
+step:1222/1490 train_time:63060ms step_avg:51.60ms
+step:1223/1490 train_time:63140ms step_avg:51.63ms
+step:1224/1490 train_time:63225ms step_avg:51.65ms
+step:1225/1490 train_time:63303ms step_avg:51.68ms
+step:1226/1490 train_time:63389ms step_avg:51.70ms
+step:1227/1490 train_time:63468ms step_avg:51.73ms
+step:1228/1490 train_time:63553ms step_avg:51.75ms
+step:1229/1490 train_time:63632ms step_avg:51.78ms
+step:1230/1490 train_time:63716ms step_avg:51.80ms
+step:1231/1490 train_time:63796ms step_avg:51.82ms
+step:1232/1490 train_time:63883ms step_avg:51.85ms
+step:1233/1490 train_time:63961ms step_avg:51.87ms
+step:1234/1490 train_time:64046ms step_avg:51.90ms
+step:1235/1490 train_time:64124ms step_avg:51.92ms
+step:1236/1490 train_time:64210ms step_avg:51.95ms
+step:1237/1490 train_time:64290ms step_avg:51.97ms
+step:1238/1490 train_time:64375ms step_avg:52.00ms
+step:1239/1490 train_time:64455ms step_avg:52.02ms
+step:1240/1490 train_time:64539ms step_avg:52.05ms
+step:1241/1490 train_time:64618ms step_avg:52.07ms
+step:1242/1490 train_time:64702ms step_avg:52.10ms
+step:1243/1490 train_time:64782ms step_avg:52.12ms
+step:1244/1490 train_time:64867ms step_avg:52.14ms
+step:1245/1490 train_time:64946ms step_avg:52.17ms
+step:1246/1490 train_time:65031ms step_avg:52.19ms
+step:1247/1490 train_time:65111ms step_avg:52.21ms
+step:1248/1490 train_time:65197ms step_avg:52.24ms
+step:1249/1490 train_time:65276ms step_avg:52.26ms
+step:1250/1490 train_time:65361ms step_avg:52.29ms
+step:1250/1490 val_loss:3.3697 train_time:65460ms step_avg:52.37ms
+step:1251/1490 train_time:65478ms step_avg:52.34ms
+step:1252/1490 train_time:65526ms step_avg:52.34ms
+step:1253/1490 train_time:65609ms step_avg:52.36ms
+step:1254/1490 train_time:65696ms step_avg:52.39ms
+step:1255/1490 train_time:65774ms step_avg:52.41ms
+step:1256/1490 train_time:65859ms step_avg:52.44ms
+step:1257/1490 train_time:65939ms step_avg:52.46ms
+step:1258/1490 train_time:66023ms step_avg:52.48ms
+step:1259/1490 train_time:66103ms step_avg:52.50ms
+step:1260/1490 train_time:66186ms step_avg:52.53ms
+step:1261/1490 train_time:66264ms step_avg:52.55ms
+step:1262/1490 train_time:66348ms step_avg:52.57ms
+step:1263/1490 train_time:66427ms step_avg:52.59ms
+step:1264/1490 train_time:66513ms step_avg:52.62ms
+step:1265/1490 train_time:66595ms step_avg:52.64ms
+step:1266/1490 train_time:66681ms step_avg:52.67ms
+step:1267/1490 train_time:66762ms step_avg:52.69ms
+step:1268/1490 train_time:66846ms step_avg:52.72ms
+step:1269/1490 train_time:66925ms step_avg:52.74ms
+step:1270/1490 train_time:67010ms step_avg:52.76ms
+step:1271/1490 train_time:67088ms step_avg:52.78ms
+step:1272/1490 train_time:67173ms step_avg:52.81ms
+step:1273/1490 train_time:67250ms step_avg:52.83ms
+step:1274/1490 train_time:67335ms step_avg:52.85ms
+step:1275/1490 train_time:67414ms step_avg:52.87ms
+step:1276/1490 train_time:67500ms step_avg:52.90ms
+step:1277/1490 train_time:67582ms step_avg:52.92ms
+step:1278/1490 train_time:67669ms step_avg:52.95ms
+step:1279/1490 train_time:67749ms step_avg:52.97ms
+step:1280/1490 train_time:67834ms step_avg:53.00ms
+step:1281/1490 train_time:67912ms step_avg:53.02ms
+step:1282/1490 train_time:67998ms step_avg:53.04ms
+step:1283/1490 train_time:68076ms step_avg:53.06ms
+step:1284/1490 train_time:68161ms step_avg:53.08ms
+step:1285/1490 train_time:68240ms step_avg:53.11ms
+step:1286/1490 train_time:68325ms step_avg:53.13ms
+step:1287/1490 train_time:68404ms step_avg:53.15ms
+step:1288/1490 train_time:68489ms step_avg:53.17ms
+step:1289/1490 train_time:68568ms step_avg:53.20ms
+step:1290/1490 train_time:68653ms step_avg:53.22ms
+step:1291/1490 train_time:68733ms step_avg:53.24ms
+step:1292/1490 train_time:68819ms step_avg:53.27ms
+step:1293/1490 train_time:68900ms step_avg:53.29ms
+step:1294/1490 train_time:68985ms step_avg:53.31ms
+step:1295/1490 train_time:69064ms step_avg:53.33ms
+step:1296/1490 train_time:69146ms step_avg:53.35ms
+step:1297/1490 train_time:69225ms step_avg:53.37ms
+step:1298/1490 train_time:69311ms step_avg:53.40ms
+step:1299/1490 train_time:69390ms step_avg:53.42ms
+step:1300/1490 train_time:69475ms step_avg:53.44ms
+step:1301/1490 train_time:69554ms step_avg:53.46ms
+step:1302/1490 train_time:69640ms step_avg:53.49ms
+step:1303/1490 train_time:69721ms step_avg:53.51ms
+step:1304/1490 train_time:69808ms step_avg:53.53ms
+step:1305/1490 train_time:69888ms step_avg:53.55ms
+step:1306/1490 train_time:69973ms step_avg:53.58ms
+step:1307/1490 train_time:70050ms step_avg:53.60ms
+step:1308/1490 train_time:70135ms step_avg:53.62ms
+step:1309/1490 train_time:70214ms step_avg:53.64ms
+step:1310/1490 train_time:70299ms step_avg:53.66ms
+step:1311/1490 train_time:70378ms step_avg:53.68ms
+step:1312/1490 train_time:70463ms step_avg:53.71ms
+step:1313/1490 train_time:70542ms step_avg:53.73ms
+step:1314/1490 train_time:70627ms step_avg:53.75ms
+step:1315/1490 train_time:70706ms step_avg:53.77ms
+step:1316/1490 train_time:70793ms step_avg:53.79ms
+step:1317/1490 train_time:70873ms step_avg:53.81ms
+step:1318/1490 train_time:70957ms step_avg:53.84ms
+step:1319/1490 train_time:71036ms step_avg:53.86ms
+step:1320/1490 train_time:71121ms step_avg:53.88ms
+step:1321/1490 train_time:71201ms step_avg:53.90ms
+step:1322/1490 train_time:71285ms step_avg:53.92ms
+step:1323/1490 train_time:71364ms step_avg:53.94ms
+step:1324/1490 train_time:71449ms step_avg:53.96ms
+step:1325/1490 train_time:71527ms step_avg:53.98ms
+step:1326/1490 train_time:71612ms step_avg:54.01ms
+step:1327/1490 train_time:71692ms step_avg:54.03ms
+step:1328/1490 train_time:71777ms step_avg:54.05ms
+step:1329/1490 train_time:71858ms step_avg:54.07ms
+step:1330/1490 train_time:71943ms step_avg:54.09ms
+step:1331/1490 train_time:72021ms step_avg:54.11ms
+step:1332/1490 train_time:72106ms step_avg:54.13ms
+step:1333/1490 train_time:72187ms step_avg:54.15ms
+step:1334/1490 train_time:72272ms step_avg:54.18ms
+step:1335/1490 train_time:72351ms step_avg:54.20ms
+step:1336/1490 train_time:72436ms step_avg:54.22ms
+step:1337/1490 train_time:72515ms step_avg:54.24ms
+step:1338/1490 train_time:72600ms step_avg:54.26ms
+step:1339/1490 train_time:72681ms step_avg:54.28ms
+step:1340/1490 train_time:72766ms step_avg:54.30ms
+step:1341/1490 train_time:72845ms step_avg:54.32ms
+step:1342/1490 train_time:72930ms step_avg:54.34ms
+step:1343/1490 train_time:73011ms step_avg:54.36ms
+step:1344/1490 train_time:73095ms step_avg:54.39ms
+step:1345/1490 train_time:73173ms step_avg:54.40ms
+step:1346/1490 train_time:73258ms step_avg:54.43ms
+step:1347/1490 train_time:73337ms step_avg:54.44ms
+step:1348/1490 train_time:73422ms step_avg:54.47ms
+step:1349/1490 train_time:73503ms step_avg:54.49ms
+step:1350/1490 train_time:73588ms step_avg:54.51ms
+step:1351/1490 train_time:73666ms step_avg:54.53ms
+step:1352/1490 train_time:73751ms step_avg:54.55ms
+step:1353/1490 train_time:73830ms step_avg:54.57ms
+step:1354/1490 train_time:73915ms step_avg:54.59ms
+step:1355/1490 train_time:73995ms step_avg:54.61ms
+step:1356/1490 train_time:74080ms step_avg:54.63ms
+step:1357/1490 train_time:74159ms step_avg:54.65ms
+step:1358/1490 train_time:74244ms step_avg:54.67ms
+step:1359/1490 train_time:74323ms step_avg:54.69ms
+step:1360/1490 train_time:74409ms step_avg:54.71ms
+step:1361/1490 train_time:74487ms step_avg:54.73ms
+step:1362/1490 train_time:74573ms step_avg:54.75ms
+step:1363/1490 train_time:74651ms step_avg:54.77ms
+step:1364/1490 train_time:74735ms step_avg:54.79ms
+step:1365/1490 train_time:74815ms step_avg:54.81ms
+step:1366/1490 train_time:74900ms step_avg:54.83ms
+step:1367/1490 train_time:74980ms step_avg:54.85ms
+step:1368/1490 train_time:75065ms step_avg:54.87ms
+step:1369/1490 train_time:75143ms step_avg:54.89ms
+step:1370/1490 train_time:75229ms step_avg:54.91ms
+step:1371/1490 train_time:75309ms step_avg:54.93ms
+step:1372/1490 train_time:75393ms step_avg:54.95ms
+step:1373/1490 train_time:75473ms step_avg:54.97ms
+step:1374/1490 train_time:75558ms step_avg:54.99ms
+step:1375/1490 train_time:75639ms step_avg:55.01ms
+step:1376/1490 train_time:75724ms step_avg:55.03ms
+step:1377/1490 train_time:75803ms step_avg:55.05ms
+step:1378/1490 train_time:75887ms step_avg:55.07ms
+step:1379/1490 train_time:75966ms step_avg:55.09ms
+step:1380/1490 train_time:76052ms step_avg:55.11ms
+step:1381/1490 train_time:76131ms step_avg:55.13ms
+step:1382/1490 train_time:76216ms step_avg:55.15ms
+step:1383/1490 train_time:76296ms step_avg:55.17ms
+step:1384/1490 train_time:76381ms step_avg:55.19ms
+step:1385/1490 train_time:76461ms step_avg:55.21ms
+step:1386/1490 train_time:76546ms step_avg:55.23ms
+step:1387/1490 train_time:76625ms step_avg:55.25ms
+step:1388/1490 train_time:76711ms step_avg:55.27ms
+step:1389/1490 train_time:76790ms step_avg:55.28ms
+step:1390/1490 train_time:76875ms step_avg:55.31ms
+step:1391/1490 train_time:76953ms step_avg:55.32ms
+step:1392/1490 train_time:77037ms step_avg:55.34ms
+step:1393/1490 train_time:77118ms step_avg:55.36ms
+step:1394/1490 train_time:77204ms step_avg:55.38ms
+step:1395/1490 train_time:77283ms step_avg:55.40ms
+step:1396/1490 train_time:77369ms step_avg:55.42ms
+step:1397/1490 train_time:77447ms step_avg:55.44ms
+step:1398/1490 train_time:77532ms step_avg:55.46ms
+step:1399/1490 train_time:77612ms step_avg:55.48ms
+step:1400/1490 train_time:77697ms step_avg:55.50ms
+step:1401/1490 train_time:77776ms step_avg:55.51ms
+step:1402/1490 train_time:77861ms step_avg:55.54ms
+step:1403/1490 train_time:77940ms step_avg:55.55ms
+step:1404/1490 train_time:78025ms step_avg:55.57ms
+step:1405/1490 train_time:78105ms step_avg:55.59ms
+step:1406/1490 train_time:78190ms step_avg:55.61ms
+step:1407/1490 train_time:78270ms step_avg:55.63ms
+step:1408/1490 train_time:78355ms step_avg:55.65ms
+step:1409/1490 train_time:78433ms step_avg:55.67ms
+step:1410/1490 train_time:78519ms step_avg:55.69ms
+step:1411/1490 train_time:78599ms step_avg:55.70ms
+step:1412/1490 train_time:78684ms step_avg:55.72ms
+step:1413/1490 train_time:78763ms step_avg:55.74ms
+step:1414/1490 train_time:78847ms step_avg:55.76ms
+step:1415/1490 train_time:78926ms step_avg:55.78ms
+step:1416/1490 train_time:79011ms step_avg:55.80ms
+step:1417/1490 train_time:79092ms step_avg:55.82ms
+step:1418/1490 train_time:79175ms step_avg:55.84ms
+step:1419/1490 train_time:79256ms step_avg:55.85ms
+step:1420/1490 train_time:79340ms step_avg:55.87ms
+step:1421/1490 train_time:79420ms step_avg:55.89ms
+step:1422/1490 train_time:79505ms step_avg:55.91ms
+step:1423/1490 train_time:79585ms step_avg:55.93ms
+step:1424/1490 train_time:79671ms step_avg:55.95ms
+step:1425/1490 train_time:79751ms step_avg:55.97ms
+step:1426/1490 train_time:79836ms step_avg:55.99ms
+step:1427/1490 train_time:79915ms step_avg:56.00ms
+step:1428/1490 train_time:80000ms step_avg:56.02ms
+step:1429/1490 train_time:80080ms step_avg:56.04ms
+step:1430/1490 train_time:80164ms step_avg:56.06ms
+step:1431/1490 train_time:80244ms step_avg:56.08ms
+step:1432/1490 train_time:80328ms step_avg:56.09ms
+step:1433/1490 train_time:80406ms step_avg:56.11ms
+step:1434/1490 train_time:80493ms step_avg:56.13ms
+step:1435/1490 train_time:80572ms step_avg:56.15ms
+step:1436/1490 train_time:80657ms step_avg:56.17ms
+step:1437/1490 train_time:80736ms step_avg:56.18ms
+step:1438/1490 train_time:80820ms step_avg:56.20ms
+step:1439/1490 train_time:80901ms step_avg:56.22ms
+step:1440/1490 train_time:80985ms step_avg:56.24ms
+step:1441/1490 train_time:81064ms step_avg:56.26ms
+step:1442/1490 train_time:81149ms step_avg:56.28ms
+step:1443/1490 train_time:81228ms step_avg:56.29ms
+step:1444/1490 train_time:81313ms step_avg:56.31ms
+step:1445/1490 train_time:81393ms step_avg:56.33ms
+step:1446/1490 train_time:81478ms step_avg:56.35ms
+step:1447/1490 train_time:81556ms step_avg:56.36ms
+step:1448/1490 train_time:81642ms step_avg:56.38ms
+step:1449/1490 train_time:81720ms step_avg:56.40ms
+step:1450/1490 train_time:81807ms step_avg:56.42ms
+step:1451/1490 train_time:81892ms step_avg:56.44ms
+step:1452/1490 train_time:81978ms step_avg:56.46ms
+step:1453/1490 train_time:82057ms step_avg:56.47ms
+step:1454/1490 train_time:82144ms step_avg:56.49ms
+step:1455/1490 train_time:82224ms step_avg:56.51ms
+step:1456/1490 train_time:82309ms step_avg:56.53ms
+step:1457/1490 train_time:82390ms step_avg:56.55ms
+step:1458/1490 train_time:82475ms step_avg:56.57ms
+step:1459/1490 train_time:82554ms step_avg:56.58ms
+step:1460/1490 train_time:82639ms step_avg:56.60ms
+step:1461/1490 train_time:82720ms step_avg:56.62ms
+step:1462/1490 train_time:82806ms step_avg:56.64ms
+step:1463/1490 train_time:82887ms step_avg:56.66ms
+step:1464/1490 train_time:82972ms step_avg:56.68ms
+step:1465/1490 train_time:83052ms step_avg:56.69ms
+step:1466/1490 train_time:83137ms step_avg:56.71ms
+step:1467/1490 train_time:83217ms step_avg:56.73ms
+step:1468/1490 train_time:83304ms step_avg:56.75ms
+step:1469/1490 train_time:83384ms step_avg:56.76ms
+step:1470/1490 train_time:83468ms step_avg:56.78ms
+step:1471/1490 train_time:83547ms step_avg:56.80ms
+step:1472/1490 train_time:83632ms step_avg:56.82ms
+step:1473/1490 train_time:83711ms step_avg:56.83ms
+step:1474/1490 train_time:83798ms step_avg:56.85ms
+step:1475/1490 train_time:83877ms step_avg:56.87ms
+step:1476/1490 train_time:83963ms step_avg:56.89ms
+step:1477/1490 train_time:84043ms step_avg:56.90ms
+step:1478/1490 train_time:84128ms step_avg:56.92ms
+step:1479/1490 train_time:84208ms step_avg:56.94ms
+step:1480/1490 train_time:84295ms step_avg:56.96ms
+step:1481/1490 train_time:84373ms step_avg:56.97ms
+step:1482/1490 train_time:84458ms step_avg:56.99ms
+step:1483/1490 train_time:84539ms step_avg:57.01ms
+step:1484/1490 train_time:84624ms step_avg:57.02ms
+step:1485/1490 train_time:84704ms step_avg:57.04ms
+step:1486/1490 train_time:84789ms step_avg:57.06ms
+step:1487/1490 train_time:84867ms step_avg:57.07ms
+step:1488/1490 train_time:84954ms step_avg:57.09ms
+step:1489/1490 train_time:85034ms step_avg:57.11ms
+step:1490/1490 train_time:85118ms step_avg:57.13ms
+step:1490/1490 val_loss:3.2776 train_time:85221ms step_avg:57.20ms
+peak memory allocated: 31296 MiB reserved: 46782 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/a52c9989-08ef-4159-a6e6-091210ee5363.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/a52c9989-08ef-4159-a6e6-091210ee5363.txt
@@ -1,0 +1,4681 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 21:34:19 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   33C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8286 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:78ms step_avg:78.12ms
+step:2/1490 train_time:104ms step_avg:52.14ms
+step:3/1490 train_time:122ms step_avg:40.80ms
+step:4/1490 train_time:148ms step_avg:37.00ms
+step:5/1490 train_time:174ms step_avg:34.87ms
+step:6/1490 train_time:209ms step_avg:34.80ms
+step:7/1490 train_time:236ms step_avg:33.66ms
+step:8/1490 train_time:270ms step_avg:33.79ms
+step:9/1490 train_time:297ms step_avg:33.05ms
+step:10/1490 train_time:332ms step_avg:33.18ms
+step:11/1490 train_time:359ms step_avg:32.62ms
+step:12/1490 train_time:393ms step_avg:32.79ms
+step:13/1490 train_time:421ms step_avg:32.35ms
+step:14/1490 train_time:455ms step_avg:32.48ms
+step:15/1490 train_time:482ms step_avg:32.12ms
+step:16/1490 train_time:516ms step_avg:32.24ms
+step:17/1490 train_time:543ms step_avg:31.96ms
+step:18/1490 train_time:577ms step_avg:32.07ms
+step:19/1490 train_time:605ms step_avg:31.83ms
+step:20/1490 train_time:639ms step_avg:31.93ms
+step:21/1490 train_time:666ms step_avg:31.71ms
+step:22/1490 train_time:700ms step_avg:31.81ms
+step:23/1490 train_time:727ms step_avg:31.62ms
+step:24/1490 train_time:761ms step_avg:31.72ms
+step:25/1490 train_time:789ms step_avg:31.54ms
+step:26/1490 train_time:822ms step_avg:31.62ms
+step:27/1490 train_time:850ms step_avg:31.47ms
+step:28/1490 train_time:883ms step_avg:31.55ms
+step:29/1490 train_time:911ms step_avg:31.41ms
+step:30/1490 train_time:945ms step_avg:31.50ms
+step:31/1490 train_time:973ms step_avg:31.37ms
+step:32/1490 train_time:1008ms step_avg:31.49ms
+step:33/1490 train_time:1036ms step_avg:31.38ms
+step:34/1490 train_time:1071ms step_avg:31.49ms
+step:35/1490 train_time:1098ms step_avg:31.38ms
+step:36/1490 train_time:1133ms step_avg:31.46ms
+step:37/1490 train_time:1160ms step_avg:31.35ms
+step:38/1490 train_time:1194ms step_avg:31.43ms
+step:39/1490 train_time:1222ms step_avg:31.33ms
+step:40/1490 train_time:1256ms step_avg:31.40ms
+step:41/1490 train_time:1283ms step_avg:31.29ms
+step:42/1490 train_time:1317ms step_avg:31.36ms
+step:43/1490 train_time:1344ms step_avg:31.27ms
+step:44/1490 train_time:1378ms step_avg:31.32ms
+step:45/1490 train_time:1406ms step_avg:31.24ms
+step:46/1490 train_time:1440ms step_avg:31.31ms
+step:47/1490 train_time:1467ms step_avg:31.21ms
+step:48/1490 train_time:1501ms step_avg:31.27ms
+step:49/1490 train_time:1528ms step_avg:31.19ms
+step:50/1490 train_time:1562ms step_avg:31.24ms
+step:51/1490 train_time:1590ms step_avg:31.17ms
+step:52/1490 train_time:1624ms step_avg:31.22ms
+step:53/1490 train_time:1651ms step_avg:31.16ms
+step:54/1490 train_time:1685ms step_avg:31.21ms
+step:55/1490 train_time:1713ms step_avg:31.15ms
+step:56/1490 train_time:1747ms step_avg:31.20ms
+step:57/1490 train_time:1775ms step_avg:31.13ms
+step:58/1490 train_time:1809ms step_avg:31.19ms
+step:59/1490 train_time:1836ms step_avg:31.12ms
+step:60/1490 train_time:1870ms step_avg:31.17ms
+step:61/1490 train_time:1897ms step_avg:31.11ms
+step:62/1490 train_time:1932ms step_avg:31.16ms
+step:63/1490 train_time:1959ms step_avg:31.10ms
+step:64/1490 train_time:1993ms step_avg:31.14ms
+step:65/1490 train_time:2021ms step_avg:31.09ms
+step:66/1490 train_time:2055ms step_avg:31.14ms
+step:67/1490 train_time:2082ms step_avg:31.07ms
+step:68/1490 train_time:2116ms step_avg:31.12ms
+step:69/1490 train_time:2144ms step_avg:31.07ms
+step:70/1490 train_time:2178ms step_avg:31.11ms
+step:71/1490 train_time:2206ms step_avg:31.07ms
+step:72/1490 train_time:2240ms step_avg:31.11ms
+step:73/1490 train_time:2268ms step_avg:31.06ms
+step:74/1490 train_time:2301ms step_avg:31.10ms
+step:75/1490 train_time:2329ms step_avg:31.05ms
+step:76/1490 train_time:2363ms step_avg:31.09ms
+step:77/1490 train_time:2391ms step_avg:31.05ms
+step:78/1490 train_time:2425ms step_avg:31.09ms
+step:79/1490 train_time:2452ms step_avg:31.04ms
+step:80/1490 train_time:2486ms step_avg:31.08ms
+step:81/1490 train_time:2513ms step_avg:31.03ms
+step:82/1490 train_time:2548ms step_avg:31.07ms
+step:83/1490 train_time:2575ms step_avg:31.02ms
+step:84/1490 train_time:2610ms step_avg:31.07ms
+step:85/1490 train_time:2637ms step_avg:31.02ms
+step:86/1490 train_time:2671ms step_avg:31.06ms
+step:87/1490 train_time:2698ms step_avg:31.01ms
+step:88/1490 train_time:2732ms step_avg:31.05ms
+step:89/1490 train_time:2759ms step_avg:31.00ms
+step:90/1490 train_time:2793ms step_avg:31.04ms
+step:91/1490 train_time:2821ms step_avg:30.99ms
+step:92/1490 train_time:2854ms step_avg:31.02ms
+step:93/1490 train_time:2881ms step_avg:30.98ms
+step:94/1490 train_time:2916ms step_avg:31.02ms
+step:95/1490 train_time:2943ms step_avg:30.98ms
+step:96/1490 train_time:2976ms step_avg:31.00ms
+step:97/1490 train_time:3004ms step_avg:30.97ms
+step:98/1490 train_time:3038ms step_avg:31.00ms
+step:99/1490 train_time:3065ms step_avg:30.96ms
+step:100/1490 train_time:3099ms step_avg:30.99ms
+step:101/1490 train_time:3126ms step_avg:30.95ms
+step:102/1490 train_time:3162ms step_avg:31.00ms
+step:103/1490 train_time:3188ms step_avg:30.95ms
+step:104/1490 train_time:3222ms step_avg:30.98ms
+step:105/1490 train_time:3250ms step_avg:30.95ms
+step:106/1490 train_time:3283ms step_avg:30.98ms
+step:107/1490 train_time:3310ms step_avg:30.94ms
+step:108/1490 train_time:3345ms step_avg:30.97ms
+step:109/1490 train_time:3372ms step_avg:30.94ms
+step:110/1490 train_time:3406ms step_avg:30.97ms
+step:111/1490 train_time:3434ms step_avg:30.93ms
+step:112/1490 train_time:3468ms step_avg:30.96ms
+step:113/1490 train_time:3495ms step_avg:30.93ms
+step:114/1490 train_time:3530ms step_avg:30.96ms
+step:115/1490 train_time:3557ms step_avg:30.93ms
+step:116/1490 train_time:3591ms step_avg:30.96ms
+step:117/1490 train_time:3618ms step_avg:30.92ms
+step:118/1490 train_time:3653ms step_avg:30.95ms
+step:119/1490 train_time:3679ms step_avg:30.92ms
+step:120/1490 train_time:3714ms step_avg:30.95ms
+step:121/1490 train_time:3741ms step_avg:30.91ms
+step:122/1490 train_time:3775ms step_avg:30.94ms
+step:123/1490 train_time:3802ms step_avg:30.91ms
+step:124/1490 train_time:3836ms step_avg:30.94ms
+step:125/1490 train_time:3863ms step_avg:30.91ms
+step:126/1490 train_time:3898ms step_avg:30.94ms
+step:127/1490 train_time:3924ms step_avg:30.90ms
+step:128/1490 train_time:3958ms step_avg:30.93ms
+step:129/1490 train_time:3986ms step_avg:30.90ms
+step:130/1490 train_time:4019ms step_avg:30.92ms
+step:131/1490 train_time:4047ms step_avg:30.89ms
+step:132/1490 train_time:4080ms step_avg:30.91ms
+step:133/1490 train_time:4108ms step_avg:30.89ms
+step:134/1490 train_time:4142ms step_avg:30.91ms
+step:135/1490 train_time:4169ms step_avg:30.88ms
+step:136/1490 train_time:4204ms step_avg:30.91ms
+step:137/1490 train_time:4231ms step_avg:30.88ms
+step:138/1490 train_time:4266ms step_avg:30.91ms
+step:139/1490 train_time:4293ms step_avg:30.88ms
+step:140/1490 train_time:4327ms step_avg:30.91ms
+step:141/1490 train_time:4354ms step_avg:30.88ms
+step:142/1490 train_time:4389ms step_avg:30.91ms
+step:143/1490 train_time:4416ms step_avg:30.88ms
+step:144/1490 train_time:4450ms step_avg:30.91ms
+step:145/1490 train_time:4477ms step_avg:30.88ms
+step:146/1490 train_time:4512ms step_avg:30.90ms
+step:147/1490 train_time:4539ms step_avg:30.88ms
+step:148/1490 train_time:4573ms step_avg:30.90ms
+step:149/1490 train_time:4600ms step_avg:30.87ms
+step:150/1490 train_time:4634ms step_avg:30.90ms
+step:151/1490 train_time:4661ms step_avg:30.87ms
+step:152/1490 train_time:4695ms step_avg:30.89ms
+step:153/1490 train_time:4723ms step_avg:30.87ms
+step:154/1490 train_time:4757ms step_avg:30.89ms
+step:155/1490 train_time:4783ms step_avg:30.86ms
+step:156/1490 train_time:4817ms step_avg:30.88ms
+step:157/1490 train_time:4846ms step_avg:30.87ms
+step:158/1490 train_time:4879ms step_avg:30.88ms
+step:159/1490 train_time:4906ms step_avg:30.86ms
+step:160/1490 train_time:4940ms step_avg:30.88ms
+step:161/1490 train_time:4967ms step_avg:30.85ms
+step:162/1490 train_time:5001ms step_avg:30.87ms
+step:163/1490 train_time:5028ms step_avg:30.85ms
+step:164/1490 train_time:5062ms step_avg:30.87ms
+step:165/1490 train_time:5089ms step_avg:30.84ms
+step:166/1490 train_time:5124ms step_avg:30.87ms
+step:167/1490 train_time:5151ms step_avg:30.85ms
+step:168/1490 train_time:5185ms step_avg:30.87ms
+step:169/1490 train_time:5212ms step_avg:30.84ms
+step:170/1490 train_time:5247ms step_avg:30.86ms
+step:171/1490 train_time:5274ms step_avg:30.84ms
+step:172/1490 train_time:5309ms step_avg:30.86ms
+step:173/1490 train_time:5335ms step_avg:30.84ms
+step:174/1490 train_time:5370ms step_avg:30.86ms
+step:175/1490 train_time:5397ms step_avg:30.84ms
+step:176/1490 train_time:5433ms step_avg:30.87ms
+step:177/1490 train_time:5459ms step_avg:30.84ms
+step:178/1490 train_time:5493ms step_avg:30.86ms
+step:179/1490 train_time:5521ms step_avg:30.84ms
+step:180/1490 train_time:5555ms step_avg:30.86ms
+step:181/1490 train_time:5582ms step_avg:30.84ms
+step:182/1490 train_time:5616ms step_avg:30.86ms
+step:183/1490 train_time:5643ms step_avg:30.83ms
+step:184/1490 train_time:5677ms step_avg:30.85ms
+step:185/1490 train_time:5704ms step_avg:30.83ms
+step:186/1490 train_time:5738ms step_avg:30.85ms
+step:187/1490 train_time:5765ms step_avg:30.83ms
+step:188/1490 train_time:5799ms step_avg:30.85ms
+step:189/1490 train_time:5826ms step_avg:30.83ms
+step:190/1490 train_time:5860ms step_avg:30.84ms
+step:191/1490 train_time:5888ms step_avg:30.83ms
+step:192/1490 train_time:5922ms step_avg:30.84ms
+step:193/1490 train_time:5949ms step_avg:30.82ms
+step:194/1490 train_time:5983ms step_avg:30.84ms
+step:195/1490 train_time:6010ms step_avg:30.82ms
+step:196/1490 train_time:6045ms step_avg:30.84ms
+step:197/1490 train_time:6072ms step_avg:30.82ms
+step:198/1490 train_time:6107ms step_avg:30.84ms
+step:199/1490 train_time:6133ms step_avg:30.82ms
+step:200/1490 train_time:6168ms step_avg:30.84ms
+step:201/1490 train_time:6195ms step_avg:30.82ms
+step:202/1490 train_time:6230ms step_avg:30.84ms
+step:203/1490 train_time:6257ms step_avg:30.82ms
+step:204/1490 train_time:6291ms step_avg:30.84ms
+step:205/1490 train_time:6318ms step_avg:30.82ms
+step:206/1490 train_time:6353ms step_avg:30.84ms
+step:207/1490 train_time:6379ms step_avg:30.82ms
+step:208/1490 train_time:6413ms step_avg:30.83ms
+step:209/1490 train_time:6440ms step_avg:30.82ms
+step:210/1490 train_time:6475ms step_avg:30.83ms
+step:211/1490 train_time:6502ms step_avg:30.81ms
+step:212/1490 train_time:6536ms step_avg:30.83ms
+step:213/1490 train_time:6563ms step_avg:30.81ms
+step:214/1490 train_time:6598ms step_avg:30.83ms
+step:215/1490 train_time:6625ms step_avg:30.81ms
+step:216/1490 train_time:6659ms step_avg:30.83ms
+step:217/1490 train_time:6686ms step_avg:30.81ms
+step:218/1490 train_time:6720ms step_avg:30.83ms
+step:219/1490 train_time:6748ms step_avg:30.81ms
+step:220/1490 train_time:6782ms step_avg:30.83ms
+step:221/1490 train_time:6809ms step_avg:30.81ms
+step:222/1490 train_time:6843ms step_avg:30.82ms
+step:223/1490 train_time:6870ms step_avg:30.81ms
+step:224/1490 train_time:6904ms step_avg:30.82ms
+step:225/1490 train_time:6931ms step_avg:30.80ms
+step:226/1490 train_time:6965ms step_avg:30.82ms
+step:227/1490 train_time:6992ms step_avg:30.80ms
+step:228/1490 train_time:7026ms step_avg:30.82ms
+step:229/1490 train_time:7054ms step_avg:30.80ms
+step:230/1490 train_time:7088ms step_avg:30.82ms
+step:231/1490 train_time:7116ms step_avg:30.80ms
+step:232/1490 train_time:7150ms step_avg:30.82ms
+step:233/1490 train_time:7177ms step_avg:30.80ms
+step:234/1490 train_time:7212ms step_avg:30.82ms
+step:235/1490 train_time:7239ms step_avg:30.80ms
+step:236/1490 train_time:7274ms step_avg:30.82ms
+step:237/1490 train_time:7301ms step_avg:30.81ms
+step:238/1490 train_time:7335ms step_avg:30.82ms
+step:239/1490 train_time:7362ms step_avg:30.80ms
+step:240/1490 train_time:7396ms step_avg:30.82ms
+step:241/1490 train_time:7423ms step_avg:30.80ms
+step:242/1490 train_time:7457ms step_avg:30.82ms
+step:243/1490 train_time:7484ms step_avg:30.80ms
+step:244/1490 train_time:7518ms step_avg:30.81ms
+step:245/1490 train_time:7546ms step_avg:30.80ms
+step:246/1490 train_time:7579ms step_avg:30.81ms
+step:247/1490 train_time:7607ms step_avg:30.80ms
+step:248/1490 train_time:7641ms step_avg:30.81ms
+step:249/1490 train_time:7668ms step_avg:30.80ms
+step:250/1490 train_time:7702ms step_avg:30.81ms
+step:250/1490 val_loss:4.5120 train_time:7744ms step_avg:30.98ms
+step:251/1490 train_time:7768ms step_avg:30.95ms
+step:252/1490 train_time:7789ms step_avg:30.91ms
+step:253/1490 train_time:7804ms step_avg:30.85ms
+step:254/1490 train_time:7832ms step_avg:30.83ms
+step:255/1490 train_time:7860ms step_avg:30.82ms
+step:256/1490 train_time:7895ms step_avg:30.84ms
+step:257/1490 train_time:7923ms step_avg:30.83ms
+step:258/1490 train_time:7957ms step_avg:30.84ms
+step:259/1490 train_time:7985ms step_avg:30.83ms
+step:260/1490 train_time:8019ms step_avg:30.84ms
+step:261/1490 train_time:8047ms step_avg:30.83ms
+step:262/1490 train_time:8081ms step_avg:30.84ms
+step:263/1490 train_time:8108ms step_avg:30.83ms
+step:264/1490 train_time:8142ms step_avg:30.84ms
+step:265/1490 train_time:8169ms step_avg:30.83ms
+step:266/1490 train_time:8204ms step_avg:30.84ms
+step:267/1490 train_time:8231ms step_avg:30.83ms
+step:268/1490 train_time:8265ms step_avg:30.84ms
+step:269/1490 train_time:8292ms step_avg:30.82ms
+step:270/1490 train_time:8326ms step_avg:30.84ms
+step:271/1490 train_time:8353ms step_avg:30.82ms
+step:272/1490 train_time:8388ms step_avg:30.84ms
+step:273/1490 train_time:8414ms step_avg:30.82ms
+step:274/1490 train_time:8448ms step_avg:30.83ms
+step:275/1490 train_time:8475ms step_avg:30.82ms
+step:276/1490 train_time:8509ms step_avg:30.83ms
+step:277/1490 train_time:8536ms step_avg:30.82ms
+step:278/1490 train_time:8570ms step_avg:30.83ms
+step:279/1490 train_time:8597ms step_avg:30.81ms
+step:280/1490 train_time:8631ms step_avg:30.82ms
+step:281/1490 train_time:8658ms step_avg:30.81ms
+step:282/1490 train_time:8692ms step_avg:30.82ms
+step:283/1490 train_time:8719ms step_avg:30.81ms
+step:284/1490 train_time:8753ms step_avg:30.82ms
+step:285/1490 train_time:8782ms step_avg:30.81ms
+step:286/1490 train_time:8816ms step_avg:30.82ms
+step:287/1490 train_time:8843ms step_avg:30.81ms
+step:288/1490 train_time:8878ms step_avg:30.83ms
+step:289/1490 train_time:8906ms step_avg:30.81ms
+step:290/1490 train_time:8940ms step_avg:30.83ms
+step:291/1490 train_time:8968ms step_avg:30.82ms
+step:292/1490 train_time:9002ms step_avg:30.83ms
+step:293/1490 train_time:9030ms step_avg:30.82ms
+step:294/1490 train_time:9064ms step_avg:30.83ms
+step:295/1490 train_time:9091ms step_avg:30.82ms
+step:296/1490 train_time:9126ms step_avg:30.83ms
+step:297/1490 train_time:9153ms step_avg:30.82ms
+step:298/1490 train_time:9188ms step_avg:30.83ms
+step:299/1490 train_time:9215ms step_avg:30.82ms
+step:300/1490 train_time:9249ms step_avg:30.83ms
+step:301/1490 train_time:9276ms step_avg:30.82ms
+step:302/1490 train_time:9310ms step_avg:30.83ms
+step:303/1490 train_time:9337ms step_avg:30.81ms
+step:304/1490 train_time:9371ms step_avg:30.82ms
+step:305/1490 train_time:9398ms step_avg:30.81ms
+step:306/1490 train_time:9432ms step_avg:30.82ms
+step:307/1490 train_time:9460ms step_avg:30.81ms
+step:308/1490 train_time:9494ms step_avg:30.83ms
+step:309/1490 train_time:9521ms step_avg:30.81ms
+step:310/1490 train_time:9555ms step_avg:30.82ms
+step:311/1490 train_time:9582ms step_avg:30.81ms
+step:312/1490 train_time:9616ms step_avg:30.82ms
+step:313/1490 train_time:9643ms step_avg:30.81ms
+step:314/1490 train_time:9677ms step_avg:30.82ms
+step:315/1490 train_time:9705ms step_avg:30.81ms
+step:316/1490 train_time:9739ms step_avg:30.82ms
+step:317/1490 train_time:9766ms step_avg:30.81ms
+step:318/1490 train_time:9801ms step_avg:30.82ms
+step:319/1490 train_time:9828ms step_avg:30.81ms
+step:320/1490 train_time:9863ms step_avg:30.82ms
+step:321/1490 train_time:9890ms step_avg:30.81ms
+step:322/1490 train_time:9925ms step_avg:30.82ms
+step:323/1490 train_time:9952ms step_avg:30.81ms
+step:324/1490 train_time:9986ms step_avg:30.82ms
+step:325/1490 train_time:10014ms step_avg:30.81ms
+step:326/1490 train_time:10048ms step_avg:30.82ms
+step:327/1490 train_time:10075ms step_avg:30.81ms
+step:328/1490 train_time:10109ms step_avg:30.82ms
+step:329/1490 train_time:10137ms step_avg:30.81ms
+step:330/1490 train_time:10170ms step_avg:30.82ms
+step:331/1490 train_time:10198ms step_avg:30.81ms
+step:332/1490 train_time:10232ms step_avg:30.82ms
+step:333/1490 train_time:10259ms step_avg:30.81ms
+step:334/1490 train_time:10294ms step_avg:30.82ms
+step:335/1490 train_time:10321ms step_avg:30.81ms
+step:336/1490 train_time:10355ms step_avg:30.82ms
+step:337/1490 train_time:10383ms step_avg:30.81ms
+step:338/1490 train_time:10417ms step_avg:30.82ms
+step:339/1490 train_time:10445ms step_avg:30.81ms
+step:340/1490 train_time:10479ms step_avg:30.82ms
+step:341/1490 train_time:10506ms step_avg:30.81ms
+step:342/1490 train_time:10540ms step_avg:30.82ms
+step:343/1490 train_time:10568ms step_avg:30.81ms
+step:344/1490 train_time:10602ms step_avg:30.82ms
+step:345/1490 train_time:10629ms step_avg:30.81ms
+step:346/1490 train_time:10663ms step_avg:30.82ms
+step:347/1490 train_time:10690ms step_avg:30.81ms
+step:348/1490 train_time:10725ms step_avg:30.82ms
+step:349/1490 train_time:10752ms step_avg:30.81ms
+step:350/1490 train_time:10787ms step_avg:30.82ms
+step:351/1490 train_time:10814ms step_avg:30.81ms
+step:352/1490 train_time:10848ms step_avg:30.82ms
+step:353/1490 train_time:10875ms step_avg:30.81ms
+step:354/1490 train_time:10909ms step_avg:30.82ms
+step:355/1490 train_time:10936ms step_avg:30.81ms
+step:356/1490 train_time:10970ms step_avg:30.82ms
+step:357/1490 train_time:10998ms step_avg:30.81ms
+step:358/1490 train_time:11032ms step_avg:30.81ms
+step:359/1490 train_time:11059ms step_avg:30.81ms
+step:360/1490 train_time:11093ms step_avg:30.81ms
+step:361/1490 train_time:11121ms step_avg:30.81ms
+step:362/1490 train_time:11155ms step_avg:30.81ms
+step:363/1490 train_time:11182ms step_avg:30.81ms
+step:364/1490 train_time:11216ms step_avg:30.81ms
+step:365/1490 train_time:11244ms step_avg:30.80ms
+step:366/1490 train_time:11277ms step_avg:30.81ms
+step:367/1490 train_time:11305ms step_avg:30.80ms
+step:368/1490 train_time:11340ms step_avg:30.81ms
+step:369/1490 train_time:11367ms step_avg:30.80ms
+step:370/1490 train_time:11401ms step_avg:30.81ms
+step:371/1490 train_time:11428ms step_avg:30.80ms
+step:372/1490 train_time:11463ms step_avg:30.81ms
+step:373/1490 train_time:11490ms step_avg:30.80ms
+step:374/1490 train_time:11525ms step_avg:30.82ms
+step:375/1490 train_time:11552ms step_avg:30.81ms
+step:376/1490 train_time:11586ms step_avg:30.81ms
+step:377/1490 train_time:11613ms step_avg:30.80ms
+step:378/1490 train_time:11647ms step_avg:30.81ms
+step:379/1490 train_time:11675ms step_avg:30.80ms
+step:380/1490 train_time:11709ms step_avg:30.81ms
+step:381/1490 train_time:11736ms step_avg:30.80ms
+step:382/1490 train_time:11770ms step_avg:30.81ms
+step:383/1490 train_time:11798ms step_avg:30.80ms
+step:384/1490 train_time:11832ms step_avg:30.81ms
+step:385/1490 train_time:11859ms step_avg:30.80ms
+step:386/1490 train_time:11893ms step_avg:30.81ms
+step:387/1490 train_time:11921ms step_avg:30.80ms
+step:388/1490 train_time:11955ms step_avg:30.81ms
+step:389/1490 train_time:11982ms step_avg:30.80ms
+step:390/1490 train_time:12017ms step_avg:30.81ms
+step:391/1490 train_time:12044ms step_avg:30.80ms
+step:392/1490 train_time:12078ms step_avg:30.81ms
+step:393/1490 train_time:12105ms step_avg:30.80ms
+step:394/1490 train_time:12140ms step_avg:30.81ms
+step:395/1490 train_time:12167ms step_avg:30.80ms
+step:396/1490 train_time:12202ms step_avg:30.81ms
+step:397/1490 train_time:12229ms step_avg:30.80ms
+step:398/1490 train_time:12266ms step_avg:30.82ms
+step:399/1490 train_time:12291ms step_avg:30.80ms
+step:400/1490 train_time:12327ms step_avg:30.82ms
+step:401/1490 train_time:12353ms step_avg:30.81ms
+step:402/1490 train_time:12389ms step_avg:30.82ms
+step:403/1490 train_time:12415ms step_avg:30.81ms
+step:404/1490 train_time:12450ms step_avg:30.82ms
+step:405/1490 train_time:12476ms step_avg:30.80ms
+step:406/1490 train_time:12511ms step_avg:30.82ms
+step:407/1490 train_time:12537ms step_avg:30.80ms
+step:408/1490 train_time:12573ms step_avg:30.82ms
+step:409/1490 train_time:12599ms step_avg:30.80ms
+step:410/1490 train_time:12634ms step_avg:30.82ms
+step:411/1490 train_time:12660ms step_avg:30.80ms
+step:412/1490 train_time:12694ms step_avg:30.81ms
+step:413/1490 train_time:12722ms step_avg:30.80ms
+step:414/1490 train_time:12756ms step_avg:30.81ms
+step:415/1490 train_time:12783ms step_avg:30.80ms
+step:416/1490 train_time:12818ms step_avg:30.81ms
+step:417/1490 train_time:12845ms step_avg:30.80ms
+step:418/1490 train_time:12879ms step_avg:30.81ms
+step:419/1490 train_time:12907ms step_avg:30.80ms
+step:420/1490 train_time:12941ms step_avg:30.81ms
+step:421/1490 train_time:12968ms step_avg:30.80ms
+step:422/1490 train_time:13002ms step_avg:30.81ms
+step:423/1490 train_time:13029ms step_avg:30.80ms
+step:424/1490 train_time:13063ms step_avg:30.81ms
+step:425/1490 train_time:13091ms step_avg:30.80ms
+step:426/1490 train_time:13125ms step_avg:30.81ms
+step:427/1490 train_time:13153ms step_avg:30.80ms
+step:428/1490 train_time:13187ms step_avg:30.81ms
+step:429/1490 train_time:13214ms step_avg:30.80ms
+step:430/1490 train_time:13248ms step_avg:30.81ms
+step:431/1490 train_time:13276ms step_avg:30.80ms
+step:432/1490 train_time:13310ms step_avg:30.81ms
+step:433/1490 train_time:13337ms step_avg:30.80ms
+step:434/1490 train_time:13371ms step_avg:30.81ms
+step:435/1490 train_time:13399ms step_avg:30.80ms
+step:436/1490 train_time:13433ms step_avg:30.81ms
+step:437/1490 train_time:13460ms step_avg:30.80ms
+step:438/1490 train_time:13494ms step_avg:30.81ms
+step:439/1490 train_time:13521ms step_avg:30.80ms
+step:440/1490 train_time:13555ms step_avg:30.81ms
+step:441/1490 train_time:13582ms step_avg:30.80ms
+step:442/1490 train_time:13616ms step_avg:30.81ms
+step:443/1490 train_time:13644ms step_avg:30.80ms
+step:444/1490 train_time:13679ms step_avg:30.81ms
+step:445/1490 train_time:13706ms step_avg:30.80ms
+step:446/1490 train_time:13741ms step_avg:30.81ms
+step:447/1490 train_time:13768ms step_avg:30.80ms
+step:448/1490 train_time:13802ms step_avg:30.81ms
+step:449/1490 train_time:13830ms step_avg:30.80ms
+step:450/1490 train_time:13864ms step_avg:30.81ms
+step:451/1490 train_time:13891ms step_avg:30.80ms
+step:452/1490 train_time:13925ms step_avg:30.81ms
+step:453/1490 train_time:13953ms step_avg:30.80ms
+step:454/1490 train_time:13988ms step_avg:30.81ms
+step:455/1490 train_time:14014ms step_avg:30.80ms
+step:456/1490 train_time:14048ms step_avg:30.81ms
+step:457/1490 train_time:14075ms step_avg:30.80ms
+step:458/1490 train_time:14109ms step_avg:30.81ms
+step:459/1490 train_time:14137ms step_avg:30.80ms
+step:460/1490 train_time:14171ms step_avg:30.81ms
+step:461/1490 train_time:14199ms step_avg:30.80ms
+step:462/1490 train_time:14233ms step_avg:30.81ms
+step:463/1490 train_time:14260ms step_avg:30.80ms
+step:464/1490 train_time:14294ms step_avg:30.81ms
+step:465/1490 train_time:14322ms step_avg:30.80ms
+step:466/1490 train_time:14356ms step_avg:30.81ms
+step:467/1490 train_time:14384ms step_avg:30.80ms
+step:468/1490 train_time:14418ms step_avg:30.81ms
+step:469/1490 train_time:14446ms step_avg:30.80ms
+step:470/1490 train_time:14480ms step_avg:30.81ms
+step:471/1490 train_time:14507ms step_avg:30.80ms
+step:472/1490 train_time:14542ms step_avg:30.81ms
+step:473/1490 train_time:14569ms step_avg:30.80ms
+step:474/1490 train_time:14603ms step_avg:30.81ms
+step:475/1490 train_time:14630ms step_avg:30.80ms
+step:476/1490 train_time:14665ms step_avg:30.81ms
+step:477/1490 train_time:14692ms step_avg:30.80ms
+step:478/1490 train_time:14726ms step_avg:30.81ms
+step:479/1490 train_time:14753ms step_avg:30.80ms
+step:480/1490 train_time:14787ms step_avg:30.81ms
+step:481/1490 train_time:14814ms step_avg:30.80ms
+step:482/1490 train_time:14848ms step_avg:30.81ms
+step:483/1490 train_time:14876ms step_avg:30.80ms
+step:484/1490 train_time:14913ms step_avg:30.81ms
+step:485/1490 train_time:14963ms step_avg:30.85ms
+step:486/1490 train_time:15022ms step_avg:30.91ms
+step:487/1490 train_time:15075ms step_avg:30.95ms
+step:488/1490 train_time:15134ms step_avg:31.01ms
+step:489/1490 train_time:15187ms step_avg:31.06ms
+step:490/1490 train_time:15245ms step_avg:31.11ms
+step:491/1490 train_time:15299ms step_avg:31.16ms
+step:492/1490 train_time:15358ms step_avg:31.21ms
+step:493/1490 train_time:15411ms step_avg:31.26ms
+step:494/1490 train_time:15471ms step_avg:31.32ms
+step:495/1490 train_time:15524ms step_avg:31.36ms
+step:496/1490 train_time:15584ms step_avg:31.42ms
+step:497/1490 train_time:15638ms step_avg:31.46ms
+step:498/1490 train_time:15696ms step_avg:31.52ms
+step:499/1490 train_time:15750ms step_avg:31.56ms
+step:500/1490 train_time:15808ms step_avg:31.62ms
+step:500/1490 val_loss:4.2528 train_time:15879ms step_avg:31.76ms
+step:501/1490 train_time:15901ms step_avg:31.74ms
+step:502/1490 train_time:15924ms step_avg:31.72ms
+step:503/1490 train_time:15979ms step_avg:31.77ms
+step:504/1490 train_time:16040ms step_avg:31.82ms
+step:505/1490 train_time:16095ms step_avg:31.87ms
+step:506/1490 train_time:16156ms step_avg:31.93ms
+step:507/1490 train_time:16209ms step_avg:31.97ms
+step:508/1490 train_time:16267ms step_avg:32.02ms
+step:509/1490 train_time:16321ms step_avg:32.06ms
+step:510/1490 train_time:16379ms step_avg:32.11ms
+step:511/1490 train_time:16431ms step_avg:32.15ms
+step:512/1490 train_time:16490ms step_avg:32.21ms
+step:513/1490 train_time:16543ms step_avg:32.25ms
+step:514/1490 train_time:16601ms step_avg:32.30ms
+step:515/1490 train_time:16654ms step_avg:32.34ms
+step:516/1490 train_time:16712ms step_avg:32.39ms
+step:517/1490 train_time:16765ms step_avg:32.43ms
+step:518/1490 train_time:16824ms step_avg:32.48ms
+step:519/1490 train_time:16879ms step_avg:32.52ms
+step:520/1490 train_time:16940ms step_avg:32.58ms
+step:521/1490 train_time:16995ms step_avg:32.62ms
+step:522/1490 train_time:17056ms step_avg:32.68ms
+step:523/1490 train_time:17110ms step_avg:32.72ms
+step:524/1490 train_time:17170ms step_avg:32.77ms
+step:525/1490 train_time:17223ms step_avg:32.81ms
+step:526/1490 train_time:17282ms step_avg:32.86ms
+step:527/1490 train_time:17335ms step_avg:32.89ms
+step:528/1490 train_time:17394ms step_avg:32.94ms
+step:529/1490 train_time:17447ms step_avg:32.98ms
+step:530/1490 train_time:17505ms step_avg:33.03ms
+step:531/1490 train_time:17558ms step_avg:33.07ms
+step:532/1490 train_time:17616ms step_avg:33.11ms
+step:533/1490 train_time:17669ms step_avg:33.15ms
+step:534/1490 train_time:17728ms step_avg:33.20ms
+step:535/1490 train_time:17781ms step_avg:33.24ms
+step:536/1490 train_time:17840ms step_avg:33.28ms
+step:537/1490 train_time:17894ms step_avg:33.32ms
+step:538/1490 train_time:17955ms step_avg:33.37ms
+step:539/1490 train_time:18009ms step_avg:33.41ms
+step:540/1490 train_time:18069ms step_avg:33.46ms
+step:541/1490 train_time:18123ms step_avg:33.50ms
+step:542/1490 train_time:18182ms step_avg:33.55ms
+step:543/1490 train_time:18235ms step_avg:33.58ms
+step:544/1490 train_time:18295ms step_avg:33.63ms
+step:545/1490 train_time:18349ms step_avg:33.67ms
+step:546/1490 train_time:18407ms step_avg:33.71ms
+step:547/1490 train_time:18461ms step_avg:33.75ms
+step:548/1490 train_time:18519ms step_avg:33.79ms
+step:549/1490 train_time:18572ms step_avg:33.83ms
+step:550/1490 train_time:18630ms step_avg:33.87ms
+step:551/1490 train_time:18684ms step_avg:33.91ms
+step:552/1490 train_time:18742ms step_avg:33.95ms
+step:553/1490 train_time:18795ms step_avg:33.99ms
+step:554/1490 train_time:18855ms step_avg:34.03ms
+step:555/1490 train_time:18908ms step_avg:34.07ms
+step:556/1490 train_time:18968ms step_avg:34.11ms
+step:557/1490 train_time:19022ms step_avg:34.15ms
+step:558/1490 train_time:19081ms step_avg:34.20ms
+step:559/1490 train_time:19134ms step_avg:34.23ms
+step:560/1490 train_time:19194ms step_avg:34.28ms
+step:561/1490 train_time:19249ms step_avg:34.31ms
+step:562/1490 train_time:19308ms step_avg:34.36ms
+step:563/1490 train_time:19361ms step_avg:34.39ms
+step:564/1490 train_time:19419ms step_avg:34.43ms
+step:565/1490 train_time:19473ms step_avg:34.47ms
+step:566/1490 train_time:19532ms step_avg:34.51ms
+step:567/1490 train_time:19585ms step_avg:34.54ms
+step:568/1490 train_time:19644ms step_avg:34.59ms
+step:569/1490 train_time:19697ms step_avg:34.62ms
+step:570/1490 train_time:19757ms step_avg:34.66ms
+step:571/1490 train_time:19811ms step_avg:34.69ms
+step:572/1490 train_time:19870ms step_avg:34.74ms
+step:573/1490 train_time:19923ms step_avg:34.77ms
+step:574/1490 train_time:19982ms step_avg:34.81ms
+step:575/1490 train_time:20036ms step_avg:34.85ms
+step:576/1490 train_time:20095ms step_avg:34.89ms
+step:577/1490 train_time:20150ms step_avg:34.92ms
+step:578/1490 train_time:20208ms step_avg:34.96ms
+step:579/1490 train_time:20262ms step_avg:34.99ms
+step:580/1490 train_time:20321ms step_avg:35.04ms
+step:581/1490 train_time:20374ms step_avg:35.07ms
+step:582/1490 train_time:20433ms step_avg:35.11ms
+step:583/1490 train_time:20486ms step_avg:35.14ms
+step:584/1490 train_time:20546ms step_avg:35.18ms
+step:585/1490 train_time:20600ms step_avg:35.21ms
+step:586/1490 train_time:20659ms step_avg:35.25ms
+step:587/1490 train_time:20712ms step_avg:35.28ms
+step:588/1490 train_time:20771ms step_avg:35.32ms
+step:589/1490 train_time:20824ms step_avg:35.35ms
+step:590/1490 train_time:20882ms step_avg:35.39ms
+step:591/1490 train_time:20936ms step_avg:35.42ms
+step:592/1490 train_time:20995ms step_avg:35.46ms
+step:593/1490 train_time:21050ms step_avg:35.50ms
+step:594/1490 train_time:21108ms step_avg:35.54ms
+step:595/1490 train_time:21162ms step_avg:35.57ms
+step:596/1490 train_time:21221ms step_avg:35.61ms
+step:597/1490 train_time:21275ms step_avg:35.64ms
+step:598/1490 train_time:21334ms step_avg:35.67ms
+step:599/1490 train_time:21387ms step_avg:35.70ms
+step:600/1490 train_time:21446ms step_avg:35.74ms
+step:601/1490 train_time:21500ms step_avg:35.77ms
+step:602/1490 train_time:21559ms step_avg:35.81ms
+step:603/1490 train_time:21612ms step_avg:35.84ms
+step:604/1490 train_time:21670ms step_avg:35.88ms
+step:605/1490 train_time:21724ms step_avg:35.91ms
+step:606/1490 train_time:21783ms step_avg:35.95ms
+step:607/1490 train_time:21836ms step_avg:35.97ms
+step:608/1490 train_time:21895ms step_avg:36.01ms
+step:609/1490 train_time:21950ms step_avg:36.04ms
+step:610/1490 train_time:22008ms step_avg:36.08ms
+step:611/1490 train_time:22063ms step_avg:36.11ms
+step:612/1490 train_time:22121ms step_avg:36.15ms
+step:613/1490 train_time:22174ms step_avg:36.17ms
+step:614/1490 train_time:22234ms step_avg:36.21ms
+step:615/1490 train_time:22287ms step_avg:36.24ms
+step:616/1490 train_time:22347ms step_avg:36.28ms
+step:617/1490 train_time:22401ms step_avg:36.31ms
+step:618/1490 train_time:22460ms step_avg:36.34ms
+step:619/1490 train_time:22513ms step_avg:36.37ms
+step:620/1490 train_time:22573ms step_avg:36.41ms
+step:621/1490 train_time:22626ms step_avg:36.44ms
+step:622/1490 train_time:22685ms step_avg:36.47ms
+step:623/1490 train_time:22739ms step_avg:36.50ms
+step:624/1490 train_time:22798ms step_avg:36.53ms
+step:625/1490 train_time:22853ms step_avg:36.56ms
+step:626/1490 train_time:22911ms step_avg:36.60ms
+step:627/1490 train_time:22965ms step_avg:36.63ms
+step:628/1490 train_time:23023ms step_avg:36.66ms
+step:629/1490 train_time:23077ms step_avg:36.69ms
+step:630/1490 train_time:23135ms step_avg:36.72ms
+step:631/1490 train_time:23190ms step_avg:36.75ms
+step:632/1490 train_time:23250ms step_avg:36.79ms
+step:633/1490 train_time:23304ms step_avg:36.81ms
+step:634/1490 train_time:23362ms step_avg:36.85ms
+step:635/1490 train_time:23417ms step_avg:36.88ms
+step:636/1490 train_time:23475ms step_avg:36.91ms
+step:637/1490 train_time:23529ms step_avg:36.94ms
+step:638/1490 train_time:23588ms step_avg:36.97ms
+step:639/1490 train_time:23641ms step_avg:37.00ms
+step:640/1490 train_time:23700ms step_avg:37.03ms
+step:641/1490 train_time:23754ms step_avg:37.06ms
+step:642/1490 train_time:23812ms step_avg:37.09ms
+step:643/1490 train_time:23865ms step_avg:37.12ms
+step:644/1490 train_time:23925ms step_avg:37.15ms
+step:645/1490 train_time:23978ms step_avg:37.18ms
+step:646/1490 train_time:24037ms step_avg:37.21ms
+step:647/1490 train_time:24091ms step_avg:37.24ms
+step:648/1490 train_time:24150ms step_avg:37.27ms
+step:649/1490 train_time:24204ms step_avg:37.29ms
+step:650/1490 train_time:24263ms step_avg:37.33ms
+step:651/1490 train_time:24316ms step_avg:37.35ms
+step:652/1490 train_time:24376ms step_avg:37.39ms
+step:653/1490 train_time:24430ms step_avg:37.41ms
+step:654/1490 train_time:24488ms step_avg:37.44ms
+step:655/1490 train_time:24542ms step_avg:37.47ms
+step:656/1490 train_time:24600ms step_avg:37.50ms
+step:657/1490 train_time:24654ms step_avg:37.52ms
+step:658/1490 train_time:24712ms step_avg:37.56ms
+step:659/1490 train_time:24766ms step_avg:37.58ms
+step:660/1490 train_time:24826ms step_avg:37.61ms
+step:661/1490 train_time:24879ms step_avg:37.64ms
+step:662/1490 train_time:24937ms step_avg:37.67ms
+step:663/1490 train_time:24992ms step_avg:37.69ms
+step:664/1490 train_time:25052ms step_avg:37.73ms
+step:665/1490 train_time:25105ms step_avg:37.75ms
+step:666/1490 train_time:25165ms step_avg:37.78ms
+step:667/1490 train_time:25218ms step_avg:37.81ms
+step:668/1490 train_time:25277ms step_avg:37.84ms
+step:669/1490 train_time:25330ms step_avg:37.86ms
+step:670/1490 train_time:25390ms step_avg:37.90ms
+step:671/1490 train_time:25443ms step_avg:37.92ms
+step:672/1490 train_time:25502ms step_avg:37.95ms
+step:673/1490 train_time:25556ms step_avg:37.97ms
+step:674/1490 train_time:25614ms step_avg:38.00ms
+step:675/1490 train_time:25668ms step_avg:38.03ms
+step:676/1490 train_time:25727ms step_avg:38.06ms
+step:677/1490 train_time:25781ms step_avg:38.08ms
+step:678/1490 train_time:25839ms step_avg:38.11ms
+step:679/1490 train_time:25894ms step_avg:38.13ms
+step:680/1490 train_time:25952ms step_avg:38.17ms
+step:681/1490 train_time:26005ms step_avg:38.19ms
+step:682/1490 train_time:26065ms step_avg:38.22ms
+step:683/1490 train_time:26118ms step_avg:38.24ms
+step:684/1490 train_time:26177ms step_avg:38.27ms
+step:685/1490 train_time:26231ms step_avg:38.29ms
+step:686/1490 train_time:26290ms step_avg:38.32ms
+step:687/1490 train_time:26344ms step_avg:38.35ms
+step:688/1490 train_time:26402ms step_avg:38.38ms
+step:689/1490 train_time:26456ms step_avg:38.40ms
+step:690/1490 train_time:26515ms step_avg:38.43ms
+step:691/1490 train_time:26569ms step_avg:38.45ms
+step:692/1490 train_time:26627ms step_avg:38.48ms
+step:693/1490 train_time:26681ms step_avg:38.50ms
+step:694/1490 train_time:26739ms step_avg:38.53ms
+step:695/1490 train_time:26793ms step_avg:38.55ms
+step:696/1490 train_time:26852ms step_avg:38.58ms
+step:697/1490 train_time:26905ms step_avg:38.60ms
+step:698/1490 train_time:26965ms step_avg:38.63ms
+step:699/1490 train_time:27019ms step_avg:38.65ms
+step:700/1490 train_time:27077ms step_avg:38.68ms
+step:701/1490 train_time:27131ms step_avg:38.70ms
+step:702/1490 train_time:27190ms step_avg:38.73ms
+step:703/1490 train_time:27244ms step_avg:38.75ms
+step:704/1490 train_time:27303ms step_avg:38.78ms
+step:705/1490 train_time:27356ms step_avg:38.80ms
+step:706/1490 train_time:27415ms step_avg:38.83ms
+step:707/1490 train_time:27469ms step_avg:38.85ms
+step:708/1490 train_time:27527ms step_avg:38.88ms
+step:709/1490 train_time:27581ms step_avg:38.90ms
+step:710/1490 train_time:27640ms step_avg:38.93ms
+step:711/1490 train_time:27694ms step_avg:38.95ms
+step:712/1490 train_time:27754ms step_avg:38.98ms
+step:713/1490 train_time:27807ms step_avg:39.00ms
+step:714/1490 train_time:27866ms step_avg:39.03ms
+step:715/1490 train_time:27919ms step_avg:39.05ms
+step:716/1490 train_time:27979ms step_avg:39.08ms
+step:717/1490 train_time:28033ms step_avg:39.10ms
+step:718/1490 train_time:28093ms step_avg:39.13ms
+step:719/1490 train_time:28147ms step_avg:39.15ms
+step:720/1490 train_time:28205ms step_avg:39.17ms
+step:721/1490 train_time:28259ms step_avg:39.19ms
+step:722/1490 train_time:28317ms step_avg:39.22ms
+step:723/1490 train_time:28371ms step_avg:39.24ms
+step:724/1490 train_time:28430ms step_avg:39.27ms
+step:725/1490 train_time:28483ms step_avg:39.29ms
+step:726/1490 train_time:28542ms step_avg:39.31ms
+step:727/1490 train_time:28595ms step_avg:39.33ms
+step:728/1490 train_time:28654ms step_avg:39.36ms
+step:729/1490 train_time:28707ms step_avg:39.38ms
+step:730/1490 train_time:28767ms step_avg:39.41ms
+step:731/1490 train_time:28821ms step_avg:39.43ms
+step:732/1490 train_time:28879ms step_avg:39.45ms
+step:733/1490 train_time:28932ms step_avg:39.47ms
+step:734/1490 train_time:28991ms step_avg:39.50ms
+step:735/1490 train_time:29045ms step_avg:39.52ms
+step:736/1490 train_time:29104ms step_avg:39.54ms
+step:737/1490 train_time:29159ms step_avg:39.56ms
+step:738/1490 train_time:29217ms step_avg:39.59ms
+step:739/1490 train_time:29272ms step_avg:39.61ms
+step:740/1490 train_time:29330ms step_avg:39.64ms
+step:741/1490 train_time:29384ms step_avg:39.65ms
+step:742/1490 train_time:29443ms step_avg:39.68ms
+step:743/1490 train_time:29497ms step_avg:39.70ms
+step:744/1490 train_time:29556ms step_avg:39.73ms
+step:745/1490 train_time:29610ms step_avg:39.74ms
+step:746/1490 train_time:29668ms step_avg:39.77ms
+step:747/1490 train_time:29722ms step_avg:39.79ms
+step:748/1490 train_time:29780ms step_avg:39.81ms
+step:749/1490 train_time:29834ms step_avg:39.83ms
+step:750/1490 train_time:29893ms step_avg:39.86ms
+step:750/1490 val_loss:3.8003 train_time:29964ms step_avg:39.95ms
+step:751/1490 train_time:29987ms step_avg:39.93ms
+step:752/1490 train_time:30009ms step_avg:39.91ms
+step:753/1490 train_time:30066ms step_avg:39.93ms
+step:754/1490 train_time:30127ms step_avg:39.96ms
+step:755/1490 train_time:30180ms step_avg:39.97ms
+step:756/1490 train_time:30240ms step_avg:40.00ms
+step:757/1490 train_time:30293ms step_avg:40.02ms
+step:758/1490 train_time:30351ms step_avg:40.04ms
+step:759/1490 train_time:30404ms step_avg:40.06ms
+step:760/1490 train_time:30463ms step_avg:40.08ms
+step:761/1490 train_time:30516ms step_avg:40.10ms
+step:762/1490 train_time:30574ms step_avg:40.12ms
+step:763/1490 train_time:30627ms step_avg:40.14ms
+step:764/1490 train_time:30685ms step_avg:40.16ms
+step:765/1490 train_time:30738ms step_avg:40.18ms
+step:766/1490 train_time:30796ms step_avg:40.20ms
+step:767/1490 train_time:30849ms step_avg:40.22ms
+step:768/1490 train_time:30909ms step_avg:40.25ms
+step:769/1490 train_time:30964ms step_avg:40.26ms
+step:770/1490 train_time:31024ms step_avg:40.29ms
+step:771/1490 train_time:31079ms step_avg:40.31ms
+step:772/1490 train_time:31139ms step_avg:40.34ms
+step:773/1490 train_time:31193ms step_avg:40.35ms
+step:774/1490 train_time:31253ms step_avg:40.38ms
+step:775/1490 train_time:31306ms step_avg:40.40ms
+step:776/1490 train_time:31365ms step_avg:40.42ms
+step:777/1490 train_time:31419ms step_avg:40.44ms
+step:778/1490 train_time:31477ms step_avg:40.46ms
+step:779/1490 train_time:31530ms step_avg:40.48ms
+step:780/1490 train_time:31589ms step_avg:40.50ms
+step:781/1490 train_time:31642ms step_avg:40.51ms
+step:782/1490 train_time:31700ms step_avg:40.54ms
+step:783/1490 train_time:31752ms step_avg:40.55ms
+step:784/1490 train_time:31812ms step_avg:40.58ms
+step:785/1490 train_time:31866ms step_avg:40.59ms
+step:786/1490 train_time:31925ms step_avg:40.62ms
+step:787/1490 train_time:31979ms step_avg:40.63ms
+step:788/1490 train_time:32038ms step_avg:40.66ms
+step:789/1490 train_time:32093ms step_avg:40.68ms
+step:790/1490 train_time:32152ms step_avg:40.70ms
+step:791/1490 train_time:32206ms step_avg:40.72ms
+step:792/1490 train_time:32268ms step_avg:40.74ms
+step:793/1490 train_time:32320ms step_avg:40.76ms
+step:794/1490 train_time:32379ms step_avg:40.78ms
+step:795/1490 train_time:32432ms step_avg:40.79ms
+step:796/1490 train_time:32490ms step_avg:40.82ms
+step:797/1490 train_time:32543ms step_avg:40.83ms
+step:798/1490 train_time:32602ms step_avg:40.85ms
+step:799/1490 train_time:32654ms step_avg:40.87ms
+step:800/1490 train_time:32713ms step_avg:40.89ms
+step:801/1490 train_time:32767ms step_avg:40.91ms
+step:802/1490 train_time:32826ms step_avg:40.93ms
+step:803/1490 train_time:32880ms step_avg:40.95ms
+step:804/1490 train_time:32939ms step_avg:40.97ms
+step:805/1490 train_time:32993ms step_avg:40.98ms
+step:806/1490 train_time:33052ms step_avg:41.01ms
+step:807/1490 train_time:33106ms step_avg:41.02ms
+step:808/1490 train_time:33166ms step_avg:41.05ms
+step:809/1490 train_time:33220ms step_avg:41.06ms
+step:810/1490 train_time:33280ms step_avg:41.09ms
+step:811/1490 train_time:33333ms step_avg:41.10ms
+step:812/1490 train_time:33393ms step_avg:41.12ms
+step:813/1490 train_time:33446ms step_avg:41.14ms
+step:814/1490 train_time:33505ms step_avg:41.16ms
+step:815/1490 train_time:33558ms step_avg:41.18ms
+step:816/1490 train_time:33616ms step_avg:41.20ms
+step:817/1490 train_time:33669ms step_avg:41.21ms
+step:818/1490 train_time:33729ms step_avg:41.23ms
+step:819/1490 train_time:33781ms step_avg:41.25ms
+step:820/1490 train_time:33840ms step_avg:41.27ms
+step:821/1490 train_time:33893ms step_avg:41.28ms
+step:822/1490 train_time:33952ms step_avg:41.30ms
+step:823/1490 train_time:34006ms step_avg:41.32ms
+step:824/1490 train_time:34066ms step_avg:41.34ms
+step:825/1490 train_time:34119ms step_avg:41.36ms
+step:826/1490 train_time:34179ms step_avg:41.38ms
+step:827/1490 train_time:34232ms step_avg:41.39ms
+step:828/1490 train_time:34291ms step_avg:41.41ms
+step:829/1490 train_time:34344ms step_avg:41.43ms
+step:830/1490 train_time:34404ms step_avg:41.45ms
+step:831/1490 train_time:34457ms step_avg:41.46ms
+step:832/1490 train_time:34516ms step_avg:41.49ms
+step:833/1490 train_time:34569ms step_avg:41.50ms
+step:834/1490 train_time:34628ms step_avg:41.52ms
+step:835/1490 train_time:34681ms step_avg:41.53ms
+step:836/1490 train_time:34739ms step_avg:41.55ms
+step:837/1490 train_time:34792ms step_avg:41.57ms
+step:838/1490 train_time:34851ms step_avg:41.59ms
+step:839/1490 train_time:34905ms step_avg:41.60ms
+step:840/1490 train_time:34964ms step_avg:41.62ms
+step:841/1490 train_time:35018ms step_avg:41.64ms
+step:842/1490 train_time:35077ms step_avg:41.66ms
+step:843/1490 train_time:35131ms step_avg:41.67ms
+step:844/1490 train_time:35190ms step_avg:41.69ms
+step:845/1490 train_time:35244ms step_avg:41.71ms
+step:846/1490 train_time:35303ms step_avg:41.73ms
+step:847/1490 train_time:35356ms step_avg:41.74ms
+step:848/1490 train_time:35415ms step_avg:41.76ms
+step:849/1490 train_time:35469ms step_avg:41.78ms
+step:850/1490 train_time:35528ms step_avg:41.80ms
+step:851/1490 train_time:35581ms step_avg:41.81ms
+step:852/1490 train_time:35639ms step_avg:41.83ms
+step:853/1490 train_time:35693ms step_avg:41.84ms
+step:854/1490 train_time:35752ms step_avg:41.86ms
+step:855/1490 train_time:35806ms step_avg:41.88ms
+step:856/1490 train_time:35865ms step_avg:41.90ms
+step:857/1490 train_time:35919ms step_avg:41.91ms
+step:858/1490 train_time:35977ms step_avg:41.93ms
+step:859/1490 train_time:36030ms step_avg:41.94ms
+step:860/1490 train_time:36090ms step_avg:41.96ms
+step:861/1490 train_time:36143ms step_avg:41.98ms
+step:862/1490 train_time:36203ms step_avg:42.00ms
+step:863/1490 train_time:36256ms step_avg:42.01ms
+step:864/1490 train_time:36314ms step_avg:42.03ms
+step:865/1490 train_time:36368ms step_avg:42.04ms
+step:866/1490 train_time:36428ms step_avg:42.07ms
+step:867/1490 train_time:36482ms step_avg:42.08ms
+step:868/1490 train_time:36540ms step_avg:42.10ms
+step:869/1490 train_time:36593ms step_avg:42.11ms
+step:870/1490 train_time:36653ms step_avg:42.13ms
+step:871/1490 train_time:36706ms step_avg:42.14ms
+step:872/1490 train_time:36766ms step_avg:42.16ms
+step:873/1490 train_time:36819ms step_avg:42.18ms
+step:874/1490 train_time:36877ms step_avg:42.19ms
+step:875/1490 train_time:36931ms step_avg:42.21ms
+step:876/1490 train_time:36989ms step_avg:42.23ms
+step:877/1490 train_time:37043ms step_avg:42.24ms
+step:878/1490 train_time:37101ms step_avg:42.26ms
+step:879/1490 train_time:37155ms step_avg:42.27ms
+step:880/1490 train_time:37214ms step_avg:42.29ms
+step:881/1490 train_time:37268ms step_avg:42.30ms
+step:882/1490 train_time:37327ms step_avg:42.32ms
+step:883/1490 train_time:37379ms step_avg:42.33ms
+step:884/1490 train_time:37438ms step_avg:42.35ms
+step:885/1490 train_time:37492ms step_avg:42.36ms
+step:886/1490 train_time:37551ms step_avg:42.38ms
+step:887/1490 train_time:37605ms step_avg:42.40ms
+step:888/1490 train_time:37663ms step_avg:42.41ms
+step:889/1490 train_time:37716ms step_avg:42.43ms
+step:890/1490 train_time:37776ms step_avg:42.45ms
+step:891/1490 train_time:37829ms step_avg:42.46ms
+step:892/1490 train_time:37888ms step_avg:42.48ms
+step:893/1490 train_time:37942ms step_avg:42.49ms
+step:894/1490 train_time:38000ms step_avg:42.51ms
+step:895/1490 train_time:38053ms step_avg:42.52ms
+step:896/1490 train_time:38113ms step_avg:42.54ms
+step:897/1490 train_time:38168ms step_avg:42.55ms
+step:898/1490 train_time:38226ms step_avg:42.57ms
+step:899/1490 train_time:38279ms step_avg:42.58ms
+step:900/1490 train_time:38338ms step_avg:42.60ms
+step:901/1490 train_time:38392ms step_avg:42.61ms
+step:902/1490 train_time:38450ms step_avg:42.63ms
+step:903/1490 train_time:38504ms step_avg:42.64ms
+step:904/1490 train_time:38565ms step_avg:42.66ms
+step:905/1490 train_time:38618ms step_avg:42.67ms
+step:906/1490 train_time:38677ms step_avg:42.69ms
+step:907/1490 train_time:38730ms step_avg:42.70ms
+step:908/1490 train_time:38789ms step_avg:42.72ms
+step:909/1490 train_time:38843ms step_avg:42.73ms
+step:910/1490 train_time:38901ms step_avg:42.75ms
+step:911/1490 train_time:38954ms step_avg:42.76ms
+step:912/1490 train_time:39013ms step_avg:42.78ms
+step:913/1490 train_time:39068ms step_avg:42.79ms
+step:914/1490 train_time:39126ms step_avg:42.81ms
+step:915/1490 train_time:39180ms step_avg:42.82ms
+step:916/1490 train_time:39238ms step_avg:42.84ms
+step:917/1490 train_time:39293ms step_avg:42.85ms
+step:918/1490 train_time:39352ms step_avg:42.87ms
+step:919/1490 train_time:39405ms step_avg:42.88ms
+step:920/1490 train_time:39465ms step_avg:42.90ms
+step:921/1490 train_time:39518ms step_avg:42.91ms
+step:922/1490 train_time:39577ms step_avg:42.93ms
+step:923/1490 train_time:39631ms step_avg:42.94ms
+step:924/1490 train_time:39689ms step_avg:42.95ms
+step:925/1490 train_time:39743ms step_avg:42.97ms
+step:926/1490 train_time:39801ms step_avg:42.98ms
+step:927/1490 train_time:39854ms step_avg:42.99ms
+step:928/1490 train_time:39913ms step_avg:43.01ms
+step:929/1490 train_time:39968ms step_avg:43.02ms
+step:930/1490 train_time:40027ms step_avg:43.04ms
+step:931/1490 train_time:40080ms step_avg:43.05ms
+step:932/1490 train_time:40138ms step_avg:43.07ms
+step:933/1490 train_time:40192ms step_avg:43.08ms
+step:934/1490 train_time:40251ms step_avg:43.10ms
+step:935/1490 train_time:40305ms step_avg:43.11ms
+step:936/1490 train_time:40363ms step_avg:43.12ms
+step:937/1490 train_time:40417ms step_avg:43.13ms
+step:938/1490 train_time:40477ms step_avg:43.15ms
+step:939/1490 train_time:40530ms step_avg:43.16ms
+step:940/1490 train_time:40589ms step_avg:43.18ms
+step:941/1490 train_time:40643ms step_avg:43.19ms
+step:942/1490 train_time:40701ms step_avg:43.21ms
+step:943/1490 train_time:40754ms step_avg:43.22ms
+step:944/1490 train_time:40814ms step_avg:43.23ms
+step:945/1490 train_time:40868ms step_avg:43.25ms
+step:946/1490 train_time:40926ms step_avg:43.26ms
+step:947/1490 train_time:40980ms step_avg:43.27ms
+step:948/1490 train_time:41039ms step_avg:43.29ms
+step:949/1490 train_time:41093ms step_avg:43.30ms
+step:950/1490 train_time:41151ms step_avg:43.32ms
+step:951/1490 train_time:41204ms step_avg:43.33ms
+step:952/1490 train_time:41264ms step_avg:43.34ms
+step:953/1490 train_time:41318ms step_avg:43.36ms
+step:954/1490 train_time:41376ms step_avg:43.37ms
+step:955/1490 train_time:41430ms step_avg:43.38ms
+step:956/1490 train_time:41489ms step_avg:43.40ms
+step:957/1490 train_time:41542ms step_avg:43.41ms
+step:958/1490 train_time:41601ms step_avg:43.43ms
+step:959/1490 train_time:41655ms step_avg:43.44ms
+step:960/1490 train_time:41714ms step_avg:43.45ms
+step:961/1490 train_time:41769ms step_avg:43.46ms
+step:962/1490 train_time:41828ms step_avg:43.48ms
+step:963/1490 train_time:41881ms step_avg:43.49ms
+step:964/1490 train_time:41940ms step_avg:43.51ms
+step:965/1490 train_time:41993ms step_avg:43.52ms
+step:966/1490 train_time:42053ms step_avg:43.53ms
+step:967/1490 train_time:42107ms step_avg:43.54ms
+step:968/1490 train_time:42168ms step_avg:43.56ms
+step:969/1490 train_time:42246ms step_avg:43.60ms
+step:970/1490 train_time:42331ms step_avg:43.64ms
+step:971/1490 train_time:42410ms step_avg:43.68ms
+step:972/1490 train_time:42494ms step_avg:43.72ms
+step:973/1490 train_time:42573ms step_avg:43.75ms
+step:974/1490 train_time:42658ms step_avg:43.80ms
+step:975/1490 train_time:42737ms step_avg:43.83ms
+step:976/1490 train_time:42822ms step_avg:43.87ms
+step:977/1490 train_time:42902ms step_avg:43.91ms
+step:978/1490 train_time:42986ms step_avg:43.95ms
+step:979/1490 train_time:43065ms step_avg:43.99ms
+step:980/1490 train_time:43149ms step_avg:44.03ms
+step:981/1490 train_time:43228ms step_avg:44.07ms
+step:982/1490 train_time:43313ms step_avg:44.11ms
+step:983/1490 train_time:43393ms step_avg:44.14ms
+step:984/1490 train_time:43476ms step_avg:44.18ms
+step:985/1490 train_time:43555ms step_avg:44.22ms
+step:986/1490 train_time:43640ms step_avg:44.26ms
+step:987/1490 train_time:43720ms step_avg:44.30ms
+step:988/1490 train_time:43805ms step_avg:44.34ms
+step:989/1490 train_time:43884ms step_avg:44.37ms
+step:990/1490 train_time:43970ms step_avg:44.41ms
+step:991/1490 train_time:44050ms step_avg:44.45ms
+step:992/1490 train_time:44135ms step_avg:44.49ms
+step:993/1490 train_time:44214ms step_avg:44.53ms
+step:994/1490 train_time:44299ms step_avg:44.57ms
+step:995/1490 train_time:44378ms step_avg:44.60ms
+step:996/1490 train_time:44462ms step_avg:44.64ms
+step:997/1490 train_time:44541ms step_avg:44.67ms
+step:998/1490 train_time:44626ms step_avg:44.72ms
+step:999/1490 train_time:44706ms step_avg:44.75ms
+step:1000/1490 train_time:44791ms step_avg:44.79ms
+step:1000/1490 val_loss:3.5144 train_time:44891ms step_avg:44.89ms
+step:1001/1490 train_time:44909ms step_avg:44.86ms
+step:1002/1490 train_time:44957ms step_avg:44.87ms
+step:1003/1490 train_time:45043ms step_avg:44.91ms
+step:1004/1490 train_time:45127ms step_avg:44.95ms
+step:1005/1490 train_time:45207ms step_avg:44.98ms
+step:1006/1490 train_time:45291ms step_avg:45.02ms
+step:1007/1490 train_time:45370ms step_avg:45.05ms
+step:1008/1490 train_time:45454ms step_avg:45.09ms
+step:1009/1490 train_time:45535ms step_avg:45.13ms
+step:1010/1490 train_time:45618ms step_avg:45.17ms
+step:1011/1490 train_time:45698ms step_avg:45.20ms
+step:1012/1490 train_time:45781ms step_avg:45.24ms
+step:1013/1490 train_time:45860ms step_avg:45.27ms
+step:1014/1490 train_time:45948ms step_avg:45.31ms
+step:1015/1490 train_time:46031ms step_avg:45.35ms
+step:1016/1490 train_time:46118ms step_avg:45.39ms
+step:1017/1490 train_time:46197ms step_avg:45.42ms
+step:1018/1490 train_time:46281ms step_avg:45.46ms
+step:1019/1490 train_time:46359ms step_avg:45.49ms
+step:1020/1490 train_time:46444ms step_avg:45.53ms
+step:1021/1490 train_time:46523ms step_avg:45.57ms
+step:1022/1490 train_time:46606ms step_avg:45.60ms
+step:1023/1490 train_time:46684ms step_avg:45.63ms
+step:1024/1490 train_time:46768ms step_avg:45.67ms
+step:1025/1490 train_time:46848ms step_avg:45.70ms
+step:1026/1490 train_time:46934ms step_avg:45.74ms
+step:1027/1490 train_time:47016ms step_avg:45.78ms
+step:1028/1490 train_time:47103ms step_avg:45.82ms
+step:1029/1490 train_time:47183ms step_avg:45.85ms
+step:1030/1490 train_time:47267ms step_avg:45.89ms
+step:1031/1490 train_time:47345ms step_avg:45.92ms
+step:1032/1490 train_time:47429ms step_avg:45.96ms
+step:1033/1490 train_time:47508ms step_avg:45.99ms
+step:1034/1490 train_time:47591ms step_avg:46.03ms
+step:1035/1490 train_time:47671ms step_avg:46.06ms
+step:1036/1490 train_time:47756ms step_avg:46.10ms
+step:1037/1490 train_time:47835ms step_avg:46.13ms
+step:1038/1490 train_time:47920ms step_avg:46.17ms
+step:1039/1490 train_time:48001ms step_avg:46.20ms
+step:1040/1490 train_time:48087ms step_avg:46.24ms
+step:1041/1490 train_time:48166ms step_avg:46.27ms
+step:1042/1490 train_time:48251ms step_avg:46.31ms
+step:1043/1490 train_time:48330ms step_avg:46.34ms
+step:1044/1490 train_time:48415ms step_avg:46.37ms
+step:1045/1490 train_time:48495ms step_avg:46.41ms
+step:1046/1490 train_time:48579ms step_avg:46.44ms
+step:1047/1490 train_time:48657ms step_avg:46.47ms
+step:1048/1490 train_time:48741ms step_avg:46.51ms
+step:1049/1490 train_time:48819ms step_avg:46.54ms
+step:1050/1490 train_time:48905ms step_avg:46.58ms
+step:1051/1490 train_time:48986ms step_avg:46.61ms
+step:1052/1490 train_time:49070ms step_avg:46.64ms
+step:1053/1490 train_time:49150ms step_avg:46.68ms
+step:1054/1490 train_time:49235ms step_avg:46.71ms
+step:1055/1490 train_time:49315ms step_avg:46.74ms
+step:1056/1490 train_time:49400ms step_avg:46.78ms
+step:1057/1490 train_time:49478ms step_avg:46.81ms
+step:1058/1490 train_time:49562ms step_avg:46.85ms
+step:1059/1490 train_time:49641ms step_avg:46.88ms
+step:1060/1490 train_time:49724ms step_avg:46.91ms
+step:1061/1490 train_time:49804ms step_avg:46.94ms
+step:1062/1490 train_time:49890ms step_avg:46.98ms
+step:1063/1490 train_time:49968ms step_avg:47.01ms
+step:1064/1490 train_time:50053ms step_avg:47.04ms
+step:1065/1490 train_time:50134ms step_avg:47.07ms
+step:1066/1490 train_time:50219ms step_avg:47.11ms
+step:1067/1490 train_time:50298ms step_avg:47.14ms
+step:1068/1490 train_time:50383ms step_avg:47.18ms
+step:1069/1490 train_time:50461ms step_avg:47.20ms
+step:1070/1490 train_time:50547ms step_avg:47.24ms
+step:1071/1490 train_time:50625ms step_avg:47.27ms
+step:1072/1490 train_time:50711ms step_avg:47.31ms
+step:1073/1490 train_time:50789ms step_avg:47.33ms
+step:1074/1490 train_time:50873ms step_avg:47.37ms
+step:1075/1490 train_time:50953ms step_avg:47.40ms
+step:1076/1490 train_time:51038ms step_avg:47.43ms
+step:1077/1490 train_time:51119ms step_avg:47.46ms
+step:1078/1490 train_time:51204ms step_avg:47.50ms
+step:1079/1490 train_time:51282ms step_avg:47.53ms
+step:1080/1490 train_time:51366ms step_avg:47.56ms
+step:1081/1490 train_time:51445ms step_avg:47.59ms
+step:1082/1490 train_time:51529ms step_avg:47.62ms
+step:1083/1490 train_time:51608ms step_avg:47.65ms
+step:1084/1490 train_time:51693ms step_avg:47.69ms
+step:1085/1490 train_time:51772ms step_avg:47.72ms
+step:1086/1490 train_time:51857ms step_avg:47.75ms
+step:1087/1490 train_time:51938ms step_avg:47.78ms
+step:1088/1490 train_time:52023ms step_avg:47.81ms
+step:1089/1490 train_time:52101ms step_avg:47.84ms
+step:1090/1490 train_time:52187ms step_avg:47.88ms
+step:1091/1490 train_time:52266ms step_avg:47.91ms
+step:1092/1490 train_time:52352ms step_avg:47.94ms
+step:1093/1490 train_time:52431ms step_avg:47.97ms
+step:1094/1490 train_time:52515ms step_avg:48.00ms
+step:1095/1490 train_time:52595ms step_avg:48.03ms
+step:1096/1490 train_time:52679ms step_avg:48.07ms
+step:1097/1490 train_time:52759ms step_avg:48.09ms
+step:1098/1490 train_time:52843ms step_avg:48.13ms
+step:1099/1490 train_time:52922ms step_avg:48.15ms
+step:1100/1490 train_time:53008ms step_avg:48.19ms
+step:1101/1490 train_time:53086ms step_avg:48.22ms
+step:1102/1490 train_time:53172ms step_avg:48.25ms
+step:1103/1490 train_time:53252ms step_avg:48.28ms
+step:1104/1490 train_time:53338ms step_avg:48.31ms
+step:1105/1490 train_time:53416ms step_avg:48.34ms
+step:1106/1490 train_time:53501ms step_avg:48.37ms
+step:1107/1490 train_time:53580ms step_avg:48.40ms
+step:1108/1490 train_time:53664ms step_avg:48.43ms
+step:1109/1490 train_time:53744ms step_avg:48.46ms
+step:1110/1490 train_time:53828ms step_avg:48.49ms
+step:1111/1490 train_time:53907ms step_avg:48.52ms
+step:1112/1490 train_time:53990ms step_avg:48.55ms
+step:1113/1490 train_time:54070ms step_avg:48.58ms
+step:1114/1490 train_time:54154ms step_avg:48.61ms
+step:1115/1490 train_time:54235ms step_avg:48.64ms
+step:1116/1490 train_time:54320ms step_avg:48.67ms
+step:1117/1490 train_time:54400ms step_avg:48.70ms
+step:1118/1490 train_time:54485ms step_avg:48.73ms
+step:1119/1490 train_time:54564ms step_avg:48.76ms
+step:1120/1490 train_time:54649ms step_avg:48.79ms
+step:1121/1490 train_time:54727ms step_avg:48.82ms
+step:1122/1490 train_time:54813ms step_avg:48.85ms
+step:1123/1490 train_time:54893ms step_avg:48.88ms
+step:1124/1490 train_time:54978ms step_avg:48.91ms
+step:1125/1490 train_time:55057ms step_avg:48.94ms
+step:1126/1490 train_time:55142ms step_avg:48.97ms
+step:1127/1490 train_time:55220ms step_avg:49.00ms
+step:1128/1490 train_time:55306ms step_avg:49.03ms
+step:1129/1490 train_time:55386ms step_avg:49.06ms
+step:1130/1490 train_time:55471ms step_avg:49.09ms
+step:1131/1490 train_time:55552ms step_avg:49.12ms
+step:1132/1490 train_time:55637ms step_avg:49.15ms
+step:1133/1490 train_time:55716ms step_avg:49.18ms
+step:1134/1490 train_time:55802ms step_avg:49.21ms
+step:1135/1490 train_time:55881ms step_avg:49.23ms
+step:1136/1490 train_time:55966ms step_avg:49.27ms
+step:1137/1490 train_time:56045ms step_avg:49.29ms
+step:1138/1490 train_time:56129ms step_avg:49.32ms
+step:1139/1490 train_time:56209ms step_avg:49.35ms
+step:1140/1490 train_time:56294ms step_avg:49.38ms
+step:1141/1490 train_time:56374ms step_avg:49.41ms
+step:1142/1490 train_time:56460ms step_avg:49.44ms
+step:1143/1490 train_time:56540ms step_avg:49.47ms
+step:1144/1490 train_time:56624ms step_avg:49.50ms
+step:1145/1490 train_time:56704ms step_avg:49.52ms
+step:1146/1490 train_time:56788ms step_avg:49.55ms
+step:1147/1490 train_time:56867ms step_avg:49.58ms
+step:1148/1490 train_time:56951ms step_avg:49.61ms
+step:1149/1490 train_time:57031ms step_avg:49.63ms
+step:1150/1490 train_time:57115ms step_avg:49.67ms
+step:1151/1490 train_time:57196ms step_avg:49.69ms
+step:1152/1490 train_time:57280ms step_avg:49.72ms
+step:1153/1490 train_time:57358ms step_avg:49.75ms
+step:1154/1490 train_time:57443ms step_avg:49.78ms
+step:1155/1490 train_time:57523ms step_avg:49.80ms
+step:1156/1490 train_time:57608ms step_avg:49.83ms
+step:1157/1490 train_time:57686ms step_avg:49.86ms
+step:1158/1490 train_time:57771ms step_avg:49.89ms
+step:1159/1490 train_time:57850ms step_avg:49.91ms
+step:1160/1490 train_time:57934ms step_avg:49.94ms
+step:1161/1490 train_time:58013ms step_avg:49.97ms
+step:1162/1490 train_time:58097ms step_avg:50.00ms
+step:1163/1490 train_time:58178ms step_avg:50.02ms
+step:1164/1490 train_time:58263ms step_avg:50.05ms
+step:1165/1490 train_time:58342ms step_avg:50.08ms
+step:1166/1490 train_time:58427ms step_avg:50.11ms
+step:1167/1490 train_time:58507ms step_avg:50.13ms
+step:1168/1490 train_time:58593ms step_avg:50.17ms
+step:1169/1490 train_time:58672ms step_avg:50.19ms
+step:1170/1490 train_time:58757ms step_avg:50.22ms
+step:1171/1490 train_time:58837ms step_avg:50.25ms
+step:1172/1490 train_time:58921ms step_avg:50.27ms
+step:1173/1490 train_time:58999ms step_avg:50.30ms
+step:1174/1490 train_time:59084ms step_avg:50.33ms
+step:1175/1490 train_time:59162ms step_avg:50.35ms
+step:1176/1490 train_time:59248ms step_avg:50.38ms
+step:1177/1490 train_time:59329ms step_avg:50.41ms
+step:1178/1490 train_time:59414ms step_avg:50.44ms
+step:1179/1490 train_time:59493ms step_avg:50.46ms
+step:1180/1490 train_time:59578ms step_avg:50.49ms
+step:1181/1490 train_time:59658ms step_avg:50.51ms
+step:1182/1490 train_time:59743ms step_avg:50.54ms
+step:1183/1490 train_time:59822ms step_avg:50.57ms
+step:1184/1490 train_time:59908ms step_avg:50.60ms
+step:1185/1490 train_time:59987ms step_avg:50.62ms
+step:1186/1490 train_time:60071ms step_avg:50.65ms
+step:1187/1490 train_time:60152ms step_avg:50.68ms
+step:1188/1490 train_time:60237ms step_avg:50.70ms
+step:1189/1490 train_time:60317ms step_avg:50.73ms
+step:1190/1490 train_time:60402ms step_avg:50.76ms
+step:1191/1490 train_time:60480ms step_avg:50.78ms
+step:1192/1490 train_time:60566ms step_avg:50.81ms
+step:1193/1490 train_time:60644ms step_avg:50.83ms
+step:1194/1490 train_time:60729ms step_avg:50.86ms
+step:1195/1490 train_time:60809ms step_avg:50.89ms
+step:1196/1490 train_time:60892ms step_avg:50.91ms
+step:1197/1490 train_time:60973ms step_avg:50.94ms
+step:1198/1490 train_time:61058ms step_avg:50.97ms
+step:1199/1490 train_time:61136ms step_avg:50.99ms
+step:1200/1490 train_time:61221ms step_avg:51.02ms
+step:1201/1490 train_time:61301ms step_avg:51.04ms
+step:1202/1490 train_time:61386ms step_avg:51.07ms
+step:1203/1490 train_time:61465ms step_avg:51.09ms
+step:1204/1490 train_time:61549ms step_avg:51.12ms
+step:1205/1490 train_time:61628ms step_avg:51.14ms
+step:1206/1490 train_time:61714ms step_avg:51.17ms
+step:1207/1490 train_time:61794ms step_avg:51.20ms
+step:1208/1490 train_time:61879ms step_avg:51.22ms
+step:1209/1490 train_time:61958ms step_avg:51.25ms
+step:1210/1490 train_time:62043ms step_avg:51.28ms
+step:1211/1490 train_time:62123ms step_avg:51.30ms
+step:1212/1490 train_time:62207ms step_avg:51.33ms
+step:1213/1490 train_time:62286ms step_avg:51.35ms
+step:1214/1490 train_time:62370ms step_avg:51.38ms
+step:1215/1490 train_time:62450ms step_avg:51.40ms
+step:1216/1490 train_time:62535ms step_avg:51.43ms
+step:1217/1490 train_time:62615ms step_avg:51.45ms
+step:1218/1490 train_time:62699ms step_avg:51.48ms
+step:1219/1490 train_time:62779ms step_avg:51.50ms
+step:1220/1490 train_time:62864ms step_avg:51.53ms
+step:1221/1490 train_time:62942ms step_avg:51.55ms
+step:1222/1490 train_time:63028ms step_avg:51.58ms
+step:1223/1490 train_time:63107ms step_avg:51.60ms
+step:1224/1490 train_time:63192ms step_avg:51.63ms
+step:1225/1490 train_time:63270ms step_avg:51.65ms
+step:1226/1490 train_time:63375ms step_avg:51.69ms
+step:1227/1490 train_time:63436ms step_avg:51.70ms
+step:1228/1490 train_time:63521ms step_avg:51.73ms
+step:1229/1490 train_time:63600ms step_avg:51.75ms
+step:1230/1490 train_time:63684ms step_avg:51.78ms
+step:1231/1490 train_time:63764ms step_avg:51.80ms
+step:1232/1490 train_time:63848ms step_avg:51.83ms
+step:1233/1490 train_time:63928ms step_avg:51.85ms
+step:1234/1490 train_time:64012ms step_avg:51.87ms
+step:1235/1490 train_time:64091ms step_avg:51.90ms
+step:1236/1490 train_time:64176ms step_avg:51.92ms
+step:1237/1490 train_time:64255ms step_avg:51.94ms
+step:1238/1490 train_time:64340ms step_avg:51.97ms
+step:1239/1490 train_time:64419ms step_avg:51.99ms
+step:1240/1490 train_time:64505ms step_avg:52.02ms
+step:1241/1490 train_time:64582ms step_avg:52.04ms
+step:1242/1490 train_time:64667ms step_avg:52.07ms
+step:1243/1490 train_time:64746ms step_avg:52.09ms
+step:1244/1490 train_time:64831ms step_avg:52.11ms
+step:1245/1490 train_time:64910ms step_avg:52.14ms
+step:1246/1490 train_time:64994ms step_avg:52.16ms
+step:1247/1490 train_time:65075ms step_avg:52.19ms
+step:1248/1490 train_time:65159ms step_avg:52.21ms
+step:1249/1490 train_time:65238ms step_avg:52.23ms
+step:1250/1490 train_time:65324ms step_avg:52.26ms
+step:1250/1490 val_loss:3.3695 train_time:65424ms step_avg:52.34ms
+step:1251/1490 train_time:65451ms step_avg:52.32ms
+step:1252/1490 train_time:65491ms step_avg:52.31ms
+step:1253/1490 train_time:65574ms step_avg:52.33ms
+step:1254/1490 train_time:65660ms step_avg:52.36ms
+step:1255/1490 train_time:65740ms step_avg:52.38ms
+step:1256/1490 train_time:65825ms step_avg:52.41ms
+step:1257/1490 train_time:65905ms step_avg:52.43ms
+step:1258/1490 train_time:65989ms step_avg:52.46ms
+step:1259/1490 train_time:66067ms step_avg:52.48ms
+step:1260/1490 train_time:66152ms step_avg:52.50ms
+step:1261/1490 train_time:66230ms step_avg:52.52ms
+step:1262/1490 train_time:66315ms step_avg:52.55ms
+step:1263/1490 train_time:66394ms step_avg:52.57ms
+step:1264/1490 train_time:66482ms step_avg:52.60ms
+step:1265/1490 train_time:66565ms step_avg:52.62ms
+step:1266/1490 train_time:66650ms step_avg:52.65ms
+step:1267/1490 train_time:66730ms step_avg:52.67ms
+step:1268/1490 train_time:66816ms step_avg:52.69ms
+step:1269/1490 train_time:66894ms step_avg:52.71ms
+step:1270/1490 train_time:66978ms step_avg:52.74ms
+step:1271/1490 train_time:67057ms step_avg:52.76ms
+step:1272/1490 train_time:67142ms step_avg:52.78ms
+step:1273/1490 train_time:67220ms step_avg:52.80ms
+step:1274/1490 train_time:67305ms step_avg:52.83ms
+step:1275/1490 train_time:67384ms step_avg:52.85ms
+step:1276/1490 train_time:67470ms step_avg:52.88ms
+step:1277/1490 train_time:67551ms step_avg:52.90ms
+step:1278/1490 train_time:67635ms step_avg:52.92ms
+step:1279/1490 train_time:67716ms step_avg:52.94ms
+step:1280/1490 train_time:67800ms step_avg:52.97ms
+step:1281/1490 train_time:67878ms step_avg:52.99ms
+step:1282/1490 train_time:67963ms step_avg:53.01ms
+step:1283/1490 train_time:68042ms step_avg:53.03ms
+step:1284/1490 train_time:68127ms step_avg:53.06ms
+step:1285/1490 train_time:68206ms step_avg:53.08ms
+step:1286/1490 train_time:68290ms step_avg:53.10ms
+step:1287/1490 train_time:68369ms step_avg:53.12ms
+step:1288/1490 train_time:68456ms step_avg:53.15ms
+step:1289/1490 train_time:68536ms step_avg:53.17ms
+step:1290/1490 train_time:68621ms step_avg:53.19ms
+step:1291/1490 train_time:68700ms step_avg:53.21ms
+step:1292/1490 train_time:68785ms step_avg:53.24ms
+step:1293/1490 train_time:68865ms step_avg:53.26ms
+step:1294/1490 train_time:68949ms step_avg:53.28ms
+step:1295/1490 train_time:69028ms step_avg:53.30ms
+step:1296/1490 train_time:69112ms step_avg:53.33ms
+step:1297/1490 train_time:69191ms step_avg:53.35ms
+step:1298/1490 train_time:69276ms step_avg:53.37ms
+step:1299/1490 train_time:69355ms step_avg:53.39ms
+step:1300/1490 train_time:69442ms step_avg:53.42ms
+step:1301/1490 train_time:69522ms step_avg:53.44ms
+step:1302/1490 train_time:69606ms step_avg:53.46ms
+step:1303/1490 train_time:69686ms step_avg:53.48ms
+step:1304/1490 train_time:69770ms step_avg:53.50ms
+step:1305/1490 train_time:69850ms step_avg:53.53ms
+step:1306/1490 train_time:69936ms step_avg:53.55ms
+step:1307/1490 train_time:70015ms step_avg:53.57ms
+step:1308/1490 train_time:70100ms step_avg:53.59ms
+step:1309/1490 train_time:70178ms step_avg:53.61ms
+step:1310/1490 train_time:70262ms step_avg:53.64ms
+step:1311/1490 train_time:70343ms step_avg:53.66ms
+step:1312/1490 train_time:70429ms step_avg:53.68ms
+step:1313/1490 train_time:70510ms step_avg:53.70ms
+step:1314/1490 train_time:70594ms step_avg:53.72ms
+step:1315/1490 train_time:70674ms step_avg:53.74ms
+step:1316/1490 train_time:70758ms step_avg:53.77ms
+step:1317/1490 train_time:70838ms step_avg:53.79ms
+step:1318/1490 train_time:70922ms step_avg:53.81ms
+step:1319/1490 train_time:71001ms step_avg:53.83ms
+step:1320/1490 train_time:71086ms step_avg:53.85ms
+step:1321/1490 train_time:71165ms step_avg:53.87ms
+step:1322/1490 train_time:71249ms step_avg:53.89ms
+step:1323/1490 train_time:71328ms step_avg:53.91ms
+step:1324/1490 train_time:71414ms step_avg:53.94ms
+step:1325/1490 train_time:71493ms step_avg:53.96ms
+step:1326/1490 train_time:71579ms step_avg:53.98ms
+step:1327/1490 train_time:71659ms step_avg:54.00ms
+step:1328/1490 train_time:71744ms step_avg:54.02ms
+step:1329/1490 train_time:71824ms step_avg:54.04ms
+step:1330/1490 train_time:71909ms step_avg:54.07ms
+step:1331/1490 train_time:71987ms step_avg:54.09ms
+step:1332/1490 train_time:72072ms step_avg:54.11ms
+step:1333/1490 train_time:72151ms step_avg:54.13ms
+step:1334/1490 train_time:72235ms step_avg:54.15ms
+step:1335/1490 train_time:72314ms step_avg:54.17ms
+step:1336/1490 train_time:72399ms step_avg:54.19ms
+step:1337/1490 train_time:72479ms step_avg:54.21ms
+step:1338/1490 train_time:72564ms step_avg:54.23ms
+step:1339/1490 train_time:72645ms step_avg:54.25ms
+step:1340/1490 train_time:72729ms step_avg:54.28ms
+step:1341/1490 train_time:72809ms step_avg:54.29ms
+step:1342/1490 train_time:72893ms step_avg:54.32ms
+step:1343/1490 train_time:72971ms step_avg:54.33ms
+step:1344/1490 train_time:73057ms step_avg:54.36ms
+step:1345/1490 train_time:73135ms step_avg:54.38ms
+step:1346/1490 train_time:73221ms step_avg:54.40ms
+step:1347/1490 train_time:73300ms step_avg:54.42ms
+step:1348/1490 train_time:73383ms step_avg:54.44ms
+step:1349/1490 train_time:73463ms step_avg:54.46ms
+step:1350/1490 train_time:73549ms step_avg:54.48ms
+step:1351/1490 train_time:73628ms step_avg:54.50ms
+step:1352/1490 train_time:73714ms step_avg:54.52ms
+step:1353/1490 train_time:73794ms step_avg:54.54ms
+step:1354/1490 train_time:73879ms step_avg:54.56ms
+step:1355/1490 train_time:73958ms step_avg:54.58ms
+step:1356/1490 train_time:74043ms step_avg:54.60ms
+step:1357/1490 train_time:74123ms step_avg:54.62ms
+step:1358/1490 train_time:74208ms step_avg:54.65ms
+step:1359/1490 train_time:74288ms step_avg:54.66ms
+step:1360/1490 train_time:74373ms step_avg:54.69ms
+step:1361/1490 train_time:74450ms step_avg:54.70ms
+step:1362/1490 train_time:74535ms step_avg:54.72ms
+step:1363/1490 train_time:74616ms step_avg:54.74ms
+step:1364/1490 train_time:74700ms step_avg:54.77ms
+step:1365/1490 train_time:74781ms step_avg:54.78ms
+step:1366/1490 train_time:74865ms step_avg:54.81ms
+step:1367/1490 train_time:74944ms step_avg:54.82ms
+step:1368/1490 train_time:75028ms step_avg:54.85ms
+step:1369/1490 train_time:75108ms step_avg:54.86ms
+step:1370/1490 train_time:75194ms step_avg:54.89ms
+step:1371/1490 train_time:75273ms step_avg:54.90ms
+step:1372/1490 train_time:75358ms step_avg:54.93ms
+step:1373/1490 train_time:75436ms step_avg:54.94ms
+step:1374/1490 train_time:75522ms step_avg:54.96ms
+step:1375/1490 train_time:75602ms step_avg:54.98ms
+step:1376/1490 train_time:75687ms step_avg:55.00ms
+step:1377/1490 train_time:75765ms step_avg:55.02ms
+step:1378/1490 train_time:75850ms step_avg:55.04ms
+step:1379/1490 train_time:75928ms step_avg:55.06ms
+step:1380/1490 train_time:76014ms step_avg:55.08ms
+step:1381/1490 train_time:76092ms step_avg:55.10ms
+step:1382/1490 train_time:76177ms step_avg:55.12ms
+step:1383/1490 train_time:76256ms step_avg:55.14ms
+step:1384/1490 train_time:76340ms step_avg:55.16ms
+step:1385/1490 train_time:76419ms step_avg:55.18ms
+step:1386/1490 train_time:76503ms step_avg:55.20ms
+step:1387/1490 train_time:76583ms step_avg:55.21ms
+step:1388/1490 train_time:76669ms step_avg:55.24ms
+step:1389/1490 train_time:76750ms step_avg:55.26ms
+step:1390/1490 train_time:76835ms step_avg:55.28ms
+step:1391/1490 train_time:76914ms step_avg:55.29ms
+step:1392/1490 train_time:76998ms step_avg:55.31ms
+step:1393/1490 train_time:77077ms step_avg:55.33ms
+step:1394/1490 train_time:77162ms step_avg:55.35ms
+step:1395/1490 train_time:77242ms step_avg:55.37ms
+step:1396/1490 train_time:77327ms step_avg:55.39ms
+step:1397/1490 train_time:77406ms step_avg:55.41ms
+step:1398/1490 train_time:77491ms step_avg:55.43ms
+step:1399/1490 train_time:77570ms step_avg:55.45ms
+step:1400/1490 train_time:77656ms step_avg:55.47ms
+step:1401/1490 train_time:77736ms step_avg:55.49ms
+step:1402/1490 train_time:77822ms step_avg:55.51ms
+step:1403/1490 train_time:77902ms step_avg:55.53ms
+step:1404/1490 train_time:77987ms step_avg:55.55ms
+step:1405/1490 train_time:78067ms step_avg:55.56ms
+step:1406/1490 train_time:78152ms step_avg:55.58ms
+step:1407/1490 train_time:78230ms step_avg:55.60ms
+step:1408/1490 train_time:78315ms step_avg:55.62ms
+step:1409/1490 train_time:78394ms step_avg:55.64ms
+step:1410/1490 train_time:78479ms step_avg:55.66ms
+step:1411/1490 train_time:78558ms step_avg:55.68ms
+step:1412/1490 train_time:78643ms step_avg:55.70ms
+step:1413/1490 train_time:78723ms step_avg:55.71ms
+step:1414/1490 train_time:78808ms step_avg:55.73ms
+step:1415/1490 train_time:78887ms step_avg:55.75ms
+step:1416/1490 train_time:78972ms step_avg:55.77ms
+step:1417/1490 train_time:79051ms step_avg:55.79ms
+step:1418/1490 train_time:79136ms step_avg:55.81ms
+step:1419/1490 train_time:79215ms step_avg:55.82ms
+step:1420/1490 train_time:79300ms step_avg:55.84ms
+step:1421/1490 train_time:79378ms step_avg:55.86ms
+step:1422/1490 train_time:79463ms step_avg:55.88ms
+step:1423/1490 train_time:79543ms step_avg:55.90ms
+step:1424/1490 train_time:79629ms step_avg:55.92ms
+step:1425/1490 train_time:79709ms step_avg:55.94ms
+step:1426/1490 train_time:79794ms step_avg:55.96ms
+step:1427/1490 train_time:79873ms step_avg:55.97ms
+step:1428/1490 train_time:79957ms step_avg:55.99ms
+step:1429/1490 train_time:80036ms step_avg:56.01ms
+step:1430/1490 train_time:80121ms step_avg:56.03ms
+step:1431/1490 train_time:80200ms step_avg:56.04ms
+step:1432/1490 train_time:80284ms step_avg:56.06ms
+step:1433/1490 train_time:80364ms step_avg:56.08ms
+step:1434/1490 train_time:80449ms step_avg:56.10ms
+step:1435/1490 train_time:80529ms step_avg:56.12ms
+step:1436/1490 train_time:80613ms step_avg:56.14ms
+step:1437/1490 train_time:80692ms step_avg:56.15ms
+step:1438/1490 train_time:80776ms step_avg:56.17ms
+step:1439/1490 train_time:80856ms step_avg:56.19ms
+step:1440/1490 train_time:80941ms step_avg:56.21ms
+step:1441/1490 train_time:81021ms step_avg:56.23ms
+step:1442/1490 train_time:81107ms step_avg:56.25ms
+step:1443/1490 train_time:81186ms step_avg:56.26ms
+step:1444/1490 train_time:81270ms step_avg:56.28ms
+step:1445/1490 train_time:81349ms step_avg:56.30ms
+step:1446/1490 train_time:81434ms step_avg:56.32ms
+step:1447/1490 train_time:81514ms step_avg:56.33ms
+step:1448/1490 train_time:81599ms step_avg:56.35ms
+step:1449/1490 train_time:81679ms step_avg:56.37ms
+step:1450/1490 train_time:81765ms step_avg:56.39ms
+step:1451/1490 train_time:81849ms step_avg:56.41ms
+step:1452/1490 train_time:81935ms step_avg:56.43ms
+step:1453/1490 train_time:82015ms step_avg:56.45ms
+step:1454/1490 train_time:82100ms step_avg:56.46ms
+step:1455/1490 train_time:82178ms step_avg:56.48ms
+step:1456/1490 train_time:82263ms step_avg:56.50ms
+step:1457/1490 train_time:82343ms step_avg:56.52ms
+step:1458/1490 train_time:82428ms step_avg:56.53ms
+step:1459/1490 train_time:82507ms step_avg:56.55ms
+step:1460/1490 train_time:82593ms step_avg:56.57ms
+step:1461/1490 train_time:82672ms step_avg:56.59ms
+step:1462/1490 train_time:82758ms step_avg:56.61ms
+step:1463/1490 train_time:82838ms step_avg:56.62ms
+step:1464/1490 train_time:82924ms step_avg:56.64ms
+step:1465/1490 train_time:83004ms step_avg:56.66ms
+step:1466/1490 train_time:83088ms step_avg:56.68ms
+step:1467/1490 train_time:83167ms step_avg:56.69ms
+step:1468/1490 train_time:83252ms step_avg:56.71ms
+step:1469/1490 train_time:83331ms step_avg:56.73ms
+step:1470/1490 train_time:83416ms step_avg:56.75ms
+step:1471/1490 train_time:83496ms step_avg:56.76ms
+step:1472/1490 train_time:83582ms step_avg:56.78ms
+step:1473/1490 train_time:83663ms step_avg:56.80ms
+step:1474/1490 train_time:83748ms step_avg:56.82ms
+step:1475/1490 train_time:83827ms step_avg:56.83ms
+step:1476/1490 train_time:83915ms step_avg:56.85ms
+step:1477/1490 train_time:83994ms step_avg:56.87ms
+step:1478/1490 train_time:84078ms step_avg:56.89ms
+step:1479/1490 train_time:84158ms step_avg:56.90ms
+step:1480/1490 train_time:84243ms step_avg:56.92ms
+step:1481/1490 train_time:84324ms step_avg:56.94ms
+step:1482/1490 train_time:84409ms step_avg:56.96ms
+step:1483/1490 train_time:84489ms step_avg:56.97ms
+step:1484/1490 train_time:84573ms step_avg:56.99ms
+step:1485/1490 train_time:84654ms step_avg:57.01ms
+step:1486/1490 train_time:84739ms step_avg:57.02ms
+step:1487/1490 train_time:84819ms step_avg:57.04ms
+step:1488/1490 train_time:84904ms step_avg:57.06ms
+step:1489/1490 train_time:84986ms step_avg:57.08ms
+step:1490/1490 train_time:85071ms step_avg:57.09ms
+step:1490/1490 val_loss:3.2770 train_time:85172ms step_avg:57.16ms
+peak memory allocated: 31296 MiB reserved: 46782 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/a9c1c6cf-c98a-4464-88df-747866c4a13f.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/a9c1c6cf-c98a-4464-88df-747866c4a13f.txt
@@ -1,0 +1,4681 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 21:29:54 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8299 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:71ms step_avg:71.39ms
+step:2/1490 train_time:102ms step_avg:51.21ms
+step:3/1490 train_time:121ms step_avg:40.19ms
+step:4/1490 train_time:143ms step_avg:35.80ms
+step:5/1490 train_time:169ms step_avg:33.78ms
+step:6/1490 train_time:203ms step_avg:33.85ms
+step:7/1490 train_time:230ms step_avg:32.83ms
+step:8/1490 train_time:264ms step_avg:33.04ms
+step:9/1490 train_time:291ms step_avg:32.35ms
+step:10/1490 train_time:325ms step_avg:32.54ms
+step:11/1490 train_time:353ms step_avg:32.08ms
+step:12/1490 train_time:387ms step_avg:32.23ms
+step:13/1490 train_time:414ms step_avg:31.87ms
+step:14/1490 train_time:448ms step_avg:32.01ms
+step:15/1490 train_time:476ms step_avg:31.72ms
+step:16/1490 train_time:510ms step_avg:31.86ms
+step:17/1490 train_time:537ms step_avg:31.61ms
+step:18/1490 train_time:571ms step_avg:31.75ms
+step:19/1490 train_time:599ms step_avg:31.52ms
+step:20/1490 train_time:633ms step_avg:31.66ms
+step:21/1490 train_time:660ms step_avg:31.45ms
+step:22/1490 train_time:694ms step_avg:31.57ms
+step:23/1490 train_time:722ms step_avg:31.39ms
+step:24/1490 train_time:756ms step_avg:31.51ms
+step:25/1490 train_time:783ms step_avg:31.33ms
+step:26/1490 train_time:818ms step_avg:31.45ms
+step:27/1490 train_time:845ms step_avg:31.29ms
+step:28/1490 train_time:879ms step_avg:31.39ms
+step:29/1490 train_time:906ms step_avg:31.24ms
+step:30/1490 train_time:941ms step_avg:31.35ms
+step:31/1490 train_time:968ms step_avg:31.23ms
+step:32/1490 train_time:1003ms step_avg:31.35ms
+step:33/1490 train_time:1031ms step_avg:31.23ms
+step:34/1490 train_time:1065ms step_avg:31.33ms
+step:35/1490 train_time:1093ms step_avg:31.22ms
+step:36/1490 train_time:1127ms step_avg:31.30ms
+step:37/1490 train_time:1155ms step_avg:31.21ms
+step:38/1490 train_time:1189ms step_avg:31.28ms
+step:39/1490 train_time:1216ms step_avg:31.19ms
+step:40/1490 train_time:1250ms step_avg:31.25ms
+step:41/1490 train_time:1278ms step_avg:31.16ms
+step:42/1490 train_time:1314ms step_avg:31.28ms
+step:43/1490 train_time:1340ms step_avg:31.16ms
+step:44/1490 train_time:1374ms step_avg:31.23ms
+step:45/1490 train_time:1402ms step_avg:31.15ms
+step:46/1490 train_time:1436ms step_avg:31.23ms
+step:47/1490 train_time:1464ms step_avg:31.14ms
+step:48/1490 train_time:1498ms step_avg:31.20ms
+step:49/1490 train_time:1525ms step_avg:31.13ms
+step:50/1490 train_time:1560ms step_avg:31.20ms
+step:51/1490 train_time:1587ms step_avg:31.12ms
+step:52/1490 train_time:1621ms step_avg:31.17ms
+step:53/1490 train_time:1648ms step_avg:31.10ms
+step:54/1490 train_time:1682ms step_avg:31.15ms
+step:55/1490 train_time:1710ms step_avg:31.08ms
+step:56/1490 train_time:1744ms step_avg:31.14ms
+step:57/1490 train_time:1771ms step_avg:31.06ms
+step:58/1490 train_time:1805ms step_avg:31.11ms
+step:59/1490 train_time:1832ms step_avg:31.06ms
+step:60/1490 train_time:1866ms step_avg:31.10ms
+step:61/1490 train_time:1894ms step_avg:31.06ms
+step:62/1490 train_time:1928ms step_avg:31.10ms
+step:63/1490 train_time:1956ms step_avg:31.05ms
+step:64/1490 train_time:1990ms step_avg:31.10ms
+step:65/1490 train_time:2017ms step_avg:31.04ms
+step:66/1490 train_time:2052ms step_avg:31.09ms
+step:67/1490 train_time:2079ms step_avg:31.03ms
+step:68/1490 train_time:2114ms step_avg:31.08ms
+step:69/1490 train_time:2141ms step_avg:31.03ms
+step:70/1490 train_time:2176ms step_avg:31.08ms
+step:71/1490 train_time:2203ms step_avg:31.03ms
+step:72/1490 train_time:2238ms step_avg:31.08ms
+step:73/1490 train_time:2265ms step_avg:31.02ms
+step:74/1490 train_time:2299ms step_avg:31.07ms
+step:75/1490 train_time:2326ms step_avg:31.02ms
+step:76/1490 train_time:2361ms step_avg:31.07ms
+step:77/1490 train_time:2388ms step_avg:31.01ms
+step:78/1490 train_time:2422ms step_avg:31.05ms
+step:79/1490 train_time:2450ms step_avg:31.01ms
+step:80/1490 train_time:2484ms step_avg:31.06ms
+step:81/1490 train_time:2512ms step_avg:31.01ms
+step:82/1490 train_time:2546ms step_avg:31.05ms
+step:83/1490 train_time:2574ms step_avg:31.01ms
+step:84/1490 train_time:2607ms step_avg:31.04ms
+step:85/1490 train_time:2635ms step_avg:31.00ms
+step:86/1490 train_time:2669ms step_avg:31.03ms
+step:87/1490 train_time:2696ms step_avg:30.99ms
+step:88/1490 train_time:2729ms step_avg:31.02ms
+step:89/1490 train_time:2757ms step_avg:30.98ms
+step:90/1490 train_time:2791ms step_avg:31.01ms
+step:91/1490 train_time:2818ms step_avg:30.97ms
+step:92/1490 train_time:2853ms step_avg:31.01ms
+step:93/1490 train_time:2880ms step_avg:30.97ms
+step:94/1490 train_time:2915ms step_avg:31.01ms
+step:95/1490 train_time:2942ms step_avg:30.97ms
+step:96/1490 train_time:2976ms step_avg:31.00ms
+step:97/1490 train_time:3003ms step_avg:30.96ms
+step:98/1490 train_time:3038ms step_avg:31.00ms
+step:99/1490 train_time:3065ms step_avg:30.96ms
+step:100/1490 train_time:3099ms step_avg:30.99ms
+step:101/1490 train_time:3126ms step_avg:30.95ms
+step:102/1490 train_time:3161ms step_avg:30.99ms
+step:103/1490 train_time:3188ms step_avg:30.95ms
+step:104/1490 train_time:3222ms step_avg:30.98ms
+step:105/1490 train_time:3249ms step_avg:30.95ms
+step:106/1490 train_time:3283ms step_avg:30.97ms
+step:107/1490 train_time:3310ms step_avg:30.94ms
+step:108/1490 train_time:3344ms step_avg:30.97ms
+step:109/1490 train_time:3372ms step_avg:30.94ms
+step:110/1490 train_time:3407ms step_avg:30.97ms
+step:111/1490 train_time:3434ms step_avg:30.93ms
+step:112/1490 train_time:3468ms step_avg:30.96ms
+step:113/1490 train_time:3495ms step_avg:30.93ms
+step:114/1490 train_time:3529ms step_avg:30.95ms
+step:115/1490 train_time:3556ms step_avg:30.93ms
+step:116/1490 train_time:3590ms step_avg:30.95ms
+step:117/1490 train_time:3618ms step_avg:30.92ms
+step:118/1490 train_time:3651ms step_avg:30.94ms
+step:119/1490 train_time:3679ms step_avg:30.91ms
+step:120/1490 train_time:3712ms step_avg:30.94ms
+step:121/1490 train_time:3740ms step_avg:30.91ms
+step:122/1490 train_time:3774ms step_avg:30.93ms
+step:123/1490 train_time:3801ms step_avg:30.90ms
+step:124/1490 train_time:3835ms step_avg:30.93ms
+step:125/1490 train_time:3862ms step_avg:30.90ms
+step:126/1490 train_time:3896ms step_avg:30.92ms
+step:127/1490 train_time:3923ms step_avg:30.89ms
+step:128/1490 train_time:3958ms step_avg:30.92ms
+step:129/1490 train_time:3985ms step_avg:30.89ms
+step:130/1490 train_time:4019ms step_avg:30.92ms
+step:131/1490 train_time:4046ms step_avg:30.89ms
+step:132/1490 train_time:4081ms step_avg:30.91ms
+step:133/1490 train_time:4108ms step_avg:30.89ms
+step:134/1490 train_time:4142ms step_avg:30.91ms
+step:135/1490 train_time:4170ms step_avg:30.89ms
+step:136/1490 train_time:4204ms step_avg:30.91ms
+step:137/1490 train_time:4231ms step_avg:30.88ms
+step:138/1490 train_time:4265ms step_avg:30.91ms
+step:139/1490 train_time:4292ms step_avg:30.88ms
+step:140/1490 train_time:4326ms step_avg:30.90ms
+step:141/1490 train_time:4353ms step_avg:30.87ms
+step:142/1490 train_time:4387ms step_avg:30.90ms
+step:143/1490 train_time:4415ms step_avg:30.87ms
+step:144/1490 train_time:4449ms step_avg:30.89ms
+step:145/1490 train_time:4476ms step_avg:30.87ms
+step:146/1490 train_time:4510ms step_avg:30.89ms
+step:147/1490 train_time:4537ms step_avg:30.86ms
+step:148/1490 train_time:4571ms step_avg:30.88ms
+step:149/1490 train_time:4598ms step_avg:30.86ms
+step:150/1490 train_time:4632ms step_avg:30.88ms
+step:151/1490 train_time:4660ms step_avg:30.86ms
+step:152/1490 train_time:4694ms step_avg:30.88ms
+step:153/1490 train_time:4721ms step_avg:30.86ms
+step:154/1490 train_time:4755ms step_avg:30.88ms
+step:155/1490 train_time:4782ms step_avg:30.85ms
+step:156/1490 train_time:4816ms step_avg:30.87ms
+step:157/1490 train_time:4844ms step_avg:30.85ms
+step:158/1490 train_time:4878ms step_avg:30.87ms
+step:159/1490 train_time:4905ms step_avg:30.85ms
+step:160/1490 train_time:4939ms step_avg:30.87ms
+step:161/1490 train_time:4966ms step_avg:30.85ms
+step:162/1490 train_time:5000ms step_avg:30.87ms
+step:163/1490 train_time:5027ms step_avg:30.84ms
+step:164/1490 train_time:5062ms step_avg:30.86ms
+step:165/1490 train_time:5088ms step_avg:30.84ms
+step:166/1490 train_time:5122ms step_avg:30.86ms
+step:167/1490 train_time:5150ms step_avg:30.84ms
+step:168/1490 train_time:5184ms step_avg:30.86ms
+step:169/1490 train_time:5211ms step_avg:30.84ms
+step:170/1490 train_time:5245ms step_avg:30.85ms
+step:171/1490 train_time:5273ms step_avg:30.83ms
+step:172/1490 train_time:5306ms step_avg:30.85ms
+step:173/1490 train_time:5334ms step_avg:30.83ms
+step:174/1490 train_time:5368ms step_avg:30.85ms
+step:175/1490 train_time:5395ms step_avg:30.83ms
+step:176/1490 train_time:5429ms step_avg:30.85ms
+step:177/1490 train_time:5456ms step_avg:30.83ms
+step:178/1490 train_time:5490ms step_avg:30.84ms
+step:179/1490 train_time:5517ms step_avg:30.82ms
+step:180/1490 train_time:5551ms step_avg:30.84ms
+step:181/1490 train_time:5579ms step_avg:30.82ms
+step:182/1490 train_time:5613ms step_avg:30.84ms
+step:183/1490 train_time:5640ms step_avg:30.82ms
+step:184/1490 train_time:5674ms step_avg:30.84ms
+step:185/1490 train_time:5702ms step_avg:30.82ms
+step:186/1490 train_time:5736ms step_avg:30.84ms
+step:187/1490 train_time:5763ms step_avg:30.82ms
+step:188/1490 train_time:5798ms step_avg:30.84ms
+step:189/1490 train_time:5825ms step_avg:30.82ms
+step:190/1490 train_time:5860ms step_avg:30.84ms
+step:191/1490 train_time:5887ms step_avg:30.82ms
+step:192/1490 train_time:5921ms step_avg:30.84ms
+step:193/1490 train_time:5948ms step_avg:30.82ms
+step:194/1490 train_time:5982ms step_avg:30.83ms
+step:195/1490 train_time:6009ms step_avg:30.82ms
+step:196/1490 train_time:6043ms step_avg:30.83ms
+step:197/1490 train_time:6071ms step_avg:30.82ms
+step:198/1490 train_time:6105ms step_avg:30.83ms
+step:199/1490 train_time:6132ms step_avg:30.82ms
+step:200/1490 train_time:6167ms step_avg:30.83ms
+step:201/1490 train_time:6194ms step_avg:30.81ms
+step:202/1490 train_time:6227ms step_avg:30.83ms
+step:203/1490 train_time:6255ms step_avg:30.81ms
+step:204/1490 train_time:6288ms step_avg:30.83ms
+step:205/1490 train_time:6316ms step_avg:30.81ms
+step:206/1490 train_time:6349ms step_avg:30.82ms
+step:207/1490 train_time:6377ms step_avg:30.81ms
+step:208/1490 train_time:6411ms step_avg:30.82ms
+step:209/1490 train_time:6438ms step_avg:30.80ms
+step:210/1490 train_time:6472ms step_avg:30.82ms
+step:211/1490 train_time:6500ms step_avg:30.80ms
+step:212/1490 train_time:6534ms step_avg:30.82ms
+step:213/1490 train_time:6561ms step_avg:30.80ms
+step:214/1490 train_time:6595ms step_avg:30.82ms
+step:215/1490 train_time:6622ms step_avg:30.80ms
+step:216/1490 train_time:6657ms step_avg:30.82ms
+step:217/1490 train_time:6684ms step_avg:30.80ms
+step:218/1490 train_time:6718ms step_avg:30.82ms
+step:219/1490 train_time:6745ms step_avg:30.80ms
+step:220/1490 train_time:6780ms step_avg:30.82ms
+step:221/1490 train_time:6807ms step_avg:30.80ms
+step:222/1490 train_time:6841ms step_avg:30.81ms
+step:223/1490 train_time:6868ms step_avg:30.80ms
+step:224/1490 train_time:6902ms step_avg:30.81ms
+step:225/1490 train_time:6929ms step_avg:30.80ms
+step:226/1490 train_time:6963ms step_avg:30.81ms
+step:227/1490 train_time:6991ms step_avg:30.80ms
+step:228/1490 train_time:7024ms step_avg:30.81ms
+step:229/1490 train_time:7052ms step_avg:30.79ms
+step:230/1490 train_time:7086ms step_avg:30.81ms
+step:231/1490 train_time:7114ms step_avg:30.79ms
+step:232/1490 train_time:7147ms step_avg:30.81ms
+step:233/1490 train_time:7175ms step_avg:30.79ms
+step:234/1490 train_time:7209ms step_avg:30.81ms
+step:235/1490 train_time:7236ms step_avg:30.79ms
+step:236/1490 train_time:7270ms step_avg:30.81ms
+step:237/1490 train_time:7298ms step_avg:30.79ms
+step:238/1490 train_time:7331ms step_avg:30.80ms
+step:239/1490 train_time:7359ms step_avg:30.79ms
+step:240/1490 train_time:7393ms step_avg:30.80ms
+step:241/1490 train_time:7421ms step_avg:30.79ms
+step:242/1490 train_time:7455ms step_avg:30.80ms
+step:243/1490 train_time:7482ms step_avg:30.79ms
+step:244/1490 train_time:7516ms step_avg:30.80ms
+step:245/1490 train_time:7543ms step_avg:30.79ms
+step:246/1490 train_time:7578ms step_avg:30.80ms
+step:247/1490 train_time:7605ms step_avg:30.79ms
+step:248/1490 train_time:7639ms step_avg:30.80ms
+step:249/1490 train_time:7667ms step_avg:30.79ms
+step:250/1490 train_time:7701ms step_avg:30.80ms
+step:250/1490 val_loss:4.5250 train_time:7742ms step_avg:30.97ms
+step:251/1490 train_time:7759ms step_avg:30.91ms
+step:252/1490 train_time:7778ms step_avg:30.86ms
+step:253/1490 train_time:7793ms step_avg:30.80ms
+step:254/1490 train_time:7826ms step_avg:30.81ms
+step:255/1490 train_time:7856ms step_avg:30.81ms
+step:256/1490 train_time:7891ms step_avg:30.82ms
+step:257/1490 train_time:7919ms step_avg:30.81ms
+step:258/1490 train_time:7953ms step_avg:30.83ms
+step:259/1490 train_time:7981ms step_avg:30.81ms
+step:260/1490 train_time:8016ms step_avg:30.83ms
+step:261/1490 train_time:8043ms step_avg:30.82ms
+step:262/1490 train_time:8077ms step_avg:30.83ms
+step:263/1490 train_time:8105ms step_avg:30.82ms
+step:264/1490 train_time:8139ms step_avg:30.83ms
+step:265/1490 train_time:8166ms step_avg:30.81ms
+step:266/1490 train_time:8200ms step_avg:30.83ms
+step:267/1490 train_time:8227ms step_avg:30.81ms
+step:268/1490 train_time:8260ms step_avg:30.82ms
+step:269/1490 train_time:8288ms step_avg:30.81ms
+step:270/1490 train_time:8323ms step_avg:30.82ms
+step:271/1490 train_time:8349ms step_avg:30.81ms
+step:272/1490 train_time:8383ms step_avg:30.82ms
+step:273/1490 train_time:8410ms step_avg:30.81ms
+step:274/1490 train_time:8444ms step_avg:30.82ms
+step:275/1490 train_time:8471ms step_avg:30.80ms
+step:276/1490 train_time:8505ms step_avg:30.82ms
+step:277/1490 train_time:8532ms step_avg:30.80ms
+step:278/1490 train_time:8566ms step_avg:30.81ms
+step:279/1490 train_time:8593ms step_avg:30.80ms
+step:280/1490 train_time:8627ms step_avg:30.81ms
+step:281/1490 train_time:8654ms step_avg:30.80ms
+step:282/1490 train_time:8688ms step_avg:30.81ms
+step:283/1490 train_time:8716ms step_avg:30.80ms
+step:284/1490 train_time:8749ms step_avg:30.81ms
+step:285/1490 train_time:8777ms step_avg:30.80ms
+step:286/1490 train_time:8812ms step_avg:30.81ms
+step:287/1490 train_time:8839ms step_avg:30.80ms
+step:288/1490 train_time:8874ms step_avg:30.81ms
+step:289/1490 train_time:8902ms step_avg:30.80ms
+step:290/1490 train_time:8936ms step_avg:30.81ms
+step:291/1490 train_time:8964ms step_avg:30.80ms
+step:292/1490 train_time:8999ms step_avg:30.82ms
+step:293/1490 train_time:9026ms step_avg:30.80ms
+step:294/1490 train_time:9060ms step_avg:30.82ms
+step:295/1490 train_time:9088ms step_avg:30.81ms
+step:296/1490 train_time:9122ms step_avg:30.82ms
+step:297/1490 train_time:9149ms step_avg:30.80ms
+step:298/1490 train_time:9183ms step_avg:30.82ms
+step:299/1490 train_time:9211ms step_avg:30.80ms
+step:300/1490 train_time:9244ms step_avg:30.81ms
+step:301/1490 train_time:9272ms step_avg:30.80ms
+step:302/1490 train_time:9306ms step_avg:30.81ms
+step:303/1490 train_time:9333ms step_avg:30.80ms
+step:304/1490 train_time:9367ms step_avg:30.81ms
+step:305/1490 train_time:9394ms step_avg:30.80ms
+step:306/1490 train_time:9428ms step_avg:30.81ms
+step:307/1490 train_time:9455ms step_avg:30.80ms
+step:308/1490 train_time:9489ms step_avg:30.81ms
+step:309/1490 train_time:9517ms step_avg:30.80ms
+step:310/1490 train_time:9551ms step_avg:30.81ms
+step:311/1490 train_time:9577ms step_avg:30.80ms
+step:312/1490 train_time:9612ms step_avg:30.81ms
+step:313/1490 train_time:9639ms step_avg:30.79ms
+step:314/1490 train_time:9673ms step_avg:30.81ms
+step:315/1490 train_time:9700ms step_avg:30.79ms
+step:316/1490 train_time:9734ms step_avg:30.80ms
+step:317/1490 train_time:9761ms step_avg:30.79ms
+step:318/1490 train_time:9796ms step_avg:30.81ms
+step:319/1490 train_time:9823ms step_avg:30.79ms
+step:320/1490 train_time:9858ms step_avg:30.80ms
+step:321/1490 train_time:9885ms step_avg:30.79ms
+step:322/1490 train_time:9919ms step_avg:30.81ms
+step:323/1490 train_time:9947ms step_avg:30.80ms
+step:324/1490 train_time:9981ms step_avg:30.80ms
+step:325/1490 train_time:10008ms step_avg:30.79ms
+step:326/1490 train_time:10042ms step_avg:30.80ms
+step:327/1490 train_time:10070ms step_avg:30.80ms
+step:328/1490 train_time:10106ms step_avg:30.81ms
+step:329/1490 train_time:10131ms step_avg:30.79ms
+step:330/1490 train_time:10165ms step_avg:30.80ms
+step:331/1490 train_time:10193ms step_avg:30.79ms
+step:332/1490 train_time:10227ms step_avg:30.80ms
+step:333/1490 train_time:10254ms step_avg:30.79ms
+step:334/1490 train_time:10288ms step_avg:30.80ms
+step:335/1490 train_time:10316ms step_avg:30.79ms
+step:336/1490 train_time:10350ms step_avg:30.80ms
+step:337/1490 train_time:10377ms step_avg:30.79ms
+step:338/1490 train_time:10411ms step_avg:30.80ms
+step:339/1490 train_time:10439ms step_avg:30.79ms
+step:340/1490 train_time:10473ms step_avg:30.80ms
+step:341/1490 train_time:10500ms step_avg:30.79ms
+step:342/1490 train_time:10534ms step_avg:30.80ms
+step:343/1490 train_time:10561ms step_avg:30.79ms
+step:344/1490 train_time:10595ms step_avg:30.80ms
+step:345/1490 train_time:10622ms step_avg:30.79ms
+step:346/1490 train_time:10656ms step_avg:30.80ms
+step:347/1490 train_time:10683ms step_avg:30.79ms
+step:348/1490 train_time:10718ms step_avg:30.80ms
+step:349/1490 train_time:10745ms step_avg:30.79ms
+step:350/1490 train_time:10779ms step_avg:30.80ms
+step:351/1490 train_time:10806ms step_avg:30.79ms
+step:352/1490 train_time:10840ms step_avg:30.80ms
+step:353/1490 train_time:10868ms step_avg:30.79ms
+step:354/1490 train_time:10902ms step_avg:30.80ms
+step:355/1490 train_time:10930ms step_avg:30.79ms
+step:356/1490 train_time:10963ms step_avg:30.80ms
+step:357/1490 train_time:10991ms step_avg:30.79ms
+step:358/1490 train_time:11026ms step_avg:30.80ms
+step:359/1490 train_time:11054ms step_avg:30.79ms
+step:360/1490 train_time:11087ms step_avg:30.80ms
+step:361/1490 train_time:11115ms step_avg:30.79ms
+step:362/1490 train_time:11149ms step_avg:30.80ms
+step:363/1490 train_time:11176ms step_avg:30.79ms
+step:364/1490 train_time:11210ms step_avg:30.80ms
+step:365/1490 train_time:11238ms step_avg:30.79ms
+step:366/1490 train_time:11272ms step_avg:30.80ms
+step:367/1490 train_time:11299ms step_avg:30.79ms
+step:368/1490 train_time:11333ms step_avg:30.80ms
+step:369/1490 train_time:11360ms step_avg:30.79ms
+step:370/1490 train_time:11395ms step_avg:30.80ms
+step:371/1490 train_time:11422ms step_avg:30.79ms
+step:372/1490 train_time:11456ms step_avg:30.80ms
+step:373/1490 train_time:11483ms step_avg:30.79ms
+step:374/1490 train_time:11518ms step_avg:30.80ms
+step:375/1490 train_time:11545ms step_avg:30.79ms
+step:376/1490 train_time:11579ms step_avg:30.79ms
+step:377/1490 train_time:11606ms step_avg:30.79ms
+step:378/1490 train_time:11640ms step_avg:30.79ms
+step:379/1490 train_time:11667ms step_avg:30.78ms
+step:380/1490 train_time:11703ms step_avg:30.80ms
+step:381/1490 train_time:11729ms step_avg:30.78ms
+step:382/1490 train_time:11763ms step_avg:30.79ms
+step:383/1490 train_time:11790ms step_avg:30.78ms
+step:384/1490 train_time:11825ms step_avg:30.79ms
+step:385/1490 train_time:11852ms step_avg:30.78ms
+step:386/1490 train_time:11886ms step_avg:30.79ms
+step:387/1490 train_time:11914ms step_avg:30.78ms
+step:388/1490 train_time:11947ms step_avg:30.79ms
+step:389/1490 train_time:11975ms step_avg:30.79ms
+step:390/1490 train_time:12009ms step_avg:30.79ms
+step:391/1490 train_time:12037ms step_avg:30.79ms
+step:392/1490 train_time:12071ms step_avg:30.79ms
+step:393/1490 train_time:12098ms step_avg:30.78ms
+step:394/1490 train_time:12133ms step_avg:30.79ms
+step:395/1490 train_time:12160ms step_avg:30.79ms
+step:396/1490 train_time:12194ms step_avg:30.79ms
+step:397/1490 train_time:12221ms step_avg:30.78ms
+step:398/1490 train_time:12256ms step_avg:30.79ms
+step:399/1490 train_time:12283ms step_avg:30.78ms
+step:400/1490 train_time:12317ms step_avg:30.79ms
+step:401/1490 train_time:12344ms step_avg:30.78ms
+step:402/1490 train_time:12380ms step_avg:30.79ms
+step:403/1490 train_time:12406ms step_avg:30.78ms
+step:404/1490 train_time:12440ms step_avg:30.79ms
+step:405/1490 train_time:12467ms step_avg:30.78ms
+step:406/1490 train_time:12501ms step_avg:30.79ms
+step:407/1490 train_time:12529ms step_avg:30.78ms
+step:408/1490 train_time:12563ms step_avg:30.79ms
+step:409/1490 train_time:12590ms step_avg:30.78ms
+step:410/1490 train_time:12624ms step_avg:30.79ms
+step:411/1490 train_time:12652ms step_avg:30.78ms
+step:412/1490 train_time:12686ms step_avg:30.79ms
+step:413/1490 train_time:12713ms step_avg:30.78ms
+step:414/1490 train_time:12747ms step_avg:30.79ms
+step:415/1490 train_time:12774ms step_avg:30.78ms
+step:416/1490 train_time:12808ms step_avg:30.79ms
+step:417/1490 train_time:12836ms step_avg:30.78ms
+step:418/1490 train_time:12869ms step_avg:30.79ms
+step:419/1490 train_time:12897ms step_avg:30.78ms
+step:420/1490 train_time:12931ms step_avg:30.79ms
+step:421/1490 train_time:12959ms step_avg:30.78ms
+step:422/1490 train_time:12994ms step_avg:30.79ms
+step:423/1490 train_time:13021ms step_avg:30.78ms
+step:424/1490 train_time:13055ms step_avg:30.79ms
+step:425/1490 train_time:13082ms step_avg:30.78ms
+step:426/1490 train_time:13117ms step_avg:30.79ms
+step:427/1490 train_time:13144ms step_avg:30.78ms
+step:428/1490 train_time:13178ms step_avg:30.79ms
+step:429/1490 train_time:13205ms step_avg:30.78ms
+step:430/1490 train_time:13240ms step_avg:30.79ms
+step:431/1490 train_time:13267ms step_avg:30.78ms
+step:432/1490 train_time:13301ms step_avg:30.79ms
+step:433/1490 train_time:13329ms step_avg:30.78ms
+step:434/1490 train_time:13363ms step_avg:30.79ms
+step:435/1490 train_time:13391ms step_avg:30.78ms
+step:436/1490 train_time:13425ms step_avg:30.79ms
+step:437/1490 train_time:13452ms step_avg:30.78ms
+step:438/1490 train_time:13486ms step_avg:30.79ms
+step:439/1490 train_time:13513ms step_avg:30.78ms
+step:440/1490 train_time:13547ms step_avg:30.79ms
+step:441/1490 train_time:13575ms step_avg:30.78ms
+step:442/1490 train_time:13609ms step_avg:30.79ms
+step:443/1490 train_time:13636ms step_avg:30.78ms
+step:444/1490 train_time:13670ms step_avg:30.79ms
+step:445/1490 train_time:13697ms step_avg:30.78ms
+step:446/1490 train_time:13732ms step_avg:30.79ms
+step:447/1490 train_time:13759ms step_avg:30.78ms
+step:448/1490 train_time:13793ms step_avg:30.79ms
+step:449/1490 train_time:13820ms step_avg:30.78ms
+step:450/1490 train_time:13855ms step_avg:30.79ms
+step:451/1490 train_time:13882ms step_avg:30.78ms
+step:452/1490 train_time:13916ms step_avg:30.79ms
+step:453/1490 train_time:13943ms step_avg:30.78ms
+step:454/1490 train_time:13978ms step_avg:30.79ms
+step:455/1490 train_time:14005ms step_avg:30.78ms
+step:456/1490 train_time:14039ms step_avg:30.79ms
+step:457/1490 train_time:14066ms step_avg:30.78ms
+step:458/1490 train_time:14100ms step_avg:30.79ms
+step:459/1490 train_time:14128ms step_avg:30.78ms
+step:460/1490 train_time:14162ms step_avg:30.79ms
+step:461/1490 train_time:14189ms step_avg:30.78ms
+step:462/1490 train_time:14224ms step_avg:30.79ms
+step:463/1490 train_time:14251ms step_avg:30.78ms
+step:464/1490 train_time:14285ms step_avg:30.79ms
+step:465/1490 train_time:14313ms step_avg:30.78ms
+step:466/1490 train_time:14347ms step_avg:30.79ms
+step:467/1490 train_time:14375ms step_avg:30.78ms
+step:468/1490 train_time:14408ms step_avg:30.79ms
+step:469/1490 train_time:14436ms step_avg:30.78ms
+step:470/1490 train_time:14470ms step_avg:30.79ms
+step:471/1490 train_time:14498ms step_avg:30.78ms
+step:472/1490 train_time:14532ms step_avg:30.79ms
+step:473/1490 train_time:14559ms step_avg:30.78ms
+step:474/1490 train_time:14593ms step_avg:30.79ms
+step:475/1490 train_time:14621ms step_avg:30.78ms
+step:476/1490 train_time:14655ms step_avg:30.79ms
+step:477/1490 train_time:14682ms step_avg:30.78ms
+step:478/1490 train_time:14716ms step_avg:30.79ms
+step:479/1490 train_time:14744ms step_avg:30.78ms
+step:480/1490 train_time:14778ms step_avg:30.79ms
+step:481/1490 train_time:14805ms step_avg:30.78ms
+step:482/1490 train_time:14839ms step_avg:30.79ms
+step:483/1490 train_time:14867ms step_avg:30.78ms
+step:484/1490 train_time:14904ms step_avg:30.79ms
+step:485/1490 train_time:14954ms step_avg:30.83ms
+step:486/1490 train_time:15012ms step_avg:30.89ms
+step:487/1490 train_time:15065ms step_avg:30.93ms
+step:488/1490 train_time:15124ms step_avg:30.99ms
+step:489/1490 train_time:15177ms step_avg:31.04ms
+step:490/1490 train_time:15236ms step_avg:31.09ms
+step:491/1490 train_time:15289ms step_avg:31.14ms
+step:492/1490 train_time:15348ms step_avg:31.19ms
+step:493/1490 train_time:15401ms step_avg:31.24ms
+step:494/1490 train_time:15460ms step_avg:31.30ms
+step:495/1490 train_time:15514ms step_avg:31.34ms
+step:496/1490 train_time:15572ms step_avg:31.40ms
+step:497/1490 train_time:15625ms step_avg:31.44ms
+step:498/1490 train_time:15684ms step_avg:31.49ms
+step:499/1490 train_time:15739ms step_avg:31.54ms
+step:500/1490 train_time:15797ms step_avg:31.59ms
+step:500/1490 val_loss:4.2422 train_time:15869ms step_avg:31.74ms
+step:501/1490 train_time:15894ms step_avg:31.72ms
+step:502/1490 train_time:15915ms step_avg:31.70ms
+step:503/1490 train_time:15971ms step_avg:31.75ms
+step:504/1490 train_time:16032ms step_avg:31.81ms
+step:505/1490 train_time:16087ms step_avg:31.86ms
+step:506/1490 train_time:16148ms step_avg:31.91ms
+step:507/1490 train_time:16202ms step_avg:31.96ms
+step:508/1490 train_time:16259ms step_avg:32.01ms
+step:509/1490 train_time:16313ms step_avg:32.05ms
+step:510/1490 train_time:16372ms step_avg:32.10ms
+step:511/1490 train_time:16424ms step_avg:32.14ms
+step:512/1490 train_time:16482ms step_avg:32.19ms
+step:513/1490 train_time:16535ms step_avg:32.23ms
+step:514/1490 train_time:16593ms step_avg:32.28ms
+step:515/1490 train_time:16646ms step_avg:32.32ms
+step:516/1490 train_time:16705ms step_avg:32.37ms
+step:517/1490 train_time:16757ms step_avg:32.41ms
+step:518/1490 train_time:16816ms step_avg:32.46ms
+step:519/1490 train_time:16870ms step_avg:32.51ms
+step:520/1490 train_time:16930ms step_avg:32.56ms
+step:521/1490 train_time:16985ms step_avg:32.60ms
+step:522/1490 train_time:17045ms step_avg:32.65ms
+step:523/1490 train_time:17099ms step_avg:32.69ms
+step:524/1490 train_time:17159ms step_avg:32.75ms
+step:525/1490 train_time:17213ms step_avg:32.79ms
+step:526/1490 train_time:17272ms step_avg:32.84ms
+step:527/1490 train_time:17326ms step_avg:32.88ms
+step:528/1490 train_time:17384ms step_avg:32.92ms
+step:529/1490 train_time:17438ms step_avg:32.96ms
+step:530/1490 train_time:17496ms step_avg:33.01ms
+step:531/1490 train_time:17549ms step_avg:33.05ms
+step:532/1490 train_time:17607ms step_avg:33.10ms
+step:533/1490 train_time:17661ms step_avg:33.13ms
+step:534/1490 train_time:17719ms step_avg:33.18ms
+step:535/1490 train_time:17773ms step_avg:33.22ms
+step:536/1490 train_time:17833ms step_avg:33.27ms
+step:537/1490 train_time:17887ms step_avg:33.31ms
+step:538/1490 train_time:17947ms step_avg:33.36ms
+step:539/1490 train_time:18002ms step_avg:33.40ms
+step:540/1490 train_time:18062ms step_avg:33.45ms
+step:541/1490 train_time:18116ms step_avg:33.49ms
+step:542/1490 train_time:18175ms step_avg:33.53ms
+step:543/1490 train_time:18228ms step_avg:33.57ms
+step:544/1490 train_time:18287ms step_avg:33.62ms
+step:545/1490 train_time:18341ms step_avg:33.65ms
+step:546/1490 train_time:18399ms step_avg:33.70ms
+step:547/1490 train_time:18453ms step_avg:33.73ms
+step:548/1490 train_time:18511ms step_avg:33.78ms
+step:549/1490 train_time:18565ms step_avg:33.82ms
+step:550/1490 train_time:18623ms step_avg:33.86ms
+step:551/1490 train_time:18676ms step_avg:33.89ms
+step:552/1490 train_time:18734ms step_avg:33.94ms
+step:553/1490 train_time:18788ms step_avg:33.97ms
+step:554/1490 train_time:18847ms step_avg:34.02ms
+step:555/1490 train_time:18901ms step_avg:34.06ms
+step:556/1490 train_time:18961ms step_avg:34.10ms
+step:557/1490 train_time:19015ms step_avg:34.14ms
+step:558/1490 train_time:19074ms step_avg:34.18ms
+step:559/1490 train_time:19127ms step_avg:34.22ms
+step:560/1490 train_time:19186ms step_avg:34.26ms
+step:561/1490 train_time:19240ms step_avg:34.30ms
+step:562/1490 train_time:19298ms step_avg:34.34ms
+step:563/1490 train_time:19352ms step_avg:34.37ms
+step:564/1490 train_time:19411ms step_avg:34.42ms
+step:565/1490 train_time:19465ms step_avg:34.45ms
+step:566/1490 train_time:19524ms step_avg:34.49ms
+step:567/1490 train_time:19578ms step_avg:34.53ms
+step:568/1490 train_time:19636ms step_avg:34.57ms
+step:569/1490 train_time:19689ms step_avg:34.60ms
+step:570/1490 train_time:19748ms step_avg:34.65ms
+step:571/1490 train_time:19802ms step_avg:34.68ms
+step:572/1490 train_time:19861ms step_avg:34.72ms
+step:573/1490 train_time:19914ms step_avg:34.75ms
+step:574/1490 train_time:19973ms step_avg:34.80ms
+step:575/1490 train_time:20027ms step_avg:34.83ms
+step:576/1490 train_time:20087ms step_avg:34.87ms
+step:577/1490 train_time:20140ms step_avg:34.90ms
+step:578/1490 train_time:20199ms step_avg:34.95ms
+step:579/1490 train_time:20253ms step_avg:34.98ms
+step:580/1490 train_time:20312ms step_avg:35.02ms
+step:581/1490 train_time:20366ms step_avg:35.05ms
+step:582/1490 train_time:20424ms step_avg:35.09ms
+step:583/1490 train_time:20477ms step_avg:35.12ms
+step:584/1490 train_time:20535ms step_avg:35.16ms
+step:585/1490 train_time:20589ms step_avg:35.19ms
+step:586/1490 train_time:20648ms step_avg:35.24ms
+step:587/1490 train_time:20701ms step_avg:35.27ms
+step:588/1490 train_time:20761ms step_avg:35.31ms
+step:589/1490 train_time:20814ms step_avg:35.34ms
+step:590/1490 train_time:20873ms step_avg:35.38ms
+step:591/1490 train_time:20927ms step_avg:35.41ms
+step:592/1490 train_time:20986ms step_avg:35.45ms
+step:593/1490 train_time:21040ms step_avg:35.48ms
+step:594/1490 train_time:21099ms step_avg:35.52ms
+step:595/1490 train_time:21153ms step_avg:35.55ms
+step:596/1490 train_time:21212ms step_avg:35.59ms
+step:597/1490 train_time:21267ms step_avg:35.62ms
+step:598/1490 train_time:21326ms step_avg:35.66ms
+step:599/1490 train_time:21380ms step_avg:35.69ms
+step:600/1490 train_time:21438ms step_avg:35.73ms
+step:601/1490 train_time:21491ms step_avg:35.76ms
+step:602/1490 train_time:21550ms step_avg:35.80ms
+step:603/1490 train_time:21604ms step_avg:35.83ms
+step:604/1490 train_time:21663ms step_avg:35.87ms
+step:605/1490 train_time:21716ms step_avg:35.89ms
+step:606/1490 train_time:21775ms step_avg:35.93ms
+step:607/1490 train_time:21829ms step_avg:35.96ms
+step:608/1490 train_time:21888ms step_avg:36.00ms
+step:609/1490 train_time:21942ms step_avg:36.03ms
+step:610/1490 train_time:22001ms step_avg:36.07ms
+step:611/1490 train_time:22055ms step_avg:36.10ms
+step:612/1490 train_time:22113ms step_avg:36.13ms
+step:613/1490 train_time:22168ms step_avg:36.16ms
+step:614/1490 train_time:22226ms step_avg:36.20ms
+step:615/1490 train_time:22281ms step_avg:36.23ms
+step:616/1490 train_time:22340ms step_avg:36.27ms
+step:617/1490 train_time:22393ms step_avg:36.29ms
+step:618/1490 train_time:22452ms step_avg:36.33ms
+step:619/1490 train_time:22506ms step_avg:36.36ms
+step:620/1490 train_time:22564ms step_avg:36.39ms
+step:621/1490 train_time:22618ms step_avg:36.42ms
+step:622/1490 train_time:22676ms step_avg:36.46ms
+step:623/1490 train_time:22730ms step_avg:36.49ms
+step:624/1490 train_time:22790ms step_avg:36.52ms
+step:625/1490 train_time:22843ms step_avg:36.55ms
+step:626/1490 train_time:22902ms step_avg:36.58ms
+step:627/1490 train_time:22955ms step_avg:36.61ms
+step:628/1490 train_time:23013ms step_avg:36.65ms
+step:629/1490 train_time:23069ms step_avg:36.67ms
+step:630/1490 train_time:23127ms step_avg:36.71ms
+step:631/1490 train_time:23181ms step_avg:36.74ms
+step:632/1490 train_time:23240ms step_avg:36.77ms
+step:633/1490 train_time:23294ms step_avg:36.80ms
+step:634/1490 train_time:23353ms step_avg:36.83ms
+step:635/1490 train_time:23407ms step_avg:36.86ms
+step:636/1490 train_time:23466ms step_avg:36.90ms
+step:637/1490 train_time:23519ms step_avg:36.92ms
+step:638/1490 train_time:23579ms step_avg:36.96ms
+step:639/1490 train_time:23632ms step_avg:36.98ms
+step:640/1490 train_time:23690ms step_avg:37.02ms
+step:641/1490 train_time:23743ms step_avg:37.04ms
+step:642/1490 train_time:23803ms step_avg:37.08ms
+step:643/1490 train_time:23856ms step_avg:37.10ms
+step:644/1490 train_time:23915ms step_avg:37.13ms
+step:645/1490 train_time:23969ms step_avg:37.16ms
+step:646/1490 train_time:24027ms step_avg:37.19ms
+step:647/1490 train_time:24081ms step_avg:37.22ms
+step:648/1490 train_time:24139ms step_avg:37.25ms
+step:649/1490 train_time:24193ms step_avg:37.28ms
+step:650/1490 train_time:24253ms step_avg:37.31ms
+step:651/1490 train_time:24307ms step_avg:37.34ms
+step:652/1490 train_time:24366ms step_avg:37.37ms
+step:653/1490 train_time:24420ms step_avg:37.40ms
+step:654/1490 train_time:24479ms step_avg:37.43ms
+step:655/1490 train_time:24532ms step_avg:37.45ms
+step:656/1490 train_time:24590ms step_avg:37.49ms
+step:657/1490 train_time:24644ms step_avg:37.51ms
+step:658/1490 train_time:24703ms step_avg:37.54ms
+step:659/1490 train_time:24757ms step_avg:37.57ms
+step:660/1490 train_time:24815ms step_avg:37.60ms
+step:661/1490 train_time:24869ms step_avg:37.62ms
+step:662/1490 train_time:24927ms step_avg:37.65ms
+step:663/1490 train_time:24981ms step_avg:37.68ms
+step:664/1490 train_time:25041ms step_avg:37.71ms
+step:665/1490 train_time:25094ms step_avg:37.74ms
+step:666/1490 train_time:25152ms step_avg:37.77ms
+step:667/1490 train_time:25207ms step_avg:37.79ms
+step:668/1490 train_time:25266ms step_avg:37.82ms
+step:669/1490 train_time:25319ms step_avg:37.85ms
+step:670/1490 train_time:25379ms step_avg:37.88ms
+step:671/1490 train_time:25432ms step_avg:37.90ms
+step:672/1490 train_time:25491ms step_avg:37.93ms
+step:673/1490 train_time:25544ms step_avg:37.96ms
+step:674/1490 train_time:25603ms step_avg:37.99ms
+step:675/1490 train_time:25657ms step_avg:38.01ms
+step:676/1490 train_time:25715ms step_avg:38.04ms
+step:677/1490 train_time:25770ms step_avg:38.07ms
+step:678/1490 train_time:25828ms step_avg:38.09ms
+step:679/1490 train_time:25882ms step_avg:38.12ms
+step:680/1490 train_time:25941ms step_avg:38.15ms
+step:681/1490 train_time:25994ms step_avg:38.17ms
+step:682/1490 train_time:26053ms step_avg:38.20ms
+step:683/1490 train_time:26107ms step_avg:38.22ms
+step:684/1490 train_time:26167ms step_avg:38.26ms
+step:685/1490 train_time:26220ms step_avg:38.28ms
+step:686/1490 train_time:26279ms step_avg:38.31ms
+step:687/1490 train_time:26333ms step_avg:38.33ms
+step:688/1490 train_time:26392ms step_avg:38.36ms
+step:689/1490 train_time:26446ms step_avg:38.38ms
+step:690/1490 train_time:26505ms step_avg:38.41ms
+step:691/1490 train_time:26559ms step_avg:38.44ms
+step:692/1490 train_time:26617ms step_avg:38.46ms
+step:693/1490 train_time:26671ms step_avg:38.49ms
+step:694/1490 train_time:26730ms step_avg:38.52ms
+step:695/1490 train_time:26784ms step_avg:38.54ms
+step:696/1490 train_time:26842ms step_avg:38.57ms
+step:697/1490 train_time:26896ms step_avg:38.59ms
+step:698/1490 train_time:26954ms step_avg:38.62ms
+step:699/1490 train_time:27008ms step_avg:38.64ms
+step:700/1490 train_time:27068ms step_avg:38.67ms
+step:701/1490 train_time:27121ms step_avg:38.69ms
+step:702/1490 train_time:27180ms step_avg:38.72ms
+step:703/1490 train_time:27234ms step_avg:38.74ms
+step:704/1490 train_time:27292ms step_avg:38.77ms
+step:705/1490 train_time:27347ms step_avg:38.79ms
+step:706/1490 train_time:27406ms step_avg:38.82ms
+step:707/1490 train_time:27461ms step_avg:38.84ms
+step:708/1490 train_time:27520ms step_avg:38.87ms
+step:709/1490 train_time:27574ms step_avg:38.89ms
+step:710/1490 train_time:27632ms step_avg:38.92ms
+step:711/1490 train_time:27686ms step_avg:38.94ms
+step:712/1490 train_time:27745ms step_avg:38.97ms
+step:713/1490 train_time:27798ms step_avg:38.99ms
+step:714/1490 train_time:27857ms step_avg:39.02ms
+step:715/1490 train_time:27911ms step_avg:39.04ms
+step:716/1490 train_time:27970ms step_avg:39.06ms
+step:717/1490 train_time:28023ms step_avg:39.08ms
+step:718/1490 train_time:28082ms step_avg:39.11ms
+step:719/1490 train_time:28135ms step_avg:39.13ms
+step:720/1490 train_time:28194ms step_avg:39.16ms
+step:721/1490 train_time:28247ms step_avg:39.18ms
+step:722/1490 train_time:28306ms step_avg:39.21ms
+step:723/1490 train_time:28360ms step_avg:39.23ms
+step:724/1490 train_time:28419ms step_avg:39.25ms
+step:725/1490 train_time:28474ms step_avg:39.27ms
+step:726/1490 train_time:28532ms step_avg:39.30ms
+step:727/1490 train_time:28586ms step_avg:39.32ms
+step:728/1490 train_time:28644ms step_avg:39.35ms
+step:729/1490 train_time:28698ms step_avg:39.37ms
+step:730/1490 train_time:28757ms step_avg:39.39ms
+step:731/1490 train_time:28810ms step_avg:39.41ms
+step:732/1490 train_time:28869ms step_avg:39.44ms
+step:733/1490 train_time:28923ms step_avg:39.46ms
+step:734/1490 train_time:28982ms step_avg:39.48ms
+step:735/1490 train_time:29036ms step_avg:39.50ms
+step:736/1490 train_time:29093ms step_avg:39.53ms
+step:737/1490 train_time:29147ms step_avg:39.55ms
+step:738/1490 train_time:29206ms step_avg:39.57ms
+step:739/1490 train_time:29259ms step_avg:39.59ms
+step:740/1490 train_time:29318ms step_avg:39.62ms
+step:741/1490 train_time:29372ms step_avg:39.64ms
+step:742/1490 train_time:29430ms step_avg:39.66ms
+step:743/1490 train_time:29485ms step_avg:39.68ms
+step:744/1490 train_time:29543ms step_avg:39.71ms
+step:745/1490 train_time:29596ms step_avg:39.73ms
+step:746/1490 train_time:29655ms step_avg:39.75ms
+step:747/1490 train_time:29709ms step_avg:39.77ms
+step:748/1490 train_time:29769ms step_avg:39.80ms
+step:749/1490 train_time:29823ms step_avg:39.82ms
+step:750/1490 train_time:29882ms step_avg:39.84ms
+step:750/1490 val_loss:3.8015 train_time:29952ms step_avg:39.94ms
+step:751/1490 train_time:29970ms step_avg:39.91ms
+step:752/1490 train_time:29996ms step_avg:39.89ms
+step:753/1490 train_time:30053ms step_avg:39.91ms
+step:754/1490 train_time:30114ms step_avg:39.94ms
+step:755/1490 train_time:30169ms step_avg:39.96ms
+step:756/1490 train_time:30230ms step_avg:39.99ms
+step:757/1490 train_time:30283ms step_avg:40.00ms
+step:758/1490 train_time:30341ms step_avg:40.03ms
+step:759/1490 train_time:30395ms step_avg:40.05ms
+step:760/1490 train_time:30452ms step_avg:40.07ms
+step:761/1490 train_time:30506ms step_avg:40.09ms
+step:762/1490 train_time:30565ms step_avg:40.11ms
+step:763/1490 train_time:30618ms step_avg:40.13ms
+step:764/1490 train_time:30675ms step_avg:40.15ms
+step:765/1490 train_time:30730ms step_avg:40.17ms
+step:766/1490 train_time:30789ms step_avg:40.19ms
+step:767/1490 train_time:30841ms step_avg:40.21ms
+step:768/1490 train_time:30900ms step_avg:40.23ms
+step:769/1490 train_time:30954ms step_avg:40.25ms
+step:770/1490 train_time:31014ms step_avg:40.28ms
+step:771/1490 train_time:31068ms step_avg:40.30ms
+step:772/1490 train_time:31129ms step_avg:40.32ms
+step:773/1490 train_time:31183ms step_avg:40.34ms
+step:774/1490 train_time:31242ms step_avg:40.36ms
+step:775/1490 train_time:31297ms step_avg:40.38ms
+step:776/1490 train_time:31355ms step_avg:40.41ms
+step:777/1490 train_time:31410ms step_avg:40.42ms
+step:778/1490 train_time:31468ms step_avg:40.45ms
+step:779/1490 train_time:31521ms step_avg:40.46ms
+step:780/1490 train_time:31580ms step_avg:40.49ms
+step:781/1490 train_time:31632ms step_avg:40.50ms
+step:782/1490 train_time:31692ms step_avg:40.53ms
+step:783/1490 train_time:31745ms step_avg:40.54ms
+step:784/1490 train_time:31804ms step_avg:40.57ms
+step:785/1490 train_time:31857ms step_avg:40.58ms
+step:786/1490 train_time:31915ms step_avg:40.60ms
+step:787/1490 train_time:31970ms step_avg:40.62ms
+step:788/1490 train_time:32029ms step_avg:40.65ms
+step:789/1490 train_time:32084ms step_avg:40.66ms
+step:790/1490 train_time:32142ms step_avg:40.69ms
+step:791/1490 train_time:32196ms step_avg:40.70ms
+step:792/1490 train_time:32255ms step_avg:40.73ms
+step:793/1490 train_time:32309ms step_avg:40.74ms
+step:794/1490 train_time:32368ms step_avg:40.77ms
+step:795/1490 train_time:32421ms step_avg:40.78ms
+step:796/1490 train_time:32480ms step_avg:40.80ms
+step:797/1490 train_time:32534ms step_avg:40.82ms
+step:798/1490 train_time:32593ms step_avg:40.84ms
+step:799/1490 train_time:32646ms step_avg:40.86ms
+step:800/1490 train_time:32704ms step_avg:40.88ms
+step:801/1490 train_time:32758ms step_avg:40.90ms
+step:802/1490 train_time:32816ms step_avg:40.92ms
+step:803/1490 train_time:32870ms step_avg:40.93ms
+step:804/1490 train_time:32929ms step_avg:40.96ms
+step:805/1490 train_time:32983ms step_avg:40.97ms
+step:806/1490 train_time:33042ms step_avg:40.99ms
+step:807/1490 train_time:33096ms step_avg:41.01ms
+step:808/1490 train_time:33154ms step_avg:41.03ms
+step:809/1490 train_time:33210ms step_avg:41.05ms
+step:810/1490 train_time:33269ms step_avg:41.07ms
+step:811/1490 train_time:33322ms step_avg:41.09ms
+step:812/1490 train_time:33382ms step_avg:41.11ms
+step:813/1490 train_time:33434ms step_avg:41.12ms
+step:814/1490 train_time:33493ms step_avg:41.15ms
+step:815/1490 train_time:33547ms step_avg:41.16ms
+step:816/1490 train_time:33606ms step_avg:41.18ms
+step:817/1490 train_time:33659ms step_avg:41.20ms
+step:818/1490 train_time:33717ms step_avg:41.22ms
+step:819/1490 train_time:33770ms step_avg:41.23ms
+step:820/1490 train_time:33829ms step_avg:41.25ms
+step:821/1490 train_time:33882ms step_avg:41.27ms
+step:822/1490 train_time:33942ms step_avg:41.29ms
+step:823/1490 train_time:33995ms step_avg:41.31ms
+step:824/1490 train_time:34054ms step_avg:41.33ms
+step:825/1490 train_time:34108ms step_avg:41.34ms
+step:826/1490 train_time:34167ms step_avg:41.36ms
+step:827/1490 train_time:34222ms step_avg:41.38ms
+step:828/1490 train_time:34280ms step_avg:41.40ms
+step:829/1490 train_time:34334ms step_avg:41.42ms
+step:830/1490 train_time:34393ms step_avg:41.44ms
+step:831/1490 train_time:34447ms step_avg:41.45ms
+step:832/1490 train_time:34505ms step_avg:41.47ms
+step:833/1490 train_time:34558ms step_avg:41.49ms
+step:834/1490 train_time:34616ms step_avg:41.51ms
+step:835/1490 train_time:34670ms step_avg:41.52ms
+step:836/1490 train_time:34729ms step_avg:41.54ms
+step:837/1490 train_time:34783ms step_avg:41.56ms
+step:838/1490 train_time:34842ms step_avg:41.58ms
+step:839/1490 train_time:34895ms step_avg:41.59ms
+step:840/1490 train_time:34953ms step_avg:41.61ms
+step:841/1490 train_time:35007ms step_avg:41.63ms
+step:842/1490 train_time:35065ms step_avg:41.65ms
+step:843/1490 train_time:35119ms step_avg:41.66ms
+step:844/1490 train_time:35177ms step_avg:41.68ms
+step:845/1490 train_time:35232ms step_avg:41.69ms
+step:846/1490 train_time:35292ms step_avg:41.72ms
+step:847/1490 train_time:35345ms step_avg:41.73ms
+step:848/1490 train_time:35405ms step_avg:41.75ms
+step:849/1490 train_time:35458ms step_avg:41.76ms
+step:850/1490 train_time:35516ms step_avg:41.78ms
+step:851/1490 train_time:35570ms step_avg:41.80ms
+step:852/1490 train_time:35628ms step_avg:41.82ms
+step:853/1490 train_time:35682ms step_avg:41.83ms
+step:854/1490 train_time:35740ms step_avg:41.85ms
+step:855/1490 train_time:35794ms step_avg:41.86ms
+step:856/1490 train_time:35852ms step_avg:41.88ms
+step:857/1490 train_time:35906ms step_avg:41.90ms
+step:858/1490 train_time:35965ms step_avg:41.92ms
+step:859/1490 train_time:36019ms step_avg:41.93ms
+step:860/1490 train_time:36077ms step_avg:41.95ms
+step:861/1490 train_time:36131ms step_avg:41.96ms
+step:862/1490 train_time:36191ms step_avg:41.99ms
+step:863/1490 train_time:36244ms step_avg:42.00ms
+step:864/1490 train_time:36304ms step_avg:42.02ms
+step:865/1490 train_time:36357ms step_avg:42.03ms
+step:866/1490 train_time:36416ms step_avg:42.05ms
+step:867/1490 train_time:36469ms step_avg:42.06ms
+step:868/1490 train_time:36528ms step_avg:42.08ms
+step:869/1490 train_time:36582ms step_avg:42.10ms
+step:870/1490 train_time:36640ms step_avg:42.11ms
+step:871/1490 train_time:36693ms step_avg:42.13ms
+step:872/1490 train_time:36752ms step_avg:42.15ms
+step:873/1490 train_time:36806ms step_avg:42.16ms
+step:874/1490 train_time:36864ms step_avg:42.18ms
+step:875/1490 train_time:36917ms step_avg:42.19ms
+step:876/1490 train_time:36975ms step_avg:42.21ms
+step:877/1490 train_time:37030ms step_avg:42.22ms
+step:878/1490 train_time:37090ms step_avg:42.24ms
+step:879/1490 train_time:37144ms step_avg:42.26ms
+step:880/1490 train_time:37202ms step_avg:42.28ms
+step:881/1490 train_time:37256ms step_avg:42.29ms
+step:882/1490 train_time:37314ms step_avg:42.31ms
+step:883/1490 train_time:37367ms step_avg:42.32ms
+step:884/1490 train_time:37426ms step_avg:42.34ms
+step:885/1490 train_time:37479ms step_avg:42.35ms
+step:886/1490 train_time:37538ms step_avg:42.37ms
+step:887/1490 train_time:37593ms step_avg:42.38ms
+step:888/1490 train_time:37651ms step_avg:42.40ms
+step:889/1490 train_time:37704ms step_avg:42.41ms
+step:890/1490 train_time:37764ms step_avg:42.43ms
+step:891/1490 train_time:37817ms step_avg:42.44ms
+step:892/1490 train_time:37875ms step_avg:42.46ms
+step:893/1490 train_time:37930ms step_avg:42.47ms
+step:894/1490 train_time:37989ms step_avg:42.49ms
+step:895/1490 train_time:38042ms step_avg:42.51ms
+step:896/1490 train_time:38101ms step_avg:42.52ms
+step:897/1490 train_time:38153ms step_avg:42.53ms
+step:898/1490 train_time:38213ms step_avg:42.55ms
+step:899/1490 train_time:38267ms step_avg:42.57ms
+step:900/1490 train_time:38326ms step_avg:42.58ms
+step:901/1490 train_time:38380ms step_avg:42.60ms
+step:902/1490 train_time:38438ms step_avg:42.61ms
+step:903/1490 train_time:38492ms step_avg:42.63ms
+step:904/1490 train_time:38551ms step_avg:42.64ms
+step:905/1490 train_time:38605ms step_avg:42.66ms
+step:906/1490 train_time:38664ms step_avg:42.68ms
+step:907/1490 train_time:38718ms step_avg:42.69ms
+step:908/1490 train_time:38776ms step_avg:42.70ms
+step:909/1490 train_time:38830ms step_avg:42.72ms
+step:910/1490 train_time:38889ms step_avg:42.74ms
+step:911/1490 train_time:38943ms step_avg:42.75ms
+step:912/1490 train_time:39001ms step_avg:42.76ms
+step:913/1490 train_time:39055ms step_avg:42.78ms
+step:914/1490 train_time:39113ms step_avg:42.79ms
+step:915/1490 train_time:39167ms step_avg:42.81ms
+step:916/1490 train_time:39226ms step_avg:42.82ms
+step:917/1490 train_time:39280ms step_avg:42.84ms
+step:918/1490 train_time:39338ms step_avg:42.85ms
+step:919/1490 train_time:39392ms step_avg:42.86ms
+step:920/1490 train_time:39451ms step_avg:42.88ms
+step:921/1490 train_time:39504ms step_avg:42.89ms
+step:922/1490 train_time:39563ms step_avg:42.91ms
+step:923/1490 train_time:39616ms step_avg:42.92ms
+step:924/1490 train_time:39674ms step_avg:42.94ms
+step:925/1490 train_time:39729ms step_avg:42.95ms
+step:926/1490 train_time:39789ms step_avg:42.97ms
+step:927/1490 train_time:39843ms step_avg:42.98ms
+step:928/1490 train_time:39902ms step_avg:43.00ms
+step:929/1490 train_time:39956ms step_avg:43.01ms
+step:930/1490 train_time:40014ms step_avg:43.03ms
+step:931/1490 train_time:40070ms step_avg:43.04ms
+step:932/1490 train_time:40128ms step_avg:43.06ms
+step:933/1490 train_time:40182ms step_avg:43.07ms
+step:934/1490 train_time:40242ms step_avg:43.09ms
+step:935/1490 train_time:40295ms step_avg:43.10ms
+step:936/1490 train_time:40354ms step_avg:43.11ms
+step:937/1490 train_time:40408ms step_avg:43.12ms
+step:938/1490 train_time:40466ms step_avg:43.14ms
+step:939/1490 train_time:40520ms step_avg:43.15ms
+step:940/1490 train_time:40578ms step_avg:43.17ms
+step:941/1490 train_time:40633ms step_avg:43.18ms
+step:942/1490 train_time:40692ms step_avg:43.20ms
+step:943/1490 train_time:40745ms step_avg:43.21ms
+step:944/1490 train_time:40805ms step_avg:43.23ms
+step:945/1490 train_time:40859ms step_avg:43.24ms
+step:946/1490 train_time:40917ms step_avg:43.25ms
+step:947/1490 train_time:40971ms step_avg:43.26ms
+step:948/1490 train_time:41030ms step_avg:43.28ms
+step:949/1490 train_time:41084ms step_avg:43.29ms
+step:950/1490 train_time:41144ms step_avg:43.31ms
+step:951/1490 train_time:41197ms step_avg:43.32ms
+step:952/1490 train_time:41255ms step_avg:43.34ms
+step:953/1490 train_time:41309ms step_avg:43.35ms
+step:954/1490 train_time:41368ms step_avg:43.36ms
+step:955/1490 train_time:41422ms step_avg:43.37ms
+step:956/1490 train_time:41481ms step_avg:43.39ms
+step:957/1490 train_time:41534ms step_avg:43.40ms
+step:958/1490 train_time:41593ms step_avg:43.42ms
+step:959/1490 train_time:41646ms step_avg:43.43ms
+step:960/1490 train_time:41705ms step_avg:43.44ms
+step:961/1490 train_time:41759ms step_avg:43.45ms
+step:962/1490 train_time:41817ms step_avg:43.47ms
+step:963/1490 train_time:41871ms step_avg:43.48ms
+step:964/1490 train_time:41930ms step_avg:43.50ms
+step:965/1490 train_time:41984ms step_avg:43.51ms
+step:966/1490 train_time:42042ms step_avg:43.52ms
+step:967/1490 train_time:42096ms step_avg:43.53ms
+step:968/1490 train_time:42158ms step_avg:43.55ms
+step:969/1490 train_time:42237ms step_avg:43.59ms
+step:970/1490 train_time:42321ms step_avg:43.63ms
+step:971/1490 train_time:42401ms step_avg:43.67ms
+step:972/1490 train_time:42486ms step_avg:43.71ms
+step:973/1490 train_time:42564ms step_avg:43.75ms
+step:974/1490 train_time:42649ms step_avg:43.79ms
+step:975/1490 train_time:42729ms step_avg:43.82ms
+step:976/1490 train_time:42814ms step_avg:43.87ms
+step:977/1490 train_time:42892ms step_avg:43.90ms
+step:978/1490 train_time:42977ms step_avg:43.94ms
+step:979/1490 train_time:43058ms step_avg:43.98ms
+step:980/1490 train_time:43143ms step_avg:44.02ms
+step:981/1490 train_time:43224ms step_avg:44.06ms
+step:982/1490 train_time:43309ms step_avg:44.10ms
+step:983/1490 train_time:43389ms step_avg:44.14ms
+step:984/1490 train_time:43473ms step_avg:44.18ms
+step:985/1490 train_time:43553ms step_avg:44.22ms
+step:986/1490 train_time:43638ms step_avg:44.26ms
+step:987/1490 train_time:43717ms step_avg:44.29ms
+step:988/1490 train_time:43802ms step_avg:44.33ms
+step:989/1490 train_time:43881ms step_avg:44.37ms
+step:990/1490 train_time:43966ms step_avg:44.41ms
+step:991/1490 train_time:44045ms step_avg:44.45ms
+step:992/1490 train_time:44130ms step_avg:44.49ms
+step:993/1490 train_time:44209ms step_avg:44.52ms
+step:994/1490 train_time:44293ms step_avg:44.56ms
+step:995/1490 train_time:44372ms step_avg:44.60ms
+step:996/1490 train_time:44458ms step_avg:44.64ms
+step:997/1490 train_time:44537ms step_avg:44.67ms
+step:998/1490 train_time:44621ms step_avg:44.71ms
+step:999/1490 train_time:44700ms step_avg:44.74ms
+step:1000/1490 train_time:44786ms step_avg:44.79ms
+step:1000/1490 val_loss:3.5159 train_time:44886ms step_avg:44.89ms
+step:1001/1490 train_time:44905ms step_avg:44.86ms
+step:1002/1490 train_time:44956ms step_avg:44.87ms
+step:1003/1490 train_time:45037ms step_avg:44.90ms
+step:1004/1490 train_time:45126ms step_avg:44.95ms
+step:1005/1490 train_time:45205ms step_avg:44.98ms
+step:1006/1490 train_time:45288ms step_avg:45.02ms
+step:1007/1490 train_time:45367ms step_avg:45.05ms
+step:1008/1490 train_time:45452ms step_avg:45.09ms
+step:1009/1490 train_time:45530ms step_avg:45.12ms
+step:1010/1490 train_time:45614ms step_avg:45.16ms
+step:1011/1490 train_time:45693ms step_avg:45.20ms
+step:1012/1490 train_time:45777ms step_avg:45.23ms
+step:1013/1490 train_time:45859ms step_avg:45.27ms
+step:1014/1490 train_time:45944ms step_avg:45.31ms
+step:1015/1490 train_time:46026ms step_avg:45.35ms
+step:1016/1490 train_time:46113ms step_avg:45.39ms
+step:1017/1490 train_time:46194ms step_avg:45.42ms
+step:1018/1490 train_time:46279ms step_avg:45.46ms
+step:1019/1490 train_time:46357ms step_avg:45.49ms
+step:1020/1490 train_time:46441ms step_avg:45.53ms
+step:1021/1490 train_time:46519ms step_avg:45.56ms
+step:1022/1490 train_time:46602ms step_avg:45.60ms
+step:1023/1490 train_time:46679ms step_avg:45.63ms
+step:1024/1490 train_time:46765ms step_avg:45.67ms
+step:1025/1490 train_time:46844ms step_avg:45.70ms
+step:1026/1490 train_time:46930ms step_avg:45.74ms
+step:1027/1490 train_time:47010ms step_avg:45.77ms
+step:1028/1490 train_time:47096ms step_avg:45.81ms
+step:1029/1490 train_time:47178ms step_avg:45.85ms
+step:1030/1490 train_time:47262ms step_avg:45.89ms
+step:1031/1490 train_time:47341ms step_avg:45.92ms
+step:1032/1490 train_time:47427ms step_avg:45.96ms
+step:1033/1490 train_time:47504ms step_avg:45.99ms
+step:1034/1490 train_time:47588ms step_avg:46.02ms
+step:1035/1490 train_time:47667ms step_avg:46.06ms
+step:1036/1490 train_time:47752ms step_avg:46.09ms
+step:1037/1490 train_time:47831ms step_avg:46.12ms
+step:1038/1490 train_time:47916ms step_avg:46.16ms
+step:1039/1490 train_time:47998ms step_avg:46.20ms
+step:1040/1490 train_time:48084ms step_avg:46.23ms
+step:1041/1490 train_time:48164ms step_avg:46.27ms
+step:1042/1490 train_time:48248ms step_avg:46.30ms
+step:1043/1490 train_time:48328ms step_avg:46.34ms
+step:1044/1490 train_time:48412ms step_avg:46.37ms
+step:1045/1490 train_time:48490ms step_avg:46.40ms
+step:1046/1490 train_time:48575ms step_avg:46.44ms
+step:1047/1490 train_time:48655ms step_avg:46.47ms
+step:1048/1490 train_time:48739ms step_avg:46.51ms
+step:1049/1490 train_time:48818ms step_avg:46.54ms
+step:1050/1490 train_time:48903ms step_avg:46.57ms
+step:1051/1490 train_time:48982ms step_avg:46.60ms
+step:1052/1490 train_time:49067ms step_avg:46.64ms
+step:1053/1490 train_time:49147ms step_avg:46.67ms
+step:1054/1490 train_time:49232ms step_avg:46.71ms
+step:1055/1490 train_time:49312ms step_avg:46.74ms
+step:1056/1490 train_time:49396ms step_avg:46.78ms
+step:1057/1490 train_time:49476ms step_avg:46.81ms
+step:1058/1490 train_time:49560ms step_avg:46.84ms
+step:1059/1490 train_time:49640ms step_avg:46.87ms
+step:1060/1490 train_time:49724ms step_avg:46.91ms
+step:1061/1490 train_time:49803ms step_avg:46.94ms
+step:1062/1490 train_time:49887ms step_avg:46.97ms
+step:1063/1490 train_time:49967ms step_avg:47.01ms
+step:1064/1490 train_time:50052ms step_avg:47.04ms
+step:1065/1490 train_time:50133ms step_avg:47.07ms
+step:1066/1490 train_time:50219ms step_avg:47.11ms
+step:1067/1490 train_time:50298ms step_avg:47.14ms
+step:1068/1490 train_time:50382ms step_avg:47.17ms
+step:1069/1490 train_time:50460ms step_avg:47.20ms
+step:1070/1490 train_time:50545ms step_avg:47.24ms
+step:1071/1490 train_time:50625ms step_avg:47.27ms
+step:1072/1490 train_time:50710ms step_avg:47.30ms
+step:1073/1490 train_time:50788ms step_avg:47.33ms
+step:1074/1490 train_time:50873ms step_avg:47.37ms
+step:1075/1490 train_time:50953ms step_avg:47.40ms
+step:1076/1490 train_time:51038ms step_avg:47.43ms
+step:1077/1490 train_time:51119ms step_avg:47.46ms
+step:1078/1490 train_time:51202ms step_avg:47.50ms
+step:1079/1490 train_time:51282ms step_avg:47.53ms
+step:1080/1490 train_time:51367ms step_avg:47.56ms
+step:1081/1490 train_time:51446ms step_avg:47.59ms
+step:1082/1490 train_time:51530ms step_avg:47.63ms
+step:1083/1490 train_time:51609ms step_avg:47.65ms
+step:1084/1490 train_time:51694ms step_avg:47.69ms
+step:1085/1490 train_time:51775ms step_avg:47.72ms
+step:1086/1490 train_time:51859ms step_avg:47.75ms
+step:1087/1490 train_time:51939ms step_avg:47.78ms
+step:1088/1490 train_time:52026ms step_avg:47.82ms
+step:1089/1490 train_time:52105ms step_avg:47.85ms
+step:1090/1490 train_time:52190ms step_avg:47.88ms
+step:1091/1490 train_time:52269ms step_avg:47.91ms
+step:1092/1490 train_time:52354ms step_avg:47.94ms
+step:1093/1490 train_time:52434ms step_avg:47.97ms
+step:1094/1490 train_time:52519ms step_avg:48.01ms
+step:1095/1490 train_time:52598ms step_avg:48.03ms
+step:1096/1490 train_time:52683ms step_avg:48.07ms
+step:1097/1490 train_time:52763ms step_avg:48.10ms
+step:1098/1490 train_time:52847ms step_avg:48.13ms
+step:1099/1490 train_time:52927ms step_avg:48.16ms
+step:1100/1490 train_time:53011ms step_avg:48.19ms
+step:1101/1490 train_time:53092ms step_avg:48.22ms
+step:1102/1490 train_time:53177ms step_avg:48.25ms
+step:1103/1490 train_time:53255ms step_avg:48.28ms
+step:1104/1490 train_time:53342ms step_avg:48.32ms
+step:1105/1490 train_time:53422ms step_avg:48.35ms
+step:1106/1490 train_time:53505ms step_avg:48.38ms
+step:1107/1490 train_time:53584ms step_avg:48.41ms
+step:1108/1490 train_time:53669ms step_avg:48.44ms
+step:1109/1490 train_time:53748ms step_avg:48.47ms
+step:1110/1490 train_time:53833ms step_avg:48.50ms
+step:1111/1490 train_time:53912ms step_avg:48.53ms
+step:1112/1490 train_time:53996ms step_avg:48.56ms
+step:1113/1490 train_time:54077ms step_avg:48.59ms
+step:1114/1490 train_time:54162ms step_avg:48.62ms
+step:1115/1490 train_time:54241ms step_avg:48.65ms
+step:1116/1490 train_time:54326ms step_avg:48.68ms
+step:1117/1490 train_time:54405ms step_avg:48.71ms
+step:1118/1490 train_time:54489ms step_avg:48.74ms
+step:1119/1490 train_time:54569ms step_avg:48.77ms
+step:1120/1490 train_time:54655ms step_avg:48.80ms
+step:1121/1490 train_time:54735ms step_avg:48.83ms
+step:1122/1490 train_time:54820ms step_avg:48.86ms
+step:1123/1490 train_time:54899ms step_avg:48.89ms
+step:1124/1490 train_time:54984ms step_avg:48.92ms
+step:1125/1490 train_time:55065ms step_avg:48.95ms
+step:1126/1490 train_time:55150ms step_avg:48.98ms
+step:1127/1490 train_time:55229ms step_avg:49.01ms
+step:1128/1490 train_time:55314ms step_avg:49.04ms
+step:1129/1490 train_time:55394ms step_avg:49.06ms
+step:1130/1490 train_time:55477ms step_avg:49.10ms
+step:1131/1490 train_time:55557ms step_avg:49.12ms
+step:1132/1490 train_time:55642ms step_avg:49.15ms
+step:1133/1490 train_time:55721ms step_avg:49.18ms
+step:1134/1490 train_time:55806ms step_avg:49.21ms
+step:1135/1490 train_time:55885ms step_avg:49.24ms
+step:1136/1490 train_time:55969ms step_avg:49.27ms
+step:1137/1490 train_time:56049ms step_avg:49.30ms
+step:1138/1490 train_time:56134ms step_avg:49.33ms
+step:1139/1490 train_time:56214ms step_avg:49.35ms
+step:1140/1490 train_time:56299ms step_avg:49.38ms
+step:1141/1490 train_time:56378ms step_avg:49.41ms
+step:1142/1490 train_time:56462ms step_avg:49.44ms
+step:1143/1490 train_time:56541ms step_avg:49.47ms
+step:1144/1490 train_time:56626ms step_avg:49.50ms
+step:1145/1490 train_time:56705ms step_avg:49.52ms
+step:1146/1490 train_time:56789ms step_avg:49.55ms
+step:1147/1490 train_time:56869ms step_avg:49.58ms
+step:1148/1490 train_time:56954ms step_avg:49.61ms
+step:1149/1490 train_time:57034ms step_avg:49.64ms
+step:1150/1490 train_time:57119ms step_avg:49.67ms
+step:1151/1490 train_time:57198ms step_avg:49.69ms
+step:1152/1490 train_time:57282ms step_avg:49.72ms
+step:1153/1490 train_time:57362ms step_avg:49.75ms
+step:1154/1490 train_time:57447ms step_avg:49.78ms
+step:1155/1490 train_time:57526ms step_avg:49.81ms
+step:1156/1490 train_time:57610ms step_avg:49.84ms
+step:1157/1490 train_time:57689ms step_avg:49.86ms
+step:1158/1490 train_time:57773ms step_avg:49.89ms
+step:1159/1490 train_time:57853ms step_avg:49.92ms
+step:1160/1490 train_time:57939ms step_avg:49.95ms
+step:1161/1490 train_time:58019ms step_avg:49.97ms
+step:1162/1490 train_time:58103ms step_avg:50.00ms
+step:1163/1490 train_time:58184ms step_avg:50.03ms
+step:1164/1490 train_time:58268ms step_avg:50.06ms
+step:1165/1490 train_time:58347ms step_avg:50.08ms
+step:1166/1490 train_time:58431ms step_avg:50.11ms
+step:1167/1490 train_time:58511ms step_avg:50.14ms
+step:1168/1490 train_time:58596ms step_avg:50.17ms
+step:1169/1490 train_time:58674ms step_avg:50.19ms
+step:1170/1490 train_time:58759ms step_avg:50.22ms
+step:1171/1490 train_time:58839ms step_avg:50.25ms
+step:1172/1490 train_time:58924ms step_avg:50.28ms
+step:1173/1490 train_time:59003ms step_avg:50.30ms
+step:1174/1490 train_time:59088ms step_avg:50.33ms
+step:1175/1490 train_time:59168ms step_avg:50.36ms
+step:1176/1490 train_time:59252ms step_avg:50.38ms
+step:1177/1490 train_time:59332ms step_avg:50.41ms
+step:1178/1490 train_time:59417ms step_avg:50.44ms
+step:1179/1490 train_time:59498ms step_avg:50.46ms
+step:1180/1490 train_time:59582ms step_avg:50.49ms
+step:1181/1490 train_time:59660ms step_avg:50.52ms
+step:1182/1490 train_time:59745ms step_avg:50.55ms
+step:1183/1490 train_time:59826ms step_avg:50.57ms
+step:1184/1490 train_time:59910ms step_avg:50.60ms
+step:1185/1490 train_time:59988ms step_avg:50.62ms
+step:1186/1490 train_time:60074ms step_avg:50.65ms
+step:1187/1490 train_time:60154ms step_avg:50.68ms
+step:1188/1490 train_time:60238ms step_avg:50.71ms
+step:1189/1490 train_time:60318ms step_avg:50.73ms
+step:1190/1490 train_time:60403ms step_avg:50.76ms
+step:1191/1490 train_time:60482ms step_avg:50.78ms
+step:1192/1490 train_time:60567ms step_avg:50.81ms
+step:1193/1490 train_time:60647ms step_avg:50.84ms
+step:1194/1490 train_time:60732ms step_avg:50.86ms
+step:1195/1490 train_time:60813ms step_avg:50.89ms
+step:1196/1490 train_time:60899ms step_avg:50.92ms
+step:1197/1490 train_time:60978ms step_avg:50.94ms
+step:1198/1490 train_time:61062ms step_avg:50.97ms
+step:1199/1490 train_time:61141ms step_avg:50.99ms
+step:1200/1490 train_time:61226ms step_avg:51.02ms
+step:1201/1490 train_time:61304ms step_avg:51.04ms
+step:1202/1490 train_time:61389ms step_avg:51.07ms
+step:1203/1490 train_time:61468ms step_avg:51.10ms
+step:1204/1490 train_time:61553ms step_avg:51.12ms
+step:1205/1490 train_time:61633ms step_avg:51.15ms
+step:1206/1490 train_time:61718ms step_avg:51.18ms
+step:1207/1490 train_time:61797ms step_avg:51.20ms
+step:1208/1490 train_time:61882ms step_avg:51.23ms
+step:1209/1490 train_time:61962ms step_avg:51.25ms
+step:1210/1490 train_time:62048ms step_avg:51.28ms
+step:1211/1490 train_time:62127ms step_avg:51.30ms
+step:1212/1490 train_time:62211ms step_avg:51.33ms
+step:1213/1490 train_time:62291ms step_avg:51.35ms
+step:1214/1490 train_time:62377ms step_avg:51.38ms
+step:1215/1490 train_time:62456ms step_avg:51.40ms
+step:1216/1490 train_time:62541ms step_avg:51.43ms
+step:1217/1490 train_time:62620ms step_avg:51.45ms
+step:1218/1490 train_time:62706ms step_avg:51.48ms
+step:1219/1490 train_time:62786ms step_avg:51.51ms
+step:1220/1490 train_time:62870ms step_avg:51.53ms
+step:1221/1490 train_time:62949ms step_avg:51.56ms
+step:1222/1490 train_time:63035ms step_avg:51.58ms
+step:1223/1490 train_time:63114ms step_avg:51.61ms
+step:1224/1490 train_time:63199ms step_avg:51.63ms
+step:1225/1490 train_time:63277ms step_avg:51.66ms
+step:1226/1490 train_time:63362ms step_avg:51.68ms
+step:1227/1490 train_time:63442ms step_avg:51.71ms
+step:1228/1490 train_time:63527ms step_avg:51.73ms
+step:1229/1490 train_time:63606ms step_avg:51.75ms
+step:1230/1490 train_time:63691ms step_avg:51.78ms
+step:1231/1490 train_time:63772ms step_avg:51.80ms
+step:1232/1490 train_time:63857ms step_avg:51.83ms
+step:1233/1490 train_time:63936ms step_avg:51.85ms
+step:1234/1490 train_time:64021ms step_avg:51.88ms
+step:1235/1490 train_time:64101ms step_avg:51.90ms
+step:1236/1490 train_time:64185ms step_avg:51.93ms
+step:1237/1490 train_time:64264ms step_avg:51.95ms
+step:1238/1490 train_time:64349ms step_avg:51.98ms
+step:1239/1490 train_time:64428ms step_avg:52.00ms
+step:1240/1490 train_time:64513ms step_avg:52.03ms
+step:1241/1490 train_time:64593ms step_avg:52.05ms
+step:1242/1490 train_time:64678ms step_avg:52.08ms
+step:1243/1490 train_time:64758ms step_avg:52.10ms
+step:1244/1490 train_time:64843ms step_avg:52.12ms
+step:1245/1490 train_time:64921ms step_avg:52.15ms
+step:1246/1490 train_time:65006ms step_avg:52.17ms
+step:1247/1490 train_time:65086ms step_avg:52.19ms
+step:1248/1490 train_time:65171ms step_avg:52.22ms
+step:1249/1490 train_time:65250ms step_avg:52.24ms
+step:1250/1490 train_time:65335ms step_avg:52.27ms
+step:1250/1490 val_loss:3.3713 train_time:65437ms step_avg:52.35ms
+step:1251/1490 train_time:65463ms step_avg:52.33ms
+step:1252/1490 train_time:65507ms step_avg:52.32ms
+step:1253/1490 train_time:65594ms step_avg:52.35ms
+step:1254/1490 train_time:65680ms step_avg:52.38ms
+step:1255/1490 train_time:65760ms step_avg:52.40ms
+step:1256/1490 train_time:65844ms step_avg:52.42ms
+step:1257/1490 train_time:65922ms step_avg:52.44ms
+step:1258/1490 train_time:66005ms step_avg:52.47ms
+step:1259/1490 train_time:66084ms step_avg:52.49ms
+step:1260/1490 train_time:66167ms step_avg:52.51ms
+step:1261/1490 train_time:66246ms step_avg:52.53ms
+step:1262/1490 train_time:66330ms step_avg:52.56ms
+step:1263/1490 train_time:66408ms step_avg:52.58ms
+step:1264/1490 train_time:66494ms step_avg:52.61ms
+step:1265/1490 train_time:66579ms step_avg:52.63ms
+step:1266/1490 train_time:66666ms step_avg:52.66ms
+step:1267/1490 train_time:66748ms step_avg:52.68ms
+step:1268/1490 train_time:66832ms step_avg:52.71ms
+step:1269/1490 train_time:66910ms step_avg:52.73ms
+step:1270/1490 train_time:66994ms step_avg:52.75ms
+step:1271/1490 train_time:67072ms step_avg:52.77ms
+step:1272/1490 train_time:67156ms step_avg:52.80ms
+step:1273/1490 train_time:67235ms step_avg:52.82ms
+step:1274/1490 train_time:67318ms step_avg:52.84ms
+step:1275/1490 train_time:67398ms step_avg:52.86ms
+step:1276/1490 train_time:67485ms step_avg:52.89ms
+step:1277/1490 train_time:67567ms step_avg:52.91ms
+step:1278/1490 train_time:67653ms step_avg:52.94ms
+step:1279/1490 train_time:67734ms step_avg:52.96ms
+step:1280/1490 train_time:67818ms step_avg:52.98ms
+step:1281/1490 train_time:67896ms step_avg:53.00ms
+step:1282/1490 train_time:67981ms step_avg:53.03ms
+step:1283/1490 train_time:68059ms step_avg:53.05ms
+step:1284/1490 train_time:68144ms step_avg:53.07ms
+step:1285/1490 train_time:68222ms step_avg:53.09ms
+step:1286/1490 train_time:68306ms step_avg:53.11ms
+step:1287/1490 train_time:68388ms step_avg:53.14ms
+step:1288/1490 train_time:68474ms step_avg:53.16ms
+step:1289/1490 train_time:68553ms step_avg:53.18ms
+step:1290/1490 train_time:68639ms step_avg:53.21ms
+step:1291/1490 train_time:68720ms step_avg:53.23ms
+step:1292/1490 train_time:68804ms step_avg:53.25ms
+step:1293/1490 train_time:68884ms step_avg:53.27ms
+step:1294/1490 train_time:68969ms step_avg:53.30ms
+step:1295/1490 train_time:69049ms step_avg:53.32ms
+step:1296/1490 train_time:69132ms step_avg:53.34ms
+step:1297/1490 train_time:69210ms step_avg:53.36ms
+step:1298/1490 train_time:69294ms step_avg:53.39ms
+step:1299/1490 train_time:69374ms step_avg:53.41ms
+step:1300/1490 train_time:69460ms step_avg:53.43ms
+step:1301/1490 train_time:69540ms step_avg:53.45ms
+step:1302/1490 train_time:69626ms step_avg:53.48ms
+step:1303/1490 train_time:69706ms step_avg:53.50ms
+step:1304/1490 train_time:69791ms step_avg:53.52ms
+step:1305/1490 train_time:69871ms step_avg:53.54ms
+step:1306/1490 train_time:69957ms step_avg:53.57ms
+step:1307/1490 train_time:70036ms step_avg:53.59ms
+step:1308/1490 train_time:70120ms step_avg:53.61ms
+step:1309/1490 train_time:70199ms step_avg:53.63ms
+step:1310/1490 train_time:70282ms step_avg:53.65ms
+step:1311/1490 train_time:70361ms step_avg:53.67ms
+step:1312/1490 train_time:70446ms step_avg:53.69ms
+step:1313/1490 train_time:70527ms step_avg:53.71ms
+step:1314/1490 train_time:70612ms step_avg:53.74ms
+step:1315/1490 train_time:70691ms step_avg:53.76ms
+step:1316/1490 train_time:70776ms step_avg:53.78ms
+step:1317/1490 train_time:70856ms step_avg:53.80ms
+step:1318/1490 train_time:70941ms step_avg:53.82ms
+step:1319/1490 train_time:71019ms step_avg:53.84ms
+step:1320/1490 train_time:71103ms step_avg:53.87ms
+step:1321/1490 train_time:71183ms step_avg:53.89ms
+step:1322/1490 train_time:71268ms step_avg:53.91ms
+step:1323/1490 train_time:71347ms step_avg:53.93ms
+step:1324/1490 train_time:71433ms step_avg:53.95ms
+step:1325/1490 train_time:71512ms step_avg:53.97ms
+step:1326/1490 train_time:71597ms step_avg:53.99ms
+step:1327/1490 train_time:71678ms step_avg:54.02ms
+step:1328/1490 train_time:71763ms step_avg:54.04ms
+step:1329/1490 train_time:71843ms step_avg:54.06ms
+step:1330/1490 train_time:71927ms step_avg:54.08ms
+step:1331/1490 train_time:72008ms step_avg:54.10ms
+step:1332/1490 train_time:72092ms step_avg:54.12ms
+step:1333/1490 train_time:72171ms step_avg:54.14ms
+step:1334/1490 train_time:72256ms step_avg:54.17ms
+step:1335/1490 train_time:72337ms step_avg:54.18ms
+step:1336/1490 train_time:72421ms step_avg:54.21ms
+step:1337/1490 train_time:72500ms step_avg:54.23ms
+step:1338/1490 train_time:72585ms step_avg:54.25ms
+step:1339/1490 train_time:72667ms step_avg:54.27ms
+step:1340/1490 train_time:72752ms step_avg:54.29ms
+step:1341/1490 train_time:72833ms step_avg:54.31ms
+step:1342/1490 train_time:72919ms step_avg:54.34ms
+step:1343/1490 train_time:72997ms step_avg:54.35ms
+step:1344/1490 train_time:73081ms step_avg:54.38ms
+step:1345/1490 train_time:73160ms step_avg:54.39ms
+step:1346/1490 train_time:73246ms step_avg:54.42ms
+step:1347/1490 train_time:73325ms step_avg:54.44ms
+step:1348/1490 train_time:73410ms step_avg:54.46ms
+step:1349/1490 train_time:73489ms step_avg:54.48ms
+step:1350/1490 train_time:73574ms step_avg:54.50ms
+step:1351/1490 train_time:73654ms step_avg:54.52ms
+step:1352/1490 train_time:73740ms step_avg:54.54ms
+step:1353/1490 train_time:73819ms step_avg:54.56ms
+step:1354/1490 train_time:73905ms step_avg:54.58ms
+step:1355/1490 train_time:73983ms step_avg:54.60ms
+step:1356/1490 train_time:74068ms step_avg:54.62ms
+step:1357/1490 train_time:74147ms step_avg:54.64ms
+step:1358/1490 train_time:74232ms step_avg:54.66ms
+step:1359/1490 train_time:74311ms step_avg:54.68ms
+step:1360/1490 train_time:74394ms step_avg:54.70ms
+step:1361/1490 train_time:74474ms step_avg:54.72ms
+step:1362/1490 train_time:74560ms step_avg:54.74ms
+step:1363/1490 train_time:74640ms step_avg:54.76ms
+step:1364/1490 train_time:74725ms step_avg:54.78ms
+step:1365/1490 train_time:74805ms step_avg:54.80ms
+step:1366/1490 train_time:74890ms step_avg:54.82ms
+step:1367/1490 train_time:74972ms step_avg:54.84ms
+step:1368/1490 train_time:75055ms step_avg:54.86ms
+step:1369/1490 train_time:75134ms step_avg:54.88ms
+step:1370/1490 train_time:75220ms step_avg:54.90ms
+step:1371/1490 train_time:75298ms step_avg:54.92ms
+step:1372/1490 train_time:75384ms step_avg:54.94ms
+step:1373/1490 train_time:75463ms step_avg:54.96ms
+step:1374/1490 train_time:75548ms step_avg:54.98ms
+step:1375/1490 train_time:75629ms step_avg:55.00ms
+step:1376/1490 train_time:75712ms step_avg:55.02ms
+step:1377/1490 train_time:75791ms step_avg:55.04ms
+step:1378/1490 train_time:75877ms step_avg:55.06ms
+step:1379/1490 train_time:75957ms step_avg:55.08ms
+step:1380/1490 train_time:76042ms step_avg:55.10ms
+step:1381/1490 train_time:76120ms step_avg:55.12ms
+step:1382/1490 train_time:76205ms step_avg:55.14ms
+step:1383/1490 train_time:76287ms step_avg:55.16ms
+step:1384/1490 train_time:76371ms step_avg:55.18ms
+step:1385/1490 train_time:76451ms step_avg:55.20ms
+step:1386/1490 train_time:76536ms step_avg:55.22ms
+step:1387/1490 train_time:76615ms step_avg:55.24ms
+step:1388/1490 train_time:76700ms step_avg:55.26ms
+step:1389/1490 train_time:76779ms step_avg:55.28ms
+step:1390/1490 train_time:76865ms step_avg:55.30ms
+step:1391/1490 train_time:76945ms step_avg:55.32ms
+step:1392/1490 train_time:77031ms step_avg:55.34ms
+step:1393/1490 train_time:77111ms step_avg:55.36ms
+step:1394/1490 train_time:77195ms step_avg:55.38ms
+step:1395/1490 train_time:77274ms step_avg:55.39ms
+step:1396/1490 train_time:77358ms step_avg:55.41ms
+step:1397/1490 train_time:77438ms step_avg:55.43ms
+step:1398/1490 train_time:77521ms step_avg:55.45ms
+step:1399/1490 train_time:77601ms step_avg:55.47ms
+step:1400/1490 train_time:77686ms step_avg:55.49ms
+step:1401/1490 train_time:77765ms step_avg:55.51ms
+step:1402/1490 train_time:77851ms step_avg:55.53ms
+step:1403/1490 train_time:77931ms step_avg:55.55ms
+step:1404/1490 train_time:78017ms step_avg:55.57ms
+step:1405/1490 train_time:78094ms step_avg:55.58ms
+step:1406/1490 train_time:78180ms step_avg:55.60ms
+step:1407/1490 train_time:78259ms step_avg:55.62ms
+step:1408/1490 train_time:78345ms step_avg:55.64ms
+step:1409/1490 train_time:78425ms step_avg:55.66ms
+step:1410/1490 train_time:78510ms step_avg:55.68ms
+step:1411/1490 train_time:78590ms step_avg:55.70ms
+step:1412/1490 train_time:78675ms step_avg:55.72ms
+step:1413/1490 train_time:78755ms step_avg:55.74ms
+step:1414/1490 train_time:78840ms step_avg:55.76ms
+step:1415/1490 train_time:78920ms step_avg:55.77ms
+step:1416/1490 train_time:79004ms step_avg:55.79ms
+step:1417/1490 train_time:79084ms step_avg:55.81ms
+step:1418/1490 train_time:79169ms step_avg:55.83ms
+step:1419/1490 train_time:79250ms step_avg:55.85ms
+step:1420/1490 train_time:79334ms step_avg:55.87ms
+step:1421/1490 train_time:79413ms step_avg:55.89ms
+step:1422/1490 train_time:79499ms step_avg:55.91ms
+step:1423/1490 train_time:79578ms step_avg:55.92ms
+step:1424/1490 train_time:79663ms step_avg:55.94ms
+step:1425/1490 train_time:79743ms step_avg:55.96ms
+step:1426/1490 train_time:79827ms step_avg:55.98ms
+step:1427/1490 train_time:79907ms step_avg:56.00ms
+step:1428/1490 train_time:79992ms step_avg:56.02ms
+step:1429/1490 train_time:80071ms step_avg:56.03ms
+step:1430/1490 train_time:80155ms step_avg:56.05ms
+step:1431/1490 train_time:80236ms step_avg:56.07ms
+step:1432/1490 train_time:80319ms step_avg:56.09ms
+step:1433/1490 train_time:80399ms step_avg:56.11ms
+step:1434/1490 train_time:80485ms step_avg:56.13ms
+step:1435/1490 train_time:80565ms step_avg:56.14ms
+step:1436/1490 train_time:80650ms step_avg:56.16ms
+step:1437/1490 train_time:80729ms step_avg:56.18ms
+step:1438/1490 train_time:80814ms step_avg:56.20ms
+step:1439/1490 train_time:80892ms step_avg:56.21ms
+step:1440/1490 train_time:80978ms step_avg:56.23ms
+step:1441/1490 train_time:81058ms step_avg:56.25ms
+step:1442/1490 train_time:81144ms step_avg:56.27ms
+step:1443/1490 train_time:81222ms step_avg:56.29ms
+step:1444/1490 train_time:81305ms step_avg:56.31ms
+step:1445/1490 train_time:81387ms step_avg:56.32ms
+step:1446/1490 train_time:81472ms step_avg:56.34ms
+step:1447/1490 train_time:81552ms step_avg:56.36ms
+step:1448/1490 train_time:81637ms step_avg:56.38ms
+step:1449/1490 train_time:81716ms step_avg:56.39ms
+step:1450/1490 train_time:81801ms step_avg:56.41ms
+step:1451/1490 train_time:81884ms step_avg:56.43ms
+step:1452/1490 train_time:81970ms step_avg:56.45ms
+step:1453/1490 train_time:82050ms step_avg:56.47ms
+step:1454/1490 train_time:82137ms step_avg:56.49ms
+step:1455/1490 train_time:82216ms step_avg:56.51ms
+step:1456/1490 train_time:82301ms step_avg:56.53ms
+step:1457/1490 train_time:82380ms step_avg:56.54ms
+step:1458/1490 train_time:82467ms step_avg:56.56ms
+step:1459/1490 train_time:82547ms step_avg:56.58ms
+step:1460/1490 train_time:82634ms step_avg:56.60ms
+step:1461/1490 train_time:82714ms step_avg:56.61ms
+step:1462/1490 train_time:82798ms step_avg:56.63ms
+step:1463/1490 train_time:82878ms step_avg:56.65ms
+step:1464/1490 train_time:82963ms step_avg:56.67ms
+step:1465/1490 train_time:83044ms step_avg:56.69ms
+step:1466/1490 train_time:83131ms step_avg:56.71ms
+step:1467/1490 train_time:83211ms step_avg:56.72ms
+step:1468/1490 train_time:83298ms step_avg:56.74ms
+step:1469/1490 train_time:83377ms step_avg:56.76ms
+step:1470/1490 train_time:83460ms step_avg:56.78ms
+step:1471/1490 train_time:83541ms step_avg:56.79ms
+step:1472/1490 train_time:83626ms step_avg:56.81ms
+step:1473/1490 train_time:83707ms step_avg:56.83ms
+step:1474/1490 train_time:83791ms step_avg:56.85ms
+step:1475/1490 train_time:83871ms step_avg:56.86ms
+step:1476/1490 train_time:83956ms step_avg:56.88ms
+step:1477/1490 train_time:84035ms step_avg:56.90ms
+step:1478/1490 train_time:84121ms step_avg:56.92ms
+step:1479/1490 train_time:84201ms step_avg:56.93ms
+step:1480/1490 train_time:84287ms step_avg:56.95ms
+step:1481/1490 train_time:84367ms step_avg:56.97ms
+step:1482/1490 train_time:84452ms step_avg:56.99ms
+step:1483/1490 train_time:84532ms step_avg:57.00ms
+step:1484/1490 train_time:84616ms step_avg:57.02ms
+step:1485/1490 train_time:84695ms step_avg:57.03ms
+step:1486/1490 train_time:84780ms step_avg:57.05ms
+step:1487/1490 train_time:84859ms step_avg:57.07ms
+step:1488/1490 train_time:84945ms step_avg:57.09ms
+step:1489/1490 train_time:85025ms step_avg:57.10ms
+step:1490/1490 train_time:85110ms step_avg:57.12ms
+step:1490/1490 val_loss:3.2787 train_time:85213ms step_avg:57.19ms
+peak memory allocated: 31296 MiB reserved: 46782 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/b93fd2a6-4b75-44e3-b8b1-a1fb1164aaa0.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/b93fd2a6-4b75-44e3-b8b1-a1fb1164aaa0.txt
@@ -1,0 +1,4681 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 21:25:35 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   33C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   33C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8330 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:80ms step_avg:80.05ms
+step:2/1490 train_time:107ms step_avg:53.29ms
+step:3/1490 train_time:124ms step_avg:41.37ms
+step:4/1490 train_time:157ms step_avg:39.23ms
+step:5/1490 train_time:176ms step_avg:35.10ms
+step:6/1490 train_time:210ms step_avg:34.95ms
+step:7/1490 train_time:237ms step_avg:33.82ms
+step:8/1490 train_time:271ms step_avg:33.88ms
+step:9/1490 train_time:298ms step_avg:33.14ms
+step:10/1490 train_time:332ms step_avg:33.24ms
+step:11/1490 train_time:360ms step_avg:32.70ms
+step:12/1490 train_time:394ms step_avg:32.81ms
+step:13/1490 train_time:421ms step_avg:32.39ms
+step:14/1490 train_time:455ms step_avg:32.52ms
+step:15/1490 train_time:483ms step_avg:32.19ms
+step:16/1490 train_time:517ms step_avg:32.30ms
+step:17/1490 train_time:544ms step_avg:32.01ms
+step:18/1490 train_time:578ms step_avg:32.11ms
+step:19/1490 train_time:605ms step_avg:31.86ms
+step:20/1490 train_time:639ms step_avg:31.96ms
+step:21/1490 train_time:666ms step_avg:31.74ms
+step:22/1490 train_time:700ms step_avg:31.84ms
+step:23/1490 train_time:728ms step_avg:31.66ms
+step:24/1490 train_time:762ms step_avg:31.74ms
+step:25/1490 train_time:790ms step_avg:31.58ms
+step:26/1490 train_time:823ms step_avg:31.67ms
+step:27/1490 train_time:851ms step_avg:31.52ms
+step:28/1490 train_time:885ms step_avg:31.59ms
+step:29/1490 train_time:913ms step_avg:31.47ms
+step:30/1490 train_time:946ms step_avg:31.54ms
+step:31/1490 train_time:974ms step_avg:31.42ms
+step:32/1490 train_time:1010ms step_avg:31.56ms
+step:33/1490 train_time:1037ms step_avg:31.44ms
+step:34/1490 train_time:1073ms step_avg:31.55ms
+step:35/1490 train_time:1100ms step_avg:31.43ms
+step:36/1490 train_time:1135ms step_avg:31.52ms
+step:37/1490 train_time:1162ms step_avg:31.41ms
+step:38/1490 train_time:1197ms step_avg:31.50ms
+step:39/1490 train_time:1224ms step_avg:31.38ms
+step:40/1490 train_time:1258ms step_avg:31.45ms
+step:41/1490 train_time:1285ms step_avg:31.34ms
+step:42/1490 train_time:1321ms step_avg:31.46ms
+step:43/1490 train_time:1347ms step_avg:31.32ms
+step:44/1490 train_time:1381ms step_avg:31.38ms
+step:45/1490 train_time:1408ms step_avg:31.29ms
+step:46/1490 train_time:1442ms step_avg:31.35ms
+step:47/1490 train_time:1470ms step_avg:31.28ms
+step:48/1490 train_time:1504ms step_avg:31.33ms
+step:49/1490 train_time:1532ms step_avg:31.26ms
+step:50/1490 train_time:1565ms step_avg:31.30ms
+step:51/1490 train_time:1593ms step_avg:31.23ms
+step:52/1490 train_time:1626ms step_avg:31.27ms
+step:53/1490 train_time:1654ms step_avg:31.20ms
+step:54/1490 train_time:1687ms step_avg:31.25ms
+step:55/1490 train_time:1715ms step_avg:31.18ms
+step:56/1490 train_time:1749ms step_avg:31.23ms
+step:57/1490 train_time:1776ms step_avg:31.17ms
+step:58/1490 train_time:1810ms step_avg:31.21ms
+step:59/1490 train_time:1838ms step_avg:31.16ms
+step:60/1490 train_time:1872ms step_avg:31.20ms
+step:61/1490 train_time:1899ms step_avg:31.13ms
+step:62/1490 train_time:1933ms step_avg:31.18ms
+step:63/1490 train_time:1961ms step_avg:31.13ms
+step:64/1490 train_time:1998ms step_avg:31.21ms
+step:65/1490 train_time:2023ms step_avg:31.12ms
+step:66/1490 train_time:2057ms step_avg:31.17ms
+step:67/1490 train_time:2084ms step_avg:31.11ms
+step:68/1490 train_time:2118ms step_avg:31.15ms
+step:69/1490 train_time:2146ms step_avg:31.10ms
+step:70/1490 train_time:2180ms step_avg:31.14ms
+step:71/1490 train_time:2207ms step_avg:31.09ms
+step:72/1490 train_time:2241ms step_avg:31.13ms
+step:73/1490 train_time:2269ms step_avg:31.08ms
+step:74/1490 train_time:2303ms step_avg:31.12ms
+step:75/1490 train_time:2331ms step_avg:31.08ms
+step:76/1490 train_time:2365ms step_avg:31.11ms
+step:77/1490 train_time:2392ms step_avg:31.07ms
+step:78/1490 train_time:2426ms step_avg:31.11ms
+step:79/1490 train_time:2454ms step_avg:31.06ms
+step:80/1490 train_time:2488ms step_avg:31.10ms
+step:81/1490 train_time:2516ms step_avg:31.06ms
+step:82/1490 train_time:2549ms step_avg:31.09ms
+step:83/1490 train_time:2577ms step_avg:31.05ms
+step:84/1490 train_time:2612ms step_avg:31.09ms
+step:85/1490 train_time:2639ms step_avg:31.04ms
+step:86/1490 train_time:2673ms step_avg:31.08ms
+step:87/1490 train_time:2700ms step_avg:31.04ms
+step:88/1490 train_time:2734ms step_avg:31.07ms
+step:89/1490 train_time:2761ms step_avg:31.03ms
+step:90/1490 train_time:2795ms step_avg:31.06ms
+step:91/1490 train_time:2823ms step_avg:31.02ms
+step:92/1490 train_time:2856ms step_avg:31.05ms
+step:93/1490 train_time:2883ms step_avg:31.00ms
+step:94/1490 train_time:2917ms step_avg:31.03ms
+step:95/1490 train_time:2944ms step_avg:30.99ms
+step:96/1490 train_time:2979ms step_avg:31.03ms
+step:97/1490 train_time:3006ms step_avg:30.99ms
+step:98/1490 train_time:3040ms step_avg:31.02ms
+step:99/1490 train_time:3067ms step_avg:30.98ms
+step:100/1490 train_time:3101ms step_avg:31.01ms
+step:101/1490 train_time:3129ms step_avg:30.98ms
+step:102/1490 train_time:3163ms step_avg:31.01ms
+step:103/1490 train_time:3190ms step_avg:30.98ms
+step:104/1490 train_time:3224ms step_avg:31.00ms
+step:105/1490 train_time:3252ms step_avg:30.97ms
+step:106/1490 train_time:3286ms step_avg:31.00ms
+step:107/1490 train_time:3314ms step_avg:30.97ms
+step:108/1490 train_time:3347ms step_avg:30.99ms
+step:109/1490 train_time:3375ms step_avg:30.96ms
+step:110/1490 train_time:3409ms step_avg:30.99ms
+step:111/1490 train_time:3436ms step_avg:30.95ms
+step:112/1490 train_time:3470ms step_avg:30.98ms
+step:113/1490 train_time:3497ms step_avg:30.95ms
+step:114/1490 train_time:3531ms step_avg:30.98ms
+step:115/1490 train_time:3559ms step_avg:30.95ms
+step:116/1490 train_time:3594ms step_avg:30.98ms
+step:117/1490 train_time:3621ms step_avg:30.95ms
+step:118/1490 train_time:3655ms step_avg:30.98ms
+step:119/1490 train_time:3682ms step_avg:30.95ms
+step:120/1490 train_time:3716ms step_avg:30.97ms
+step:121/1490 train_time:3744ms step_avg:30.94ms
+step:122/1490 train_time:3778ms step_avg:30.96ms
+step:123/1490 train_time:3805ms step_avg:30.94ms
+step:124/1490 train_time:3839ms step_avg:30.96ms
+step:125/1490 train_time:3867ms step_avg:30.94ms
+step:126/1490 train_time:3901ms step_avg:30.96ms
+step:127/1490 train_time:3929ms step_avg:30.94ms
+step:128/1490 train_time:3963ms step_avg:30.96ms
+step:129/1490 train_time:3990ms step_avg:30.93ms
+step:130/1490 train_time:4024ms step_avg:30.96ms
+step:131/1490 train_time:4052ms step_avg:30.93ms
+step:132/1490 train_time:4086ms step_avg:30.95ms
+step:133/1490 train_time:4113ms step_avg:30.93ms
+step:134/1490 train_time:4147ms step_avg:30.95ms
+step:135/1490 train_time:4174ms step_avg:30.92ms
+step:136/1490 train_time:4208ms step_avg:30.94ms
+step:137/1490 train_time:4236ms step_avg:30.92ms
+step:138/1490 train_time:4270ms step_avg:30.94ms
+step:139/1490 train_time:4297ms step_avg:30.92ms
+step:140/1490 train_time:4331ms step_avg:30.94ms
+step:141/1490 train_time:4359ms step_avg:30.92ms
+step:142/1490 train_time:4393ms step_avg:30.94ms
+step:143/1490 train_time:4420ms step_avg:30.91ms
+step:144/1490 train_time:4454ms step_avg:30.93ms
+step:145/1490 train_time:4482ms step_avg:30.91ms
+step:146/1490 train_time:4516ms step_avg:30.93ms
+step:147/1490 train_time:4543ms step_avg:30.91ms
+step:148/1490 train_time:4577ms step_avg:30.93ms
+step:149/1490 train_time:4604ms step_avg:30.90ms
+step:150/1490 train_time:4638ms step_avg:30.92ms
+step:151/1490 train_time:4666ms step_avg:30.90ms
+step:152/1490 train_time:4700ms step_avg:30.92ms
+step:153/1490 train_time:4727ms step_avg:30.90ms
+step:154/1490 train_time:4761ms step_avg:30.92ms
+step:155/1490 train_time:4789ms step_avg:30.90ms
+step:156/1490 train_time:4823ms step_avg:30.91ms
+step:157/1490 train_time:4850ms step_avg:30.89ms
+step:158/1490 train_time:4884ms step_avg:30.91ms
+step:159/1490 train_time:4912ms step_avg:30.89ms
+step:160/1490 train_time:4946ms step_avg:30.91ms
+step:161/1490 train_time:4974ms step_avg:30.89ms
+step:162/1490 train_time:5008ms step_avg:30.91ms
+step:163/1490 train_time:5035ms step_avg:30.89ms
+step:164/1490 train_time:5069ms step_avg:30.91ms
+step:165/1490 train_time:5097ms step_avg:30.89ms
+step:166/1490 train_time:5131ms step_avg:30.91ms
+step:167/1490 train_time:5158ms step_avg:30.89ms
+step:168/1490 train_time:5192ms step_avg:30.91ms
+step:169/1490 train_time:5219ms step_avg:30.88ms
+step:170/1490 train_time:5253ms step_avg:30.90ms
+step:171/1490 train_time:5281ms step_avg:30.88ms
+step:172/1490 train_time:5315ms step_avg:30.90ms
+step:173/1490 train_time:5342ms step_avg:30.88ms
+step:174/1490 train_time:5376ms step_avg:30.90ms
+step:175/1490 train_time:5403ms step_avg:30.88ms
+step:176/1490 train_time:5438ms step_avg:30.90ms
+step:177/1490 train_time:5465ms step_avg:30.88ms
+step:178/1490 train_time:5499ms step_avg:30.89ms
+step:179/1490 train_time:5526ms step_avg:30.87ms
+step:180/1490 train_time:5560ms step_avg:30.89ms
+step:181/1490 train_time:5588ms step_avg:30.87ms
+step:182/1490 train_time:5621ms step_avg:30.89ms
+step:183/1490 train_time:5649ms step_avg:30.87ms
+step:184/1490 train_time:5683ms step_avg:30.88ms
+step:185/1490 train_time:5711ms step_avg:30.87ms
+step:186/1490 train_time:5745ms step_avg:30.89ms
+step:187/1490 train_time:5772ms step_avg:30.87ms
+step:188/1490 train_time:5806ms step_avg:30.88ms
+step:189/1490 train_time:5833ms step_avg:30.86ms
+step:190/1490 train_time:5867ms step_avg:30.88ms
+step:191/1490 train_time:5895ms step_avg:30.86ms
+step:192/1490 train_time:5928ms step_avg:30.88ms
+step:193/1490 train_time:5956ms step_avg:30.86ms
+step:194/1490 train_time:5990ms step_avg:30.88ms
+step:195/1490 train_time:6018ms step_avg:30.86ms
+step:196/1490 train_time:6052ms step_avg:30.88ms
+step:197/1490 train_time:6079ms step_avg:30.86ms
+step:198/1490 train_time:6113ms step_avg:30.88ms
+step:199/1490 train_time:6141ms step_avg:30.86ms
+step:200/1490 train_time:6174ms step_avg:30.87ms
+step:201/1490 train_time:6202ms step_avg:30.85ms
+step:202/1490 train_time:6236ms step_avg:30.87ms
+step:203/1490 train_time:6264ms step_avg:30.86ms
+step:204/1490 train_time:6298ms step_avg:30.87ms
+step:205/1490 train_time:6325ms step_avg:30.85ms
+step:206/1490 train_time:6359ms step_avg:30.87ms
+step:207/1490 train_time:6387ms step_avg:30.85ms
+step:208/1490 train_time:6421ms step_avg:30.87ms
+step:209/1490 train_time:6448ms step_avg:30.85ms
+step:210/1490 train_time:6482ms step_avg:30.87ms
+step:211/1490 train_time:6509ms step_avg:30.85ms
+step:212/1490 train_time:6543ms step_avg:30.86ms
+step:213/1490 train_time:6571ms step_avg:30.85ms
+step:214/1490 train_time:6606ms step_avg:30.87ms
+step:215/1490 train_time:6632ms step_avg:30.85ms
+step:216/1490 train_time:6667ms step_avg:30.86ms
+step:217/1490 train_time:6694ms step_avg:30.85ms
+step:218/1490 train_time:6728ms step_avg:30.86ms
+step:219/1490 train_time:6755ms step_avg:30.85ms
+step:220/1490 train_time:6790ms step_avg:30.86ms
+step:221/1490 train_time:6817ms step_avg:30.85ms
+step:222/1490 train_time:6851ms step_avg:30.86ms
+step:223/1490 train_time:6878ms step_avg:30.84ms
+step:224/1490 train_time:6913ms step_avg:30.86ms
+step:225/1490 train_time:6940ms step_avg:30.84ms
+step:226/1490 train_time:6974ms step_avg:30.86ms
+step:227/1490 train_time:7001ms step_avg:30.84ms
+step:228/1490 train_time:7035ms step_avg:30.86ms
+step:229/1490 train_time:7063ms step_avg:30.84ms
+step:230/1490 train_time:7096ms step_avg:30.85ms
+step:231/1490 train_time:7124ms step_avg:30.84ms
+step:232/1490 train_time:7158ms step_avg:30.85ms
+step:233/1490 train_time:7185ms step_avg:30.84ms
+step:234/1490 train_time:7219ms step_avg:30.85ms
+step:235/1490 train_time:7247ms step_avg:30.84ms
+step:236/1490 train_time:7281ms step_avg:30.85ms
+step:237/1490 train_time:7308ms step_avg:30.84ms
+step:238/1490 train_time:7342ms step_avg:30.85ms
+step:239/1490 train_time:7370ms step_avg:30.84ms
+step:240/1490 train_time:7403ms step_avg:30.85ms
+step:241/1490 train_time:7431ms step_avg:30.83ms
+step:242/1490 train_time:7465ms step_avg:30.85ms
+step:243/1490 train_time:7492ms step_avg:30.83ms
+step:244/1490 train_time:7526ms step_avg:30.85ms
+step:245/1490 train_time:7554ms step_avg:30.83ms
+step:246/1490 train_time:7587ms step_avg:30.84ms
+step:247/1490 train_time:7615ms step_avg:30.83ms
+step:248/1490 train_time:7649ms step_avg:30.84ms
+step:249/1490 train_time:7676ms step_avg:30.83ms
+step:250/1490 train_time:7710ms step_avg:30.84ms
+step:250/1490 val_loss:4.5146 train_time:7752ms step_avg:31.01ms
+step:251/1490 train_time:7775ms step_avg:30.98ms
+step:252/1490 train_time:7795ms step_avg:30.93ms
+step:253/1490 train_time:7809ms step_avg:30.87ms
+step:254/1490 train_time:7838ms step_avg:30.86ms
+step:255/1490 train_time:7867ms step_avg:30.85ms
+step:256/1490 train_time:7902ms step_avg:30.87ms
+step:257/1490 train_time:7930ms step_avg:30.86ms
+step:258/1490 train_time:7964ms step_avg:30.87ms
+step:259/1490 train_time:7991ms step_avg:30.85ms
+step:260/1490 train_time:8026ms step_avg:30.87ms
+step:261/1490 train_time:8053ms step_avg:30.85ms
+step:262/1490 train_time:8087ms step_avg:30.86ms
+step:263/1490 train_time:8114ms step_avg:30.85ms
+step:264/1490 train_time:8148ms step_avg:30.86ms
+step:265/1490 train_time:8175ms step_avg:30.85ms
+step:266/1490 train_time:8209ms step_avg:30.86ms
+step:267/1490 train_time:8236ms step_avg:30.85ms
+step:268/1490 train_time:8270ms step_avg:30.86ms
+step:269/1490 train_time:8297ms step_avg:30.84ms
+step:270/1490 train_time:8331ms step_avg:30.86ms
+step:271/1490 train_time:8359ms step_avg:30.85ms
+step:272/1490 train_time:8393ms step_avg:30.86ms
+step:273/1490 train_time:8420ms step_avg:30.84ms
+step:274/1490 train_time:8454ms step_avg:30.85ms
+step:275/1490 train_time:8481ms step_avg:30.84ms
+step:276/1490 train_time:8515ms step_avg:30.85ms
+step:277/1490 train_time:8543ms step_avg:30.84ms
+step:278/1490 train_time:8576ms step_avg:30.85ms
+step:279/1490 train_time:8604ms step_avg:30.84ms
+step:280/1490 train_time:8637ms step_avg:30.85ms
+step:281/1490 train_time:8665ms step_avg:30.84ms
+step:282/1490 train_time:8698ms step_avg:30.85ms
+step:283/1490 train_time:8726ms step_avg:30.83ms
+step:284/1490 train_time:8760ms step_avg:30.85ms
+step:285/1490 train_time:8788ms step_avg:30.84ms
+step:286/1490 train_time:8823ms step_avg:30.85ms
+step:287/1490 train_time:8850ms step_avg:30.84ms
+step:288/1490 train_time:8885ms step_avg:30.85ms
+step:289/1490 train_time:8912ms step_avg:30.84ms
+step:290/1490 train_time:8947ms step_avg:30.85ms
+step:291/1490 train_time:8975ms step_avg:30.84ms
+step:292/1490 train_time:9009ms step_avg:30.85ms
+step:293/1490 train_time:9036ms step_avg:30.84ms
+step:294/1490 train_time:9071ms step_avg:30.85ms
+step:295/1490 train_time:9099ms step_avg:30.84ms
+step:296/1490 train_time:9133ms step_avg:30.85ms
+step:297/1490 train_time:9160ms step_avg:30.84ms
+step:298/1490 train_time:9194ms step_avg:30.85ms
+step:299/1490 train_time:9222ms step_avg:30.84ms
+step:300/1490 train_time:9255ms step_avg:30.85ms
+step:301/1490 train_time:9283ms step_avg:30.84ms
+step:302/1490 train_time:9317ms step_avg:30.85ms
+step:303/1490 train_time:9345ms step_avg:30.84ms
+step:304/1490 train_time:9379ms step_avg:30.85ms
+step:305/1490 train_time:9406ms step_avg:30.84ms
+step:306/1490 train_time:9440ms step_avg:30.85ms
+step:307/1490 train_time:9468ms step_avg:30.84ms
+step:308/1490 train_time:9501ms step_avg:30.85ms
+step:309/1490 train_time:9529ms step_avg:30.84ms
+step:310/1490 train_time:9563ms step_avg:30.85ms
+step:311/1490 train_time:9590ms step_avg:30.84ms
+step:312/1490 train_time:9624ms step_avg:30.85ms
+step:313/1490 train_time:9652ms step_avg:30.84ms
+step:314/1490 train_time:9686ms step_avg:30.85ms
+step:315/1490 train_time:9713ms step_avg:30.83ms
+step:316/1490 train_time:9747ms step_avg:30.85ms
+step:317/1490 train_time:9775ms step_avg:30.83ms
+step:318/1490 train_time:9809ms step_avg:30.84ms
+step:319/1490 train_time:9836ms step_avg:30.83ms
+step:320/1490 train_time:9871ms step_avg:30.85ms
+step:321/1490 train_time:9898ms step_avg:30.84ms
+step:322/1490 train_time:9932ms step_avg:30.85ms
+step:323/1490 train_time:9960ms step_avg:30.83ms
+step:324/1490 train_time:9993ms step_avg:30.84ms
+step:325/1490 train_time:10021ms step_avg:30.84ms
+step:326/1490 train_time:10055ms step_avg:30.84ms
+step:327/1490 train_time:10083ms step_avg:30.83ms
+step:328/1490 train_time:10117ms step_avg:30.84ms
+step:329/1490 train_time:10145ms step_avg:30.83ms
+step:330/1490 train_time:10178ms step_avg:30.84ms
+step:331/1490 train_time:10206ms step_avg:30.83ms
+step:332/1490 train_time:10240ms step_avg:30.84ms
+step:333/1490 train_time:10268ms step_avg:30.83ms
+step:334/1490 train_time:10301ms step_avg:30.84ms
+step:335/1490 train_time:10329ms step_avg:30.83ms
+step:336/1490 train_time:10363ms step_avg:30.84ms
+step:337/1490 train_time:10391ms step_avg:30.83ms
+step:338/1490 train_time:10425ms step_avg:30.84ms
+step:339/1490 train_time:10452ms step_avg:30.83ms
+step:340/1490 train_time:10486ms step_avg:30.84ms
+step:341/1490 train_time:10513ms step_avg:30.83ms
+step:342/1490 train_time:10547ms step_avg:30.84ms
+step:343/1490 train_time:10574ms step_avg:30.83ms
+step:344/1490 train_time:10608ms step_avg:30.84ms
+step:345/1490 train_time:10636ms step_avg:30.83ms
+step:346/1490 train_time:10669ms step_avg:30.84ms
+step:347/1490 train_time:10697ms step_avg:30.83ms
+step:348/1490 train_time:10730ms step_avg:30.83ms
+step:349/1490 train_time:10758ms step_avg:30.83ms
+step:350/1490 train_time:10793ms step_avg:30.84ms
+step:351/1490 train_time:10820ms step_avg:30.83ms
+step:352/1490 train_time:10854ms step_avg:30.83ms
+step:353/1490 train_time:10882ms step_avg:30.83ms
+step:354/1490 train_time:10916ms step_avg:30.84ms
+step:355/1490 train_time:10943ms step_avg:30.83ms
+step:356/1490 train_time:10977ms step_avg:30.84ms
+step:357/1490 train_time:11005ms step_avg:30.83ms
+step:358/1490 train_time:11039ms step_avg:30.83ms
+step:359/1490 train_time:11067ms step_avg:30.83ms
+step:360/1490 train_time:11101ms step_avg:30.84ms
+step:361/1490 train_time:11128ms step_avg:30.83ms
+step:362/1490 train_time:11163ms step_avg:30.84ms
+step:363/1490 train_time:11190ms step_avg:30.83ms
+step:364/1490 train_time:11224ms step_avg:30.84ms
+step:365/1490 train_time:11252ms step_avg:30.83ms
+step:366/1490 train_time:11286ms step_avg:30.84ms
+step:367/1490 train_time:11313ms step_avg:30.83ms
+step:368/1490 train_time:11347ms step_avg:30.83ms
+step:369/1490 train_time:11375ms step_avg:30.83ms
+step:370/1490 train_time:11409ms step_avg:30.83ms
+step:371/1490 train_time:11436ms step_avg:30.83ms
+step:372/1490 train_time:11470ms step_avg:30.83ms
+step:373/1490 train_time:11497ms step_avg:30.82ms
+step:374/1490 train_time:11531ms step_avg:30.83ms
+step:375/1490 train_time:11559ms step_avg:30.82ms
+step:376/1490 train_time:11593ms step_avg:30.83ms
+step:377/1490 train_time:11621ms step_avg:30.82ms
+step:378/1490 train_time:11654ms step_avg:30.83ms
+step:379/1490 train_time:11682ms step_avg:30.82ms
+step:380/1490 train_time:11715ms step_avg:30.83ms
+step:381/1490 train_time:11743ms step_avg:30.82ms
+step:382/1490 train_time:11777ms step_avg:30.83ms
+step:383/1490 train_time:11804ms step_avg:30.82ms
+step:384/1490 train_time:11838ms step_avg:30.83ms
+step:385/1490 train_time:11866ms step_avg:30.82ms
+step:386/1490 train_time:11900ms step_avg:30.83ms
+step:387/1490 train_time:11927ms step_avg:30.82ms
+step:388/1490 train_time:11961ms step_avg:30.83ms
+step:389/1490 train_time:11989ms step_avg:30.82ms
+step:390/1490 train_time:12023ms step_avg:30.83ms
+step:391/1490 train_time:12051ms step_avg:30.82ms
+step:392/1490 train_time:12085ms step_avg:30.83ms
+step:393/1490 train_time:12112ms step_avg:30.82ms
+step:394/1490 train_time:12147ms step_avg:30.83ms
+step:395/1490 train_time:12174ms step_avg:30.82ms
+step:396/1490 train_time:12208ms step_avg:30.83ms
+step:397/1490 train_time:12236ms step_avg:30.82ms
+step:398/1490 train_time:12270ms step_avg:30.83ms
+step:399/1490 train_time:12297ms step_avg:30.82ms
+step:400/1490 train_time:12331ms step_avg:30.83ms
+step:401/1490 train_time:12359ms step_avg:30.82ms
+step:402/1490 train_time:12393ms step_avg:30.83ms
+step:403/1490 train_time:12421ms step_avg:30.82ms
+step:404/1490 train_time:12455ms step_avg:30.83ms
+step:405/1490 train_time:12483ms step_avg:30.82ms
+step:406/1490 train_time:12516ms step_avg:30.83ms
+step:407/1490 train_time:12544ms step_avg:30.82ms
+step:408/1490 train_time:12578ms step_avg:30.83ms
+step:409/1490 train_time:12606ms step_avg:30.82ms
+step:410/1490 train_time:12640ms step_avg:30.83ms
+step:411/1490 train_time:12667ms step_avg:30.82ms
+step:412/1490 train_time:12702ms step_avg:30.83ms
+step:413/1490 train_time:12729ms step_avg:30.82ms
+step:414/1490 train_time:12764ms step_avg:30.83ms
+step:415/1490 train_time:12791ms step_avg:30.82ms
+step:416/1490 train_time:12825ms step_avg:30.83ms
+step:417/1490 train_time:12853ms step_avg:30.82ms
+step:418/1490 train_time:12887ms step_avg:30.83ms
+step:419/1490 train_time:12914ms step_avg:30.82ms
+step:420/1490 train_time:12948ms step_avg:30.83ms
+step:421/1490 train_time:12976ms step_avg:30.82ms
+step:422/1490 train_time:13009ms step_avg:30.83ms
+step:423/1490 train_time:13037ms step_avg:30.82ms
+step:424/1490 train_time:13071ms step_avg:30.83ms
+step:425/1490 train_time:13099ms step_avg:30.82ms
+step:426/1490 train_time:13133ms step_avg:30.83ms
+step:427/1490 train_time:13161ms step_avg:30.82ms
+step:428/1490 train_time:13194ms step_avg:30.83ms
+step:429/1490 train_time:13223ms step_avg:30.82ms
+step:430/1490 train_time:13256ms step_avg:30.83ms
+step:431/1490 train_time:13284ms step_avg:30.82ms
+step:432/1490 train_time:13317ms step_avg:30.83ms
+step:433/1490 train_time:13345ms step_avg:30.82ms
+step:434/1490 train_time:13379ms step_avg:30.83ms
+step:435/1490 train_time:13407ms step_avg:30.82ms
+step:436/1490 train_time:13441ms step_avg:30.83ms
+step:437/1490 train_time:13469ms step_avg:30.82ms
+step:438/1490 train_time:13503ms step_avg:30.83ms
+step:439/1490 train_time:13531ms step_avg:30.82ms
+step:440/1490 train_time:13565ms step_avg:30.83ms
+step:441/1490 train_time:13592ms step_avg:30.82ms
+step:442/1490 train_time:13626ms step_avg:30.83ms
+step:443/1490 train_time:13654ms step_avg:30.82ms
+step:444/1490 train_time:13688ms step_avg:30.83ms
+step:445/1490 train_time:13715ms step_avg:30.82ms
+step:446/1490 train_time:13749ms step_avg:30.83ms
+step:447/1490 train_time:13776ms step_avg:30.82ms
+step:448/1490 train_time:13810ms step_avg:30.83ms
+step:449/1490 train_time:13837ms step_avg:30.82ms
+step:450/1490 train_time:13871ms step_avg:30.83ms
+step:451/1490 train_time:13899ms step_avg:30.82ms
+step:452/1490 train_time:13933ms step_avg:30.83ms
+step:453/1490 train_time:13961ms step_avg:30.82ms
+step:454/1490 train_time:13995ms step_avg:30.83ms
+step:455/1490 train_time:14022ms step_avg:30.82ms
+step:456/1490 train_time:14056ms step_avg:30.82ms
+step:457/1490 train_time:14084ms step_avg:30.82ms
+step:458/1490 train_time:14117ms step_avg:30.82ms
+step:459/1490 train_time:14146ms step_avg:30.82ms
+step:460/1490 train_time:14179ms step_avg:30.82ms
+step:461/1490 train_time:14207ms step_avg:30.82ms
+step:462/1490 train_time:14242ms step_avg:30.83ms
+step:463/1490 train_time:14269ms step_avg:30.82ms
+step:464/1490 train_time:14303ms step_avg:30.83ms
+step:465/1490 train_time:14331ms step_avg:30.82ms
+step:466/1490 train_time:14365ms step_avg:30.83ms
+step:467/1490 train_time:14392ms step_avg:30.82ms
+step:468/1490 train_time:14427ms step_avg:30.83ms
+step:469/1490 train_time:14454ms step_avg:30.82ms
+step:470/1490 train_time:14488ms step_avg:30.83ms
+step:471/1490 train_time:14515ms step_avg:30.82ms
+step:472/1490 train_time:14549ms step_avg:30.82ms
+step:473/1490 train_time:14577ms step_avg:30.82ms
+step:474/1490 train_time:14611ms step_avg:30.82ms
+step:475/1490 train_time:14638ms step_avg:30.82ms
+step:476/1490 train_time:14672ms step_avg:30.82ms
+step:477/1490 train_time:14700ms step_avg:30.82ms
+step:478/1490 train_time:14733ms step_avg:30.82ms
+step:479/1490 train_time:14761ms step_avg:30.82ms
+step:480/1490 train_time:14795ms step_avg:30.82ms
+step:481/1490 train_time:14823ms step_avg:30.82ms
+step:482/1490 train_time:14856ms step_avg:30.82ms
+step:483/1490 train_time:14884ms step_avg:30.82ms
+step:484/1490 train_time:14920ms step_avg:30.83ms
+step:485/1490 train_time:14971ms step_avg:30.87ms
+step:486/1490 train_time:15030ms step_avg:30.93ms
+step:487/1490 train_time:15083ms step_avg:30.97ms
+step:488/1490 train_time:15142ms step_avg:31.03ms
+step:489/1490 train_time:15196ms step_avg:31.07ms
+step:490/1490 train_time:15254ms step_avg:31.13ms
+step:491/1490 train_time:15308ms step_avg:31.18ms
+step:492/1490 train_time:15368ms step_avg:31.24ms
+step:493/1490 train_time:15421ms step_avg:31.28ms
+step:494/1490 train_time:15481ms step_avg:31.34ms
+step:495/1490 train_time:15534ms step_avg:31.38ms
+step:496/1490 train_time:15595ms step_avg:31.44ms
+step:497/1490 train_time:15648ms step_avg:31.49ms
+step:498/1490 train_time:15707ms step_avg:31.54ms
+step:499/1490 train_time:15760ms step_avg:31.58ms
+step:500/1490 train_time:15819ms step_avg:31.64ms
+step:500/1490 val_loss:4.2259 train_time:15890ms step_avg:31.78ms
+step:501/1490 train_time:15914ms step_avg:31.76ms
+step:502/1490 train_time:15936ms step_avg:31.75ms
+step:503/1490 train_time:15995ms step_avg:31.80ms
+step:504/1490 train_time:16056ms step_avg:31.86ms
+step:505/1490 train_time:16111ms step_avg:31.90ms
+step:506/1490 train_time:16171ms step_avg:31.96ms
+step:507/1490 train_time:16224ms step_avg:32.00ms
+step:508/1490 train_time:16282ms step_avg:32.05ms
+step:509/1490 train_time:16336ms step_avg:32.09ms
+step:510/1490 train_time:16395ms step_avg:32.15ms
+step:511/1490 train_time:16447ms step_avg:32.19ms
+step:512/1490 train_time:16505ms step_avg:32.24ms
+step:513/1490 train_time:16558ms step_avg:32.28ms
+step:514/1490 train_time:16617ms step_avg:32.33ms
+step:515/1490 train_time:16670ms step_avg:32.37ms
+step:516/1490 train_time:16728ms step_avg:32.42ms
+step:517/1490 train_time:16780ms step_avg:32.46ms
+step:518/1490 train_time:16839ms step_avg:32.51ms
+step:519/1490 train_time:16894ms step_avg:32.55ms
+step:520/1490 train_time:16955ms step_avg:32.61ms
+step:521/1490 train_time:17011ms step_avg:32.65ms
+step:522/1490 train_time:17071ms step_avg:32.70ms
+step:523/1490 train_time:17126ms step_avg:32.75ms
+step:524/1490 train_time:17185ms step_avg:32.80ms
+step:525/1490 train_time:17239ms step_avg:32.84ms
+step:526/1490 train_time:17297ms step_avg:32.88ms
+step:527/1490 train_time:17351ms step_avg:32.92ms
+step:528/1490 train_time:17409ms step_avg:32.97ms
+step:529/1490 train_time:17463ms step_avg:33.01ms
+step:530/1490 train_time:17522ms step_avg:33.06ms
+step:531/1490 train_time:17575ms step_avg:33.10ms
+step:532/1490 train_time:17633ms step_avg:33.15ms
+step:533/1490 train_time:17686ms step_avg:33.18ms
+step:534/1490 train_time:17744ms step_avg:33.23ms
+step:535/1490 train_time:17797ms step_avg:33.27ms
+step:536/1490 train_time:17856ms step_avg:33.31ms
+step:537/1490 train_time:17911ms step_avg:33.35ms
+step:538/1490 train_time:17971ms step_avg:33.40ms
+step:539/1490 train_time:18025ms step_avg:33.44ms
+step:540/1490 train_time:18084ms step_avg:33.49ms
+step:541/1490 train_time:18139ms step_avg:33.53ms
+step:542/1490 train_time:18198ms step_avg:33.57ms
+step:543/1490 train_time:18251ms step_avg:33.61ms
+step:544/1490 train_time:18311ms step_avg:33.66ms
+step:545/1490 train_time:18364ms step_avg:33.70ms
+step:546/1490 train_time:18423ms step_avg:33.74ms
+step:547/1490 train_time:18477ms step_avg:33.78ms
+step:548/1490 train_time:18535ms step_avg:33.82ms
+step:549/1490 train_time:18589ms step_avg:33.86ms
+step:550/1490 train_time:18647ms step_avg:33.90ms
+step:551/1490 train_time:18700ms step_avg:33.94ms
+step:552/1490 train_time:18759ms step_avg:33.98ms
+step:553/1490 train_time:18813ms step_avg:34.02ms
+step:554/1490 train_time:18872ms step_avg:34.07ms
+step:555/1490 train_time:18926ms step_avg:34.10ms
+step:556/1490 train_time:18985ms step_avg:34.15ms
+step:557/1490 train_time:19040ms step_avg:34.18ms
+step:558/1490 train_time:19099ms step_avg:34.23ms
+step:559/1490 train_time:19153ms step_avg:34.26ms
+step:560/1490 train_time:19212ms step_avg:34.31ms
+step:561/1490 train_time:19266ms step_avg:34.34ms
+step:562/1490 train_time:19325ms step_avg:34.39ms
+step:563/1490 train_time:19378ms step_avg:34.42ms
+step:564/1490 train_time:19437ms step_avg:34.46ms
+step:565/1490 train_time:19491ms step_avg:34.50ms
+step:566/1490 train_time:19549ms step_avg:34.54ms
+step:567/1490 train_time:19603ms step_avg:34.57ms
+step:568/1490 train_time:19661ms step_avg:34.61ms
+step:569/1490 train_time:19715ms step_avg:34.65ms
+step:570/1490 train_time:19774ms step_avg:34.69ms
+step:571/1490 train_time:19827ms step_avg:34.72ms
+step:572/1490 train_time:19885ms step_avg:34.76ms
+step:573/1490 train_time:19940ms step_avg:34.80ms
+step:574/1490 train_time:19999ms step_avg:34.84ms
+step:575/1490 train_time:20053ms step_avg:34.88ms
+step:576/1490 train_time:20113ms step_avg:34.92ms
+step:577/1490 train_time:20166ms step_avg:34.95ms
+step:578/1490 train_time:20225ms step_avg:34.99ms
+step:579/1490 train_time:20279ms step_avg:35.02ms
+step:580/1490 train_time:20338ms step_avg:35.07ms
+step:581/1490 train_time:20392ms step_avg:35.10ms
+step:582/1490 train_time:20451ms step_avg:35.14ms
+step:583/1490 train_time:20505ms step_avg:35.17ms
+step:584/1490 train_time:20563ms step_avg:35.21ms
+step:585/1490 train_time:20617ms step_avg:35.24ms
+step:586/1490 train_time:20675ms step_avg:35.28ms
+step:587/1490 train_time:20729ms step_avg:35.31ms
+step:588/1490 train_time:20788ms step_avg:35.35ms
+step:589/1490 train_time:20841ms step_avg:35.38ms
+step:590/1490 train_time:20900ms step_avg:35.42ms
+step:591/1490 train_time:20954ms step_avg:35.45ms
+step:592/1490 train_time:21014ms step_avg:35.50ms
+step:593/1490 train_time:21068ms step_avg:35.53ms
+step:594/1490 train_time:21127ms step_avg:35.57ms
+step:595/1490 train_time:21180ms step_avg:35.60ms
+step:596/1490 train_time:21239ms step_avg:35.64ms
+step:597/1490 train_time:21293ms step_avg:35.67ms
+step:598/1490 train_time:21351ms step_avg:35.70ms
+step:599/1490 train_time:21406ms step_avg:35.74ms
+step:600/1490 train_time:21464ms step_avg:35.77ms
+step:601/1490 train_time:21518ms step_avg:35.80ms
+step:602/1490 train_time:21576ms step_avg:35.84ms
+step:603/1490 train_time:21630ms step_avg:35.87ms
+step:604/1490 train_time:21689ms step_avg:35.91ms
+step:605/1490 train_time:21742ms step_avg:35.94ms
+step:606/1490 train_time:21800ms step_avg:35.97ms
+step:607/1490 train_time:21854ms step_avg:36.00ms
+step:608/1490 train_time:21914ms step_avg:36.04ms
+step:609/1490 train_time:21968ms step_avg:36.07ms
+step:610/1490 train_time:22026ms step_avg:36.11ms
+step:611/1490 train_time:22080ms step_avg:36.14ms
+step:612/1490 train_time:22139ms step_avg:36.17ms
+step:613/1490 train_time:22192ms step_avg:36.20ms
+step:614/1490 train_time:22251ms step_avg:36.24ms
+step:615/1490 train_time:22305ms step_avg:36.27ms
+step:616/1490 train_time:22364ms step_avg:36.30ms
+step:617/1490 train_time:22418ms step_avg:36.33ms
+step:618/1490 train_time:22477ms step_avg:36.37ms
+step:619/1490 train_time:22530ms step_avg:36.40ms
+step:620/1490 train_time:22589ms step_avg:36.43ms
+step:621/1490 train_time:22642ms step_avg:36.46ms
+step:622/1490 train_time:22701ms step_avg:36.50ms
+step:623/1490 train_time:22755ms step_avg:36.52ms
+step:624/1490 train_time:22814ms step_avg:36.56ms
+step:625/1490 train_time:22868ms step_avg:36.59ms
+step:626/1490 train_time:22926ms step_avg:36.62ms
+step:627/1490 train_time:22980ms step_avg:36.65ms
+step:628/1490 train_time:23039ms step_avg:36.69ms
+step:629/1490 train_time:23093ms step_avg:36.71ms
+step:630/1490 train_time:23152ms step_avg:36.75ms
+step:631/1490 train_time:23206ms step_avg:36.78ms
+step:632/1490 train_time:23264ms step_avg:36.81ms
+step:633/1490 train_time:23319ms step_avg:36.84ms
+step:634/1490 train_time:23377ms step_avg:36.87ms
+step:635/1490 train_time:23430ms step_avg:36.90ms
+step:636/1490 train_time:23489ms step_avg:36.93ms
+step:637/1490 train_time:23542ms step_avg:36.96ms
+step:638/1490 train_time:23601ms step_avg:36.99ms
+step:639/1490 train_time:23655ms step_avg:37.02ms
+step:640/1490 train_time:23715ms step_avg:37.05ms
+step:641/1490 train_time:23769ms step_avg:37.08ms
+step:642/1490 train_time:23827ms step_avg:37.11ms
+step:643/1490 train_time:23881ms step_avg:37.14ms
+step:644/1490 train_time:23939ms step_avg:37.17ms
+step:645/1490 train_time:23994ms step_avg:37.20ms
+step:646/1490 train_time:24052ms step_avg:37.23ms
+step:647/1490 train_time:24105ms step_avg:37.26ms
+step:648/1490 train_time:24164ms step_avg:37.29ms
+step:649/1490 train_time:24219ms step_avg:37.32ms
+step:650/1490 train_time:24277ms step_avg:37.35ms
+step:651/1490 train_time:24331ms step_avg:37.38ms
+step:652/1490 train_time:24390ms step_avg:37.41ms
+step:653/1490 train_time:24444ms step_avg:37.43ms
+step:654/1490 train_time:24502ms step_avg:37.46ms
+step:655/1490 train_time:24556ms step_avg:37.49ms
+step:656/1490 train_time:24615ms step_avg:37.52ms
+step:657/1490 train_time:24669ms step_avg:37.55ms
+step:658/1490 train_time:24728ms step_avg:37.58ms
+step:659/1490 train_time:24782ms step_avg:37.61ms
+step:660/1490 train_time:24840ms step_avg:37.64ms
+step:661/1490 train_time:24894ms step_avg:37.66ms
+step:662/1490 train_time:24953ms step_avg:37.69ms
+step:663/1490 train_time:25006ms step_avg:37.72ms
+step:664/1490 train_time:25064ms step_avg:37.75ms
+step:665/1490 train_time:25119ms step_avg:37.77ms
+step:666/1490 train_time:25179ms step_avg:37.81ms
+step:667/1490 train_time:25233ms step_avg:37.83ms
+step:668/1490 train_time:25292ms step_avg:37.86ms
+step:669/1490 train_time:25345ms step_avg:37.89ms
+step:670/1490 train_time:25404ms step_avg:37.92ms
+step:671/1490 train_time:25458ms step_avg:37.94ms
+step:672/1490 train_time:25518ms step_avg:37.97ms
+step:673/1490 train_time:25571ms step_avg:38.00ms
+step:674/1490 train_time:25629ms step_avg:38.03ms
+step:675/1490 train_time:25683ms step_avg:38.05ms
+step:676/1490 train_time:25742ms step_avg:38.08ms
+step:677/1490 train_time:25796ms step_avg:38.10ms
+step:678/1490 train_time:25854ms step_avg:38.13ms
+step:679/1490 train_time:25908ms step_avg:38.16ms
+step:680/1490 train_time:25967ms step_avg:38.19ms
+step:681/1490 train_time:26020ms step_avg:38.21ms
+step:682/1490 train_time:26079ms step_avg:38.24ms
+step:683/1490 train_time:26133ms step_avg:38.26ms
+step:684/1490 train_time:26192ms step_avg:38.29ms
+step:685/1490 train_time:26246ms step_avg:38.31ms
+step:686/1490 train_time:26304ms step_avg:38.34ms
+step:687/1490 train_time:26358ms step_avg:38.37ms
+step:688/1490 train_time:26417ms step_avg:38.40ms
+step:689/1490 train_time:26471ms step_avg:38.42ms
+step:690/1490 train_time:26530ms step_avg:38.45ms
+step:691/1490 train_time:26584ms step_avg:38.47ms
+step:692/1490 train_time:26642ms step_avg:38.50ms
+step:693/1490 train_time:26696ms step_avg:38.52ms
+step:694/1490 train_time:26755ms step_avg:38.55ms
+step:695/1490 train_time:26809ms step_avg:38.57ms
+step:696/1490 train_time:26868ms step_avg:38.60ms
+step:697/1490 train_time:26921ms step_avg:38.62ms
+step:698/1490 train_time:26980ms step_avg:38.65ms
+step:699/1490 train_time:27034ms step_avg:38.68ms
+step:700/1490 train_time:27093ms step_avg:38.70ms
+step:701/1490 train_time:27146ms step_avg:38.72ms
+step:702/1490 train_time:27205ms step_avg:38.75ms
+step:703/1490 train_time:27259ms step_avg:38.78ms
+step:704/1490 train_time:27318ms step_avg:38.80ms
+step:705/1490 train_time:27371ms step_avg:38.82ms
+step:706/1490 train_time:27430ms step_avg:38.85ms
+step:707/1490 train_time:27484ms step_avg:38.87ms
+step:708/1490 train_time:27543ms step_avg:38.90ms
+step:709/1490 train_time:27597ms step_avg:38.92ms
+step:710/1490 train_time:27656ms step_avg:38.95ms
+step:711/1490 train_time:27711ms step_avg:38.97ms
+step:712/1490 train_time:27770ms step_avg:39.00ms
+step:713/1490 train_time:27824ms step_avg:39.02ms
+step:714/1490 train_time:27882ms step_avg:39.05ms
+step:715/1490 train_time:27936ms step_avg:39.07ms
+step:716/1490 train_time:27994ms step_avg:39.10ms
+step:717/1490 train_time:28048ms step_avg:39.12ms
+step:718/1490 train_time:28106ms step_avg:39.14ms
+step:719/1490 train_time:28160ms step_avg:39.17ms
+step:720/1490 train_time:28219ms step_avg:39.19ms
+step:721/1490 train_time:28273ms step_avg:39.21ms
+step:722/1490 train_time:28331ms step_avg:39.24ms
+step:723/1490 train_time:28386ms step_avg:39.26ms
+step:724/1490 train_time:28444ms step_avg:39.29ms
+step:725/1490 train_time:28497ms step_avg:39.31ms
+step:726/1490 train_time:28557ms step_avg:39.33ms
+step:727/1490 train_time:28610ms step_avg:39.35ms
+step:728/1490 train_time:28670ms step_avg:39.38ms
+step:729/1490 train_time:28724ms step_avg:39.40ms
+step:730/1490 train_time:28782ms step_avg:39.43ms
+step:731/1490 train_time:28836ms step_avg:39.45ms
+step:732/1490 train_time:28895ms step_avg:39.47ms
+step:733/1490 train_time:28948ms step_avg:39.49ms
+step:734/1490 train_time:29008ms step_avg:39.52ms
+step:735/1490 train_time:29061ms step_avg:39.54ms
+step:736/1490 train_time:29121ms step_avg:39.57ms
+step:737/1490 train_time:29175ms step_avg:39.59ms
+step:738/1490 train_time:29234ms step_avg:39.61ms
+step:739/1490 train_time:29287ms step_avg:39.63ms
+step:740/1490 train_time:29346ms step_avg:39.66ms
+step:741/1490 train_time:29400ms step_avg:39.68ms
+step:742/1490 train_time:29458ms step_avg:39.70ms
+step:743/1490 train_time:29513ms step_avg:39.72ms
+step:744/1490 train_time:29572ms step_avg:39.75ms
+step:745/1490 train_time:29627ms step_avg:39.77ms
+step:746/1490 train_time:29684ms step_avg:39.79ms
+step:747/1490 train_time:29738ms step_avg:39.81ms
+step:748/1490 train_time:29798ms step_avg:39.84ms
+step:749/1490 train_time:29851ms step_avg:39.85ms
+step:750/1490 train_time:29910ms step_avg:39.88ms
+step:750/1490 val_loss:3.8048 train_time:29981ms step_avg:39.98ms
+step:751/1490 train_time:30000ms step_avg:39.95ms
+step:752/1490 train_time:30028ms step_avg:39.93ms
+step:753/1490 train_time:30085ms step_avg:39.95ms
+step:754/1490 train_time:30147ms step_avg:39.98ms
+step:755/1490 train_time:30201ms step_avg:40.00ms
+step:756/1490 train_time:30260ms step_avg:40.03ms
+step:757/1490 train_time:30314ms step_avg:40.04ms
+step:758/1490 train_time:30372ms step_avg:40.07ms
+step:759/1490 train_time:30426ms step_avg:40.09ms
+step:760/1490 train_time:30484ms step_avg:40.11ms
+step:761/1490 train_time:30538ms step_avg:40.13ms
+step:762/1490 train_time:30596ms step_avg:40.15ms
+step:763/1490 train_time:30648ms step_avg:40.17ms
+step:764/1490 train_time:30706ms step_avg:40.19ms
+step:765/1490 train_time:30759ms step_avg:40.21ms
+step:766/1490 train_time:30817ms step_avg:40.23ms
+step:767/1490 train_time:30870ms step_avg:40.25ms
+step:768/1490 train_time:30929ms step_avg:40.27ms
+step:769/1490 train_time:30984ms step_avg:40.29ms
+step:770/1490 train_time:31044ms step_avg:40.32ms
+step:771/1490 train_time:31098ms step_avg:40.33ms
+step:772/1490 train_time:31158ms step_avg:40.36ms
+step:773/1490 train_time:31213ms step_avg:40.38ms
+step:774/1490 train_time:31273ms step_avg:40.40ms
+step:775/1490 train_time:31327ms step_avg:40.42ms
+step:776/1490 train_time:31386ms step_avg:40.45ms
+step:777/1490 train_time:31439ms step_avg:40.46ms
+step:778/1490 train_time:31497ms step_avg:40.48ms
+step:779/1490 train_time:31551ms step_avg:40.50ms
+step:780/1490 train_time:31609ms step_avg:40.52ms
+step:781/1490 train_time:31663ms step_avg:40.54ms
+step:782/1490 train_time:31721ms step_avg:40.56ms
+step:783/1490 train_time:31775ms step_avg:40.58ms
+step:784/1490 train_time:31834ms step_avg:40.61ms
+step:785/1490 train_time:31888ms step_avg:40.62ms
+step:786/1490 train_time:31946ms step_avg:40.64ms
+step:787/1490 train_time:32001ms step_avg:40.66ms
+step:788/1490 train_time:32059ms step_avg:40.68ms
+step:789/1490 train_time:32114ms step_avg:40.70ms
+step:790/1490 train_time:32173ms step_avg:40.73ms
+step:791/1490 train_time:32227ms step_avg:40.74ms
+step:792/1490 train_time:32286ms step_avg:40.77ms
+step:793/1490 train_time:32340ms step_avg:40.78ms
+step:794/1490 train_time:32399ms step_avg:40.80ms
+step:795/1490 train_time:32452ms step_avg:40.82ms
+step:796/1490 train_time:32510ms step_avg:40.84ms
+step:797/1490 train_time:32563ms step_avg:40.86ms
+step:798/1490 train_time:32621ms step_avg:40.88ms
+step:799/1490 train_time:32675ms step_avg:40.90ms
+step:800/1490 train_time:32734ms step_avg:40.92ms
+step:801/1490 train_time:32788ms step_avg:40.93ms
+step:802/1490 train_time:32846ms step_avg:40.96ms
+step:803/1490 train_time:32899ms step_avg:40.97ms
+step:804/1490 train_time:32958ms step_avg:40.99ms
+step:805/1490 train_time:33012ms step_avg:41.01ms
+step:806/1490 train_time:33071ms step_avg:41.03ms
+step:807/1490 train_time:33126ms step_avg:41.05ms
+step:808/1490 train_time:33184ms step_avg:41.07ms
+step:809/1490 train_time:33238ms step_avg:41.09ms
+step:810/1490 train_time:33297ms step_avg:41.11ms
+step:811/1490 train_time:33352ms step_avg:41.12ms
+step:812/1490 train_time:33411ms step_avg:41.15ms
+step:813/1490 train_time:33464ms step_avg:41.16ms
+step:814/1490 train_time:33522ms step_avg:41.18ms
+step:815/1490 train_time:33576ms step_avg:41.20ms
+step:816/1490 train_time:33635ms step_avg:41.22ms
+step:817/1490 train_time:33689ms step_avg:41.23ms
+step:818/1490 train_time:33747ms step_avg:41.26ms
+step:819/1490 train_time:33801ms step_avg:41.27ms
+step:820/1490 train_time:33860ms step_avg:41.29ms
+step:821/1490 train_time:33914ms step_avg:41.31ms
+step:822/1490 train_time:33973ms step_avg:41.33ms
+step:823/1490 train_time:34026ms step_avg:41.34ms
+step:824/1490 train_time:34086ms step_avg:41.37ms
+step:825/1490 train_time:34139ms step_avg:41.38ms
+step:826/1490 train_time:34198ms step_avg:41.40ms
+step:827/1490 train_time:34252ms step_avg:41.42ms
+step:828/1490 train_time:34311ms step_avg:41.44ms
+step:829/1490 train_time:34364ms step_avg:41.45ms
+step:830/1490 train_time:34423ms step_avg:41.47ms
+step:831/1490 train_time:34476ms step_avg:41.49ms
+step:832/1490 train_time:34535ms step_avg:41.51ms
+step:833/1490 train_time:34589ms step_avg:41.52ms
+step:834/1490 train_time:34648ms step_avg:41.54ms
+step:835/1490 train_time:34700ms step_avg:41.56ms
+step:836/1490 train_time:34759ms step_avg:41.58ms
+step:837/1490 train_time:34812ms step_avg:41.59ms
+step:838/1490 train_time:34872ms step_avg:41.61ms
+step:839/1490 train_time:34925ms step_avg:41.63ms
+step:840/1490 train_time:34983ms step_avg:41.65ms
+step:841/1490 train_time:35038ms step_avg:41.66ms
+step:842/1490 train_time:35096ms step_avg:41.68ms
+step:843/1490 train_time:35151ms step_avg:41.70ms
+step:844/1490 train_time:35210ms step_avg:41.72ms
+step:845/1490 train_time:35264ms step_avg:41.73ms
+step:846/1490 train_time:35323ms step_avg:41.75ms
+step:847/1490 train_time:35377ms step_avg:41.77ms
+step:848/1490 train_time:35435ms step_avg:41.79ms
+step:849/1490 train_time:35489ms step_avg:41.80ms
+step:850/1490 train_time:35547ms step_avg:41.82ms
+step:851/1490 train_time:35601ms step_avg:41.83ms
+step:852/1490 train_time:35659ms step_avg:41.85ms
+step:853/1490 train_time:35714ms step_avg:41.87ms
+step:854/1490 train_time:35772ms step_avg:41.89ms
+step:855/1490 train_time:35826ms step_avg:41.90ms
+step:856/1490 train_time:35884ms step_avg:41.92ms
+step:857/1490 train_time:35938ms step_avg:41.93ms
+step:858/1490 train_time:35997ms step_avg:41.95ms
+step:859/1490 train_time:36050ms step_avg:41.97ms
+step:860/1490 train_time:36108ms step_avg:41.99ms
+step:861/1490 train_time:36161ms step_avg:42.00ms
+step:862/1490 train_time:36220ms step_avg:42.02ms
+step:863/1490 train_time:36275ms step_avg:42.03ms
+step:864/1490 train_time:36334ms step_avg:42.05ms
+step:865/1490 train_time:36387ms step_avg:42.07ms
+step:866/1490 train_time:36446ms step_avg:42.09ms
+step:867/1490 train_time:36498ms step_avg:42.10ms
+step:868/1490 train_time:36558ms step_avg:42.12ms
+step:869/1490 train_time:36611ms step_avg:42.13ms
+step:870/1490 train_time:36670ms step_avg:42.15ms
+step:871/1490 train_time:36724ms step_avg:42.16ms
+step:872/1490 train_time:36782ms step_avg:42.18ms
+step:873/1490 train_time:36836ms step_avg:42.19ms
+step:874/1490 train_time:36894ms step_avg:42.21ms
+step:875/1490 train_time:36948ms step_avg:42.23ms
+step:876/1490 train_time:37007ms step_avg:42.25ms
+step:877/1490 train_time:37060ms step_avg:42.26ms
+step:878/1490 train_time:37119ms step_avg:42.28ms
+step:879/1490 train_time:37174ms step_avg:42.29ms
+step:880/1490 train_time:37233ms step_avg:42.31ms
+step:881/1490 train_time:37287ms step_avg:42.32ms
+step:882/1490 train_time:37346ms step_avg:42.34ms
+step:883/1490 train_time:37399ms step_avg:42.35ms
+step:884/1490 train_time:37458ms step_avg:42.37ms
+step:885/1490 train_time:37512ms step_avg:42.39ms
+step:886/1490 train_time:37570ms step_avg:42.40ms
+step:887/1490 train_time:37624ms step_avg:42.42ms
+step:888/1490 train_time:37683ms step_avg:42.44ms
+step:889/1490 train_time:37737ms step_avg:42.45ms
+step:890/1490 train_time:37796ms step_avg:42.47ms
+step:891/1490 train_time:37850ms step_avg:42.48ms
+step:892/1490 train_time:37909ms step_avg:42.50ms
+step:893/1490 train_time:37963ms step_avg:42.51ms
+step:894/1490 train_time:38021ms step_avg:42.53ms
+step:895/1490 train_time:38075ms step_avg:42.54ms
+step:896/1490 train_time:38135ms step_avg:42.56ms
+step:897/1490 train_time:38187ms step_avg:42.57ms
+step:898/1490 train_time:38247ms step_avg:42.59ms
+step:899/1490 train_time:38300ms step_avg:42.60ms
+step:900/1490 train_time:38359ms step_avg:42.62ms
+step:901/1490 train_time:38412ms step_avg:42.63ms
+step:902/1490 train_time:38471ms step_avg:42.65ms
+step:903/1490 train_time:38525ms step_avg:42.66ms
+step:904/1490 train_time:38583ms step_avg:42.68ms
+step:905/1490 train_time:38637ms step_avg:42.69ms
+step:906/1490 train_time:38696ms step_avg:42.71ms
+step:907/1490 train_time:38749ms step_avg:42.72ms
+step:908/1490 train_time:38809ms step_avg:42.74ms
+step:909/1490 train_time:38862ms step_avg:42.75ms
+step:910/1490 train_time:38920ms step_avg:42.77ms
+step:911/1490 train_time:38975ms step_avg:42.78ms
+step:912/1490 train_time:39035ms step_avg:42.80ms
+step:913/1490 train_time:39088ms step_avg:42.81ms
+step:914/1490 train_time:39147ms step_avg:42.83ms
+step:915/1490 train_time:39201ms step_avg:42.84ms
+step:916/1490 train_time:39260ms step_avg:42.86ms
+step:917/1490 train_time:39314ms step_avg:42.87ms
+step:918/1490 train_time:39372ms step_avg:42.89ms
+step:919/1490 train_time:39426ms step_avg:42.90ms
+step:920/1490 train_time:39484ms step_avg:42.92ms
+step:921/1490 train_time:39538ms step_avg:42.93ms
+step:922/1490 train_time:39596ms step_avg:42.95ms
+step:923/1490 train_time:39650ms step_avg:42.96ms
+step:924/1490 train_time:39709ms step_avg:42.97ms
+step:925/1490 train_time:39762ms step_avg:42.99ms
+step:926/1490 train_time:39820ms step_avg:43.00ms
+step:927/1490 train_time:39873ms step_avg:43.01ms
+step:928/1490 train_time:39933ms step_avg:43.03ms
+step:929/1490 train_time:39986ms step_avg:43.04ms
+step:930/1490 train_time:40045ms step_avg:43.06ms
+step:931/1490 train_time:40098ms step_avg:43.07ms
+step:932/1490 train_time:40158ms step_avg:43.09ms
+step:933/1490 train_time:40212ms step_avg:43.10ms
+step:934/1490 train_time:40271ms step_avg:43.12ms
+step:935/1490 train_time:40324ms step_avg:43.13ms
+step:936/1490 train_time:40383ms step_avg:43.14ms
+step:937/1490 train_time:40437ms step_avg:43.16ms
+step:938/1490 train_time:40496ms step_avg:43.17ms
+step:939/1490 train_time:40548ms step_avg:43.18ms
+step:940/1490 train_time:40608ms step_avg:43.20ms
+step:941/1490 train_time:40662ms step_avg:43.21ms
+step:942/1490 train_time:40720ms step_avg:43.23ms
+step:943/1490 train_time:40774ms step_avg:43.24ms
+step:944/1490 train_time:40833ms step_avg:43.26ms
+step:945/1490 train_time:40886ms step_avg:43.27ms
+step:946/1490 train_time:40945ms step_avg:43.28ms
+step:947/1490 train_time:40998ms step_avg:43.29ms
+step:948/1490 train_time:41057ms step_avg:43.31ms
+step:949/1490 train_time:41110ms step_avg:43.32ms
+step:950/1490 train_time:41169ms step_avg:43.34ms
+step:951/1490 train_time:41223ms step_avg:43.35ms
+step:952/1490 train_time:41281ms step_avg:43.36ms
+step:953/1490 train_time:41336ms step_avg:43.37ms
+step:954/1490 train_time:41394ms step_avg:43.39ms
+step:955/1490 train_time:41448ms step_avg:43.40ms
+step:956/1490 train_time:41507ms step_avg:43.42ms
+step:957/1490 train_time:41560ms step_avg:43.43ms
+step:958/1490 train_time:41619ms step_avg:43.44ms
+step:959/1490 train_time:41673ms step_avg:43.45ms
+step:960/1490 train_time:41732ms step_avg:43.47ms
+step:961/1490 train_time:41785ms step_avg:43.48ms
+step:962/1490 train_time:41844ms step_avg:43.50ms
+step:963/1490 train_time:41897ms step_avg:43.51ms
+step:964/1490 train_time:41956ms step_avg:43.52ms
+step:965/1490 train_time:42010ms step_avg:43.53ms
+step:966/1490 train_time:42069ms step_avg:43.55ms
+step:967/1490 train_time:42122ms step_avg:43.56ms
+step:968/1490 train_time:42184ms step_avg:43.58ms
+step:969/1490 train_time:42264ms step_avg:43.62ms
+step:970/1490 train_time:42347ms step_avg:43.66ms
+step:971/1490 train_time:42427ms step_avg:43.69ms
+step:972/1490 train_time:42511ms step_avg:43.74ms
+step:973/1490 train_time:42590ms step_avg:43.77ms
+step:974/1490 train_time:42676ms step_avg:43.81ms
+step:975/1490 train_time:42756ms step_avg:43.85ms
+step:976/1490 train_time:42841ms step_avg:43.89ms
+step:977/1490 train_time:42919ms step_avg:43.93ms
+step:978/1490 train_time:43004ms step_avg:43.97ms
+step:979/1490 train_time:43084ms step_avg:44.01ms
+step:980/1490 train_time:43169ms step_avg:44.05ms
+step:981/1490 train_time:43249ms step_avg:44.09ms
+step:982/1490 train_time:43333ms step_avg:44.13ms
+step:983/1490 train_time:43413ms step_avg:44.16ms
+step:984/1490 train_time:43496ms step_avg:44.20ms
+step:985/1490 train_time:43575ms step_avg:44.24ms
+step:986/1490 train_time:43662ms step_avg:44.28ms
+step:987/1490 train_time:43741ms step_avg:44.32ms
+step:988/1490 train_time:43825ms step_avg:44.36ms
+step:989/1490 train_time:43906ms step_avg:44.39ms
+step:990/1490 train_time:43990ms step_avg:44.43ms
+step:991/1490 train_time:44069ms step_avg:44.47ms
+step:992/1490 train_time:44154ms step_avg:44.51ms
+step:993/1490 train_time:44234ms step_avg:44.55ms
+step:994/1490 train_time:44318ms step_avg:44.59ms
+step:995/1490 train_time:44398ms step_avg:44.62ms
+step:996/1490 train_time:44482ms step_avg:44.66ms
+step:997/1490 train_time:44561ms step_avg:44.70ms
+step:998/1490 train_time:44645ms step_avg:44.73ms
+step:999/1490 train_time:44726ms step_avg:44.77ms
+step:1000/1490 train_time:44810ms step_avg:44.81ms
+step:1000/1490 val_loss:3.5126 train_time:44910ms step_avg:44.91ms
+step:1001/1490 train_time:44927ms step_avg:44.88ms
+step:1002/1490 train_time:44977ms step_avg:44.89ms
+step:1003/1490 train_time:45065ms step_avg:44.93ms
+step:1004/1490 train_time:45153ms step_avg:44.97ms
+step:1005/1490 train_time:45233ms step_avg:45.01ms
+step:1006/1490 train_time:45316ms step_avg:45.05ms
+step:1007/1490 train_time:45396ms step_avg:45.08ms
+step:1008/1490 train_time:45480ms step_avg:45.12ms
+step:1009/1490 train_time:45559ms step_avg:45.15ms
+step:1010/1490 train_time:45642ms step_avg:45.19ms
+step:1011/1490 train_time:45721ms step_avg:45.22ms
+step:1012/1490 train_time:45803ms step_avg:45.26ms
+step:1013/1490 train_time:45883ms step_avg:45.29ms
+step:1014/1490 train_time:45970ms step_avg:45.34ms
+step:1015/1490 train_time:46051ms step_avg:45.37ms
+step:1016/1490 train_time:46138ms step_avg:45.41ms
+step:1017/1490 train_time:46218ms step_avg:45.45ms
+step:1018/1490 train_time:46303ms step_avg:45.48ms
+step:1019/1490 train_time:46383ms step_avg:45.52ms
+step:1020/1490 train_time:46467ms step_avg:45.56ms
+step:1021/1490 train_time:46543ms step_avg:45.59ms
+step:1022/1490 train_time:46628ms step_avg:45.62ms
+step:1023/1490 train_time:46707ms step_avg:45.66ms
+step:1024/1490 train_time:46792ms step_avg:45.70ms
+step:1025/1490 train_time:46871ms step_avg:45.73ms
+step:1026/1490 train_time:46955ms step_avg:45.77ms
+step:1027/1490 train_time:47037ms step_avg:45.80ms
+step:1028/1490 train_time:47123ms step_avg:45.84ms
+step:1029/1490 train_time:47205ms step_avg:45.87ms
+step:1030/1490 train_time:47290ms step_avg:45.91ms
+step:1031/1490 train_time:47369ms step_avg:45.95ms
+step:1032/1490 train_time:47453ms step_avg:45.98ms
+step:1033/1490 train_time:47531ms step_avg:46.01ms
+step:1034/1490 train_time:47616ms step_avg:46.05ms
+step:1035/1490 train_time:47697ms step_avg:46.08ms
+step:1036/1490 train_time:47782ms step_avg:46.12ms
+step:1037/1490 train_time:47861ms step_avg:46.15ms
+step:1038/1490 train_time:47946ms step_avg:46.19ms
+step:1039/1490 train_time:48026ms step_avg:46.22ms
+step:1040/1490 train_time:48111ms step_avg:46.26ms
+step:1041/1490 train_time:48191ms step_avg:46.29ms
+step:1042/1490 train_time:48277ms step_avg:46.33ms
+step:1043/1490 train_time:48358ms step_avg:46.36ms
+step:1044/1490 train_time:48443ms step_avg:46.40ms
+step:1045/1490 train_time:48522ms step_avg:46.43ms
+step:1046/1490 train_time:48605ms step_avg:46.47ms
+step:1047/1490 train_time:48684ms step_avg:46.50ms
+step:1048/1490 train_time:48771ms step_avg:46.54ms
+step:1049/1490 train_time:48849ms step_avg:46.57ms
+step:1050/1490 train_time:48934ms step_avg:46.60ms
+step:1051/1490 train_time:49014ms step_avg:46.64ms
+step:1052/1490 train_time:49100ms step_avg:46.67ms
+step:1053/1490 train_time:49180ms step_avg:46.70ms
+step:1054/1490 train_time:49266ms step_avg:46.74ms
+step:1055/1490 train_time:49344ms step_avg:46.77ms
+step:1056/1490 train_time:49430ms step_avg:46.81ms
+step:1057/1490 train_time:49509ms step_avg:46.84ms
+step:1058/1490 train_time:49593ms step_avg:46.87ms
+step:1059/1490 train_time:49672ms step_avg:46.90ms
+step:1060/1490 train_time:49756ms step_avg:46.94ms
+step:1061/1490 train_time:49836ms step_avg:46.97ms
+step:1062/1490 train_time:49919ms step_avg:47.00ms
+step:1063/1490 train_time:50001ms step_avg:47.04ms
+step:1064/1490 train_time:50086ms step_avg:47.07ms
+step:1065/1490 train_time:50165ms step_avg:47.10ms
+step:1066/1490 train_time:50251ms step_avg:47.14ms
+step:1067/1490 train_time:50331ms step_avg:47.17ms
+step:1068/1490 train_time:50415ms step_avg:47.21ms
+step:1069/1490 train_time:50495ms step_avg:47.24ms
+step:1070/1490 train_time:50579ms step_avg:47.27ms
+step:1071/1490 train_time:50659ms step_avg:47.30ms
+step:1072/1490 train_time:50743ms step_avg:47.34ms
+step:1073/1490 train_time:50822ms step_avg:47.36ms
+step:1074/1490 train_time:50905ms step_avg:47.40ms
+step:1075/1490 train_time:50986ms step_avg:47.43ms
+step:1076/1490 train_time:51071ms step_avg:47.46ms
+step:1077/1490 train_time:51150ms step_avg:47.49ms
+step:1078/1490 train_time:51234ms step_avg:47.53ms
+step:1079/1490 train_time:51315ms step_avg:47.56ms
+step:1080/1490 train_time:51399ms step_avg:47.59ms
+step:1081/1490 train_time:51478ms step_avg:47.62ms
+step:1082/1490 train_time:51563ms step_avg:47.66ms
+step:1083/1490 train_time:51643ms step_avg:47.68ms
+step:1084/1490 train_time:51727ms step_avg:47.72ms
+step:1085/1490 train_time:51808ms step_avg:47.75ms
+step:1086/1490 train_time:51893ms step_avg:47.78ms
+step:1087/1490 train_time:51973ms step_avg:47.81ms
+step:1088/1490 train_time:52057ms step_avg:47.85ms
+step:1089/1490 train_time:52137ms step_avg:47.88ms
+step:1090/1490 train_time:52222ms step_avg:47.91ms
+step:1091/1490 train_time:52303ms step_avg:47.94ms
+step:1092/1490 train_time:52388ms step_avg:47.97ms
+step:1093/1490 train_time:52467ms step_avg:48.00ms
+step:1094/1490 train_time:52551ms step_avg:48.04ms
+step:1095/1490 train_time:52630ms step_avg:48.06ms
+step:1096/1490 train_time:52715ms step_avg:48.10ms
+step:1097/1490 train_time:52795ms step_avg:48.13ms
+step:1098/1490 train_time:52880ms step_avg:48.16ms
+step:1099/1490 train_time:52961ms step_avg:48.19ms
+step:1100/1490 train_time:53047ms step_avg:48.22ms
+step:1101/1490 train_time:53127ms step_avg:48.25ms
+step:1102/1490 train_time:53211ms step_avg:48.29ms
+step:1103/1490 train_time:53291ms step_avg:48.31ms
+step:1104/1490 train_time:53375ms step_avg:48.35ms
+step:1105/1490 train_time:53454ms step_avg:48.38ms
+step:1106/1490 train_time:53539ms step_avg:48.41ms
+step:1107/1490 train_time:53619ms step_avg:48.44ms
+step:1108/1490 train_time:53705ms step_avg:48.47ms
+step:1109/1490 train_time:53784ms step_avg:48.50ms
+step:1110/1490 train_time:53869ms step_avg:48.53ms
+step:1111/1490 train_time:53948ms step_avg:48.56ms
+step:1112/1490 train_time:54032ms step_avg:48.59ms
+step:1113/1490 train_time:54112ms step_avg:48.62ms
+step:1114/1490 train_time:54196ms step_avg:48.65ms
+step:1115/1490 train_time:54276ms step_avg:48.68ms
+step:1116/1490 train_time:54362ms step_avg:48.71ms
+step:1117/1490 train_time:54441ms step_avg:48.74ms
+step:1118/1490 train_time:54526ms step_avg:48.77ms
+step:1119/1490 train_time:54605ms step_avg:48.80ms
+step:1120/1490 train_time:54690ms step_avg:48.83ms
+step:1121/1490 train_time:54770ms step_avg:48.86ms
+step:1122/1490 train_time:54855ms step_avg:48.89ms
+step:1123/1490 train_time:54934ms step_avg:48.92ms
+step:1124/1490 train_time:55019ms step_avg:48.95ms
+step:1125/1490 train_time:55098ms step_avg:48.98ms
+step:1126/1490 train_time:55183ms step_avg:49.01ms
+step:1127/1490 train_time:55263ms step_avg:49.04ms
+step:1128/1490 train_time:55346ms step_avg:49.07ms
+step:1129/1490 train_time:55426ms step_avg:49.09ms
+step:1130/1490 train_time:55512ms step_avg:49.13ms
+step:1131/1490 train_time:55591ms step_avg:49.15ms
+step:1132/1490 train_time:55676ms step_avg:49.18ms
+step:1133/1490 train_time:55755ms step_avg:49.21ms
+step:1134/1490 train_time:55840ms step_avg:49.24ms
+step:1135/1490 train_time:55919ms step_avg:49.27ms
+step:1136/1490 train_time:56004ms step_avg:49.30ms
+step:1137/1490 train_time:56083ms step_avg:49.33ms
+step:1138/1490 train_time:56168ms step_avg:49.36ms
+step:1139/1490 train_time:56247ms step_avg:49.38ms
+step:1140/1490 train_time:56332ms step_avg:49.41ms
+step:1141/1490 train_time:56412ms step_avg:49.44ms
+step:1142/1490 train_time:56497ms step_avg:49.47ms
+step:1143/1490 train_time:56576ms step_avg:49.50ms
+step:1144/1490 train_time:56661ms step_avg:49.53ms
+step:1145/1490 train_time:56740ms step_avg:49.55ms
+step:1146/1490 train_time:56824ms step_avg:49.58ms
+step:1147/1490 train_time:56904ms step_avg:49.61ms
+step:1148/1490 train_time:56989ms step_avg:49.64ms
+step:1149/1490 train_time:57069ms step_avg:49.67ms
+step:1150/1490 train_time:57153ms step_avg:49.70ms
+step:1151/1490 train_time:57232ms step_avg:49.72ms
+step:1152/1490 train_time:57317ms step_avg:49.75ms
+step:1153/1490 train_time:57398ms step_avg:49.78ms
+step:1154/1490 train_time:57483ms step_avg:49.81ms
+step:1155/1490 train_time:57562ms step_avg:49.84ms
+step:1156/1490 train_time:57647ms step_avg:49.87ms
+step:1157/1490 train_time:57725ms step_avg:49.89ms
+step:1158/1490 train_time:57810ms step_avg:49.92ms
+step:1159/1490 train_time:57890ms step_avg:49.95ms
+step:1160/1490 train_time:57975ms step_avg:49.98ms
+step:1161/1490 train_time:58054ms step_avg:50.00ms
+step:1162/1490 train_time:58138ms step_avg:50.03ms
+step:1163/1490 train_time:58219ms step_avg:50.06ms
+step:1164/1490 train_time:58303ms step_avg:50.09ms
+step:1165/1490 train_time:58383ms step_avg:50.11ms
+step:1166/1490 train_time:58469ms step_avg:50.14ms
+step:1167/1490 train_time:58548ms step_avg:50.17ms
+step:1168/1490 train_time:58634ms step_avg:50.20ms
+step:1169/1490 train_time:58712ms step_avg:50.22ms
+step:1170/1490 train_time:58797ms step_avg:50.25ms
+step:1171/1490 train_time:58876ms step_avg:50.28ms
+step:1172/1490 train_time:58962ms step_avg:50.31ms
+step:1173/1490 train_time:59042ms step_avg:50.33ms
+step:1174/1490 train_time:59126ms step_avg:50.36ms
+step:1175/1490 train_time:59207ms step_avg:50.39ms
+step:1176/1490 train_time:59290ms step_avg:50.42ms
+step:1177/1490 train_time:59370ms step_avg:50.44ms
+step:1178/1490 train_time:59454ms step_avg:50.47ms
+step:1179/1490 train_time:59533ms step_avg:50.49ms
+step:1180/1490 train_time:59618ms step_avg:50.52ms
+step:1181/1490 train_time:59698ms step_avg:50.55ms
+step:1182/1490 train_time:59784ms step_avg:50.58ms
+step:1183/1490 train_time:59864ms step_avg:50.60ms
+step:1184/1490 train_time:59949ms step_avg:50.63ms
+step:1185/1490 train_time:60027ms step_avg:50.66ms
+step:1186/1490 train_time:60113ms step_avg:50.69ms
+step:1187/1490 train_time:60193ms step_avg:50.71ms
+step:1188/1490 train_time:60277ms step_avg:50.74ms
+step:1189/1490 train_time:60357ms step_avg:50.76ms
+step:1190/1490 train_time:60443ms step_avg:50.79ms
+step:1191/1490 train_time:60522ms step_avg:50.82ms
+step:1192/1490 train_time:60606ms step_avg:50.84ms
+step:1193/1490 train_time:60686ms step_avg:50.87ms
+step:1194/1490 train_time:60772ms step_avg:50.90ms
+step:1195/1490 train_time:60851ms step_avg:50.92ms
+step:1196/1490 train_time:60934ms step_avg:50.95ms
+step:1197/1490 train_time:61015ms step_avg:50.97ms
+step:1198/1490 train_time:61100ms step_avg:51.00ms
+step:1199/1490 train_time:61180ms step_avg:51.03ms
+step:1200/1490 train_time:61266ms step_avg:51.06ms
+step:1201/1490 train_time:61346ms step_avg:51.08ms
+step:1202/1490 train_time:61430ms step_avg:51.11ms
+step:1203/1490 train_time:61510ms step_avg:51.13ms
+step:1204/1490 train_time:61595ms step_avg:51.16ms
+step:1205/1490 train_time:61674ms step_avg:51.18ms
+step:1206/1490 train_time:61759ms step_avg:51.21ms
+step:1207/1490 train_time:61839ms step_avg:51.23ms
+step:1208/1490 train_time:61923ms step_avg:51.26ms
+step:1209/1490 train_time:62004ms step_avg:51.29ms
+step:1210/1490 train_time:62088ms step_avg:51.31ms
+step:1211/1490 train_time:62168ms step_avg:51.34ms
+step:1212/1490 train_time:62252ms step_avg:51.36ms
+step:1213/1490 train_time:62331ms step_avg:51.39ms
+step:1214/1490 train_time:62416ms step_avg:51.41ms
+step:1215/1490 train_time:62496ms step_avg:51.44ms
+step:1216/1490 train_time:62581ms step_avg:51.46ms
+step:1217/1490 train_time:62661ms step_avg:51.49ms
+step:1218/1490 train_time:62747ms step_avg:51.52ms
+step:1219/1490 train_time:62826ms step_avg:51.54ms
+step:1220/1490 train_time:62911ms step_avg:51.57ms
+step:1221/1490 train_time:62990ms step_avg:51.59ms
+step:1222/1490 train_time:63075ms step_avg:51.62ms
+step:1223/1490 train_time:63155ms step_avg:51.64ms
+step:1224/1490 train_time:63239ms step_avg:51.67ms
+step:1225/1490 train_time:63319ms step_avg:51.69ms
+step:1226/1490 train_time:63403ms step_avg:51.72ms
+step:1227/1490 train_time:63483ms step_avg:51.74ms
+step:1228/1490 train_time:63568ms step_avg:51.77ms
+step:1229/1490 train_time:63646ms step_avg:51.79ms
+step:1230/1490 train_time:63731ms step_avg:51.81ms
+step:1231/1490 train_time:63810ms step_avg:51.84ms
+step:1232/1490 train_time:63895ms step_avg:51.86ms
+step:1233/1490 train_time:63975ms step_avg:51.89ms
+step:1234/1490 train_time:64060ms step_avg:51.91ms
+step:1235/1490 train_time:64140ms step_avg:51.94ms
+step:1236/1490 train_time:64224ms step_avg:51.96ms
+step:1237/1490 train_time:64304ms step_avg:51.98ms
+step:1238/1490 train_time:64388ms step_avg:52.01ms
+step:1239/1490 train_time:64468ms step_avg:52.03ms
+step:1240/1490 train_time:64552ms step_avg:52.06ms
+step:1241/1490 train_time:64631ms step_avg:52.08ms
+step:1242/1490 train_time:64715ms step_avg:52.11ms
+step:1243/1490 train_time:64794ms step_avg:52.13ms
+step:1244/1490 train_time:64878ms step_avg:52.15ms
+step:1245/1490 train_time:64959ms step_avg:52.18ms
+step:1246/1490 train_time:65045ms step_avg:52.20ms
+step:1247/1490 train_time:65124ms step_avg:52.22ms
+step:1248/1490 train_time:65210ms step_avg:52.25ms
+step:1249/1490 train_time:65290ms step_avg:52.27ms
+step:1250/1490 train_time:65375ms step_avg:52.30ms
+step:1250/1490 val_loss:3.3696 train_time:65474ms step_avg:52.38ms
+step:1251/1490 train_time:65492ms step_avg:52.35ms
+step:1252/1490 train_time:65539ms step_avg:52.35ms
+step:1253/1490 train_time:65625ms step_avg:52.37ms
+step:1254/1490 train_time:65712ms step_avg:52.40ms
+step:1255/1490 train_time:65792ms step_avg:52.42ms
+step:1256/1490 train_time:65877ms step_avg:52.45ms
+step:1257/1490 train_time:65954ms step_avg:52.47ms
+step:1258/1490 train_time:66038ms step_avg:52.49ms
+step:1259/1490 train_time:66115ms step_avg:52.51ms
+step:1260/1490 train_time:66198ms step_avg:52.54ms
+step:1261/1490 train_time:66277ms step_avg:52.56ms
+step:1262/1490 train_time:66361ms step_avg:52.58ms
+step:1263/1490 train_time:66439ms step_avg:52.60ms
+step:1264/1490 train_time:66528ms step_avg:52.63ms
+step:1265/1490 train_time:66611ms step_avg:52.66ms
+step:1266/1490 train_time:66698ms step_avg:52.68ms
+step:1267/1490 train_time:66777ms step_avg:52.70ms
+step:1268/1490 train_time:66861ms step_avg:52.73ms
+step:1269/1490 train_time:66941ms step_avg:52.75ms
+step:1270/1490 train_time:67025ms step_avg:52.78ms
+step:1271/1490 train_time:67103ms step_avg:52.80ms
+step:1272/1490 train_time:67187ms step_avg:52.82ms
+step:1273/1490 train_time:67265ms step_avg:52.84ms
+step:1274/1490 train_time:67348ms step_avg:52.86ms
+step:1275/1490 train_time:67429ms step_avg:52.89ms
+step:1276/1490 train_time:67517ms step_avg:52.91ms
+step:1277/1490 train_time:67597ms step_avg:52.93ms
+step:1278/1490 train_time:67684ms step_avg:52.96ms
+step:1279/1490 train_time:67764ms step_avg:52.98ms
+step:1280/1490 train_time:67849ms step_avg:53.01ms
+step:1281/1490 train_time:67929ms step_avg:53.03ms
+step:1282/1490 train_time:68014ms step_avg:53.05ms
+step:1283/1490 train_time:68093ms step_avg:53.07ms
+step:1284/1490 train_time:68177ms step_avg:53.10ms
+step:1285/1490 train_time:68254ms step_avg:53.12ms
+step:1286/1490 train_time:68338ms step_avg:53.14ms
+step:1287/1490 train_time:68417ms step_avg:53.16ms
+step:1288/1490 train_time:68504ms step_avg:53.19ms
+step:1289/1490 train_time:68584ms step_avg:53.21ms
+step:1290/1490 train_time:68669ms step_avg:53.23ms
+step:1291/1490 train_time:68750ms step_avg:53.25ms
+step:1292/1490 train_time:68834ms step_avg:53.28ms
+step:1293/1490 train_time:68914ms step_avg:53.30ms
+step:1294/1490 train_time:68999ms step_avg:53.32ms
+step:1295/1490 train_time:69080ms step_avg:53.34ms
+step:1296/1490 train_time:69163ms step_avg:53.37ms
+step:1297/1490 train_time:69242ms step_avg:53.39ms
+step:1298/1490 train_time:69329ms step_avg:53.41ms
+step:1299/1490 train_time:69409ms step_avg:53.43ms
+step:1300/1490 train_time:69495ms step_avg:53.46ms
+step:1301/1490 train_time:69575ms step_avg:53.48ms
+step:1302/1490 train_time:69661ms step_avg:53.50ms
+step:1303/1490 train_time:69739ms step_avg:53.52ms
+step:1304/1490 train_time:69825ms step_avg:53.55ms
+step:1305/1490 train_time:69905ms step_avg:53.57ms
+step:1306/1490 train_time:69988ms step_avg:53.59ms
+step:1307/1490 train_time:70070ms step_avg:53.61ms
+step:1308/1490 train_time:70155ms step_avg:53.64ms
+step:1309/1490 train_time:70234ms step_avg:53.65ms
+step:1310/1490 train_time:70317ms step_avg:53.68ms
+step:1311/1490 train_time:70397ms step_avg:53.70ms
+step:1312/1490 train_time:70482ms step_avg:53.72ms
+step:1313/1490 train_time:70562ms step_avg:53.74ms
+step:1314/1490 train_time:70646ms step_avg:53.76ms
+step:1315/1490 train_time:70726ms step_avg:53.78ms
+step:1316/1490 train_time:70811ms step_avg:53.81ms
+step:1317/1490 train_time:70892ms step_avg:53.83ms
+step:1318/1490 train_time:70976ms step_avg:53.85ms
+step:1319/1490 train_time:71056ms step_avg:53.87ms
+step:1320/1490 train_time:71142ms step_avg:53.90ms
+step:1321/1490 train_time:71220ms step_avg:53.91ms
+step:1322/1490 train_time:71305ms step_avg:53.94ms
+step:1323/1490 train_time:71384ms step_avg:53.96ms
+step:1324/1490 train_time:71469ms step_avg:53.98ms
+step:1325/1490 train_time:71550ms step_avg:54.00ms
+step:1326/1490 train_time:71634ms step_avg:54.02ms
+step:1327/1490 train_time:71714ms step_avg:54.04ms
+step:1328/1490 train_time:71798ms step_avg:54.06ms
+step:1329/1490 train_time:71879ms step_avg:54.09ms
+step:1330/1490 train_time:71963ms step_avg:54.11ms
+step:1331/1490 train_time:72044ms step_avg:54.13ms
+step:1332/1490 train_time:72129ms step_avg:54.15ms
+step:1333/1490 train_time:72209ms step_avg:54.17ms
+step:1334/1490 train_time:72294ms step_avg:54.19ms
+step:1335/1490 train_time:72373ms step_avg:54.21ms
+step:1336/1490 train_time:72459ms step_avg:54.24ms
+step:1337/1490 train_time:72538ms step_avg:54.25ms
+step:1338/1490 train_time:72623ms step_avg:54.28ms
+step:1339/1490 train_time:72703ms step_avg:54.30ms
+step:1340/1490 train_time:72788ms step_avg:54.32ms
+step:1341/1490 train_time:72868ms step_avg:54.34ms
+step:1342/1490 train_time:72954ms step_avg:54.36ms
+step:1343/1490 train_time:73034ms step_avg:54.38ms
+step:1344/1490 train_time:73119ms step_avg:54.40ms
+step:1345/1490 train_time:73198ms step_avg:54.42ms
+step:1346/1490 train_time:73283ms step_avg:54.44ms
+step:1347/1490 train_time:73360ms step_avg:54.46ms
+step:1348/1490 train_time:73446ms step_avg:54.49ms
+step:1349/1490 train_time:73527ms step_avg:54.50ms
+step:1350/1490 train_time:73613ms step_avg:54.53ms
+step:1351/1490 train_time:73693ms step_avg:54.55ms
+step:1352/1490 train_time:73778ms step_avg:54.57ms
+step:1353/1490 train_time:73856ms step_avg:54.59ms
+step:1354/1490 train_time:73941ms step_avg:54.61ms
+step:1355/1490 train_time:74020ms step_avg:54.63ms
+step:1356/1490 train_time:74105ms step_avg:54.65ms
+step:1357/1490 train_time:74184ms step_avg:54.67ms
+step:1358/1490 train_time:74268ms step_avg:54.69ms
+step:1359/1490 train_time:74348ms step_avg:54.71ms
+step:1360/1490 train_time:74433ms step_avg:54.73ms
+step:1361/1490 train_time:74512ms step_avg:54.75ms
+step:1362/1490 train_time:74597ms step_avg:54.77ms
+step:1363/1490 train_time:74677ms step_avg:54.79ms
+step:1364/1490 train_time:74760ms step_avg:54.81ms
+step:1365/1490 train_time:74840ms step_avg:54.83ms
+step:1366/1490 train_time:74925ms step_avg:54.85ms
+step:1367/1490 train_time:75005ms step_avg:54.87ms
+step:1368/1490 train_time:75090ms step_avg:54.89ms
+step:1369/1490 train_time:75169ms step_avg:54.91ms
+step:1370/1490 train_time:75254ms step_avg:54.93ms
+step:1371/1490 train_time:75333ms step_avg:54.95ms
+step:1372/1490 train_time:75419ms step_avg:54.97ms
+step:1373/1490 train_time:75497ms step_avg:54.99ms
+step:1374/1490 train_time:75583ms step_avg:55.01ms
+step:1375/1490 train_time:75662ms step_avg:55.03ms
+step:1376/1490 train_time:75747ms step_avg:55.05ms
+step:1377/1490 train_time:75826ms step_avg:55.07ms
+step:1378/1490 train_time:75910ms step_avg:55.09ms
+step:1379/1490 train_time:75990ms step_avg:55.11ms
+step:1380/1490 train_time:76076ms step_avg:55.13ms
+step:1381/1490 train_time:76156ms step_avg:55.15ms
+step:1382/1490 train_time:76241ms step_avg:55.17ms
+step:1383/1490 train_time:76320ms step_avg:55.18ms
+step:1384/1490 train_time:76405ms step_avg:55.21ms
+step:1385/1490 train_time:76485ms step_avg:55.22ms
+step:1386/1490 train_time:76569ms step_avg:55.24ms
+step:1387/1490 train_time:76650ms step_avg:55.26ms
+step:1388/1490 train_time:76735ms step_avg:55.28ms
+step:1389/1490 train_time:76815ms step_avg:55.30ms
+step:1390/1490 train_time:76899ms step_avg:55.32ms
+step:1391/1490 train_time:76977ms step_avg:55.34ms
+step:1392/1490 train_time:77063ms step_avg:55.36ms
+step:1393/1490 train_time:77142ms step_avg:55.38ms
+step:1394/1490 train_time:77227ms step_avg:55.40ms
+step:1395/1490 train_time:77306ms step_avg:55.42ms
+step:1396/1490 train_time:77391ms step_avg:55.44ms
+step:1397/1490 train_time:77470ms step_avg:55.45ms
+step:1398/1490 train_time:77554ms step_avg:55.48ms
+step:1399/1490 train_time:77633ms step_avg:55.49ms
+step:1400/1490 train_time:77718ms step_avg:55.51ms
+step:1401/1490 train_time:77797ms step_avg:55.53ms
+step:1402/1490 train_time:77883ms step_avg:55.55ms
+step:1403/1490 train_time:77963ms step_avg:55.57ms
+step:1404/1490 train_time:78047ms step_avg:55.59ms
+step:1405/1490 train_time:78128ms step_avg:55.61ms
+step:1406/1490 train_time:78212ms step_avg:55.63ms
+step:1407/1490 train_time:78292ms step_avg:55.64ms
+step:1408/1490 train_time:78377ms step_avg:55.67ms
+step:1409/1490 train_time:78456ms step_avg:55.68ms
+step:1410/1490 train_time:78542ms step_avg:55.70ms
+step:1411/1490 train_time:78621ms step_avg:55.72ms
+step:1412/1490 train_time:78706ms step_avg:55.74ms
+step:1413/1490 train_time:78785ms step_avg:55.76ms
+step:1414/1490 train_time:78870ms step_avg:55.78ms
+step:1415/1490 train_time:78950ms step_avg:55.80ms
+step:1416/1490 train_time:79035ms step_avg:55.82ms
+step:1417/1490 train_time:79114ms step_avg:55.83ms
+step:1418/1490 train_time:79198ms step_avg:55.85ms
+step:1419/1490 train_time:79278ms step_avg:55.87ms
+step:1420/1490 train_time:79361ms step_avg:55.89ms
+step:1421/1490 train_time:79441ms step_avg:55.91ms
+step:1422/1490 train_time:79527ms step_avg:55.93ms
+step:1423/1490 train_time:79607ms step_avg:55.94ms
+step:1424/1490 train_time:79693ms step_avg:55.96ms
+step:1425/1490 train_time:79773ms step_avg:55.98ms
+step:1426/1490 train_time:79856ms step_avg:56.00ms
+step:1427/1490 train_time:79935ms step_avg:56.02ms
+step:1428/1490 train_time:80021ms step_avg:56.04ms
+step:1429/1490 train_time:80099ms step_avg:56.05ms
+step:1430/1490 train_time:80186ms step_avg:56.07ms
+step:1431/1490 train_time:80265ms step_avg:56.09ms
+step:1432/1490 train_time:80349ms step_avg:56.11ms
+step:1433/1490 train_time:80430ms step_avg:56.13ms
+step:1434/1490 train_time:80517ms step_avg:56.15ms
+step:1435/1490 train_time:80595ms step_avg:56.16ms
+step:1436/1490 train_time:80681ms step_avg:56.18ms
+step:1437/1490 train_time:80760ms step_avg:56.20ms
+step:1438/1490 train_time:80845ms step_avg:56.22ms
+step:1439/1490 train_time:80924ms step_avg:56.24ms
+step:1440/1490 train_time:81008ms step_avg:56.26ms
+step:1441/1490 train_time:81088ms step_avg:56.27ms
+step:1442/1490 train_time:81173ms step_avg:56.29ms
+step:1443/1490 train_time:81252ms step_avg:56.31ms
+step:1444/1490 train_time:81336ms step_avg:56.33ms
+step:1445/1490 train_time:81417ms step_avg:56.34ms
+step:1446/1490 train_time:81502ms step_avg:56.36ms
+step:1447/1490 train_time:81582ms step_avg:56.38ms
+step:1448/1490 train_time:81665ms step_avg:56.40ms
+step:1449/1490 train_time:81744ms step_avg:56.41ms
+step:1450/1490 train_time:81829ms step_avg:56.43ms
+step:1451/1490 train_time:81913ms step_avg:56.45ms
+step:1452/1490 train_time:82000ms step_avg:56.47ms
+step:1453/1490 train_time:82080ms step_avg:56.49ms
+step:1454/1490 train_time:82165ms step_avg:56.51ms
+step:1455/1490 train_time:82243ms step_avg:56.52ms
+step:1456/1490 train_time:82330ms step_avg:56.55ms
+step:1457/1490 train_time:82410ms step_avg:56.56ms
+step:1458/1490 train_time:82495ms step_avg:56.58ms
+step:1459/1490 train_time:82575ms step_avg:56.60ms
+step:1460/1490 train_time:82661ms step_avg:56.62ms
+step:1461/1490 train_time:82741ms step_avg:56.63ms
+step:1462/1490 train_time:82825ms step_avg:56.65ms
+step:1463/1490 train_time:82905ms step_avg:56.67ms
+step:1464/1490 train_time:82991ms step_avg:56.69ms
+step:1465/1490 train_time:83071ms step_avg:56.70ms
+step:1466/1490 train_time:83156ms step_avg:56.72ms
+step:1467/1490 train_time:83235ms step_avg:56.74ms
+step:1468/1490 train_time:83320ms step_avg:56.76ms
+step:1469/1490 train_time:83399ms step_avg:56.77ms
+step:1470/1490 train_time:83485ms step_avg:56.79ms
+step:1471/1490 train_time:83564ms step_avg:56.81ms
+step:1472/1490 train_time:83649ms step_avg:56.83ms
+step:1473/1490 train_time:83730ms step_avg:56.84ms
+step:1474/1490 train_time:83815ms step_avg:56.86ms
+step:1475/1490 train_time:83895ms step_avg:56.88ms
+step:1476/1490 train_time:83981ms step_avg:56.90ms
+step:1477/1490 train_time:84060ms step_avg:56.91ms
+step:1478/1490 train_time:84145ms step_avg:56.93ms
+step:1479/1490 train_time:84224ms step_avg:56.95ms
+step:1480/1490 train_time:84310ms step_avg:56.97ms
+step:1481/1490 train_time:84390ms step_avg:56.98ms
+step:1482/1490 train_time:84476ms step_avg:57.00ms
+step:1483/1490 train_time:84555ms step_avg:57.02ms
+step:1484/1490 train_time:84641ms step_avg:57.04ms
+step:1485/1490 train_time:84720ms step_avg:57.05ms
+step:1486/1490 train_time:84806ms step_avg:57.07ms
+step:1487/1490 train_time:84887ms step_avg:57.09ms
+step:1488/1490 train_time:84973ms step_avg:57.11ms
+step:1489/1490 train_time:85053ms step_avg:57.12ms
+step:1490/1490 train_time:85138ms step_avg:57.14ms
+step:1490/1490 val_loss:3.2779 train_time:85240ms step_avg:57.21ms
+peak memory allocated: 31296 MiB reserved: 46782 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/d6460b6c-b62a-4579-841f-b548f9c5cbcf.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/d6460b6c-b62a-4579-841f-b548f9c5cbcf.txt
@@ -1,0 +1,4681 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+
+
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 21:38:48 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8290 train_time:0ms step_avg:0.08ms
+step:1/1490 train_time:85ms step_avg:84.70ms
+step:2/1490 train_time:110ms step_avg:54.97ms
+step:3/1490 train_time:127ms step_avg:42.32ms
+step:4/1490 train_time:147ms step_avg:36.67ms
+step:5/1490 train_time:172ms step_avg:34.31ms
+step:6/1490 train_time:206ms step_avg:34.30ms
+step:7/1490 train_time:233ms step_avg:33.27ms
+step:8/1490 train_time:267ms step_avg:33.41ms
+step:9/1490 train_time:294ms step_avg:32.71ms
+step:10/1490 train_time:329ms step_avg:32.86ms
+step:11/1490 train_time:356ms step_avg:32.35ms
+step:12/1490 train_time:390ms step_avg:32.47ms
+step:13/1490 train_time:417ms step_avg:32.08ms
+step:14/1490 train_time:452ms step_avg:32.32ms
+step:15/1490 train_time:478ms step_avg:31.88ms
+step:16/1490 train_time:512ms step_avg:32.00ms
+step:17/1490 train_time:539ms step_avg:31.73ms
+step:18/1490 train_time:573ms step_avg:31.84ms
+step:19/1490 train_time:601ms step_avg:31.62ms
+step:20/1490 train_time:634ms step_avg:31.72ms
+step:21/1490 train_time:662ms step_avg:31.52ms
+step:22/1490 train_time:696ms step_avg:31.62ms
+step:23/1490 train_time:723ms step_avg:31.44ms
+step:24/1490 train_time:757ms step_avg:31.56ms
+step:25/1490 train_time:785ms step_avg:31.38ms
+step:26/1490 train_time:819ms step_avg:31.51ms
+step:27/1490 train_time:846ms step_avg:31.34ms
+step:28/1490 train_time:882ms step_avg:31.49ms
+step:29/1490 train_time:907ms step_avg:31.28ms
+step:30/1490 train_time:942ms step_avg:31.39ms
+step:31/1490 train_time:970ms step_avg:31.28ms
+step:32/1490 train_time:1005ms step_avg:31.42ms
+step:33/1490 train_time:1032ms step_avg:31.28ms
+step:34/1490 train_time:1067ms step_avg:31.39ms
+step:35/1490 train_time:1097ms step_avg:31.34ms
+step:36/1490 train_time:1129ms step_avg:31.36ms
+step:37/1490 train_time:1157ms step_avg:31.26ms
+step:38/1490 train_time:1190ms step_avg:31.33ms
+step:39/1490 train_time:1218ms step_avg:31.23ms
+step:40/1490 train_time:1252ms step_avg:31.30ms
+step:41/1490 train_time:1280ms step_avg:31.21ms
+step:42/1490 train_time:1314ms step_avg:31.28ms
+step:43/1490 train_time:1341ms step_avg:31.19ms
+step:44/1490 train_time:1375ms step_avg:31.24ms
+step:45/1490 train_time:1402ms step_avg:31.16ms
+step:46/1490 train_time:1436ms step_avg:31.22ms
+step:47/1490 train_time:1463ms step_avg:31.14ms
+step:48/1490 train_time:1498ms step_avg:31.20ms
+step:49/1490 train_time:1525ms step_avg:31.12ms
+step:50/1490 train_time:1559ms step_avg:31.19ms
+step:51/1490 train_time:1587ms step_avg:31.12ms
+step:52/1490 train_time:1621ms step_avg:31.18ms
+step:53/1490 train_time:1648ms step_avg:31.10ms
+step:54/1490 train_time:1682ms step_avg:31.14ms
+step:55/1490 train_time:1709ms step_avg:31.07ms
+step:56/1490 train_time:1743ms step_avg:31.12ms
+step:57/1490 train_time:1770ms step_avg:31.05ms
+step:58/1490 train_time:1805ms step_avg:31.12ms
+step:59/1490 train_time:1831ms step_avg:31.04ms
+step:60/1490 train_time:1865ms step_avg:31.09ms
+step:61/1490 train_time:1893ms step_avg:31.03ms
+step:62/1490 train_time:1927ms step_avg:31.08ms
+step:63/1490 train_time:1955ms step_avg:31.03ms
+step:64/1490 train_time:1989ms step_avg:31.08ms
+step:65/1490 train_time:2017ms step_avg:31.03ms
+step:66/1490 train_time:2051ms step_avg:31.08ms
+step:67/1490 train_time:2079ms step_avg:31.03ms
+step:68/1490 train_time:2113ms step_avg:31.07ms
+step:69/1490 train_time:2141ms step_avg:31.02ms
+step:70/1490 train_time:2175ms step_avg:31.07ms
+step:71/1490 train_time:2202ms step_avg:31.01ms
+step:72/1490 train_time:2236ms step_avg:31.05ms
+step:73/1490 train_time:2263ms step_avg:31.01ms
+step:74/1490 train_time:2298ms step_avg:31.05ms
+step:75/1490 train_time:2325ms step_avg:31.00ms
+step:76/1490 train_time:2360ms step_avg:31.05ms
+step:77/1490 train_time:2388ms step_avg:31.01ms
+step:78/1490 train_time:2422ms step_avg:31.05ms
+step:79/1490 train_time:2449ms step_avg:31.00ms
+step:80/1490 train_time:2483ms step_avg:31.04ms
+step:81/1490 train_time:2510ms step_avg:30.99ms
+step:82/1490 train_time:2544ms step_avg:31.03ms
+step:83/1490 train_time:2572ms step_avg:30.99ms
+step:84/1490 train_time:2606ms step_avg:31.02ms
+step:85/1490 train_time:2633ms step_avg:30.98ms
+step:86/1490 train_time:2667ms step_avg:31.01ms
+step:87/1490 train_time:2695ms step_avg:30.97ms
+step:88/1490 train_time:2728ms step_avg:31.00ms
+step:89/1490 train_time:2756ms step_avg:30.96ms
+step:90/1490 train_time:2789ms step_avg:30.99ms
+step:91/1490 train_time:2817ms step_avg:30.96ms
+step:92/1490 train_time:2851ms step_avg:30.99ms
+step:93/1490 train_time:2879ms step_avg:30.95ms
+step:94/1490 train_time:2912ms step_avg:30.98ms
+step:95/1490 train_time:2940ms step_avg:30.94ms
+step:96/1490 train_time:2973ms step_avg:30.97ms
+step:97/1490 train_time:3001ms step_avg:30.94ms
+step:98/1490 train_time:3035ms step_avg:30.97ms
+step:99/1490 train_time:3062ms step_avg:30.93ms
+step:100/1490 train_time:3096ms step_avg:30.96ms
+step:101/1490 train_time:3123ms step_avg:30.93ms
+step:102/1490 train_time:3158ms step_avg:30.96ms
+step:103/1490 train_time:3186ms step_avg:30.93ms
+step:104/1490 train_time:3220ms step_avg:30.96ms
+step:105/1490 train_time:3247ms step_avg:30.92ms
+step:106/1490 train_time:3280ms step_avg:30.95ms
+step:107/1490 train_time:3308ms step_avg:30.92ms
+step:108/1490 train_time:3342ms step_avg:30.95ms
+step:109/1490 train_time:3370ms step_avg:30.91ms
+step:110/1490 train_time:3404ms step_avg:30.94ms
+step:111/1490 train_time:3431ms step_avg:30.91ms
+step:112/1490 train_time:3465ms step_avg:30.94ms
+step:113/1490 train_time:3492ms step_avg:30.91ms
+step:114/1490 train_time:3527ms step_avg:30.93ms
+step:115/1490 train_time:3554ms step_avg:30.90ms
+step:116/1490 train_time:3588ms step_avg:30.93ms
+step:117/1490 train_time:3616ms step_avg:30.90ms
+step:118/1490 train_time:3650ms step_avg:30.93ms
+step:119/1490 train_time:3677ms step_avg:30.90ms
+step:120/1490 train_time:3711ms step_avg:30.92ms
+step:121/1490 train_time:3738ms step_avg:30.89ms
+step:122/1490 train_time:3772ms step_avg:30.92ms
+step:123/1490 train_time:3800ms step_avg:30.89ms
+step:124/1490 train_time:3833ms step_avg:30.91ms
+step:125/1490 train_time:3861ms step_avg:30.89ms
+step:126/1490 train_time:3895ms step_avg:30.91ms
+step:127/1490 train_time:3923ms step_avg:30.89ms
+step:128/1490 train_time:3957ms step_avg:30.91ms
+step:129/1490 train_time:3984ms step_avg:30.89ms
+step:130/1490 train_time:4018ms step_avg:30.91ms
+step:131/1490 train_time:4045ms step_avg:30.88ms
+step:132/1490 train_time:4080ms step_avg:30.91ms
+step:133/1490 train_time:4107ms step_avg:30.88ms
+step:134/1490 train_time:4141ms step_avg:30.91ms
+step:135/1490 train_time:4169ms step_avg:30.88ms
+step:136/1490 train_time:4203ms step_avg:30.90ms
+step:137/1490 train_time:4230ms step_avg:30.87ms
+step:138/1490 train_time:4264ms step_avg:30.90ms
+step:139/1490 train_time:4291ms step_avg:30.87ms
+step:140/1490 train_time:4325ms step_avg:30.89ms
+step:141/1490 train_time:4353ms step_avg:30.87ms
+step:142/1490 train_time:4387ms step_avg:30.89ms
+step:143/1490 train_time:4415ms step_avg:30.87ms
+step:144/1490 train_time:4451ms step_avg:30.91ms
+step:145/1490 train_time:4476ms step_avg:30.87ms
+step:146/1490 train_time:4510ms step_avg:30.89ms
+step:147/1490 train_time:4537ms step_avg:30.87ms
+step:148/1490 train_time:4571ms step_avg:30.89ms
+step:149/1490 train_time:4599ms step_avg:30.86ms
+step:150/1490 train_time:4632ms step_avg:30.88ms
+step:151/1490 train_time:4660ms step_avg:30.86ms
+step:152/1490 train_time:4694ms step_avg:30.88ms
+step:153/1490 train_time:4721ms step_avg:30.86ms
+step:154/1490 train_time:4755ms step_avg:30.88ms
+step:155/1490 train_time:4783ms step_avg:30.86ms
+step:156/1490 train_time:4817ms step_avg:30.88ms
+step:157/1490 train_time:4844ms step_avg:30.85ms
+step:158/1490 train_time:4878ms step_avg:30.87ms
+step:159/1490 train_time:4905ms step_avg:30.85ms
+step:160/1490 train_time:4939ms step_avg:30.87ms
+step:161/1490 train_time:4966ms step_avg:30.84ms
+step:162/1490 train_time:5000ms step_avg:30.87ms
+step:163/1490 train_time:5028ms step_avg:30.84ms
+step:164/1490 train_time:5062ms step_avg:30.87ms
+step:165/1490 train_time:5090ms step_avg:30.85ms
+step:166/1490 train_time:5124ms step_avg:30.87ms
+step:167/1490 train_time:5151ms step_avg:30.85ms
+step:168/1490 train_time:5185ms step_avg:30.87ms
+step:169/1490 train_time:5213ms step_avg:30.85ms
+step:170/1490 train_time:5247ms step_avg:30.87ms
+step:171/1490 train_time:5275ms step_avg:30.85ms
+step:172/1490 train_time:5309ms step_avg:30.86ms
+step:173/1490 train_time:5336ms step_avg:30.85ms
+step:174/1490 train_time:5370ms step_avg:30.86ms
+step:175/1490 train_time:5398ms step_avg:30.84ms
+step:176/1490 train_time:5433ms step_avg:30.87ms
+step:177/1490 train_time:5459ms step_avg:30.84ms
+step:178/1490 train_time:5493ms step_avg:30.86ms
+step:179/1490 train_time:5521ms step_avg:30.84ms
+step:180/1490 train_time:5554ms step_avg:30.86ms
+step:181/1490 train_time:5582ms step_avg:30.84ms
+step:182/1490 train_time:5616ms step_avg:30.86ms
+step:183/1490 train_time:5643ms step_avg:30.84ms
+step:184/1490 train_time:5677ms step_avg:30.86ms
+step:185/1490 train_time:5705ms step_avg:30.84ms
+step:186/1490 train_time:5740ms step_avg:30.86ms
+step:187/1490 train_time:5766ms step_avg:30.84ms
+step:188/1490 train_time:5800ms step_avg:30.85ms
+step:189/1490 train_time:5828ms step_avg:30.84ms
+step:190/1490 train_time:5863ms step_avg:30.86ms
+step:191/1490 train_time:5890ms step_avg:30.84ms
+step:192/1490 train_time:5924ms step_avg:30.85ms
+step:193/1490 train_time:5951ms step_avg:30.83ms
+step:194/1490 train_time:5985ms step_avg:30.85ms
+step:195/1490 train_time:6012ms step_avg:30.83ms
+step:196/1490 train_time:6046ms step_avg:30.85ms
+step:197/1490 train_time:6074ms step_avg:30.83ms
+step:198/1490 train_time:6109ms step_avg:30.85ms
+step:199/1490 train_time:6135ms step_avg:30.83ms
+step:200/1490 train_time:6169ms step_avg:30.85ms
+step:201/1490 train_time:6196ms step_avg:30.83ms
+step:202/1490 train_time:6231ms step_avg:30.84ms
+step:203/1490 train_time:6258ms step_avg:30.83ms
+step:204/1490 train_time:6292ms step_avg:30.84ms
+step:205/1490 train_time:6319ms step_avg:30.83ms
+step:206/1490 train_time:6353ms step_avg:30.84ms
+step:207/1490 train_time:6381ms step_avg:30.83ms
+step:208/1490 train_time:6415ms step_avg:30.84ms
+step:209/1490 train_time:6442ms step_avg:30.83ms
+step:210/1490 train_time:6476ms step_avg:30.84ms
+step:211/1490 train_time:6504ms step_avg:30.82ms
+step:212/1490 train_time:6538ms step_avg:30.84ms
+step:213/1490 train_time:6565ms step_avg:30.82ms
+step:214/1490 train_time:6600ms step_avg:30.84ms
+step:215/1490 train_time:6627ms step_avg:30.82ms
+step:216/1490 train_time:6661ms step_avg:30.84ms
+step:217/1490 train_time:6689ms step_avg:30.82ms
+step:218/1490 train_time:6723ms step_avg:30.84ms
+step:219/1490 train_time:6751ms step_avg:30.83ms
+step:220/1490 train_time:6785ms step_avg:30.84ms
+step:221/1490 train_time:6812ms step_avg:30.82ms
+step:222/1490 train_time:6846ms step_avg:30.84ms
+step:223/1490 train_time:6874ms step_avg:30.82ms
+step:224/1490 train_time:6908ms step_avg:30.84ms
+step:225/1490 train_time:6935ms step_avg:30.82ms
+step:226/1490 train_time:6969ms step_avg:30.84ms
+step:227/1490 train_time:6997ms step_avg:30.82ms
+step:228/1490 train_time:7031ms step_avg:30.84ms
+step:229/1490 train_time:7058ms step_avg:30.82ms
+step:230/1490 train_time:7092ms step_avg:30.83ms
+step:231/1490 train_time:7119ms step_avg:30.82ms
+step:232/1490 train_time:7153ms step_avg:30.83ms
+step:233/1490 train_time:7181ms step_avg:30.82ms
+step:234/1490 train_time:7215ms step_avg:30.83ms
+step:235/1490 train_time:7242ms step_avg:30.82ms
+step:236/1490 train_time:7276ms step_avg:30.83ms
+step:237/1490 train_time:7304ms step_avg:30.82ms
+step:238/1490 train_time:7338ms step_avg:30.83ms
+step:239/1490 train_time:7365ms step_avg:30.82ms
+step:240/1490 train_time:7400ms step_avg:30.83ms
+step:241/1490 train_time:7427ms step_avg:30.82ms
+step:242/1490 train_time:7461ms step_avg:30.83ms
+step:243/1490 train_time:7489ms step_avg:30.82ms
+step:244/1490 train_time:7523ms step_avg:30.83ms
+step:245/1490 train_time:7550ms step_avg:30.82ms
+step:246/1490 train_time:7584ms step_avg:30.83ms
+step:247/1490 train_time:7611ms step_avg:30.81ms
+step:248/1490 train_time:7645ms step_avg:30.83ms
+step:249/1490 train_time:7673ms step_avg:30.81ms
+step:250/1490 train_time:7707ms step_avg:30.83ms
+step:250/1490 val_loss:4.5075 train_time:7748ms step_avg:30.99ms
+step:251/1490 train_time:7769ms step_avg:30.95ms
+step:252/1490 train_time:7789ms step_avg:30.91ms
+step:253/1490 train_time:7804ms step_avg:30.84ms
+step:254/1490 train_time:7836ms step_avg:30.85ms
+step:255/1490 train_time:7865ms step_avg:30.84ms
+step:256/1490 train_time:7900ms step_avg:30.86ms
+step:257/1490 train_time:7928ms step_avg:30.85ms
+step:258/1490 train_time:7962ms step_avg:30.86ms
+step:259/1490 train_time:7990ms step_avg:30.85ms
+step:260/1490 train_time:8025ms step_avg:30.86ms
+step:261/1490 train_time:8052ms step_avg:30.85ms
+step:262/1490 train_time:8086ms step_avg:30.86ms
+step:263/1490 train_time:8113ms step_avg:30.85ms
+step:264/1490 train_time:8148ms step_avg:30.86ms
+step:265/1490 train_time:8174ms step_avg:30.85ms
+step:266/1490 train_time:8208ms step_avg:30.86ms
+step:267/1490 train_time:8235ms step_avg:30.84ms
+step:268/1490 train_time:8269ms step_avg:30.85ms
+step:269/1490 train_time:8296ms step_avg:30.84ms
+step:270/1490 train_time:8330ms step_avg:30.85ms
+step:271/1490 train_time:8357ms step_avg:30.84ms
+step:272/1490 train_time:8391ms step_avg:30.85ms
+step:273/1490 train_time:8418ms step_avg:30.84ms
+step:274/1490 train_time:8452ms step_avg:30.85ms
+step:275/1490 train_time:8479ms step_avg:30.83ms
+step:276/1490 train_time:8513ms step_avg:30.84ms
+step:277/1490 train_time:8540ms step_avg:30.83ms
+step:278/1490 train_time:8575ms step_avg:30.84ms
+step:279/1490 train_time:8602ms step_avg:30.83ms
+step:280/1490 train_time:8636ms step_avg:30.84ms
+step:281/1490 train_time:8663ms step_avg:30.83ms
+step:282/1490 train_time:8697ms step_avg:30.84ms
+step:283/1490 train_time:8724ms step_avg:30.83ms
+step:284/1490 train_time:8759ms step_avg:30.84ms
+step:285/1490 train_time:8786ms step_avg:30.83ms
+step:286/1490 train_time:8820ms step_avg:30.84ms
+step:287/1490 train_time:8848ms step_avg:30.83ms
+step:288/1490 train_time:8883ms step_avg:30.84ms
+step:289/1490 train_time:8910ms step_avg:30.83ms
+step:290/1490 train_time:8944ms step_avg:30.84ms
+step:291/1490 train_time:8972ms step_avg:30.83ms
+step:292/1490 train_time:9007ms step_avg:30.84ms
+step:293/1490 train_time:9034ms step_avg:30.83ms
+step:294/1490 train_time:9068ms step_avg:30.84ms
+step:295/1490 train_time:9096ms step_avg:30.83ms
+step:296/1490 train_time:9130ms step_avg:30.84ms
+step:297/1490 train_time:9157ms step_avg:30.83ms
+step:298/1490 train_time:9191ms step_avg:30.84ms
+step:299/1490 train_time:9219ms step_avg:30.83ms
+step:300/1490 train_time:9253ms step_avg:30.84ms
+step:301/1490 train_time:9280ms step_avg:30.83ms
+step:302/1490 train_time:9314ms step_avg:30.84ms
+step:303/1490 train_time:9342ms step_avg:30.83ms
+step:304/1490 train_time:9376ms step_avg:30.84ms
+step:305/1490 train_time:9403ms step_avg:30.83ms
+step:306/1490 train_time:9437ms step_avg:30.84ms
+step:307/1490 train_time:9465ms step_avg:30.83ms
+step:308/1490 train_time:9499ms step_avg:30.84ms
+step:309/1490 train_time:9526ms step_avg:30.83ms
+step:310/1490 train_time:9560ms step_avg:30.84ms
+step:311/1490 train_time:9587ms step_avg:30.83ms
+step:312/1490 train_time:9621ms step_avg:30.84ms
+step:313/1490 train_time:9649ms step_avg:30.83ms
+step:314/1490 train_time:9683ms step_avg:30.84ms
+step:315/1490 train_time:9710ms step_avg:30.83ms
+step:316/1490 train_time:9744ms step_avg:30.84ms
+step:317/1490 train_time:9772ms step_avg:30.83ms
+step:318/1490 train_time:9806ms step_avg:30.84ms
+step:319/1490 train_time:9833ms step_avg:30.83ms
+step:320/1490 train_time:9867ms step_avg:30.84ms
+step:321/1490 train_time:9895ms step_avg:30.83ms
+step:322/1490 train_time:9929ms step_avg:30.83ms
+step:323/1490 train_time:9957ms step_avg:30.83ms
+step:324/1490 train_time:9991ms step_avg:30.84ms
+step:325/1490 train_time:10019ms step_avg:30.83ms
+step:326/1490 train_time:10053ms step_avg:30.84ms
+step:327/1490 train_time:10080ms step_avg:30.83ms
+step:328/1490 train_time:10114ms step_avg:30.84ms
+step:329/1490 train_time:10142ms step_avg:30.83ms
+step:330/1490 train_time:10178ms step_avg:30.84ms
+step:331/1490 train_time:10204ms step_avg:30.83ms
+step:332/1490 train_time:10238ms step_avg:30.84ms
+step:333/1490 train_time:10265ms step_avg:30.83ms
+step:334/1490 train_time:10306ms step_avg:30.85ms
+step:335/1490 train_time:10329ms step_avg:30.83ms
+step:336/1490 train_time:10372ms step_avg:30.87ms
+step:337/1490 train_time:10399ms step_avg:30.86ms
+step:338/1490 train_time:10433ms step_avg:30.87ms
+step:339/1490 train_time:10460ms step_avg:30.86ms
+step:340/1490 train_time:10494ms step_avg:30.87ms
+step:341/1490 train_time:10522ms step_avg:30.86ms
+step:342/1490 train_time:10556ms step_avg:30.87ms
+step:343/1490 train_time:10584ms step_avg:30.86ms
+step:344/1490 train_time:10617ms step_avg:30.86ms
+step:345/1490 train_time:10645ms step_avg:30.85ms
+step:346/1490 train_time:10680ms step_avg:30.87ms
+step:347/1490 train_time:10707ms step_avg:30.86ms
+step:348/1490 train_time:10741ms step_avg:30.86ms
+step:349/1490 train_time:10768ms step_avg:30.85ms
+step:350/1490 train_time:10803ms step_avg:30.86ms
+step:351/1490 train_time:10830ms step_avg:30.86ms
+step:352/1490 train_time:10865ms step_avg:30.87ms
+step:353/1490 train_time:10892ms step_avg:30.86ms
+step:354/1490 train_time:10926ms step_avg:30.86ms
+step:355/1490 train_time:10953ms step_avg:30.85ms
+step:356/1490 train_time:10987ms step_avg:30.86ms
+step:357/1490 train_time:11014ms step_avg:30.85ms
+step:358/1490 train_time:11048ms step_avg:30.86ms
+step:359/1490 train_time:11076ms step_avg:30.85ms
+step:360/1490 train_time:11109ms step_avg:30.86ms
+step:361/1490 train_time:11137ms step_avg:30.85ms
+step:362/1490 train_time:11171ms step_avg:30.86ms
+step:363/1490 train_time:11199ms step_avg:30.85ms
+step:364/1490 train_time:11233ms step_avg:30.86ms
+step:365/1490 train_time:11261ms step_avg:30.85ms
+step:366/1490 train_time:11295ms step_avg:30.86ms
+step:367/1490 train_time:11323ms step_avg:30.85ms
+step:368/1490 train_time:11357ms step_avg:30.86ms
+step:369/1490 train_time:11385ms step_avg:30.85ms
+step:370/1490 train_time:11419ms step_avg:30.86ms
+step:371/1490 train_time:11446ms step_avg:30.85ms
+step:372/1490 train_time:11481ms step_avg:30.86ms
+step:373/1490 train_time:11508ms step_avg:30.85ms
+step:374/1490 train_time:11542ms step_avg:30.86ms
+step:375/1490 train_time:11569ms step_avg:30.85ms
+step:376/1490 train_time:11603ms step_avg:30.86ms
+step:377/1490 train_time:11630ms step_avg:30.85ms
+step:378/1490 train_time:11664ms step_avg:30.86ms
+step:379/1490 train_time:11692ms step_avg:30.85ms
+step:380/1490 train_time:11726ms step_avg:30.86ms
+step:381/1490 train_time:11753ms step_avg:30.85ms
+step:382/1490 train_time:11787ms step_avg:30.86ms
+step:383/1490 train_time:11815ms step_avg:30.85ms
+step:384/1490 train_time:11848ms step_avg:30.85ms
+step:385/1490 train_time:11876ms step_avg:30.85ms
+step:386/1490 train_time:11910ms step_avg:30.85ms
+step:387/1490 train_time:11937ms step_avg:30.85ms
+step:388/1490 train_time:11972ms step_avg:30.85ms
+step:389/1490 train_time:11999ms step_avg:30.85ms
+step:390/1490 train_time:12033ms step_avg:30.85ms
+step:391/1490 train_time:12060ms step_avg:30.84ms
+step:392/1490 train_time:12095ms step_avg:30.85ms
+step:393/1490 train_time:12123ms step_avg:30.85ms
+step:394/1490 train_time:12156ms step_avg:30.85ms
+step:395/1490 train_time:12184ms step_avg:30.84ms
+step:396/1490 train_time:12219ms step_avg:30.85ms
+step:397/1490 train_time:12246ms step_avg:30.85ms
+step:398/1490 train_time:12281ms step_avg:30.86ms
+step:399/1490 train_time:12308ms step_avg:30.85ms
+step:400/1490 train_time:12343ms step_avg:30.86ms
+step:401/1490 train_time:12370ms step_avg:30.85ms
+step:402/1490 train_time:12404ms step_avg:30.86ms
+step:403/1490 train_time:12431ms step_avg:30.85ms
+step:404/1490 train_time:12465ms step_avg:30.85ms
+step:405/1490 train_time:12493ms step_avg:30.85ms
+step:406/1490 train_time:12527ms step_avg:30.85ms
+step:407/1490 train_time:12555ms step_avg:30.85ms
+step:408/1490 train_time:12589ms step_avg:30.85ms
+step:409/1490 train_time:12616ms step_avg:30.85ms
+step:410/1490 train_time:12650ms step_avg:30.85ms
+step:411/1490 train_time:12678ms step_avg:30.85ms
+step:412/1490 train_time:12711ms step_avg:30.85ms
+step:413/1490 train_time:12740ms step_avg:30.85ms
+step:414/1490 train_time:12774ms step_avg:30.86ms
+step:415/1490 train_time:12801ms step_avg:30.85ms
+step:416/1490 train_time:12835ms step_avg:30.85ms
+step:417/1490 train_time:12863ms step_avg:30.85ms
+step:418/1490 train_time:12897ms step_avg:30.85ms
+step:419/1490 train_time:12924ms step_avg:30.84ms
+step:420/1490 train_time:12958ms step_avg:30.85ms
+step:421/1490 train_time:12985ms step_avg:30.84ms
+step:422/1490 train_time:13020ms step_avg:30.85ms
+step:423/1490 train_time:13047ms step_avg:30.84ms
+step:424/1490 train_time:13081ms step_avg:30.85ms
+step:425/1490 train_time:13108ms step_avg:30.84ms
+step:426/1490 train_time:13142ms step_avg:30.85ms
+step:427/1490 train_time:13170ms step_avg:30.84ms
+step:428/1490 train_time:13204ms step_avg:30.85ms
+step:429/1490 train_time:13232ms step_avg:30.84ms
+step:430/1490 train_time:13266ms step_avg:30.85ms
+step:431/1490 train_time:13294ms step_avg:30.84ms
+step:432/1490 train_time:13327ms step_avg:30.85ms
+step:433/1490 train_time:13355ms step_avg:30.84ms
+step:434/1490 train_time:13389ms step_avg:30.85ms
+step:435/1490 train_time:13417ms step_avg:30.84ms
+step:436/1490 train_time:13451ms step_avg:30.85ms
+step:437/1490 train_time:13478ms step_avg:30.84ms
+step:438/1490 train_time:13513ms step_avg:30.85ms
+step:439/1490 train_time:13540ms step_avg:30.84ms
+step:440/1490 train_time:13574ms step_avg:30.85ms
+step:441/1490 train_time:13602ms step_avg:30.84ms
+step:442/1490 train_time:13636ms step_avg:30.85ms
+step:443/1490 train_time:13664ms step_avg:30.84ms
+step:444/1490 train_time:13698ms step_avg:30.85ms
+step:445/1490 train_time:13725ms step_avg:30.84ms
+step:446/1490 train_time:13760ms step_avg:30.85ms
+step:447/1490 train_time:13787ms step_avg:30.84ms
+step:448/1490 train_time:13821ms step_avg:30.85ms
+step:449/1490 train_time:13849ms step_avg:30.84ms
+step:450/1490 train_time:13883ms step_avg:30.85ms
+step:451/1490 train_time:13910ms step_avg:30.84ms
+step:452/1490 train_time:13944ms step_avg:30.85ms
+step:453/1490 train_time:13972ms step_avg:30.84ms
+step:454/1490 train_time:14006ms step_avg:30.85ms
+step:455/1490 train_time:14034ms step_avg:30.84ms
+step:456/1490 train_time:14067ms step_avg:30.85ms
+step:457/1490 train_time:14095ms step_avg:30.84ms
+step:458/1490 train_time:14129ms step_avg:30.85ms
+step:459/1490 train_time:14157ms step_avg:30.84ms
+step:460/1490 train_time:14190ms step_avg:30.85ms
+step:461/1490 train_time:14219ms step_avg:30.84ms
+step:462/1490 train_time:14253ms step_avg:30.85ms
+step:463/1490 train_time:14280ms step_avg:30.84ms
+step:464/1490 train_time:14314ms step_avg:30.85ms
+step:465/1490 train_time:14341ms step_avg:30.84ms
+step:466/1490 train_time:14376ms step_avg:30.85ms
+step:467/1490 train_time:14403ms step_avg:30.84ms
+step:468/1490 train_time:14437ms step_avg:30.85ms
+step:469/1490 train_time:14465ms step_avg:30.84ms
+step:470/1490 train_time:14499ms step_avg:30.85ms
+step:471/1490 train_time:14526ms step_avg:30.84ms
+step:472/1490 train_time:14560ms step_avg:30.85ms
+step:473/1490 train_time:14588ms step_avg:30.84ms
+step:474/1490 train_time:14622ms step_avg:30.85ms
+step:475/1490 train_time:14650ms step_avg:30.84ms
+step:476/1490 train_time:14684ms step_avg:30.85ms
+step:477/1490 train_time:14711ms step_avg:30.84ms
+step:478/1490 train_time:14745ms step_avg:30.85ms
+step:479/1490 train_time:14773ms step_avg:30.84ms
+step:480/1490 train_time:14806ms step_avg:30.85ms
+step:481/1490 train_time:14834ms step_avg:30.84ms
+step:482/1490 train_time:14868ms step_avg:30.85ms
+step:483/1490 train_time:14896ms step_avg:30.84ms
+step:484/1490 train_time:14932ms step_avg:30.85ms
+step:485/1490 train_time:14984ms step_avg:30.89ms
+step:486/1490 train_time:15042ms step_avg:30.95ms
+step:487/1490 train_time:15096ms step_avg:31.00ms
+step:488/1490 train_time:15154ms step_avg:31.05ms
+step:489/1490 train_time:15207ms step_avg:31.10ms
+step:490/1490 train_time:15267ms step_avg:31.16ms
+step:491/1490 train_time:15320ms step_avg:31.20ms
+step:492/1490 train_time:15380ms step_avg:31.26ms
+step:493/1490 train_time:15433ms step_avg:31.30ms
+step:494/1490 train_time:15491ms step_avg:31.36ms
+step:495/1490 train_time:15546ms step_avg:31.41ms
+step:496/1490 train_time:15604ms step_avg:31.46ms
+step:497/1490 train_time:15658ms step_avg:31.51ms
+step:498/1490 train_time:15718ms step_avg:31.56ms
+step:499/1490 train_time:15771ms step_avg:31.61ms
+step:500/1490 train_time:15830ms step_avg:31.66ms
+step:500/1490 val_loss:4.2586 train_time:15901ms step_avg:31.80ms
+step:501/1490 train_time:15920ms step_avg:31.78ms
+step:502/1490 train_time:15947ms step_avg:31.77ms
+step:503/1490 train_time:16005ms step_avg:31.82ms
+step:504/1490 train_time:16067ms step_avg:31.88ms
+step:505/1490 train_time:16123ms step_avg:31.93ms
+step:506/1490 train_time:16182ms step_avg:31.98ms
+step:507/1490 train_time:16235ms step_avg:32.02ms
+step:508/1490 train_time:16293ms step_avg:32.07ms
+step:509/1490 train_time:16347ms step_avg:32.12ms
+step:510/1490 train_time:16406ms step_avg:32.17ms
+step:511/1490 train_time:16459ms step_avg:32.21ms
+step:512/1490 train_time:16516ms step_avg:32.26ms
+step:513/1490 train_time:16569ms step_avg:32.30ms
+step:514/1490 train_time:16628ms step_avg:32.35ms
+step:515/1490 train_time:16681ms step_avg:32.39ms
+step:516/1490 train_time:16738ms step_avg:32.44ms
+step:517/1490 train_time:16792ms step_avg:32.48ms
+step:518/1490 train_time:16851ms step_avg:32.53ms
+step:519/1490 train_time:16905ms step_avg:32.57ms
+step:520/1490 train_time:16966ms step_avg:32.63ms
+step:521/1490 train_time:17021ms step_avg:32.67ms
+step:522/1490 train_time:17081ms step_avg:32.72ms
+step:523/1490 train_time:17135ms step_avg:32.76ms
+step:524/1490 train_time:17194ms step_avg:32.81ms
+step:525/1490 train_time:17249ms step_avg:32.86ms
+step:526/1490 train_time:17308ms step_avg:32.90ms
+step:527/1490 train_time:17361ms step_avg:32.94ms
+step:528/1490 train_time:17420ms step_avg:32.99ms
+step:529/1490 train_time:17473ms step_avg:33.03ms
+step:530/1490 train_time:17531ms step_avg:33.08ms
+step:531/1490 train_time:17585ms step_avg:33.12ms
+step:532/1490 train_time:17644ms step_avg:33.17ms
+step:533/1490 train_time:17698ms step_avg:33.20ms
+step:534/1490 train_time:17756ms step_avg:33.25ms
+step:535/1490 train_time:17809ms step_avg:33.29ms
+step:536/1490 train_time:17869ms step_avg:33.34ms
+step:537/1490 train_time:17923ms step_avg:33.38ms
+step:538/1490 train_time:17984ms step_avg:33.43ms
+step:539/1490 train_time:18038ms step_avg:33.47ms
+step:540/1490 train_time:18098ms step_avg:33.51ms
+step:541/1490 train_time:18152ms step_avg:33.55ms
+step:542/1490 train_time:18212ms step_avg:33.60ms
+step:543/1490 train_time:18266ms step_avg:33.64ms
+step:544/1490 train_time:18325ms step_avg:33.69ms
+step:545/1490 train_time:18379ms step_avg:33.72ms
+step:546/1490 train_time:18437ms step_avg:33.77ms
+step:547/1490 train_time:18491ms step_avg:33.80ms
+step:548/1490 train_time:18550ms step_avg:33.85ms
+step:549/1490 train_time:18602ms step_avg:33.88ms
+step:550/1490 train_time:18661ms step_avg:33.93ms
+step:551/1490 train_time:18714ms step_avg:33.96ms
+step:552/1490 train_time:18773ms step_avg:34.01ms
+step:553/1490 train_time:18827ms step_avg:34.04ms
+step:554/1490 train_time:18886ms step_avg:34.09ms
+step:555/1490 train_time:18939ms step_avg:34.12ms
+step:556/1490 train_time:18998ms step_avg:34.17ms
+step:557/1490 train_time:19053ms step_avg:34.21ms
+step:558/1490 train_time:19112ms step_avg:34.25ms
+step:559/1490 train_time:19167ms step_avg:34.29ms
+step:560/1490 train_time:19226ms step_avg:34.33ms
+step:561/1490 train_time:19280ms step_avg:34.37ms
+step:562/1490 train_time:19338ms step_avg:34.41ms
+step:563/1490 train_time:19392ms step_avg:34.44ms
+step:564/1490 train_time:19452ms step_avg:34.49ms
+step:565/1490 train_time:19505ms step_avg:34.52ms
+step:566/1490 train_time:19564ms step_avg:34.57ms
+step:567/1490 train_time:19618ms step_avg:34.60ms
+step:568/1490 train_time:19677ms step_avg:34.64ms
+step:569/1490 train_time:19730ms step_avg:34.68ms
+step:570/1490 train_time:19788ms step_avg:34.72ms
+step:571/1490 train_time:19842ms step_avg:34.75ms
+step:572/1490 train_time:19901ms step_avg:34.79ms
+step:573/1490 train_time:19955ms step_avg:34.83ms
+step:574/1490 train_time:20014ms step_avg:34.87ms
+step:575/1490 train_time:20069ms step_avg:34.90ms
+step:576/1490 train_time:20128ms step_avg:34.94ms
+step:577/1490 train_time:20182ms step_avg:34.98ms
+step:578/1490 train_time:20241ms step_avg:35.02ms
+step:579/1490 train_time:20296ms step_avg:35.05ms
+step:580/1490 train_time:20354ms step_avg:35.09ms
+step:581/1490 train_time:20408ms step_avg:35.13ms
+step:582/1490 train_time:20467ms step_avg:35.17ms
+step:583/1490 train_time:20521ms step_avg:35.20ms
+step:584/1490 train_time:20579ms step_avg:35.24ms
+step:585/1490 train_time:20632ms step_avg:35.27ms
+step:586/1490 train_time:20691ms step_avg:35.31ms
+step:587/1490 train_time:20746ms step_avg:35.34ms
+step:588/1490 train_time:20804ms step_avg:35.38ms
+step:589/1490 train_time:20857ms step_avg:35.41ms
+step:590/1490 train_time:20915ms step_avg:35.45ms
+step:591/1490 train_time:20970ms step_avg:35.48ms
+step:592/1490 train_time:21029ms step_avg:35.52ms
+step:593/1490 train_time:21085ms step_avg:35.56ms
+step:594/1490 train_time:21146ms step_avg:35.60ms
+step:595/1490 train_time:21200ms step_avg:35.63ms
+step:596/1490 train_time:21259ms step_avg:35.67ms
+step:597/1490 train_time:21312ms step_avg:35.70ms
+step:598/1490 train_time:21371ms step_avg:35.74ms
+step:599/1490 train_time:21425ms step_avg:35.77ms
+step:600/1490 train_time:21484ms step_avg:35.81ms
+step:601/1490 train_time:21538ms step_avg:35.84ms
+step:602/1490 train_time:21596ms step_avg:35.87ms
+step:603/1490 train_time:21651ms step_avg:35.90ms
+step:604/1490 train_time:21709ms step_avg:35.94ms
+step:605/1490 train_time:21763ms step_avg:35.97ms
+step:606/1490 train_time:21821ms step_avg:36.01ms
+step:607/1490 train_time:21875ms step_avg:36.04ms
+step:608/1490 train_time:21934ms step_avg:36.08ms
+step:609/1490 train_time:21989ms step_avg:36.11ms
+step:610/1490 train_time:22048ms step_avg:36.14ms
+step:611/1490 train_time:22102ms step_avg:36.17ms
+step:612/1490 train_time:22160ms step_avg:36.21ms
+step:613/1490 train_time:22214ms step_avg:36.24ms
+step:614/1490 train_time:22274ms step_avg:36.28ms
+step:615/1490 train_time:22328ms step_avg:36.31ms
+step:616/1490 train_time:22387ms step_avg:36.34ms
+step:617/1490 train_time:22440ms step_avg:36.37ms
+step:618/1490 train_time:22499ms step_avg:36.41ms
+step:619/1490 train_time:22553ms step_avg:36.43ms
+step:620/1490 train_time:22611ms step_avg:36.47ms
+step:621/1490 train_time:22666ms step_avg:36.50ms
+step:622/1490 train_time:22725ms step_avg:36.54ms
+step:623/1490 train_time:22779ms step_avg:36.56ms
+step:624/1490 train_time:22838ms step_avg:36.60ms
+step:625/1490 train_time:22892ms step_avg:36.63ms
+step:626/1490 train_time:22952ms step_avg:36.66ms
+step:627/1490 train_time:23006ms step_avg:36.69ms
+step:628/1490 train_time:23065ms step_avg:36.73ms
+step:629/1490 train_time:23120ms step_avg:36.76ms
+step:630/1490 train_time:23178ms step_avg:36.79ms
+step:631/1490 train_time:23232ms step_avg:36.82ms
+step:632/1490 train_time:23291ms step_avg:36.85ms
+step:633/1490 train_time:23345ms step_avg:36.88ms
+step:634/1490 train_time:23405ms step_avg:36.92ms
+step:635/1490 train_time:23458ms step_avg:36.94ms
+step:636/1490 train_time:23516ms step_avg:36.98ms
+step:637/1490 train_time:23570ms step_avg:37.00ms
+step:638/1490 train_time:23629ms step_avg:37.04ms
+step:639/1490 train_time:23683ms step_avg:37.06ms
+step:640/1490 train_time:23744ms step_avg:37.10ms
+step:641/1490 train_time:23797ms step_avg:37.13ms
+step:642/1490 train_time:23856ms step_avg:37.16ms
+step:643/1490 train_time:23909ms step_avg:37.18ms
+step:644/1490 train_time:23969ms step_avg:37.22ms
+step:645/1490 train_time:24023ms step_avg:37.24ms
+step:646/1490 train_time:24082ms step_avg:37.28ms
+step:647/1490 train_time:24136ms step_avg:37.30ms
+step:648/1490 train_time:24194ms step_avg:37.34ms
+step:649/1490 train_time:24249ms step_avg:37.36ms
+step:650/1490 train_time:24307ms step_avg:37.40ms
+step:651/1490 train_time:24361ms step_avg:37.42ms
+step:652/1490 train_time:24420ms step_avg:37.45ms
+step:653/1490 train_time:24473ms step_avg:37.48ms
+step:654/1490 train_time:24532ms step_avg:37.51ms
+step:655/1490 train_time:24585ms step_avg:37.53ms
+step:656/1490 train_time:24645ms step_avg:37.57ms
+step:657/1490 train_time:24698ms step_avg:37.59ms
+step:658/1490 train_time:24757ms step_avg:37.62ms
+step:659/1490 train_time:24811ms step_avg:37.65ms
+step:660/1490 train_time:24870ms step_avg:37.68ms
+step:661/1490 train_time:24923ms step_avg:37.71ms
+step:662/1490 train_time:24983ms step_avg:37.74ms
+step:663/1490 train_time:25036ms step_avg:37.76ms
+step:664/1490 train_time:25095ms step_avg:37.79ms
+step:665/1490 train_time:25149ms step_avg:37.82ms
+step:666/1490 train_time:25208ms step_avg:37.85ms
+step:667/1490 train_time:25261ms step_avg:37.87ms
+step:668/1490 train_time:25321ms step_avg:37.91ms
+step:669/1490 train_time:25374ms step_avg:37.93ms
+step:670/1490 train_time:25433ms step_avg:37.96ms
+step:671/1490 train_time:25486ms step_avg:37.98ms
+step:672/1490 train_time:25546ms step_avg:38.01ms
+step:673/1490 train_time:25598ms step_avg:38.04ms
+step:674/1490 train_time:25658ms step_avg:38.07ms
+step:675/1490 train_time:25712ms step_avg:38.09ms
+step:676/1490 train_time:25771ms step_avg:38.12ms
+step:677/1490 train_time:25824ms step_avg:38.15ms
+step:678/1490 train_time:25884ms step_avg:38.18ms
+step:679/1490 train_time:25937ms step_avg:38.20ms
+step:680/1490 train_time:25995ms step_avg:38.23ms
+step:681/1490 train_time:26050ms step_avg:38.25ms
+step:682/1490 train_time:26109ms step_avg:38.28ms
+step:683/1490 train_time:26162ms step_avg:38.30ms
+step:684/1490 train_time:26221ms step_avg:38.33ms
+step:685/1490 train_time:26275ms step_avg:38.36ms
+step:686/1490 train_time:26333ms step_avg:38.39ms
+step:687/1490 train_time:26387ms step_avg:38.41ms
+step:688/1490 train_time:26447ms step_avg:38.44ms
+step:689/1490 train_time:26500ms step_avg:38.46ms
+step:690/1490 train_time:26559ms step_avg:38.49ms
+step:691/1490 train_time:26612ms step_avg:38.51ms
+step:692/1490 train_time:26671ms step_avg:38.54ms
+step:693/1490 train_time:26725ms step_avg:38.56ms
+step:694/1490 train_time:26785ms step_avg:38.59ms
+step:695/1490 train_time:26839ms step_avg:38.62ms
+step:696/1490 train_time:26897ms step_avg:38.64ms
+step:697/1490 train_time:26951ms step_avg:38.67ms
+step:698/1490 train_time:27010ms step_avg:38.70ms
+step:699/1490 train_time:27064ms step_avg:38.72ms
+step:700/1490 train_time:27123ms step_avg:38.75ms
+step:701/1490 train_time:27177ms step_avg:38.77ms
+step:702/1490 train_time:27236ms step_avg:38.80ms
+step:703/1490 train_time:27290ms step_avg:38.82ms
+step:704/1490 train_time:27349ms step_avg:38.85ms
+step:705/1490 train_time:27403ms step_avg:38.87ms
+step:706/1490 train_time:27462ms step_avg:38.90ms
+step:707/1490 train_time:27516ms step_avg:38.92ms
+step:708/1490 train_time:27574ms step_avg:38.95ms
+step:709/1490 train_time:27628ms step_avg:38.97ms
+step:710/1490 train_time:27687ms step_avg:39.00ms
+step:711/1490 train_time:27741ms step_avg:39.02ms
+step:712/1490 train_time:27800ms step_avg:39.05ms
+step:713/1490 train_time:27854ms step_avg:39.07ms
+step:714/1490 train_time:27912ms step_avg:39.09ms
+step:715/1490 train_time:27966ms step_avg:39.11ms
+step:716/1490 train_time:28026ms step_avg:39.14ms
+step:717/1490 train_time:28079ms step_avg:39.16ms
+step:718/1490 train_time:28139ms step_avg:39.19ms
+step:719/1490 train_time:28193ms step_avg:39.21ms
+step:720/1490 train_time:28252ms step_avg:39.24ms
+step:721/1490 train_time:28306ms step_avg:39.26ms
+step:722/1490 train_time:28364ms step_avg:39.29ms
+step:723/1490 train_time:28418ms step_avg:39.31ms
+step:724/1490 train_time:28476ms step_avg:39.33ms
+step:725/1490 train_time:28530ms step_avg:39.35ms
+step:726/1490 train_time:28589ms step_avg:39.38ms
+step:727/1490 train_time:28642ms step_avg:39.40ms
+step:728/1490 train_time:28702ms step_avg:39.43ms
+step:729/1490 train_time:28756ms step_avg:39.45ms
+step:730/1490 train_time:28815ms step_avg:39.47ms
+step:731/1490 train_time:28869ms step_avg:39.49ms
+step:732/1490 train_time:28928ms step_avg:39.52ms
+step:733/1490 train_time:28982ms step_avg:39.54ms
+step:734/1490 train_time:29040ms step_avg:39.56ms
+step:735/1490 train_time:29095ms step_avg:39.58ms
+step:736/1490 train_time:29154ms step_avg:39.61ms
+step:737/1490 train_time:29208ms step_avg:39.63ms
+step:738/1490 train_time:29267ms step_avg:39.66ms
+step:739/1490 train_time:29321ms step_avg:39.68ms
+step:740/1490 train_time:29380ms step_avg:39.70ms
+step:741/1490 train_time:29434ms step_avg:39.72ms
+step:742/1490 train_time:29492ms step_avg:39.75ms
+step:743/1490 train_time:29546ms step_avg:39.77ms
+step:744/1490 train_time:29606ms step_avg:39.79ms
+step:745/1490 train_time:29659ms step_avg:39.81ms
+step:746/1490 train_time:29717ms step_avg:39.84ms
+step:747/1490 train_time:29771ms step_avg:39.85ms
+step:748/1490 train_time:29831ms step_avg:39.88ms
+step:749/1490 train_time:29885ms step_avg:39.90ms
+step:750/1490 train_time:29945ms step_avg:39.93ms
+step:750/1490 val_loss:3.8061 train_time:30014ms step_avg:40.02ms
+step:751/1490 train_time:30032ms step_avg:39.99ms
+step:752/1490 train_time:30059ms step_avg:39.97ms
+step:753/1490 train_time:30117ms step_avg:40.00ms
+step:754/1490 train_time:30177ms step_avg:40.02ms
+step:755/1490 train_time:30232ms step_avg:40.04ms
+step:756/1490 train_time:30291ms step_avg:40.07ms
+step:757/1490 train_time:30345ms step_avg:40.09ms
+step:758/1490 train_time:30404ms step_avg:40.11ms
+step:759/1490 train_time:30457ms step_avg:40.13ms
+step:760/1490 train_time:30515ms step_avg:40.15ms
+step:761/1490 train_time:30569ms step_avg:40.17ms
+step:762/1490 train_time:30628ms step_avg:40.19ms
+step:763/1490 train_time:30681ms step_avg:40.21ms
+step:764/1490 train_time:30738ms step_avg:40.23ms
+step:765/1490 train_time:30792ms step_avg:40.25ms
+step:766/1490 train_time:30850ms step_avg:40.27ms
+step:767/1490 train_time:30903ms step_avg:40.29ms
+step:768/1490 train_time:30961ms step_avg:40.31ms
+step:769/1490 train_time:31016ms step_avg:40.33ms
+step:770/1490 train_time:31076ms step_avg:40.36ms
+step:771/1490 train_time:31132ms step_avg:40.38ms
+step:772/1490 train_time:31191ms step_avg:40.40ms
+step:773/1490 train_time:31246ms step_avg:40.42ms
+step:774/1490 train_time:31305ms step_avg:40.45ms
+step:775/1490 train_time:31358ms step_avg:40.46ms
+step:776/1490 train_time:31417ms step_avg:40.49ms
+step:777/1490 train_time:31471ms step_avg:40.50ms
+step:778/1490 train_time:31530ms step_avg:40.53ms
+step:779/1490 train_time:31583ms step_avg:40.54ms
+step:780/1490 train_time:31642ms step_avg:40.57ms
+step:781/1490 train_time:31695ms step_avg:40.58ms
+step:782/1490 train_time:31753ms step_avg:40.60ms
+step:783/1490 train_time:31806ms step_avg:40.62ms
+step:784/1490 train_time:31866ms step_avg:40.64ms
+step:785/1490 train_time:31920ms step_avg:40.66ms
+step:786/1490 train_time:31979ms step_avg:40.69ms
+step:787/1490 train_time:32033ms step_avg:40.70ms
+step:788/1490 train_time:32092ms step_avg:40.73ms
+step:789/1490 train_time:32146ms step_avg:40.74ms
+step:790/1490 train_time:32206ms step_avg:40.77ms
+step:791/1490 train_time:32260ms step_avg:40.78ms
+step:792/1490 train_time:32319ms step_avg:40.81ms
+step:793/1490 train_time:32374ms step_avg:40.82ms
+step:794/1490 train_time:32432ms step_avg:40.85ms
+step:795/1490 train_time:32485ms step_avg:40.86ms
+step:796/1490 train_time:32544ms step_avg:40.88ms
+step:797/1490 train_time:32598ms step_avg:40.90ms
+step:798/1490 train_time:32656ms step_avg:40.92ms
+step:799/1490 train_time:32710ms step_avg:40.94ms
+step:800/1490 train_time:32769ms step_avg:40.96ms
+step:801/1490 train_time:32822ms step_avg:40.98ms
+step:802/1490 train_time:32881ms step_avg:41.00ms
+step:803/1490 train_time:32933ms step_avg:41.01ms
+step:804/1490 train_time:32993ms step_avg:41.04ms
+step:805/1490 train_time:33047ms step_avg:41.05ms
+step:806/1490 train_time:33106ms step_avg:41.07ms
+step:807/1490 train_time:33160ms step_avg:41.09ms
+step:808/1490 train_time:33220ms step_avg:41.11ms
+step:809/1490 train_time:33275ms step_avg:41.13ms
+step:810/1490 train_time:33333ms step_avg:41.15ms
+step:811/1490 train_time:33387ms step_avg:41.17ms
+step:812/1490 train_time:33447ms step_avg:41.19ms
+step:813/1490 train_time:33500ms step_avg:41.21ms
+step:814/1490 train_time:33559ms step_avg:41.23ms
+step:815/1490 train_time:33612ms step_avg:41.24ms
+step:816/1490 train_time:33671ms step_avg:41.26ms
+step:817/1490 train_time:33725ms step_avg:41.28ms
+step:818/1490 train_time:33784ms step_avg:41.30ms
+step:819/1490 train_time:33837ms step_avg:41.31ms
+step:820/1490 train_time:33895ms step_avg:41.34ms
+step:821/1490 train_time:33949ms step_avg:41.35ms
+step:822/1490 train_time:34008ms step_avg:41.37ms
+step:823/1490 train_time:34061ms step_avg:41.39ms
+step:824/1490 train_time:34119ms step_avg:41.41ms
+step:825/1490 train_time:34174ms step_avg:41.42ms
+step:826/1490 train_time:34233ms step_avg:41.44ms
+step:827/1490 train_time:34287ms step_avg:41.46ms
+step:828/1490 train_time:34347ms step_avg:41.48ms
+step:829/1490 train_time:34400ms step_avg:41.50ms
+step:830/1490 train_time:34459ms step_avg:41.52ms
+step:831/1490 train_time:34512ms step_avg:41.53ms
+step:832/1490 train_time:34572ms step_avg:41.55ms
+step:833/1490 train_time:34625ms step_avg:41.57ms
+step:834/1490 train_time:34684ms step_avg:41.59ms
+step:835/1490 train_time:34737ms step_avg:41.60ms
+step:836/1490 train_time:34796ms step_avg:41.62ms
+step:837/1490 train_time:34849ms step_avg:41.64ms
+step:838/1490 train_time:34909ms step_avg:41.66ms
+step:839/1490 train_time:34963ms step_avg:41.67ms
+step:840/1490 train_time:35022ms step_avg:41.69ms
+step:841/1490 train_time:35075ms step_avg:41.71ms
+step:842/1490 train_time:35134ms step_avg:41.73ms
+step:843/1490 train_time:35188ms step_avg:41.74ms
+step:844/1490 train_time:35247ms step_avg:41.76ms
+step:845/1490 train_time:35301ms step_avg:41.78ms
+step:846/1490 train_time:35360ms step_avg:41.80ms
+step:847/1490 train_time:35413ms step_avg:41.81ms
+step:848/1490 train_time:35473ms step_avg:41.83ms
+step:849/1490 train_time:35526ms step_avg:41.84ms
+step:850/1490 train_time:35585ms step_avg:41.86ms
+step:851/1490 train_time:35639ms step_avg:41.88ms
+step:852/1490 train_time:35697ms step_avg:41.90ms
+step:853/1490 train_time:35751ms step_avg:41.91ms
+step:854/1490 train_time:35810ms step_avg:41.93ms
+step:855/1490 train_time:35863ms step_avg:41.94ms
+step:856/1490 train_time:35921ms step_avg:41.96ms
+step:857/1490 train_time:35976ms step_avg:41.98ms
+step:858/1490 train_time:36035ms step_avg:42.00ms
+step:859/1490 train_time:36088ms step_avg:42.01ms
+step:860/1490 train_time:36147ms step_avg:42.03ms
+step:861/1490 train_time:36201ms step_avg:42.05ms
+step:862/1490 train_time:36260ms step_avg:42.06ms
+step:863/1490 train_time:36314ms step_avg:42.08ms
+step:864/1490 train_time:36374ms step_avg:42.10ms
+step:865/1490 train_time:36427ms step_avg:42.11ms
+step:866/1490 train_time:36487ms step_avg:42.13ms
+step:867/1490 train_time:36540ms step_avg:42.15ms
+step:868/1490 train_time:36599ms step_avg:42.16ms
+step:869/1490 train_time:36652ms step_avg:42.18ms
+step:870/1490 train_time:36711ms step_avg:42.20ms
+step:871/1490 train_time:36764ms step_avg:42.21ms
+step:872/1490 train_time:36823ms step_avg:42.23ms
+step:873/1490 train_time:36876ms step_avg:42.24ms
+step:874/1490 train_time:36935ms step_avg:42.26ms
+step:875/1490 train_time:36988ms step_avg:42.27ms
+step:876/1490 train_time:37047ms step_avg:42.29ms
+step:877/1490 train_time:37101ms step_avg:42.30ms
+step:878/1490 train_time:37159ms step_avg:42.32ms
+step:879/1490 train_time:37213ms step_avg:42.34ms
+step:880/1490 train_time:37272ms step_avg:42.36ms
+step:881/1490 train_time:37327ms step_avg:42.37ms
+step:882/1490 train_time:37385ms step_avg:42.39ms
+step:883/1490 train_time:37439ms step_avg:42.40ms
+step:884/1490 train_time:37498ms step_avg:42.42ms
+step:885/1490 train_time:37552ms step_avg:42.43ms
+step:886/1490 train_time:37610ms step_avg:42.45ms
+step:887/1490 train_time:37664ms step_avg:42.46ms
+step:888/1490 train_time:37723ms step_avg:42.48ms
+step:889/1490 train_time:37776ms step_avg:42.49ms
+step:890/1490 train_time:37835ms step_avg:42.51ms
+step:891/1490 train_time:37888ms step_avg:42.52ms
+step:892/1490 train_time:37947ms step_avg:42.54ms
+step:893/1490 train_time:38001ms step_avg:42.55ms
+step:894/1490 train_time:38059ms step_avg:42.57ms
+step:895/1490 train_time:38114ms step_avg:42.59ms
+step:896/1490 train_time:38173ms step_avg:42.60ms
+step:897/1490 train_time:38227ms step_avg:42.62ms
+step:898/1490 train_time:38286ms step_avg:42.63ms
+step:899/1490 train_time:38338ms step_avg:42.65ms
+step:900/1490 train_time:38397ms step_avg:42.66ms
+step:901/1490 train_time:38451ms step_avg:42.68ms
+step:902/1490 train_time:38510ms step_avg:42.69ms
+step:903/1490 train_time:38564ms step_avg:42.71ms
+step:904/1490 train_time:38623ms step_avg:42.72ms
+step:905/1490 train_time:38676ms step_avg:42.74ms
+step:906/1490 train_time:38734ms step_avg:42.75ms
+step:907/1490 train_time:38789ms step_avg:42.77ms
+step:908/1490 train_time:38848ms step_avg:42.78ms
+step:909/1490 train_time:38902ms step_avg:42.80ms
+step:910/1490 train_time:38959ms step_avg:42.81ms
+step:911/1490 train_time:39014ms step_avg:42.83ms
+step:912/1490 train_time:39073ms step_avg:42.84ms
+step:913/1490 train_time:39127ms step_avg:42.86ms
+step:914/1490 train_time:39186ms step_avg:42.87ms
+step:915/1490 train_time:39239ms step_avg:42.88ms
+step:916/1490 train_time:39298ms step_avg:42.90ms
+step:917/1490 train_time:39351ms step_avg:42.91ms
+step:918/1490 train_time:39410ms step_avg:42.93ms
+step:919/1490 train_time:39464ms step_avg:42.94ms
+step:920/1490 train_time:39523ms step_avg:42.96ms
+step:921/1490 train_time:39577ms step_avg:42.97ms
+step:922/1490 train_time:39635ms step_avg:42.99ms
+step:923/1490 train_time:39689ms step_avg:43.00ms
+step:924/1490 train_time:39747ms step_avg:43.02ms
+step:925/1490 train_time:39802ms step_avg:43.03ms
+step:926/1490 train_time:39860ms step_avg:43.05ms
+step:927/1490 train_time:39913ms step_avg:43.06ms
+step:928/1490 train_time:39973ms step_avg:43.07ms
+step:929/1490 train_time:40026ms step_avg:43.08ms
+step:930/1490 train_time:40085ms step_avg:43.10ms
+step:931/1490 train_time:40138ms step_avg:43.11ms
+step:932/1490 train_time:40197ms step_avg:43.13ms
+step:933/1490 train_time:40251ms step_avg:43.14ms
+step:934/1490 train_time:40309ms step_avg:43.16ms
+step:935/1490 train_time:40363ms step_avg:43.17ms
+step:936/1490 train_time:40422ms step_avg:43.19ms
+step:937/1490 train_time:40475ms step_avg:43.20ms
+step:938/1490 train_time:40535ms step_avg:43.21ms
+step:939/1490 train_time:40588ms step_avg:43.22ms
+step:940/1490 train_time:40646ms step_avg:43.24ms
+step:941/1490 train_time:40700ms step_avg:43.25ms
+step:942/1490 train_time:40759ms step_avg:43.27ms
+step:943/1490 train_time:40813ms step_avg:43.28ms
+step:944/1490 train_time:40872ms step_avg:43.30ms
+step:945/1490 train_time:40926ms step_avg:43.31ms
+step:946/1490 train_time:40985ms step_avg:43.32ms
+step:947/1490 train_time:41039ms step_avg:43.34ms
+step:948/1490 train_time:41097ms step_avg:43.35ms
+step:949/1490 train_time:41151ms step_avg:43.36ms
+step:950/1490 train_time:41210ms step_avg:43.38ms
+step:951/1490 train_time:41263ms step_avg:43.39ms
+step:952/1490 train_time:41322ms step_avg:43.41ms
+step:953/1490 train_time:41376ms step_avg:43.42ms
+step:954/1490 train_time:41434ms step_avg:43.43ms
+step:955/1490 train_time:41488ms step_avg:43.44ms
+step:956/1490 train_time:41547ms step_avg:43.46ms
+step:957/1490 train_time:41602ms step_avg:43.47ms
+step:958/1490 train_time:41659ms step_avg:43.49ms
+step:959/1490 train_time:41714ms step_avg:43.50ms
+step:960/1490 train_time:41774ms step_avg:43.51ms
+step:961/1490 train_time:41827ms step_avg:43.52ms
+step:962/1490 train_time:41886ms step_avg:43.54ms
+step:963/1490 train_time:41939ms step_avg:43.55ms
+step:964/1490 train_time:41997ms step_avg:43.57ms
+step:965/1490 train_time:42051ms step_avg:43.58ms
+step:966/1490 train_time:42111ms step_avg:43.59ms
+step:967/1490 train_time:42164ms step_avg:43.60ms
+step:968/1490 train_time:42227ms step_avg:43.62ms
+step:969/1490 train_time:42306ms step_avg:43.66ms
+step:970/1490 train_time:42390ms step_avg:43.70ms
+step:971/1490 train_time:42469ms step_avg:43.74ms
+step:972/1490 train_time:42553ms step_avg:43.78ms
+step:973/1490 train_time:42632ms step_avg:43.82ms
+step:974/1490 train_time:42718ms step_avg:43.86ms
+step:975/1490 train_time:42797ms step_avg:43.89ms
+step:976/1490 train_time:42881ms step_avg:43.94ms
+step:977/1490 train_time:42960ms step_avg:43.97ms
+step:978/1490 train_time:43045ms step_avg:44.01ms
+step:979/1490 train_time:43126ms step_avg:44.05ms
+step:980/1490 train_time:43211ms step_avg:44.09ms
+step:981/1490 train_time:43290ms step_avg:44.13ms
+step:982/1490 train_time:43375ms step_avg:44.17ms
+step:983/1490 train_time:43454ms step_avg:44.21ms
+step:984/1490 train_time:43539ms step_avg:44.25ms
+step:985/1490 train_time:43619ms step_avg:44.28ms
+step:986/1490 train_time:43704ms step_avg:44.32ms
+step:987/1490 train_time:43783ms step_avg:44.36ms
+step:988/1490 train_time:43867ms step_avg:44.40ms
+step:989/1490 train_time:43947ms step_avg:44.44ms
+step:990/1490 train_time:44031ms step_avg:44.48ms
+step:991/1490 train_time:44110ms step_avg:44.51ms
+step:992/1490 train_time:44196ms step_avg:44.55ms
+step:993/1490 train_time:44274ms step_avg:44.59ms
+step:994/1490 train_time:44359ms step_avg:44.63ms
+step:995/1490 train_time:44439ms step_avg:44.66ms
+step:996/1490 train_time:44523ms step_avg:44.70ms
+step:997/1490 train_time:44602ms step_avg:44.74ms
+step:998/1490 train_time:44687ms step_avg:44.78ms
+step:999/1490 train_time:44767ms step_avg:44.81ms
+step:1000/1490 train_time:44852ms step_avg:44.85ms
+step:1000/1490 val_loss:3.5139 train_time:44952ms step_avg:44.95ms
+step:1001/1490 train_time:44973ms step_avg:44.93ms
+step:1002/1490 train_time:45021ms step_avg:44.93ms
+step:1003/1490 train_time:45104ms step_avg:44.97ms
+step:1004/1490 train_time:45189ms step_avg:45.01ms
+step:1005/1490 train_time:45268ms step_avg:45.04ms
+step:1006/1490 train_time:45353ms step_avg:45.08ms
+step:1007/1490 train_time:45431ms step_avg:45.12ms
+step:1008/1490 train_time:45515ms step_avg:45.15ms
+step:1009/1490 train_time:45595ms step_avg:45.19ms
+step:1010/1490 train_time:45678ms step_avg:45.23ms
+step:1011/1490 train_time:45757ms step_avg:45.26ms
+step:1012/1490 train_time:45840ms step_avg:45.30ms
+step:1013/1490 train_time:45921ms step_avg:45.33ms
+step:1014/1490 train_time:46008ms step_avg:45.37ms
+step:1015/1490 train_time:46090ms step_avg:45.41ms
+step:1016/1490 train_time:46175ms step_avg:45.45ms
+step:1017/1490 train_time:46256ms step_avg:45.48ms
+step:1018/1490 train_time:46341ms step_avg:45.52ms
+step:1019/1490 train_time:46421ms step_avg:45.56ms
+step:1020/1490 train_time:46504ms step_avg:45.59ms
+step:1021/1490 train_time:46582ms step_avg:45.62ms
+step:1022/1490 train_time:46667ms step_avg:45.66ms
+step:1023/1490 train_time:46746ms step_avg:45.69ms
+step:1024/1490 train_time:46830ms step_avg:45.73ms
+step:1025/1490 train_time:46910ms step_avg:45.77ms
+step:1026/1490 train_time:46995ms step_avg:45.80ms
+step:1027/1490 train_time:47075ms step_avg:45.84ms
+step:1028/1490 train_time:47161ms step_avg:45.88ms
+step:1029/1490 train_time:47240ms step_avg:45.91ms
+step:1030/1490 train_time:47326ms step_avg:45.95ms
+step:1031/1490 train_time:47405ms step_avg:45.98ms
+step:1032/1490 train_time:47489ms step_avg:46.02ms
+step:1033/1490 train_time:47568ms step_avg:46.05ms
+step:1034/1490 train_time:47651ms step_avg:46.08ms
+step:1035/1490 train_time:47730ms step_avg:46.12ms
+step:1036/1490 train_time:47815ms step_avg:46.15ms
+step:1037/1490 train_time:47894ms step_avg:46.18ms
+step:1038/1490 train_time:47979ms step_avg:46.22ms
+step:1039/1490 train_time:48060ms step_avg:46.26ms
+step:1040/1490 train_time:48147ms step_avg:46.30ms
+step:1041/1490 train_time:48228ms step_avg:46.33ms
+step:1042/1490 train_time:48313ms step_avg:46.37ms
+step:1043/1490 train_time:48391ms step_avg:46.40ms
+step:1044/1490 train_time:48476ms step_avg:46.43ms
+step:1045/1490 train_time:48556ms step_avg:46.47ms
+step:1046/1490 train_time:48641ms step_avg:46.50ms
+step:1047/1490 train_time:48721ms step_avg:46.53ms
+step:1048/1490 train_time:48804ms step_avg:46.57ms
+step:1049/1490 train_time:48883ms step_avg:46.60ms
+step:1050/1490 train_time:48968ms step_avg:46.64ms
+step:1051/1490 train_time:49047ms step_avg:46.67ms
+step:1052/1490 train_time:49132ms step_avg:46.70ms
+step:1053/1490 train_time:49213ms step_avg:46.74ms
+step:1054/1490 train_time:49297ms step_avg:46.77ms
+step:1055/1490 train_time:49379ms step_avg:46.80ms
+step:1056/1490 train_time:49462ms step_avg:46.84ms
+step:1057/1490 train_time:49541ms step_avg:46.87ms
+step:1058/1490 train_time:49626ms step_avg:46.91ms
+step:1059/1490 train_time:49706ms step_avg:46.94ms
+step:1060/1490 train_time:49790ms step_avg:46.97ms
+step:1061/1490 train_time:49870ms step_avg:47.00ms
+step:1062/1490 train_time:49954ms step_avg:47.04ms
+step:1063/1490 train_time:50034ms step_avg:47.07ms
+step:1064/1490 train_time:50120ms step_avg:47.11ms
+step:1065/1490 train_time:50199ms step_avg:47.14ms
+step:1066/1490 train_time:50285ms step_avg:47.17ms
+step:1067/1490 train_time:50365ms step_avg:47.20ms
+step:1068/1490 train_time:50449ms step_avg:47.24ms
+step:1069/1490 train_time:50529ms step_avg:47.27ms
+step:1070/1490 train_time:50614ms step_avg:47.30ms
+step:1071/1490 train_time:50693ms step_avg:47.33ms
+step:1072/1490 train_time:50776ms step_avg:47.37ms
+step:1073/1490 train_time:50856ms step_avg:47.40ms
+step:1074/1490 train_time:50941ms step_avg:47.43ms
+step:1075/1490 train_time:51021ms step_avg:47.46ms
+step:1076/1490 train_time:51107ms step_avg:47.50ms
+step:1077/1490 train_time:51185ms step_avg:47.53ms
+step:1078/1490 train_time:51271ms step_avg:47.56ms
+step:1079/1490 train_time:51351ms step_avg:47.59ms
+step:1080/1490 train_time:51436ms step_avg:47.63ms
+step:1081/1490 train_time:51516ms step_avg:47.66ms
+step:1082/1490 train_time:51601ms step_avg:47.69ms
+step:1083/1490 train_time:51680ms step_avg:47.72ms
+step:1084/1490 train_time:51764ms step_avg:47.75ms
+step:1085/1490 train_time:51844ms step_avg:47.78ms
+step:1086/1490 train_time:51929ms step_avg:47.82ms
+step:1087/1490 train_time:52009ms step_avg:47.85ms
+step:1088/1490 train_time:52093ms step_avg:47.88ms
+step:1089/1490 train_time:52173ms step_avg:47.91ms
+step:1090/1490 train_time:52258ms step_avg:47.94ms
+step:1091/1490 train_time:52338ms step_avg:47.97ms
+step:1092/1490 train_time:52424ms step_avg:48.01ms
+step:1093/1490 train_time:52504ms step_avg:48.04ms
+step:1094/1490 train_time:52588ms step_avg:48.07ms
+step:1095/1490 train_time:52668ms step_avg:48.10ms
+step:1096/1490 train_time:52753ms step_avg:48.13ms
+step:1097/1490 train_time:52831ms step_avg:48.16ms
+step:1098/1490 train_time:52915ms step_avg:48.19ms
+step:1099/1490 train_time:52995ms step_avg:48.22ms
+step:1100/1490 train_time:53081ms step_avg:48.26ms
+step:1101/1490 train_time:53160ms step_avg:48.28ms
+step:1102/1490 train_time:53244ms step_avg:48.32ms
+step:1103/1490 train_time:53323ms step_avg:48.34ms
+step:1104/1490 train_time:53409ms step_avg:48.38ms
+step:1105/1490 train_time:53487ms step_avg:48.40ms
+step:1106/1490 train_time:53571ms step_avg:48.44ms
+step:1107/1490 train_time:53651ms step_avg:48.47ms
+step:1108/1490 train_time:53736ms step_avg:48.50ms
+step:1109/1490 train_time:53817ms step_avg:48.53ms
+step:1110/1490 train_time:53902ms step_avg:48.56ms
+step:1111/1490 train_time:53982ms step_avg:48.59ms
+step:1112/1490 train_time:54067ms step_avg:48.62ms
+step:1113/1490 train_time:54145ms step_avg:48.65ms
+step:1114/1490 train_time:54231ms step_avg:48.68ms
+step:1115/1490 train_time:54310ms step_avg:48.71ms
+step:1116/1490 train_time:54395ms step_avg:48.74ms
+step:1117/1490 train_time:54476ms step_avg:48.77ms
+step:1118/1490 train_time:54561ms step_avg:48.80ms
+step:1119/1490 train_time:54641ms step_avg:48.83ms
+step:1120/1490 train_time:54725ms step_avg:48.86ms
+step:1121/1490 train_time:54803ms step_avg:48.89ms
+step:1122/1490 train_time:54889ms step_avg:48.92ms
+step:1123/1490 train_time:54969ms step_avg:48.95ms
+step:1124/1490 train_time:55053ms step_avg:48.98ms
+step:1125/1490 train_time:55131ms step_avg:49.01ms
+step:1126/1490 train_time:55217ms step_avg:49.04ms
+step:1127/1490 train_time:55298ms step_avg:49.07ms
+step:1128/1490 train_time:55382ms step_avg:49.10ms
+step:1129/1490 train_time:55461ms step_avg:49.12ms
+step:1130/1490 train_time:55545ms step_avg:49.16ms
+step:1131/1490 train_time:55625ms step_avg:49.18ms
+step:1132/1490 train_time:55710ms step_avg:49.21ms
+step:1133/1490 train_time:55788ms step_avg:49.24ms
+step:1134/1490 train_time:55873ms step_avg:49.27ms
+step:1135/1490 train_time:55953ms step_avg:49.30ms
+step:1136/1490 train_time:56039ms step_avg:49.33ms
+step:1137/1490 train_time:56119ms step_avg:49.36ms
+step:1138/1490 train_time:56203ms step_avg:49.39ms
+step:1139/1490 train_time:56283ms step_avg:49.41ms
+step:1140/1490 train_time:56367ms step_avg:49.44ms
+step:1141/1490 train_time:56446ms step_avg:49.47ms
+step:1142/1490 train_time:56531ms step_avg:49.50ms
+step:1143/1490 train_time:56611ms step_avg:49.53ms
+step:1144/1490 train_time:56696ms step_avg:49.56ms
+step:1145/1490 train_time:56776ms step_avg:49.59ms
+step:1146/1490 train_time:56861ms step_avg:49.62ms
+step:1147/1490 train_time:56941ms step_avg:49.64ms
+step:1148/1490 train_time:57024ms step_avg:49.67ms
+step:1149/1490 train_time:57105ms step_avg:49.70ms
+step:1150/1490 train_time:57190ms step_avg:49.73ms
+step:1151/1490 train_time:57268ms step_avg:49.76ms
+step:1152/1490 train_time:57354ms step_avg:49.79ms
+step:1153/1490 train_time:57433ms step_avg:49.81ms
+step:1154/1490 train_time:57520ms step_avg:49.84ms
+step:1155/1490 train_time:57599ms step_avg:49.87ms
+step:1156/1490 train_time:57683ms step_avg:49.90ms
+step:1157/1490 train_time:57762ms step_avg:49.92ms
+step:1158/1490 train_time:57847ms step_avg:49.95ms
+step:1159/1490 train_time:57927ms step_avg:49.98ms
+step:1160/1490 train_time:58012ms step_avg:50.01ms
+step:1161/1490 train_time:58090ms step_avg:50.03ms
+step:1162/1490 train_time:58175ms step_avg:50.06ms
+step:1163/1490 train_time:58256ms step_avg:50.09ms
+step:1164/1490 train_time:58340ms step_avg:50.12ms
+step:1165/1490 train_time:58420ms step_avg:50.15ms
+step:1166/1490 train_time:58505ms step_avg:50.18ms
+step:1167/1490 train_time:58583ms step_avg:50.20ms
+step:1168/1490 train_time:58669ms step_avg:50.23ms
+step:1169/1490 train_time:58748ms step_avg:50.25ms
+step:1170/1490 train_time:58832ms step_avg:50.28ms
+step:1171/1490 train_time:58911ms step_avg:50.31ms
+step:1172/1490 train_time:58996ms step_avg:50.34ms
+step:1173/1490 train_time:59075ms step_avg:50.36ms
+step:1174/1490 train_time:59161ms step_avg:50.39ms
+step:1175/1490 train_time:59241ms step_avg:50.42ms
+step:1176/1490 train_time:59325ms step_avg:50.45ms
+step:1177/1490 train_time:59405ms step_avg:50.47ms
+step:1178/1490 train_time:59490ms step_avg:50.50ms
+step:1179/1490 train_time:59569ms step_avg:50.53ms
+step:1180/1490 train_time:59654ms step_avg:50.55ms
+step:1181/1490 train_time:59733ms step_avg:50.58ms
+step:1182/1490 train_time:59818ms step_avg:50.61ms
+step:1183/1490 train_time:59898ms step_avg:50.63ms
+step:1184/1490 train_time:59982ms step_avg:50.66ms
+step:1185/1490 train_time:60060ms step_avg:50.68ms
+step:1186/1490 train_time:60146ms step_avg:50.71ms
+step:1187/1490 train_time:60226ms step_avg:50.74ms
+step:1188/1490 train_time:60311ms step_avg:50.77ms
+step:1189/1490 train_time:60390ms step_avg:50.79ms
+step:1190/1490 train_time:60475ms step_avg:50.82ms
+step:1191/1490 train_time:60553ms step_avg:50.84ms
+step:1192/1490 train_time:60638ms step_avg:50.87ms
+step:1193/1490 train_time:60719ms step_avg:50.90ms
+step:1194/1490 train_time:60804ms step_avg:50.92ms
+step:1195/1490 train_time:60883ms step_avg:50.95ms
+step:1196/1490 train_time:60968ms step_avg:50.98ms
+step:1197/1490 train_time:61047ms step_avg:51.00ms
+step:1198/1490 train_time:61132ms step_avg:51.03ms
+step:1199/1490 train_time:61211ms step_avg:51.05ms
+step:1200/1490 train_time:61296ms step_avg:51.08ms
+step:1201/1490 train_time:61376ms step_avg:51.10ms
+step:1202/1490 train_time:61461ms step_avg:51.13ms
+step:1203/1490 train_time:61540ms step_avg:51.16ms
+step:1204/1490 train_time:61624ms step_avg:51.18ms
+step:1205/1490 train_time:61704ms step_avg:51.21ms
+step:1206/1490 train_time:61789ms step_avg:51.23ms
+step:1207/1490 train_time:61868ms step_avg:51.26ms
+step:1208/1490 train_time:61953ms step_avg:51.29ms
+step:1209/1490 train_time:62031ms step_avg:51.31ms
+step:1210/1490 train_time:62117ms step_avg:51.34ms
+step:1211/1490 train_time:62197ms step_avg:51.36ms
+step:1212/1490 train_time:62281ms step_avg:51.39ms
+step:1213/1490 train_time:62363ms step_avg:51.41ms
+step:1214/1490 train_time:62445ms step_avg:51.44ms
+step:1215/1490 train_time:62525ms step_avg:51.46ms
+step:1216/1490 train_time:62611ms step_avg:51.49ms
+step:1217/1490 train_time:62689ms step_avg:51.51ms
+step:1218/1490 train_time:62773ms step_avg:51.54ms
+step:1219/1490 train_time:62854ms step_avg:51.56ms
+step:1220/1490 train_time:62938ms step_avg:51.59ms
+step:1221/1490 train_time:63019ms step_avg:51.61ms
+step:1222/1490 train_time:63103ms step_avg:51.64ms
+step:1223/1490 train_time:63182ms step_avg:51.66ms
+step:1224/1490 train_time:63265ms step_avg:51.69ms
+step:1225/1490 train_time:63344ms step_avg:51.71ms
+step:1226/1490 train_time:63430ms step_avg:51.74ms
+step:1227/1490 train_time:63509ms step_avg:51.76ms
+step:1228/1490 train_time:63594ms step_avg:51.79ms
+step:1229/1490 train_time:63674ms step_avg:51.81ms
+step:1230/1490 train_time:63758ms step_avg:51.84ms
+step:1231/1490 train_time:63838ms step_avg:51.86ms
+step:1232/1490 train_time:63922ms step_avg:51.88ms
+step:1233/1490 train_time:64002ms step_avg:51.91ms
+step:1234/1490 train_time:64088ms step_avg:51.94ms
+step:1235/1490 train_time:64168ms step_avg:51.96ms
+step:1236/1490 train_time:64251ms step_avg:51.98ms
+step:1237/1490 train_time:64331ms step_avg:52.01ms
+step:1238/1490 train_time:64417ms step_avg:52.03ms
+step:1239/1490 train_time:64496ms step_avg:52.05ms
+step:1240/1490 train_time:64581ms step_avg:52.08ms
+step:1241/1490 train_time:64660ms step_avg:52.10ms
+step:1242/1490 train_time:64745ms step_avg:52.13ms
+step:1243/1490 train_time:64823ms step_avg:52.15ms
+step:1244/1490 train_time:64907ms step_avg:52.18ms
+step:1245/1490 train_time:64987ms step_avg:52.20ms
+step:1246/1490 train_time:65072ms step_avg:52.22ms
+step:1247/1490 train_time:65152ms step_avg:52.25ms
+step:1248/1490 train_time:65236ms step_avg:52.27ms
+step:1249/1490 train_time:65317ms step_avg:52.30ms
+step:1250/1490 train_time:65402ms step_avg:52.32ms
+step:1250/1490 val_loss:3.3699 train_time:65503ms step_avg:52.40ms
+step:1251/1490 train_time:65521ms step_avg:52.37ms
+step:1252/1490 train_time:65569ms step_avg:52.37ms
+step:1253/1490 train_time:65651ms step_avg:52.39ms
+step:1254/1490 train_time:65739ms step_avg:52.42ms
+step:1255/1490 train_time:65819ms step_avg:52.45ms
+step:1256/1490 train_time:65904ms step_avg:52.47ms
+step:1257/1490 train_time:65982ms step_avg:52.49ms
+step:1258/1490 train_time:66066ms step_avg:52.52ms
+step:1259/1490 train_time:66145ms step_avg:52.54ms
+step:1260/1490 train_time:66228ms step_avg:52.56ms
+step:1261/1490 train_time:66306ms step_avg:52.58ms
+step:1262/1490 train_time:66389ms step_avg:52.61ms
+step:1263/1490 train_time:66468ms step_avg:52.63ms
+step:1264/1490 train_time:66555ms step_avg:52.65ms
+step:1265/1490 train_time:66637ms step_avg:52.68ms
+step:1266/1490 train_time:66724ms step_avg:52.70ms
+step:1267/1490 train_time:66804ms step_avg:52.73ms
+step:1268/1490 train_time:66890ms step_avg:52.75ms
+step:1269/1490 train_time:66968ms step_avg:52.77ms
+step:1270/1490 train_time:67052ms step_avg:52.80ms
+step:1271/1490 train_time:67130ms step_avg:52.82ms
+step:1272/1490 train_time:67214ms step_avg:52.84ms
+step:1273/1490 train_time:67291ms step_avg:52.86ms
+step:1274/1490 train_time:67375ms step_avg:52.88ms
+step:1275/1490 train_time:67455ms step_avg:52.91ms
+step:1276/1490 train_time:67542ms step_avg:52.93ms
+step:1277/1490 train_time:67623ms step_avg:52.95ms
+step:1278/1490 train_time:67710ms step_avg:52.98ms
+step:1279/1490 train_time:67789ms step_avg:53.00ms
+step:1280/1490 train_time:67875ms step_avg:53.03ms
+step:1281/1490 train_time:67953ms step_avg:53.05ms
+step:1282/1490 train_time:68038ms step_avg:53.07ms
+step:1283/1490 train_time:68115ms step_avg:53.09ms
+step:1284/1490 train_time:68200ms step_avg:53.11ms
+step:1285/1490 train_time:68280ms step_avg:53.14ms
+step:1286/1490 train_time:68364ms step_avg:53.16ms
+step:1287/1490 train_time:68443ms step_avg:53.18ms
+step:1288/1490 train_time:68528ms step_avg:53.20ms
+step:1289/1490 train_time:68609ms step_avg:53.23ms
+step:1290/1490 train_time:68695ms step_avg:53.25ms
+step:1291/1490 train_time:68774ms step_avg:53.27ms
+step:1292/1490 train_time:68859ms step_avg:53.30ms
+step:1293/1490 train_time:68939ms step_avg:53.32ms
+step:1294/1490 train_time:69024ms step_avg:53.34ms
+step:1295/1490 train_time:69104ms step_avg:53.36ms
+step:1296/1490 train_time:69187ms step_avg:53.39ms
+step:1297/1490 train_time:69266ms step_avg:53.40ms
+step:1298/1490 train_time:69351ms step_avg:53.43ms
+step:1299/1490 train_time:69431ms step_avg:53.45ms
+step:1300/1490 train_time:69517ms step_avg:53.47ms
+step:1301/1490 train_time:69596ms step_avg:53.49ms
+step:1302/1490 train_time:69680ms step_avg:53.52ms
+step:1303/1490 train_time:69761ms step_avg:53.54ms
+step:1304/1490 train_time:69846ms step_avg:53.56ms
+step:1305/1490 train_time:69925ms step_avg:53.58ms
+step:1306/1490 train_time:70010ms step_avg:53.61ms
+step:1307/1490 train_time:70090ms step_avg:53.63ms
+step:1308/1490 train_time:70174ms step_avg:53.65ms
+step:1309/1490 train_time:70253ms step_avg:53.67ms
+step:1310/1490 train_time:70337ms step_avg:53.69ms
+step:1311/1490 train_time:70417ms step_avg:53.71ms
+step:1312/1490 train_time:70502ms step_avg:53.74ms
+step:1313/1490 train_time:70582ms step_avg:53.76ms
+step:1314/1490 train_time:70667ms step_avg:53.78ms
+step:1315/1490 train_time:70748ms step_avg:53.80ms
+step:1316/1490 train_time:70831ms step_avg:53.82ms
+step:1317/1490 train_time:70912ms step_avg:53.84ms
+step:1318/1490 train_time:70996ms step_avg:53.87ms
+step:1319/1490 train_time:71074ms step_avg:53.89ms
+step:1320/1490 train_time:71159ms step_avg:53.91ms
+step:1321/1490 train_time:71237ms step_avg:53.93ms
+step:1322/1490 train_time:71323ms step_avg:53.95ms
+step:1323/1490 train_time:71402ms step_avg:53.97ms
+step:1324/1490 train_time:71487ms step_avg:53.99ms
+step:1325/1490 train_time:71566ms step_avg:54.01ms
+step:1326/1490 train_time:71651ms step_avg:54.04ms
+step:1327/1490 train_time:71731ms step_avg:54.06ms
+step:1328/1490 train_time:71818ms step_avg:54.08ms
+step:1329/1490 train_time:71896ms step_avg:54.10ms
+step:1330/1490 train_time:71980ms step_avg:54.12ms
+step:1331/1490 train_time:72061ms step_avg:54.14ms
+step:1332/1490 train_time:72147ms step_avg:54.16ms
+step:1333/1490 train_time:72227ms step_avg:54.18ms
+step:1334/1490 train_time:72312ms step_avg:54.21ms
+step:1335/1490 train_time:72389ms step_avg:54.22ms
+step:1336/1490 train_time:72475ms step_avg:54.25ms
+step:1337/1490 train_time:72554ms step_avg:54.27ms
+step:1338/1490 train_time:72639ms step_avg:54.29ms
+step:1339/1490 train_time:72719ms step_avg:54.31ms
+step:1340/1490 train_time:72805ms step_avg:54.33ms
+step:1341/1490 train_time:72884ms step_avg:54.35ms
+step:1342/1490 train_time:72968ms step_avg:54.37ms
+step:1343/1490 train_time:73047ms step_avg:54.39ms
+step:1344/1490 train_time:73132ms step_avg:54.41ms
+step:1345/1490 train_time:73211ms step_avg:54.43ms
+step:1346/1490 train_time:73296ms step_avg:54.45ms
+step:1347/1490 train_time:73374ms step_avg:54.47ms
+step:1348/1490 train_time:73459ms step_avg:54.49ms
+step:1349/1490 train_time:73540ms step_avg:54.51ms
+step:1350/1490 train_time:73625ms step_avg:54.54ms
+step:1351/1490 train_time:73706ms step_avg:54.56ms
+step:1352/1490 train_time:73791ms step_avg:54.58ms
+step:1353/1490 train_time:73871ms step_avg:54.60ms
+step:1354/1490 train_time:73955ms step_avg:54.62ms
+step:1355/1490 train_time:74035ms step_avg:54.64ms
+step:1356/1490 train_time:74119ms step_avg:54.66ms
+step:1357/1490 train_time:74198ms step_avg:54.68ms
+step:1358/1490 train_time:74282ms step_avg:54.70ms
+step:1359/1490 train_time:74363ms step_avg:54.72ms
+step:1360/1490 train_time:74449ms step_avg:54.74ms
+step:1361/1490 train_time:74528ms step_avg:54.76ms
+step:1362/1490 train_time:74612ms step_avg:54.78ms
+step:1363/1490 train_time:74692ms step_avg:54.80ms
+step:1364/1490 train_time:74778ms step_avg:54.82ms
+step:1365/1490 train_time:74858ms step_avg:54.84ms
+step:1366/1490 train_time:74942ms step_avg:54.86ms
+step:1367/1490 train_time:75023ms step_avg:54.88ms
+step:1368/1490 train_time:75108ms step_avg:54.90ms
+step:1369/1490 train_time:75187ms step_avg:54.92ms
+step:1370/1490 train_time:75272ms step_avg:54.94ms
+step:1371/1490 train_time:75352ms step_avg:54.96ms
+step:1372/1490 train_time:75436ms step_avg:54.98ms
+step:1373/1490 train_time:75515ms step_avg:55.00ms
+step:1374/1490 train_time:75600ms step_avg:55.02ms
+step:1375/1490 train_time:75681ms step_avg:55.04ms
+step:1376/1490 train_time:75766ms step_avg:55.06ms
+step:1377/1490 train_time:75845ms step_avg:55.08ms
+step:1378/1490 train_time:75930ms step_avg:55.10ms
+step:1379/1490 train_time:76010ms step_avg:55.12ms
+step:1380/1490 train_time:76094ms step_avg:55.14ms
+step:1381/1490 train_time:76172ms step_avg:55.16ms
+step:1382/1490 train_time:76258ms step_avg:55.18ms
+step:1383/1490 train_time:76336ms step_avg:55.20ms
+step:1384/1490 train_time:76422ms step_avg:55.22ms
+step:1385/1490 train_time:76501ms step_avg:55.24ms
+step:1386/1490 train_time:76585ms step_avg:55.26ms
+step:1387/1490 train_time:76665ms step_avg:55.27ms
+step:1388/1490 train_time:76751ms step_avg:55.30ms
+step:1389/1490 train_time:76831ms step_avg:55.31ms
+step:1390/1490 train_time:76916ms step_avg:55.34ms
+step:1391/1490 train_time:76996ms step_avg:55.35ms
+step:1392/1490 train_time:77080ms step_avg:55.37ms
+step:1393/1490 train_time:77159ms step_avg:55.39ms
+step:1394/1490 train_time:77244ms step_avg:55.41ms
+step:1395/1490 train_time:77323ms step_avg:55.43ms
+step:1396/1490 train_time:77407ms step_avg:55.45ms
+step:1397/1490 train_time:77486ms step_avg:55.47ms
+step:1398/1490 train_time:77570ms step_avg:55.49ms
+step:1399/1490 train_time:77649ms step_avg:55.50ms
+step:1400/1490 train_time:77735ms step_avg:55.53ms
+step:1401/1490 train_time:77815ms step_avg:55.54ms
+step:1402/1490 train_time:77900ms step_avg:55.56ms
+step:1403/1490 train_time:77978ms step_avg:55.58ms
+step:1404/1490 train_time:78063ms step_avg:55.60ms
+step:1405/1490 train_time:78144ms step_avg:55.62ms
+step:1406/1490 train_time:78228ms step_avg:55.64ms
+step:1407/1490 train_time:78306ms step_avg:55.65ms
+step:1408/1490 train_time:78391ms step_avg:55.68ms
+step:1409/1490 train_time:78471ms step_avg:55.69ms
+step:1410/1490 train_time:78557ms step_avg:55.71ms
+step:1411/1490 train_time:78636ms step_avg:55.73ms
+step:1412/1490 train_time:78720ms step_avg:55.75ms
+step:1413/1490 train_time:78800ms step_avg:55.77ms
+step:1414/1490 train_time:78886ms step_avg:55.79ms
+step:1415/1490 train_time:78965ms step_avg:55.81ms
+step:1416/1490 train_time:79051ms step_avg:55.83ms
+step:1417/1490 train_time:79132ms step_avg:55.84ms
+step:1418/1490 train_time:79216ms step_avg:55.86ms
+step:1419/1490 train_time:79295ms step_avg:55.88ms
+step:1420/1490 train_time:79379ms step_avg:55.90ms
+step:1421/1490 train_time:79458ms step_avg:55.92ms
+step:1422/1490 train_time:79542ms step_avg:55.94ms
+step:1423/1490 train_time:79622ms step_avg:55.95ms
+step:1424/1490 train_time:79709ms step_avg:55.98ms
+step:1425/1490 train_time:79787ms step_avg:55.99ms
+step:1426/1490 train_time:79871ms step_avg:56.01ms
+step:1427/1490 train_time:79951ms step_avg:56.03ms
+step:1428/1490 train_time:80035ms step_avg:56.05ms
+step:1429/1490 train_time:80115ms step_avg:56.06ms
+step:1430/1490 train_time:80199ms step_avg:56.08ms
+step:1431/1490 train_time:80278ms step_avg:56.10ms
+step:1432/1490 train_time:80363ms step_avg:56.12ms
+step:1433/1490 train_time:80443ms step_avg:56.14ms
+step:1434/1490 train_time:80527ms step_avg:56.16ms
+step:1435/1490 train_time:80606ms step_avg:56.17ms
+step:1436/1490 train_time:80693ms step_avg:56.19ms
+step:1437/1490 train_time:80772ms step_avg:56.21ms
+step:1438/1490 train_time:80855ms step_avg:56.23ms
+step:1439/1490 train_time:80934ms step_avg:56.24ms
+step:1440/1490 train_time:81020ms step_avg:56.26ms
+step:1441/1490 train_time:81099ms step_avg:56.28ms
+step:1442/1490 train_time:81186ms step_avg:56.30ms
+step:1443/1490 train_time:81265ms step_avg:56.32ms
+step:1444/1490 train_time:81350ms step_avg:56.34ms
+step:1445/1490 train_time:81429ms step_avg:56.35ms
+step:1446/1490 train_time:81514ms step_avg:56.37ms
+step:1447/1490 train_time:81593ms step_avg:56.39ms
+step:1448/1490 train_time:81679ms step_avg:56.41ms
+step:1449/1490 train_time:81757ms step_avg:56.42ms
+step:1450/1490 train_time:81841ms step_avg:56.44ms
+step:1451/1490 train_time:81926ms step_avg:56.46ms
+step:1452/1490 train_time:82014ms step_avg:56.48ms
+step:1453/1490 train_time:82092ms step_avg:56.50ms
+step:1454/1490 train_time:82179ms step_avg:56.52ms
+step:1455/1490 train_time:82258ms step_avg:56.53ms
+step:1456/1490 train_time:82343ms step_avg:56.55ms
+step:1457/1490 train_time:82424ms step_avg:56.57ms
+step:1458/1490 train_time:82511ms step_avg:56.59ms
+step:1459/1490 train_time:82591ms step_avg:56.61ms
+step:1460/1490 train_time:82675ms step_avg:56.63ms
+step:1461/1490 train_time:82755ms step_avg:56.64ms
+step:1462/1490 train_time:82838ms step_avg:56.66ms
+step:1463/1490 train_time:82920ms step_avg:56.68ms
+step:1464/1490 train_time:83005ms step_avg:56.70ms
+step:1465/1490 train_time:83085ms step_avg:56.71ms
+step:1466/1490 train_time:83169ms step_avg:56.73ms
+step:1467/1490 train_time:83250ms step_avg:56.75ms
+step:1468/1490 train_time:83335ms step_avg:56.77ms
+step:1469/1490 train_time:83415ms step_avg:56.78ms
+step:1470/1490 train_time:83500ms step_avg:56.80ms
+step:1471/1490 train_time:83578ms step_avg:56.82ms
+step:1472/1490 train_time:83664ms step_avg:56.84ms
+step:1473/1490 train_time:83744ms step_avg:56.85ms
+step:1474/1490 train_time:83828ms step_avg:56.87ms
+step:1475/1490 train_time:83909ms step_avg:56.89ms
+step:1476/1490 train_time:83993ms step_avg:56.91ms
+step:1477/1490 train_time:84073ms step_avg:56.92ms
+step:1478/1490 train_time:84159ms step_avg:56.94ms
+step:1479/1490 train_time:84238ms step_avg:56.96ms
+step:1480/1490 train_time:84324ms step_avg:56.98ms
+step:1481/1490 train_time:84404ms step_avg:56.99ms
+step:1482/1490 train_time:84489ms step_avg:57.01ms
+step:1483/1490 train_time:84569ms step_avg:57.03ms
+step:1484/1490 train_time:84654ms step_avg:57.04ms
+step:1485/1490 train_time:84733ms step_avg:57.06ms
+step:1486/1490 train_time:84820ms step_avg:57.08ms
+step:1487/1490 train_time:84899ms step_avg:57.09ms
+step:1488/1490 train_time:84984ms step_avg:57.11ms
+step:1489/1490 train_time:85064ms step_avg:57.13ms
+step:1490/1490 train_time:85150ms step_avg:57.15ms
+step:1490/1490 val_loss:3.2775 train_time:85251ms step_avg:57.22ms
+peak memory allocated: 31254 MiB reserved: 46782 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/train_gpt.py
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/train_gpt.py
@@ -1,0 +1,2238 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/triton_kernels.py
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/baseline_plus_polar/triton_kernels.py
@@ -1,0 +1,882 @@
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+
+    max_val = -float('inf')
+    sum_exp = 0.0
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C + B_div_C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid(val_target * inv_C + B_div_C)
+                    total_loss += weight * (lse - z_target)
+
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    grad_s,
+    BLOCK_SIZE: tl.constexpr,
+    N_PREDICT: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+
+    inv_C = 1.0 / C
+    B_div_C = B * inv_C
+    inv_C_A = inv_C * A
+    inv_grad_s = 1.0 / grad_s
+
+    # Preload all targets and weights before the column loop
+    S_w = 0.0
+    t0: tl.int32 = -1
+    t1: tl.int32 = -1
+    t2: tl.int32 = -1
+    w0: tl.float32 = 0.0
+    w1: tl.float32 = 0.0
+    w2: tl.float32 = 0.0
+
+    if N_PREDICT >= 1:
+        if row_idx + 0 < n_rows:
+            w0 = tl.load(mtp_weights_ptr + 0)
+            t0 = tl.load(targets_ptr + row_idx + 0).to(tl.int32)
+            S_w += w0
+
+    if N_PREDICT >= 2:
+        if row_idx + 1 < n_rows:
+            w1 = tl.load(mtp_weights_ptr + 1)
+            t1 = tl.load(targets_ptr + row_idx + 1).to(tl.int32)
+            S_w += w1
+
+    if N_PREDICT >= 3:
+        if row_idx + 2 < n_rows:
+            w2 = tl.load(mtp_weights_ptr + 2)
+            t2 = tl.load(targets_ptr + row_idx + 2).to(tl.int32)
+            S_w += w2
+
+    # Fuse all scalar multiplications
+    grad_scale = grad_loss * inv_grad_s
+    grad_scale_icA = grad_scale * inv_C_A
+
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = val * inv_C + B_div_C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+
+        term1 = S_w * p
+
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        if N_PREDICT >= 1:
+            term2 += tl.where(cols == t0, w0, 0.0)
+        if N_PREDICT >= 2:
+            term2 += tl.where(cols == t1, w1, 0.0)
+        if N_PREDICT >= 3:
+            term2 += tl.where(cols == t2, w2, 0.0)
+
+        grad_z = term1 - term2
+        grad_x = grad_scale_icA * grad_z * sigmoid_u * (1.0 - sigmoid_u)
+        grad_x = grad_x.to(tl.float8e5)
+        tl.store(grad_row_ptr + cols, grad_x, mask=mask)
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=2048,
+            num_warps=2
+        )
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8 = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+        grad_output = grad_output.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            grad_s,
+            BLOCK_SIZE=1024,
+            num_warps=4,
+            N_PREDICT=n_predict,
+        )
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/425d4951-b129-49a1-8932-65e7047395d8.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/425d4951-b129-49a1-8932-65e7047395d8.txt
@@ -1,0 +1,4571 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 12:56:49 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   31C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8314 train_time:0ms step_avg:0.06ms
+step:1/1490 train_time:80ms step_avg:80.49ms
+step:2/1490 train_time:105ms step_avg:52.59ms
+step:3/1490 train_time:123ms step_avg:41.07ms
+step:4/1490 train_time:144ms step_avg:36.01ms
+step:5/1490 train_time:167ms step_avg:33.35ms
+step:6/1490 train_time:201ms step_avg:33.46ms
+step:7/1490 train_time:228ms step_avg:32.59ms
+step:8/1490 train_time:263ms step_avg:32.86ms
+step:9/1490 train_time:290ms step_avg:32.20ms
+step:10/1490 train_time:324ms step_avg:32.43ms
+step:11/1490 train_time:352ms step_avg:31.96ms
+step:12/1490 train_time:386ms step_avg:32.17ms
+step:13/1490 train_time:413ms step_avg:31.80ms
+step:14/1490 train_time:448ms step_avg:31.98ms
+step:15/1490 train_time:475ms step_avg:31.69ms
+step:16/1490 train_time:510ms step_avg:31.89ms
+step:17/1490 train_time:537ms step_avg:31.60ms
+step:18/1490 train_time:572ms step_avg:31.76ms
+step:19/1490 train_time:599ms step_avg:31.52ms
+step:20/1490 train_time:633ms step_avg:31.67ms
+step:21/1490 train_time:661ms step_avg:31.45ms
+step:22/1490 train_time:695ms step_avg:31.59ms
+step:23/1490 train_time:723ms step_avg:31.43ms
+step:24/1490 train_time:757ms step_avg:31.55ms
+step:25/1490 train_time:784ms step_avg:31.37ms
+step:26/1490 train_time:819ms step_avg:31.49ms
+step:27/1490 train_time:846ms step_avg:31.33ms
+step:28/1490 train_time:880ms step_avg:31.44ms
+step:29/1490 train_time:907ms step_avg:31.29ms
+step:30/1490 train_time:942ms step_avg:31.39ms
+step:31/1490 train_time:969ms step_avg:31.26ms
+step:32/1490 train_time:1005ms step_avg:31.42ms
+step:33/1490 train_time:1032ms step_avg:31.28ms
+step:34/1490 train_time:1067ms step_avg:31.37ms
+step:35/1490 train_time:1095ms step_avg:31.27ms
+step:36/1490 train_time:1129ms step_avg:31.37ms
+step:37/1490 train_time:1157ms step_avg:31.27ms
+step:38/1490 train_time:1191ms step_avg:31.35ms
+step:39/1490 train_time:1218ms step_avg:31.24ms
+step:40/1490 train_time:1253ms step_avg:31.32ms
+step:41/1490 train_time:1280ms step_avg:31.23ms
+step:42/1490 train_time:1315ms step_avg:31.30ms
+step:43/1490 train_time:1342ms step_avg:31.21ms
+step:44/1490 train_time:1377ms step_avg:31.29ms
+step:45/1490 train_time:1404ms step_avg:31.21ms
+step:46/1490 train_time:1439ms step_avg:31.29ms
+step:47/1490 train_time:1467ms step_avg:31.20ms
+step:48/1490 train_time:1501ms step_avg:31.27ms
+step:49/1490 train_time:1529ms step_avg:31.20ms
+step:50/1490 train_time:1564ms step_avg:31.28ms
+step:51/1490 train_time:1591ms step_avg:31.20ms
+step:52/1490 train_time:1626ms step_avg:31.26ms
+step:53/1490 train_time:1653ms step_avg:31.19ms
+step:54/1490 train_time:1688ms step_avg:31.25ms
+step:55/1490 train_time:1715ms step_avg:31.19ms
+step:56/1490 train_time:1749ms step_avg:31.24ms
+step:57/1490 train_time:1777ms step_avg:31.17ms
+step:58/1490 train_time:1811ms step_avg:31.23ms
+step:59/1490 train_time:1839ms step_avg:31.16ms
+step:60/1490 train_time:1873ms step_avg:31.21ms
+step:61/1490 train_time:1900ms step_avg:31.15ms
+step:62/1490 train_time:1934ms step_avg:31.20ms
+step:63/1490 train_time:1962ms step_avg:31.14ms
+step:64/1490 train_time:1997ms step_avg:31.20ms
+step:65/1490 train_time:2024ms step_avg:31.15ms
+step:66/1490 train_time:2060ms step_avg:31.21ms
+step:67/1490 train_time:2086ms step_avg:31.14ms
+step:68/1490 train_time:2121ms step_avg:31.19ms
+step:69/1490 train_time:2148ms step_avg:31.13ms
+step:70/1490 train_time:2183ms step_avg:31.18ms
+step:71/1490 train_time:2210ms step_avg:31.13ms
+step:72/1490 train_time:2245ms step_avg:31.18ms
+step:73/1490 train_time:2273ms step_avg:31.13ms
+step:74/1490 train_time:2307ms step_avg:31.18ms
+step:75/1490 train_time:2335ms step_avg:31.13ms
+step:76/1490 train_time:2369ms step_avg:31.17ms
+step:77/1490 train_time:2397ms step_avg:31.13ms
+step:78/1490 train_time:2431ms step_avg:31.17ms
+step:79/1490 train_time:2458ms step_avg:31.12ms
+step:80/1490 train_time:2493ms step_avg:31.16ms
+step:81/1490 train_time:2520ms step_avg:31.11ms
+step:82/1490 train_time:2554ms step_avg:31.15ms
+step:83/1490 train_time:2582ms step_avg:31.11ms
+step:84/1490 train_time:2617ms step_avg:31.16ms
+step:85/1490 train_time:2644ms step_avg:31.10ms
+step:86/1490 train_time:2679ms step_avg:31.15ms
+step:87/1490 train_time:2706ms step_avg:31.10ms
+step:88/1490 train_time:2742ms step_avg:31.15ms
+step:89/1490 train_time:2768ms step_avg:31.10ms
+step:90/1490 train_time:2802ms step_avg:31.13ms
+step:91/1490 train_time:2830ms step_avg:31.09ms
+step:92/1490 train_time:2864ms step_avg:31.14ms
+step:93/1490 train_time:2892ms step_avg:31.10ms
+step:94/1490 train_time:2926ms step_avg:31.13ms
+step:95/1490 train_time:2954ms step_avg:31.09ms
+step:96/1490 train_time:2988ms step_avg:31.13ms
+step:97/1490 train_time:3015ms step_avg:31.09ms
+step:98/1490 train_time:3050ms step_avg:31.12ms
+step:99/1490 train_time:3077ms step_avg:31.08ms
+step:100/1490 train_time:3111ms step_avg:31.11ms
+step:101/1490 train_time:3139ms step_avg:31.08ms
+step:102/1490 train_time:3173ms step_avg:31.11ms
+step:103/1490 train_time:3201ms step_avg:31.08ms
+step:104/1490 train_time:3235ms step_avg:31.10ms
+step:105/1490 train_time:3262ms step_avg:31.07ms
+step:106/1490 train_time:3298ms step_avg:31.11ms
+step:107/1490 train_time:3324ms step_avg:31.07ms
+step:108/1490 train_time:3360ms step_avg:31.11ms
+step:109/1490 train_time:3386ms step_avg:31.07ms
+step:110/1490 train_time:3420ms step_avg:31.09ms
+step:111/1490 train_time:3448ms step_avg:31.06ms
+step:112/1490 train_time:3482ms step_avg:31.09ms
+step:113/1490 train_time:3510ms step_avg:31.06ms
+step:114/1490 train_time:3545ms step_avg:31.09ms
+step:115/1490 train_time:3572ms step_avg:31.06ms
+step:116/1490 train_time:3607ms step_avg:31.09ms
+step:117/1490 train_time:3634ms step_avg:31.06ms
+step:118/1490 train_time:3669ms step_avg:31.09ms
+step:119/1490 train_time:3696ms step_avg:31.06ms
+step:120/1490 train_time:3730ms step_avg:31.09ms
+step:121/1490 train_time:3758ms step_avg:31.05ms
+step:122/1490 train_time:3792ms step_avg:31.08ms
+step:123/1490 train_time:3819ms step_avg:31.05ms
+step:124/1490 train_time:3853ms step_avg:31.07ms
+step:125/1490 train_time:3881ms step_avg:31.05ms
+step:126/1490 train_time:3915ms step_avg:31.07ms
+step:127/1490 train_time:3943ms step_avg:31.05ms
+step:128/1490 train_time:3977ms step_avg:31.07ms
+step:129/1490 train_time:4005ms step_avg:31.04ms
+step:130/1490 train_time:4039ms step_avg:31.07ms
+step:131/1490 train_time:4066ms step_avg:31.04ms
+step:132/1490 train_time:4101ms step_avg:31.07ms
+step:133/1490 train_time:4128ms step_avg:31.04ms
+step:134/1490 train_time:4163ms step_avg:31.07ms
+step:135/1490 train_time:4190ms step_avg:31.04ms
+step:136/1490 train_time:4224ms step_avg:31.06ms
+step:137/1490 train_time:4253ms step_avg:31.04ms
+step:138/1490 train_time:4286ms step_avg:31.06ms
+step:139/1490 train_time:4314ms step_avg:31.03ms
+step:140/1490 train_time:4348ms step_avg:31.06ms
+step:141/1490 train_time:4375ms step_avg:31.03ms
+step:142/1490 train_time:4409ms step_avg:31.05ms
+step:143/1490 train_time:4437ms step_avg:31.03ms
+step:144/1490 train_time:4471ms step_avg:31.05ms
+step:145/1490 train_time:4499ms step_avg:31.03ms
+step:146/1490 train_time:4533ms step_avg:31.05ms
+step:147/1490 train_time:4560ms step_avg:31.02ms
+step:148/1490 train_time:4595ms step_avg:31.05ms
+step:149/1490 train_time:4622ms step_avg:31.02ms
+step:150/1490 train_time:4656ms step_avg:31.04ms
+step:151/1490 train_time:4684ms step_avg:31.02ms
+step:152/1490 train_time:4718ms step_avg:31.04ms
+step:153/1490 train_time:4746ms step_avg:31.02ms
+step:154/1490 train_time:4780ms step_avg:31.04ms
+step:155/1490 train_time:4807ms step_avg:31.01ms
+step:156/1490 train_time:4842ms step_avg:31.04ms
+step:157/1490 train_time:4869ms step_avg:31.01ms
+step:158/1490 train_time:4903ms step_avg:31.03ms
+step:159/1490 train_time:4931ms step_avg:31.01ms
+step:160/1490 train_time:4966ms step_avg:31.04ms
+step:161/1490 train_time:4993ms step_avg:31.01ms
+step:162/1490 train_time:5028ms step_avg:31.04ms
+step:163/1490 train_time:5055ms step_avg:31.01ms
+step:164/1490 train_time:5089ms step_avg:31.03ms
+step:165/1490 train_time:5116ms step_avg:31.01ms
+step:166/1490 train_time:5150ms step_avg:31.03ms
+step:167/1490 train_time:5177ms step_avg:31.00ms
+step:168/1490 train_time:5212ms step_avg:31.02ms
+step:169/1490 train_time:5239ms step_avg:31.00ms
+step:170/1490 train_time:5273ms step_avg:31.02ms
+step:171/1490 train_time:5301ms step_avg:31.00ms
+step:172/1490 train_time:5335ms step_avg:31.02ms
+step:173/1490 train_time:5363ms step_avg:31.00ms
+step:174/1490 train_time:5397ms step_avg:31.02ms
+step:175/1490 train_time:5425ms step_avg:31.00ms
+step:176/1490 train_time:5459ms step_avg:31.02ms
+step:177/1490 train_time:5486ms step_avg:31.00ms
+step:178/1490 train_time:5521ms step_avg:31.01ms
+step:179/1490 train_time:5548ms step_avg:30.99ms
+step:180/1490 train_time:5582ms step_avg:31.01ms
+step:181/1490 train_time:5610ms step_avg:30.99ms
+step:182/1490 train_time:5644ms step_avg:31.01ms
+step:183/1490 train_time:5672ms step_avg:31.00ms
+step:184/1490 train_time:5706ms step_avg:31.01ms
+step:185/1490 train_time:5734ms step_avg:30.99ms
+step:186/1490 train_time:5768ms step_avg:31.01ms
+step:187/1490 train_time:5795ms step_avg:30.99ms
+step:188/1490 train_time:5830ms step_avg:31.01ms
+step:189/1490 train_time:5857ms step_avg:30.99ms
+step:190/1490 train_time:5891ms step_avg:31.00ms
+step:191/1490 train_time:5918ms step_avg:30.99ms
+step:192/1490 train_time:5952ms step_avg:31.00ms
+step:193/1490 train_time:5980ms step_avg:30.98ms
+step:194/1490 train_time:6014ms step_avg:31.00ms
+step:195/1490 train_time:6041ms step_avg:30.98ms
+step:196/1490 train_time:6075ms step_avg:31.00ms
+step:197/1490 train_time:6103ms step_avg:30.98ms
+step:198/1490 train_time:6138ms step_avg:31.00ms
+step:199/1490 train_time:6165ms step_avg:30.98ms
+step:200/1490 train_time:6199ms step_avg:31.00ms
+step:201/1490 train_time:6227ms step_avg:30.98ms
+step:202/1490 train_time:6261ms step_avg:30.99ms
+step:203/1490 train_time:6288ms step_avg:30.98ms
+step:204/1490 train_time:6323ms step_avg:30.99ms
+step:205/1490 train_time:6350ms step_avg:30.98ms
+step:206/1490 train_time:6385ms step_avg:30.99ms
+step:207/1490 train_time:6412ms step_avg:30.98ms
+step:208/1490 train_time:6446ms step_avg:30.99ms
+step:209/1490 train_time:6474ms step_avg:30.98ms
+step:210/1490 train_time:6508ms step_avg:30.99ms
+step:211/1490 train_time:6535ms step_avg:30.97ms
+step:212/1490 train_time:6570ms step_avg:30.99ms
+step:213/1490 train_time:6597ms step_avg:30.97ms
+step:214/1490 train_time:6631ms step_avg:30.99ms
+step:215/1490 train_time:6659ms step_avg:30.97ms
+step:216/1490 train_time:6693ms step_avg:30.99ms
+step:217/1490 train_time:6720ms step_avg:30.97ms
+step:218/1490 train_time:6754ms step_avg:30.98ms
+step:219/1490 train_time:6782ms step_avg:30.97ms
+step:220/1490 train_time:6817ms step_avg:30.99ms
+step:221/1490 train_time:6844ms step_avg:30.97ms
+step:222/1490 train_time:6878ms step_avg:30.98ms
+step:223/1490 train_time:6906ms step_avg:30.97ms
+step:224/1490 train_time:6941ms step_avg:30.99ms
+step:225/1490 train_time:6968ms step_avg:30.97ms
+step:226/1490 train_time:7002ms step_avg:30.98ms
+step:227/1490 train_time:7030ms step_avg:30.97ms
+step:228/1490 train_time:7064ms step_avg:30.98ms
+step:229/1490 train_time:7091ms step_avg:30.97ms
+step:230/1490 train_time:7126ms step_avg:30.98ms
+step:231/1490 train_time:7153ms step_avg:30.96ms
+step:232/1490 train_time:7187ms step_avg:30.98ms
+step:233/1490 train_time:7214ms step_avg:30.96ms
+step:234/1490 train_time:7248ms step_avg:30.98ms
+step:235/1490 train_time:7276ms step_avg:30.96ms
+step:236/1490 train_time:7310ms step_avg:30.97ms
+step:237/1490 train_time:7337ms step_avg:30.96ms
+step:238/1490 train_time:7371ms step_avg:30.97ms
+step:239/1490 train_time:7399ms step_avg:30.96ms
+step:240/1490 train_time:7433ms step_avg:30.97ms
+step:241/1490 train_time:7460ms step_avg:30.95ms
+step:242/1490 train_time:7494ms step_avg:30.97ms
+step:243/1490 train_time:7522ms step_avg:30.95ms
+step:244/1490 train_time:7556ms step_avg:30.97ms
+step:245/1490 train_time:7584ms step_avg:30.95ms
+step:246/1490 train_time:7618ms step_avg:30.97ms
+step:247/1490 train_time:7646ms step_avg:30.95ms
+step:248/1490 train_time:7680ms step_avg:30.97ms
+step:249/1490 train_time:7709ms step_avg:30.96ms
+step:250/1490 train_time:7741ms step_avg:30.96ms
+step:250/1490 val_loss:4.5128 train_time:7781ms step_avg:31.12ms
+step:251/1490 train_time:7800ms step_avg:31.08ms
+step:252/1490 train_time:7822ms step_avg:31.04ms
+step:253/1490 train_time:7838ms step_avg:30.98ms
+step:254/1490 train_time:7868ms step_avg:30.98ms
+step:255/1490 train_time:7897ms step_avg:30.97ms
+step:256/1490 train_time:7933ms step_avg:30.99ms
+step:257/1490 train_time:7961ms step_avg:30.98ms
+step:258/1490 train_time:7996ms step_avg:30.99ms
+step:259/1490 train_time:8024ms step_avg:30.98ms
+step:260/1490 train_time:8058ms step_avg:30.99ms
+step:261/1490 train_time:8086ms step_avg:30.98ms
+step:262/1490 train_time:8120ms step_avg:30.99ms
+step:263/1490 train_time:8148ms step_avg:30.98ms
+step:264/1490 train_time:8182ms step_avg:30.99ms
+step:265/1490 train_time:8210ms step_avg:30.98ms
+step:266/1490 train_time:8244ms step_avg:30.99ms
+step:267/1490 train_time:8271ms step_avg:30.98ms
+step:268/1490 train_time:8305ms step_avg:30.99ms
+step:269/1490 train_time:8332ms step_avg:30.98ms
+step:270/1490 train_time:8366ms step_avg:30.99ms
+step:271/1490 train_time:8394ms step_avg:30.97ms
+step:272/1490 train_time:8427ms step_avg:30.98ms
+step:273/1490 train_time:8455ms step_avg:30.97ms
+step:274/1490 train_time:8489ms step_avg:30.98ms
+step:275/1490 train_time:8516ms step_avg:30.97ms
+step:276/1490 train_time:8550ms step_avg:30.98ms
+step:277/1490 train_time:8577ms step_avg:30.96ms
+step:278/1490 train_time:8611ms step_avg:30.98ms
+step:279/1490 train_time:8638ms step_avg:30.96ms
+step:280/1490 train_time:8672ms step_avg:30.97ms
+step:281/1490 train_time:8699ms step_avg:30.96ms
+step:282/1490 train_time:8733ms step_avg:30.97ms
+step:283/1490 train_time:8761ms step_avg:30.96ms
+step:284/1490 train_time:8796ms step_avg:30.97ms
+step:285/1490 train_time:8824ms step_avg:30.96ms
+step:286/1490 train_time:8858ms step_avg:30.97ms
+step:287/1490 train_time:8885ms step_avg:30.96ms
+step:288/1490 train_time:8920ms step_avg:30.97ms
+step:289/1490 train_time:8948ms step_avg:30.96ms
+step:290/1490 train_time:8982ms step_avg:30.97ms
+step:291/1490 train_time:9010ms step_avg:30.96ms
+step:292/1490 train_time:9044ms step_avg:30.97ms
+step:293/1490 train_time:9072ms step_avg:30.96ms
+step:294/1490 train_time:9106ms step_avg:30.97ms
+step:295/1490 train_time:9134ms step_avg:30.96ms
+step:296/1490 train_time:9168ms step_avg:30.97ms
+step:297/1490 train_time:9195ms step_avg:30.96ms
+step:298/1490 train_time:9229ms step_avg:30.97ms
+step:299/1490 train_time:9257ms step_avg:30.96ms
+step:300/1490 train_time:9291ms step_avg:30.97ms
+step:301/1490 train_time:9318ms step_avg:30.96ms
+step:302/1490 train_time:9353ms step_avg:30.97ms
+step:303/1490 train_time:9380ms step_avg:30.96ms
+step:304/1490 train_time:9414ms step_avg:30.97ms
+step:305/1490 train_time:9441ms step_avg:30.95ms
+step:306/1490 train_time:9476ms step_avg:30.97ms
+step:307/1490 train_time:9503ms step_avg:30.95ms
+step:308/1490 train_time:9537ms step_avg:30.96ms
+step:309/1490 train_time:9564ms step_avg:30.95ms
+step:310/1490 train_time:9598ms step_avg:30.96ms
+step:311/1490 train_time:9626ms step_avg:30.95ms
+step:312/1490 train_time:9660ms step_avg:30.96ms
+step:313/1490 train_time:9687ms step_avg:30.95ms
+step:314/1490 train_time:9721ms step_avg:30.96ms
+step:315/1490 train_time:9748ms step_avg:30.95ms
+step:316/1490 train_time:9782ms step_avg:30.96ms
+step:317/1490 train_time:9811ms step_avg:30.95ms
+step:318/1490 train_time:9844ms step_avg:30.96ms
+step:319/1490 train_time:9872ms step_avg:30.95ms
+step:320/1490 train_time:9906ms step_avg:30.96ms
+step:321/1490 train_time:9934ms step_avg:30.95ms
+step:322/1490 train_time:9968ms step_avg:30.96ms
+step:323/1490 train_time:9995ms step_avg:30.94ms
+step:324/1490 train_time:10029ms step_avg:30.96ms
+step:325/1490 train_time:10057ms step_avg:30.95ms
+step:326/1490 train_time:10092ms step_avg:30.96ms
+step:327/1490 train_time:10119ms step_avg:30.95ms
+step:328/1490 train_time:10153ms step_avg:30.96ms
+step:329/1490 train_time:10181ms step_avg:30.94ms
+step:330/1490 train_time:10215ms step_avg:30.96ms
+step:331/1490 train_time:10242ms step_avg:30.94ms
+step:332/1490 train_time:10277ms step_avg:30.95ms
+step:333/1490 train_time:10304ms step_avg:30.94ms
+step:334/1490 train_time:10338ms step_avg:30.95ms
+step:335/1490 train_time:10366ms step_avg:30.94ms
+step:336/1490 train_time:10400ms step_avg:30.95ms
+step:337/1490 train_time:10428ms step_avg:30.94ms
+step:338/1490 train_time:10462ms step_avg:30.95ms
+step:339/1490 train_time:10489ms step_avg:30.94ms
+step:340/1490 train_time:10523ms step_avg:30.95ms
+step:341/1490 train_time:10551ms step_avg:30.94ms
+step:342/1490 train_time:10585ms step_avg:30.95ms
+step:343/1490 train_time:10612ms step_avg:30.94ms
+step:344/1490 train_time:10647ms step_avg:30.95ms
+step:345/1490 train_time:10674ms step_avg:30.94ms
+step:346/1490 train_time:10708ms step_avg:30.95ms
+step:347/1490 train_time:10735ms step_avg:30.94ms
+step:348/1490 train_time:10769ms step_avg:30.95ms
+step:349/1490 train_time:10797ms step_avg:30.94ms
+step:350/1490 train_time:10831ms step_avg:30.95ms
+step:351/1490 train_time:10858ms step_avg:30.94ms
+step:352/1490 train_time:10893ms step_avg:30.95ms
+step:353/1490 train_time:10920ms step_avg:30.93ms
+step:354/1490 train_time:10954ms step_avg:30.94ms
+step:355/1490 train_time:10981ms step_avg:30.93ms
+step:356/1490 train_time:11016ms step_avg:30.94ms
+step:357/1490 train_time:11043ms step_avg:30.93ms
+step:358/1490 train_time:11078ms step_avg:30.94ms
+step:359/1490 train_time:11105ms step_avg:30.93ms
+step:360/1490 train_time:11140ms step_avg:30.94ms
+step:361/1490 train_time:11167ms step_avg:30.93ms
+step:362/1490 train_time:11201ms step_avg:30.94ms
+step:363/1490 train_time:11229ms step_avg:30.93ms
+step:364/1490 train_time:11263ms step_avg:30.94ms
+step:365/1490 train_time:11291ms step_avg:30.93ms
+step:366/1490 train_time:11325ms step_avg:30.94ms
+step:367/1490 train_time:11352ms step_avg:30.93ms
+step:368/1490 train_time:11388ms step_avg:30.94ms
+step:369/1490 train_time:11413ms step_avg:30.93ms
+step:370/1490 train_time:11447ms step_avg:30.94ms
+step:371/1490 train_time:11474ms step_avg:30.93ms
+step:372/1490 train_time:11508ms step_avg:30.94ms
+step:373/1490 train_time:11535ms step_avg:30.93ms
+step:374/1490 train_time:11570ms step_avg:30.93ms
+step:375/1490 train_time:11597ms step_avg:30.93ms
+step:376/1490 train_time:11632ms step_avg:30.94ms
+step:377/1490 train_time:11659ms step_avg:30.93ms
+step:378/1490 train_time:11693ms step_avg:30.93ms
+step:379/1490 train_time:11720ms step_avg:30.92ms
+step:380/1490 train_time:11755ms step_avg:30.93ms
+step:381/1490 train_time:11782ms step_avg:30.92ms
+step:382/1490 train_time:11816ms step_avg:30.93ms
+step:383/1490 train_time:11844ms step_avg:30.92ms
+step:384/1490 train_time:11878ms step_avg:30.93ms
+step:385/1490 train_time:11906ms step_avg:30.92ms
+step:386/1490 train_time:11940ms step_avg:30.93ms
+step:387/1490 train_time:11968ms step_avg:30.92ms
+step:388/1490 train_time:12002ms step_avg:30.93ms
+step:389/1490 train_time:12030ms step_avg:30.92ms
+step:390/1490 train_time:12064ms step_avg:30.93ms
+step:391/1490 train_time:12091ms step_avg:30.92ms
+step:392/1490 train_time:12125ms step_avg:30.93ms
+step:393/1490 train_time:12152ms step_avg:30.92ms
+step:394/1490 train_time:12187ms step_avg:30.93ms
+step:395/1490 train_time:12215ms step_avg:30.92ms
+step:396/1490 train_time:12248ms step_avg:30.93ms
+step:397/1490 train_time:12275ms step_avg:30.92ms
+step:398/1490 train_time:12309ms step_avg:30.93ms
+step:399/1490 train_time:12337ms step_avg:30.92ms
+step:400/1490 train_time:12371ms step_avg:30.93ms
+step:401/1490 train_time:12399ms step_avg:30.92ms
+step:402/1490 train_time:12433ms step_avg:30.93ms
+step:403/1490 train_time:12461ms step_avg:30.92ms
+step:404/1490 train_time:12495ms step_avg:30.93ms
+step:405/1490 train_time:12522ms step_avg:30.92ms
+step:406/1490 train_time:12556ms step_avg:30.93ms
+step:407/1490 train_time:12583ms step_avg:30.92ms
+step:408/1490 train_time:12618ms step_avg:30.93ms
+step:409/1490 train_time:12645ms step_avg:30.92ms
+step:410/1490 train_time:12679ms step_avg:30.92ms
+step:411/1490 train_time:12707ms step_avg:30.92ms
+step:412/1490 train_time:12740ms step_avg:30.92ms
+step:413/1490 train_time:12768ms step_avg:30.91ms
+step:414/1490 train_time:12802ms step_avg:30.92ms
+step:415/1490 train_time:12829ms step_avg:30.91ms
+step:416/1490 train_time:12864ms step_avg:30.92ms
+step:417/1490 train_time:12891ms step_avg:30.91ms
+step:418/1490 train_time:12926ms step_avg:30.92ms
+step:419/1490 train_time:12953ms step_avg:30.91ms
+step:420/1490 train_time:12987ms step_avg:30.92ms
+step:421/1490 train_time:13014ms step_avg:30.91ms
+step:422/1490 train_time:13049ms step_avg:30.92ms
+step:423/1490 train_time:13076ms step_avg:30.91ms
+step:424/1490 train_time:13110ms step_avg:30.92ms
+step:425/1490 train_time:13137ms step_avg:30.91ms
+step:426/1490 train_time:13171ms step_avg:30.92ms
+step:427/1490 train_time:13199ms step_avg:30.91ms
+step:428/1490 train_time:13233ms step_avg:30.92ms
+step:429/1490 train_time:13260ms step_avg:30.91ms
+step:430/1490 train_time:13295ms step_avg:30.92ms
+step:431/1490 train_time:13322ms step_avg:30.91ms
+step:432/1490 train_time:13356ms step_avg:30.92ms
+step:433/1490 train_time:13383ms step_avg:30.91ms
+step:434/1490 train_time:13419ms step_avg:30.92ms
+step:435/1490 train_time:13445ms step_avg:30.91ms
+step:436/1490 train_time:13480ms step_avg:30.92ms
+step:437/1490 train_time:13507ms step_avg:30.91ms
+step:438/1490 train_time:13541ms step_avg:30.92ms
+step:439/1490 train_time:13569ms step_avg:30.91ms
+step:440/1490 train_time:13603ms step_avg:30.92ms
+step:441/1490 train_time:13630ms step_avg:30.91ms
+step:442/1490 train_time:13665ms step_avg:30.92ms
+step:443/1490 train_time:13692ms step_avg:30.91ms
+step:444/1490 train_time:13726ms step_avg:30.92ms
+step:445/1490 train_time:13754ms step_avg:30.91ms
+step:446/1490 train_time:13789ms step_avg:30.92ms
+step:447/1490 train_time:13815ms step_avg:30.91ms
+step:448/1490 train_time:13849ms step_avg:30.91ms
+step:449/1490 train_time:13876ms step_avg:30.90ms
+step:450/1490 train_time:13910ms step_avg:30.91ms
+step:451/1490 train_time:13938ms step_avg:30.90ms
+step:452/1490 train_time:13972ms step_avg:30.91ms
+step:453/1490 train_time:14000ms step_avg:30.90ms
+step:454/1490 train_time:14034ms step_avg:30.91ms
+step:455/1490 train_time:14061ms step_avg:30.90ms
+step:456/1490 train_time:14095ms step_avg:30.91ms
+step:457/1490 train_time:14123ms step_avg:30.90ms
+step:458/1490 train_time:14157ms step_avg:30.91ms
+step:459/1490 train_time:14185ms step_avg:30.90ms
+step:460/1490 train_time:14219ms step_avg:30.91ms
+step:461/1490 train_time:14247ms step_avg:30.90ms
+step:462/1490 train_time:14281ms step_avg:30.91ms
+step:463/1490 train_time:14308ms step_avg:30.90ms
+step:464/1490 train_time:14343ms step_avg:30.91ms
+step:465/1490 train_time:14370ms step_avg:30.90ms
+step:466/1490 train_time:14405ms step_avg:30.91ms
+step:467/1490 train_time:14432ms step_avg:30.90ms
+step:468/1490 train_time:14466ms step_avg:30.91ms
+step:469/1490 train_time:14493ms step_avg:30.90ms
+step:470/1490 train_time:14528ms step_avg:30.91ms
+step:471/1490 train_time:14555ms step_avg:30.90ms
+step:472/1490 train_time:14589ms step_avg:30.91ms
+step:473/1490 train_time:14616ms step_avg:30.90ms
+step:474/1490 train_time:14651ms step_avg:30.91ms
+step:475/1490 train_time:14678ms step_avg:30.90ms
+step:476/1490 train_time:14712ms step_avg:30.91ms
+step:477/1490 train_time:14739ms step_avg:30.90ms
+step:478/1490 train_time:14774ms step_avg:30.91ms
+step:479/1490 train_time:14801ms step_avg:30.90ms
+step:480/1490 train_time:14835ms step_avg:30.91ms
+step:481/1490 train_time:14863ms step_avg:30.90ms
+step:482/1490 train_time:14898ms step_avg:30.91ms
+step:483/1490 train_time:14925ms step_avg:30.90ms
+step:484/1490 train_time:14962ms step_avg:30.91ms
+step:485/1490 train_time:15014ms step_avg:30.96ms
+step:486/1490 train_time:15072ms step_avg:31.01ms
+step:487/1490 train_time:15125ms step_avg:31.06ms
+step:488/1490 train_time:15184ms step_avg:31.11ms
+step:489/1490 train_time:15237ms step_avg:31.16ms
+step:490/1490 train_time:15295ms step_avg:31.22ms
+step:491/1490 train_time:15349ms step_avg:31.26ms
+step:492/1490 train_time:15408ms step_avg:31.32ms
+step:493/1490 train_time:15461ms step_avg:31.36ms
+step:494/1490 train_time:15520ms step_avg:31.42ms
+step:495/1490 train_time:15573ms step_avg:31.46ms
+step:496/1490 train_time:15632ms step_avg:31.52ms
+step:497/1490 train_time:15685ms step_avg:31.56ms
+step:498/1490 train_time:15743ms step_avg:31.61ms
+step:499/1490 train_time:15797ms step_avg:31.66ms
+step:500/1490 train_time:15856ms step_avg:31.71ms
+step:500/1490 val_loss:4.1998 train_time:15923ms step_avg:31.85ms
+step:501/1490 train_time:15944ms step_avg:31.82ms
+step:502/1490 train_time:15971ms step_avg:31.82ms
+step:503/1490 train_time:16028ms step_avg:31.87ms
+step:504/1490 train_time:16089ms step_avg:31.92ms
+step:505/1490 train_time:16143ms step_avg:31.97ms
+step:506/1490 train_time:16202ms step_avg:32.02ms
+step:507/1490 train_time:16255ms step_avg:32.06ms
+step:508/1490 train_time:16314ms step_avg:32.11ms
+step:509/1490 train_time:16367ms step_avg:32.16ms
+step:510/1490 train_time:16425ms step_avg:32.21ms
+step:511/1490 train_time:16477ms step_avg:32.25ms
+step:512/1490 train_time:16536ms step_avg:32.30ms
+step:513/1490 train_time:16589ms step_avg:32.34ms
+step:514/1490 train_time:16647ms step_avg:32.39ms
+step:515/1490 train_time:16699ms step_avg:32.42ms
+step:516/1490 train_time:16757ms step_avg:32.47ms
+step:517/1490 train_time:16810ms step_avg:32.51ms
+step:518/1490 train_time:16869ms step_avg:32.56ms
+step:519/1490 train_time:16923ms step_avg:32.61ms
+step:520/1490 train_time:16984ms step_avg:32.66ms
+step:521/1490 train_time:17040ms step_avg:32.71ms
+step:522/1490 train_time:17100ms step_avg:32.76ms
+step:523/1490 train_time:17154ms step_avg:32.80ms
+step:524/1490 train_time:17212ms step_avg:32.85ms
+step:525/1490 train_time:17265ms step_avg:32.89ms
+step:526/1490 train_time:17324ms step_avg:32.94ms
+step:527/1490 train_time:17377ms step_avg:32.97ms
+step:528/1490 train_time:17435ms step_avg:33.02ms
+step:529/1490 train_time:17488ms step_avg:33.06ms
+step:530/1490 train_time:17545ms step_avg:33.10ms
+step:531/1490 train_time:17598ms step_avg:33.14ms
+step:532/1490 train_time:17656ms step_avg:33.19ms
+step:533/1490 train_time:17709ms step_avg:33.23ms
+step:534/1490 train_time:17767ms step_avg:33.27ms
+step:535/1490 train_time:17821ms step_avg:33.31ms
+step:536/1490 train_time:17880ms step_avg:33.36ms
+step:537/1490 train_time:17935ms step_avg:33.40ms
+step:538/1490 train_time:17994ms step_avg:33.45ms
+step:539/1490 train_time:18048ms step_avg:33.49ms
+step:540/1490 train_time:18107ms step_avg:33.53ms
+step:541/1490 train_time:18161ms step_avg:33.57ms
+step:542/1490 train_time:18221ms step_avg:33.62ms
+step:543/1490 train_time:18274ms step_avg:33.65ms
+step:544/1490 train_time:18333ms step_avg:33.70ms
+step:545/1490 train_time:18386ms step_avg:33.74ms
+step:546/1490 train_time:18444ms step_avg:33.78ms
+step:547/1490 train_time:18497ms step_avg:33.81ms
+step:548/1490 train_time:18556ms step_avg:33.86ms
+step:549/1490 train_time:18609ms step_avg:33.90ms
+step:550/1490 train_time:18666ms step_avg:33.94ms
+step:551/1490 train_time:18720ms step_avg:33.97ms
+step:552/1490 train_time:18779ms step_avg:34.02ms
+step:553/1490 train_time:18833ms step_avg:34.06ms
+step:554/1490 train_time:18892ms step_avg:34.10ms
+step:555/1490 train_time:18945ms step_avg:34.14ms
+step:556/1490 train_time:19004ms step_avg:34.18ms
+step:557/1490 train_time:19059ms step_avg:34.22ms
+step:558/1490 train_time:19118ms step_avg:34.26ms
+step:559/1490 train_time:19172ms step_avg:34.30ms
+step:560/1490 train_time:19230ms step_avg:34.34ms
+step:561/1490 train_time:19284ms step_avg:34.38ms
+step:562/1490 train_time:19344ms step_avg:34.42ms
+step:563/1490 train_time:19397ms step_avg:34.45ms
+step:564/1490 train_time:19455ms step_avg:34.49ms
+step:565/1490 train_time:19508ms step_avg:34.53ms
+step:566/1490 train_time:19567ms step_avg:34.57ms
+step:567/1490 train_time:19620ms step_avg:34.60ms
+step:568/1490 train_time:19678ms step_avg:34.65ms
+step:569/1490 train_time:19731ms step_avg:34.68ms
+step:570/1490 train_time:19790ms step_avg:34.72ms
+step:571/1490 train_time:19843ms step_avg:34.75ms
+step:572/1490 train_time:19903ms step_avg:34.80ms
+step:573/1490 train_time:19956ms step_avg:34.83ms
+step:574/1490 train_time:20015ms step_avg:34.87ms
+step:575/1490 train_time:20069ms step_avg:34.90ms
+step:576/1490 train_time:20127ms step_avg:34.94ms
+step:577/1490 train_time:20181ms step_avg:34.98ms
+step:578/1490 train_time:20240ms step_avg:35.02ms
+step:579/1490 train_time:20293ms step_avg:35.05ms
+step:580/1490 train_time:20352ms step_avg:35.09ms
+step:581/1490 train_time:20405ms step_avg:35.12ms
+step:582/1490 train_time:20464ms step_avg:35.16ms
+step:583/1490 train_time:20517ms step_avg:35.19ms
+step:584/1490 train_time:20575ms step_avg:35.23ms
+step:585/1490 train_time:20628ms step_avg:35.26ms
+step:586/1490 train_time:20687ms step_avg:35.30ms
+step:587/1490 train_time:20741ms step_avg:35.33ms
+step:588/1490 train_time:20800ms step_avg:35.37ms
+step:589/1490 train_time:20853ms step_avg:35.40ms
+step:590/1490 train_time:20912ms step_avg:35.44ms
+step:591/1490 train_time:20965ms step_avg:35.47ms
+step:592/1490 train_time:21024ms step_avg:35.51ms
+step:593/1490 train_time:21078ms step_avg:35.54ms
+step:594/1490 train_time:21137ms step_avg:35.58ms
+step:595/1490 train_time:21191ms step_avg:35.61ms
+step:596/1490 train_time:21249ms step_avg:35.65ms
+step:597/1490 train_time:21303ms step_avg:35.68ms
+step:598/1490 train_time:21362ms step_avg:35.72ms
+step:599/1490 train_time:21415ms step_avg:35.75ms
+step:600/1490 train_time:21473ms step_avg:35.79ms
+step:601/1490 train_time:21527ms step_avg:35.82ms
+step:602/1490 train_time:21584ms step_avg:35.85ms
+step:603/1490 train_time:21638ms step_avg:35.88ms
+step:604/1490 train_time:21697ms step_avg:35.92ms
+step:605/1490 train_time:21751ms step_avg:35.95ms
+step:606/1490 train_time:21810ms step_avg:35.99ms
+step:607/1490 train_time:21863ms step_avg:36.02ms
+step:608/1490 train_time:21922ms step_avg:36.06ms
+step:609/1490 train_time:21976ms step_avg:36.08ms
+step:610/1490 train_time:22035ms step_avg:36.12ms
+step:611/1490 train_time:22089ms step_avg:36.15ms
+step:612/1490 train_time:22147ms step_avg:36.19ms
+step:613/1490 train_time:22201ms step_avg:36.22ms
+step:614/1490 train_time:22260ms step_avg:36.25ms
+step:615/1490 train_time:22314ms step_avg:36.28ms
+step:616/1490 train_time:22373ms step_avg:36.32ms
+step:617/1490 train_time:22426ms step_avg:36.35ms
+step:618/1490 train_time:22484ms step_avg:36.38ms
+step:619/1490 train_time:22537ms step_avg:36.41ms
+step:620/1490 train_time:22596ms step_avg:36.45ms
+step:621/1490 train_time:22650ms step_avg:36.47ms
+step:622/1490 train_time:22708ms step_avg:36.51ms
+step:623/1490 train_time:22762ms step_avg:36.54ms
+step:624/1490 train_time:22821ms step_avg:36.57ms
+step:625/1490 train_time:22873ms step_avg:36.60ms
+step:626/1490 train_time:22932ms step_avg:36.63ms
+step:627/1490 train_time:22986ms step_avg:36.66ms
+step:628/1490 train_time:23045ms step_avg:36.70ms
+step:629/1490 train_time:23099ms step_avg:36.72ms
+step:630/1490 train_time:23158ms step_avg:36.76ms
+step:631/1490 train_time:23212ms step_avg:36.79ms
+step:632/1490 train_time:23270ms step_avg:36.82ms
+step:633/1490 train_time:23324ms step_avg:36.85ms
+step:634/1490 train_time:23383ms step_avg:36.88ms
+step:635/1490 train_time:23436ms step_avg:36.91ms
+step:636/1490 train_time:23495ms step_avg:36.94ms
+step:637/1490 train_time:23548ms step_avg:36.97ms
+step:638/1490 train_time:23606ms step_avg:37.00ms
+step:639/1490 train_time:23660ms step_avg:37.03ms
+step:640/1490 train_time:23720ms step_avg:37.06ms
+step:641/1490 train_time:23773ms step_avg:37.09ms
+step:642/1490 train_time:23832ms step_avg:37.12ms
+step:643/1490 train_time:23884ms step_avg:37.15ms
+step:644/1490 train_time:23944ms step_avg:37.18ms
+step:645/1490 train_time:23997ms step_avg:37.20ms
+step:646/1490 train_time:24057ms step_avg:37.24ms
+step:647/1490 train_time:24110ms step_avg:37.26ms
+step:648/1490 train_time:24168ms step_avg:37.30ms
+step:649/1490 train_time:24222ms step_avg:37.32ms
+step:650/1490 train_time:24281ms step_avg:37.35ms
+step:651/1490 train_time:24334ms step_avg:37.38ms
+step:652/1490 train_time:24393ms step_avg:37.41ms
+step:653/1490 train_time:24446ms step_avg:37.44ms
+step:654/1490 train_time:24504ms step_avg:37.47ms
+step:655/1490 train_time:24557ms step_avg:37.49ms
+step:656/1490 train_time:24616ms step_avg:37.52ms
+step:657/1490 train_time:24669ms step_avg:37.55ms
+step:658/1490 train_time:24728ms step_avg:37.58ms
+step:659/1490 train_time:24782ms step_avg:37.61ms
+step:660/1490 train_time:24841ms step_avg:37.64ms
+step:661/1490 train_time:24894ms step_avg:37.66ms
+step:662/1490 train_time:24952ms step_avg:37.69ms
+step:663/1490 train_time:25006ms step_avg:37.72ms
+step:664/1490 train_time:25064ms step_avg:37.75ms
+step:665/1490 train_time:25118ms step_avg:37.77ms
+step:666/1490 train_time:25177ms step_avg:37.80ms
+step:667/1490 train_time:25230ms step_avg:37.83ms
+step:668/1490 train_time:25288ms step_avg:37.86ms
+step:669/1490 train_time:25341ms step_avg:37.88ms
+step:670/1490 train_time:25400ms step_avg:37.91ms
+step:671/1490 train_time:25453ms step_avg:37.93ms
+step:672/1490 train_time:25512ms step_avg:37.96ms
+step:673/1490 train_time:25565ms step_avg:37.99ms
+step:674/1490 train_time:25624ms step_avg:38.02ms
+step:675/1490 train_time:25677ms step_avg:38.04ms
+step:676/1490 train_time:25737ms step_avg:38.07ms
+step:677/1490 train_time:25791ms step_avg:38.10ms
+step:678/1490 train_time:25848ms step_avg:38.12ms
+step:679/1490 train_time:25901ms step_avg:38.15ms
+step:680/1490 train_time:25960ms step_avg:38.18ms
+step:681/1490 train_time:26015ms step_avg:38.20ms
+step:682/1490 train_time:26073ms step_avg:38.23ms
+step:683/1490 train_time:26127ms step_avg:38.25ms
+step:684/1490 train_time:26185ms step_avg:38.28ms
+step:685/1490 train_time:26239ms step_avg:38.31ms
+step:686/1490 train_time:26298ms step_avg:38.33ms
+step:687/1490 train_time:26352ms step_avg:38.36ms
+step:688/1490 train_time:26411ms step_avg:38.39ms
+step:689/1490 train_time:26464ms step_avg:38.41ms
+step:690/1490 train_time:26523ms step_avg:38.44ms
+step:691/1490 train_time:26576ms step_avg:38.46ms
+step:692/1490 train_time:26635ms step_avg:38.49ms
+step:693/1490 train_time:26689ms step_avg:38.51ms
+step:694/1490 train_time:26747ms step_avg:38.54ms
+step:695/1490 train_time:26801ms step_avg:38.56ms
+step:696/1490 train_time:26859ms step_avg:38.59ms
+step:697/1490 train_time:26913ms step_avg:38.61ms
+step:698/1490 train_time:26972ms step_avg:38.64ms
+step:699/1490 train_time:27025ms step_avg:38.66ms
+step:700/1490 train_time:27083ms step_avg:38.69ms
+step:701/1490 train_time:27137ms step_avg:38.71ms
+step:702/1490 train_time:27196ms step_avg:38.74ms
+step:703/1490 train_time:27249ms step_avg:38.76ms
+step:704/1490 train_time:27307ms step_avg:38.79ms
+step:705/1490 train_time:27360ms step_avg:38.81ms
+step:706/1490 train_time:27421ms step_avg:38.84ms
+step:707/1490 train_time:27474ms step_avg:38.86ms
+step:708/1490 train_time:27534ms step_avg:38.89ms
+step:709/1490 train_time:27586ms step_avg:38.91ms
+step:710/1490 train_time:27644ms step_avg:38.94ms
+step:711/1490 train_time:27697ms step_avg:38.96ms
+step:712/1490 train_time:27757ms step_avg:38.98ms
+step:713/1490 train_time:27810ms step_avg:39.00ms
+step:714/1490 train_time:27869ms step_avg:39.03ms
+step:715/1490 train_time:27922ms step_avg:39.05ms
+step:716/1490 train_time:27980ms step_avg:39.08ms
+step:717/1490 train_time:28034ms step_avg:39.10ms
+step:718/1490 train_time:28092ms step_avg:39.13ms
+step:719/1490 train_time:28146ms step_avg:39.15ms
+step:720/1490 train_time:28205ms step_avg:39.17ms
+step:721/1490 train_time:28258ms step_avg:39.19ms
+step:722/1490 train_time:28318ms step_avg:39.22ms
+step:723/1490 train_time:28371ms step_avg:39.24ms
+step:724/1490 train_time:28429ms step_avg:39.27ms
+step:725/1490 train_time:28482ms step_avg:39.29ms
+step:726/1490 train_time:28541ms step_avg:39.31ms
+step:727/1490 train_time:28594ms step_avg:39.33ms
+step:728/1490 train_time:28654ms step_avg:39.36ms
+step:729/1490 train_time:28707ms step_avg:39.38ms
+step:730/1490 train_time:28766ms step_avg:39.41ms
+step:731/1490 train_time:28820ms step_avg:39.43ms
+step:732/1490 train_time:28878ms step_avg:39.45ms
+step:733/1490 train_time:28932ms step_avg:39.47ms
+step:734/1490 train_time:28991ms step_avg:39.50ms
+step:735/1490 train_time:29044ms step_avg:39.52ms
+step:736/1490 train_time:29103ms step_avg:39.54ms
+step:737/1490 train_time:29156ms step_avg:39.56ms
+step:738/1490 train_time:29215ms step_avg:39.59ms
+step:739/1490 train_time:29268ms step_avg:39.61ms
+step:740/1490 train_time:29326ms step_avg:39.63ms
+step:741/1490 train_time:29379ms step_avg:39.65ms
+step:742/1490 train_time:29438ms step_avg:39.67ms
+step:743/1490 train_time:29491ms step_avg:39.69ms
+step:744/1490 train_time:29550ms step_avg:39.72ms
+step:745/1490 train_time:29603ms step_avg:39.74ms
+step:746/1490 train_time:29662ms step_avg:39.76ms
+step:747/1490 train_time:29716ms step_avg:39.78ms
+step:748/1490 train_time:29775ms step_avg:39.81ms
+step:749/1490 train_time:29829ms step_avg:39.82ms
+step:750/1490 train_time:29886ms step_avg:39.85ms
+step:750/1490 val_loss:3.8006 train_time:29954ms step_avg:39.94ms
+step:751/1490 train_time:29972ms step_avg:39.91ms
+step:752/1490 train_time:30001ms step_avg:39.90ms
+step:753/1490 train_time:30059ms step_avg:39.92ms
+step:754/1490 train_time:30120ms step_avg:39.95ms
+step:755/1490 train_time:30174ms step_avg:39.97ms
+step:756/1490 train_time:30233ms step_avg:39.99ms
+step:757/1490 train_time:30286ms step_avg:40.01ms
+step:758/1490 train_time:30344ms step_avg:40.03ms
+step:759/1490 train_time:30397ms step_avg:40.05ms
+step:760/1490 train_time:30456ms step_avg:40.07ms
+step:761/1490 train_time:30509ms step_avg:40.09ms
+step:762/1490 train_time:30567ms step_avg:40.11ms
+step:763/1490 train_time:30619ms step_avg:40.13ms
+step:764/1490 train_time:30677ms step_avg:40.15ms
+step:765/1490 train_time:30730ms step_avg:40.17ms
+step:766/1490 train_time:30787ms step_avg:40.19ms
+step:767/1490 train_time:30840ms step_avg:40.21ms
+step:768/1490 train_time:30899ms step_avg:40.23ms
+step:769/1490 train_time:30953ms step_avg:40.25ms
+step:770/1490 train_time:31012ms step_avg:40.28ms
+step:771/1490 train_time:31067ms step_avg:40.29ms
+step:772/1490 train_time:31127ms step_avg:40.32ms
+step:773/1490 train_time:31182ms step_avg:40.34ms
+step:774/1490 train_time:31241ms step_avg:40.36ms
+step:775/1490 train_time:31294ms step_avg:40.38ms
+step:776/1490 train_time:31353ms step_avg:40.40ms
+step:777/1490 train_time:31406ms step_avg:40.42ms
+step:778/1490 train_time:31465ms step_avg:40.44ms
+step:779/1490 train_time:31518ms step_avg:40.46ms
+step:780/1490 train_time:31576ms step_avg:40.48ms
+step:781/1490 train_time:31628ms step_avg:40.50ms
+step:782/1490 train_time:31687ms step_avg:40.52ms
+step:783/1490 train_time:31740ms step_avg:40.54ms
+step:784/1490 train_time:31798ms step_avg:40.56ms
+step:785/1490 train_time:31851ms step_avg:40.57ms
+step:786/1490 train_time:31909ms step_avg:40.60ms
+step:787/1490 train_time:31963ms step_avg:40.61ms
+step:788/1490 train_time:32021ms step_avg:40.64ms
+step:789/1490 train_time:32076ms step_avg:40.65ms
+step:790/1490 train_time:32135ms step_avg:40.68ms
+step:791/1490 train_time:32189ms step_avg:40.69ms
+step:792/1490 train_time:32247ms step_avg:40.72ms
+step:793/1490 train_time:32301ms step_avg:40.73ms
+step:794/1490 train_time:32360ms step_avg:40.76ms
+step:795/1490 train_time:32413ms step_avg:40.77ms
+step:796/1490 train_time:32471ms step_avg:40.79ms
+step:797/1490 train_time:32523ms step_avg:40.81ms
+step:798/1490 train_time:32582ms step_avg:40.83ms
+step:799/1490 train_time:32635ms step_avg:40.85ms
+step:800/1490 train_time:32693ms step_avg:40.87ms
+step:801/1490 train_time:32746ms step_avg:40.88ms
+step:802/1490 train_time:32804ms step_avg:40.90ms
+step:803/1490 train_time:32858ms step_avg:40.92ms
+step:804/1490 train_time:32917ms step_avg:40.94ms
+step:805/1490 train_time:32971ms step_avg:40.96ms
+step:806/1490 train_time:33029ms step_avg:40.98ms
+step:807/1490 train_time:33083ms step_avg:40.99ms
+step:808/1490 train_time:33143ms step_avg:41.02ms
+step:809/1490 train_time:33196ms step_avg:41.03ms
+step:810/1490 train_time:33254ms step_avg:41.05ms
+step:811/1490 train_time:33308ms step_avg:41.07ms
+step:812/1490 train_time:33368ms step_avg:41.09ms
+step:813/1490 train_time:33421ms step_avg:41.11ms
+step:814/1490 train_time:33480ms step_avg:41.13ms
+step:815/1490 train_time:33533ms step_avg:41.14ms
+step:816/1490 train_time:33591ms step_avg:41.17ms
+step:817/1490 train_time:33645ms step_avg:41.18ms
+step:818/1490 train_time:33704ms step_avg:41.20ms
+step:819/1490 train_time:33757ms step_avg:41.22ms
+step:820/1490 train_time:33815ms step_avg:41.24ms
+step:821/1490 train_time:33868ms step_avg:41.25ms
+step:822/1490 train_time:33926ms step_avg:41.27ms
+step:823/1490 train_time:33980ms step_avg:41.29ms
+step:824/1490 train_time:34039ms step_avg:41.31ms
+step:825/1490 train_time:34093ms step_avg:41.32ms
+step:826/1490 train_time:34152ms step_avg:41.35ms
+step:827/1490 train_time:34205ms step_avg:41.36ms
+step:828/1490 train_time:34264ms step_avg:41.38ms
+step:829/1490 train_time:34317ms step_avg:41.40ms
+step:830/1490 train_time:34376ms step_avg:41.42ms
+step:831/1490 train_time:34429ms step_avg:41.43ms
+step:832/1490 train_time:34488ms step_avg:41.45ms
+step:833/1490 train_time:34542ms step_avg:41.47ms
+step:834/1490 train_time:34600ms step_avg:41.49ms
+step:835/1490 train_time:34654ms step_avg:41.50ms
+step:836/1490 train_time:34711ms step_avg:41.52ms
+step:837/1490 train_time:34764ms step_avg:41.53ms
+step:838/1490 train_time:34822ms step_avg:41.55ms
+step:839/1490 train_time:34876ms step_avg:41.57ms
+step:840/1490 train_time:34935ms step_avg:41.59ms
+step:841/1490 train_time:34988ms step_avg:41.60ms
+step:842/1490 train_time:35047ms step_avg:41.62ms
+step:843/1490 train_time:35100ms step_avg:41.64ms
+step:844/1490 train_time:35160ms step_avg:41.66ms
+step:845/1490 train_time:35213ms step_avg:41.67ms
+step:846/1490 train_time:35272ms step_avg:41.69ms
+step:847/1490 train_time:35325ms step_avg:41.71ms
+step:848/1490 train_time:35384ms step_avg:41.73ms
+step:849/1490 train_time:35438ms step_avg:41.74ms
+step:850/1490 train_time:35496ms step_avg:41.76ms
+step:851/1490 train_time:35549ms step_avg:41.77ms
+step:852/1490 train_time:35607ms step_avg:41.79ms
+step:853/1490 train_time:35661ms step_avg:41.81ms
+step:854/1490 train_time:35719ms step_avg:41.83ms
+step:855/1490 train_time:35773ms step_avg:41.84ms
+step:856/1490 train_time:35832ms step_avg:41.86ms
+step:857/1490 train_time:35885ms step_avg:41.87ms
+step:858/1490 train_time:35945ms step_avg:41.89ms
+step:859/1490 train_time:35998ms step_avg:41.91ms
+step:860/1490 train_time:36057ms step_avg:41.93ms
+step:861/1490 train_time:36110ms step_avg:41.94ms
+step:862/1490 train_time:36168ms step_avg:41.96ms
+step:863/1490 train_time:36221ms step_avg:41.97ms
+step:864/1490 train_time:36281ms step_avg:41.99ms
+step:865/1490 train_time:36334ms step_avg:42.00ms
+step:866/1490 train_time:36392ms step_avg:42.02ms
+step:867/1490 train_time:36446ms step_avg:42.04ms
+step:868/1490 train_time:36504ms step_avg:42.05ms
+step:869/1490 train_time:36557ms step_avg:42.07ms
+step:870/1490 train_time:36616ms step_avg:42.09ms
+step:871/1490 train_time:36668ms step_avg:42.10ms
+step:872/1490 train_time:36727ms step_avg:42.12ms
+step:873/1490 train_time:36781ms step_avg:42.13ms
+step:874/1490 train_time:36840ms step_avg:42.15ms
+step:875/1490 train_time:36893ms step_avg:42.16ms
+step:876/1490 train_time:36952ms step_avg:42.18ms
+step:877/1490 train_time:37004ms step_avg:42.19ms
+step:878/1490 train_time:37064ms step_avg:42.21ms
+step:879/1490 train_time:37116ms step_avg:42.23ms
+step:880/1490 train_time:37176ms step_avg:42.25ms
+step:881/1490 train_time:37229ms step_avg:42.26ms
+step:882/1490 train_time:37287ms step_avg:42.28ms
+step:883/1490 train_time:37341ms step_avg:42.29ms
+step:884/1490 train_time:37399ms step_avg:42.31ms
+step:885/1490 train_time:37452ms step_avg:42.32ms
+step:886/1490 train_time:37511ms step_avg:42.34ms
+step:887/1490 train_time:37564ms step_avg:42.35ms
+step:888/1490 train_time:37622ms step_avg:42.37ms
+step:889/1490 train_time:37675ms step_avg:42.38ms
+step:890/1490 train_time:37735ms step_avg:42.40ms
+step:891/1490 train_time:37788ms step_avg:42.41ms
+step:892/1490 train_time:37846ms step_avg:42.43ms
+step:893/1490 train_time:37899ms step_avg:42.44ms
+step:894/1490 train_time:37959ms step_avg:42.46ms
+step:895/1490 train_time:38012ms step_avg:42.47ms
+step:896/1490 train_time:38070ms step_avg:42.49ms
+step:897/1490 train_time:38123ms step_avg:42.50ms
+step:898/1490 train_time:38182ms step_avg:42.52ms
+step:899/1490 train_time:38235ms step_avg:42.53ms
+step:900/1490 train_time:38294ms step_avg:42.55ms
+step:901/1490 train_time:38347ms step_avg:42.56ms
+step:902/1490 train_time:38405ms step_avg:42.58ms
+step:903/1490 train_time:38459ms step_avg:42.59ms
+step:904/1490 train_time:38519ms step_avg:42.61ms
+step:905/1490 train_time:38571ms step_avg:42.62ms
+step:906/1490 train_time:38629ms step_avg:42.64ms
+step:907/1490 train_time:38683ms step_avg:42.65ms
+step:908/1490 train_time:38743ms step_avg:42.67ms
+step:909/1490 train_time:38796ms step_avg:42.68ms
+step:910/1490 train_time:38854ms step_avg:42.70ms
+step:911/1490 train_time:38908ms step_avg:42.71ms
+step:912/1490 train_time:38966ms step_avg:42.73ms
+step:913/1490 train_time:39019ms step_avg:42.74ms
+step:914/1490 train_time:39079ms step_avg:42.76ms
+step:915/1490 train_time:39132ms step_avg:42.77ms
+step:916/1490 train_time:39190ms step_avg:42.78ms
+step:917/1490 train_time:39243ms step_avg:42.80ms
+step:918/1490 train_time:39302ms step_avg:42.81ms
+step:919/1490 train_time:39355ms step_avg:42.82ms
+step:920/1490 train_time:39414ms step_avg:42.84ms
+step:921/1490 train_time:39467ms step_avg:42.85ms
+step:922/1490 train_time:39526ms step_avg:42.87ms
+step:923/1490 train_time:39579ms step_avg:42.88ms
+step:924/1490 train_time:39638ms step_avg:42.90ms
+step:925/1490 train_time:39692ms step_avg:42.91ms
+step:926/1490 train_time:39751ms step_avg:42.93ms
+step:927/1490 train_time:39804ms step_avg:42.94ms
+step:928/1490 train_time:39862ms step_avg:42.96ms
+step:929/1490 train_time:39916ms step_avg:42.97ms
+step:930/1490 train_time:39974ms step_avg:42.98ms
+step:931/1490 train_time:40027ms step_avg:42.99ms
+step:932/1490 train_time:40086ms step_avg:43.01ms
+step:933/1490 train_time:40138ms step_avg:43.02ms
+step:934/1490 train_time:40198ms step_avg:43.04ms
+step:935/1490 train_time:40251ms step_avg:43.05ms
+step:936/1490 train_time:40309ms step_avg:43.06ms
+step:937/1490 train_time:40363ms step_avg:43.08ms
+step:938/1490 train_time:40422ms step_avg:43.09ms
+step:939/1490 train_time:40475ms step_avg:43.10ms
+step:940/1490 train_time:40534ms step_avg:43.12ms
+step:941/1490 train_time:40586ms step_avg:43.13ms
+step:942/1490 train_time:40645ms step_avg:43.15ms
+step:943/1490 train_time:40698ms step_avg:43.16ms
+step:944/1490 train_time:40756ms step_avg:43.17ms
+step:945/1490 train_time:40810ms step_avg:43.19ms
+step:946/1490 train_time:40868ms step_avg:43.20ms
+step:947/1490 train_time:40922ms step_avg:43.21ms
+step:948/1490 train_time:40981ms step_avg:43.23ms
+step:949/1490 train_time:41035ms step_avg:43.24ms
+step:950/1490 train_time:41093ms step_avg:43.26ms
+step:951/1490 train_time:41146ms step_avg:43.27ms
+step:952/1490 train_time:41205ms step_avg:43.28ms
+step:953/1490 train_time:41258ms step_avg:43.29ms
+step:954/1490 train_time:41317ms step_avg:43.31ms
+step:955/1490 train_time:41370ms step_avg:43.32ms
+step:956/1490 train_time:41428ms step_avg:43.34ms
+step:957/1490 train_time:41481ms step_avg:43.35ms
+step:958/1490 train_time:41540ms step_avg:43.36ms
+step:959/1490 train_time:41593ms step_avg:43.37ms
+step:960/1490 train_time:41652ms step_avg:43.39ms
+step:961/1490 train_time:41705ms step_avg:43.40ms
+step:962/1490 train_time:41763ms step_avg:43.41ms
+step:963/1490 train_time:41816ms step_avg:43.42ms
+step:964/1490 train_time:41875ms step_avg:43.44ms
+step:965/1490 train_time:41929ms step_avg:43.45ms
+step:966/1490 train_time:41987ms step_avg:43.46ms
+step:967/1490 train_time:42041ms step_avg:43.48ms
+step:968/1490 train_time:42102ms step_avg:43.49ms
+step:969/1490 train_time:42182ms step_avg:43.53ms
+step:970/1490 train_time:42265ms step_avg:43.57ms
+step:971/1490 train_time:42343ms step_avg:43.61ms
+step:972/1490 train_time:42427ms step_avg:43.65ms
+step:973/1490 train_time:42506ms step_avg:43.69ms
+step:974/1490 train_time:42590ms step_avg:43.73ms
+step:975/1490 train_time:42668ms step_avg:43.76ms
+step:976/1490 train_time:42752ms step_avg:43.80ms
+step:977/1490 train_time:42830ms step_avg:43.84ms
+step:978/1490 train_time:42915ms step_avg:43.88ms
+step:979/1490 train_time:42995ms step_avg:43.92ms
+step:980/1490 train_time:43078ms step_avg:43.96ms
+step:981/1490 train_time:43157ms step_avg:43.99ms
+step:982/1490 train_time:43242ms step_avg:44.03ms
+step:983/1490 train_time:43322ms step_avg:44.07ms
+step:984/1490 train_time:43405ms step_avg:44.11ms
+step:985/1490 train_time:43484ms step_avg:44.15ms
+step:986/1490 train_time:43569ms step_avg:44.19ms
+step:987/1490 train_time:43647ms step_avg:44.22ms
+step:988/1490 train_time:43731ms step_avg:44.26ms
+step:989/1490 train_time:43810ms step_avg:44.30ms
+step:990/1490 train_time:43894ms step_avg:44.34ms
+step:991/1490 train_time:43973ms step_avg:44.37ms
+step:992/1490 train_time:44057ms step_avg:44.41ms
+step:993/1490 train_time:44136ms step_avg:44.45ms
+step:994/1490 train_time:44220ms step_avg:44.49ms
+step:995/1490 train_time:44299ms step_avg:44.52ms
+step:996/1490 train_time:44383ms step_avg:44.56ms
+step:997/1490 train_time:44463ms step_avg:44.60ms
+step:998/1490 train_time:44547ms step_avg:44.64ms
+step:999/1490 train_time:44627ms step_avg:44.67ms
+step:1000/1490 train_time:44710ms step_avg:44.71ms
+step:1000/1490 val_loss:3.5164 train_time:44808ms step_avg:44.81ms
+step:1001/1490 train_time:44826ms step_avg:44.78ms
+step:1002/1490 train_time:44881ms step_avg:44.79ms
+step:1003/1490 train_time:44962ms step_avg:44.83ms
+step:1004/1490 train_time:45048ms step_avg:44.87ms
+step:1005/1490 train_time:45127ms step_avg:44.90ms
+step:1006/1490 train_time:45211ms step_avg:44.94ms
+step:1007/1490 train_time:45291ms step_avg:44.98ms
+step:1008/1490 train_time:45374ms step_avg:45.01ms
+step:1009/1490 train_time:45451ms step_avg:45.05ms
+step:1010/1490 train_time:45534ms step_avg:45.08ms
+step:1011/1490 train_time:45612ms step_avg:45.12ms
+step:1012/1490 train_time:45695ms step_avg:45.15ms
+step:1013/1490 train_time:45775ms step_avg:45.19ms
+step:1014/1490 train_time:45861ms step_avg:45.23ms
+step:1015/1490 train_time:45941ms step_avg:45.26ms
+step:1016/1490 train_time:46027ms step_avg:45.30ms
+step:1017/1490 train_time:46107ms step_avg:45.34ms
+step:1018/1490 train_time:46192ms step_avg:45.38ms
+step:1019/1490 train_time:46272ms step_avg:45.41ms
+step:1020/1490 train_time:46356ms step_avg:45.45ms
+step:1021/1490 train_time:46433ms step_avg:45.48ms
+step:1022/1490 train_time:46518ms step_avg:45.52ms
+step:1023/1490 train_time:46596ms step_avg:45.55ms
+step:1024/1490 train_time:46681ms step_avg:45.59ms
+step:1025/1490 train_time:46758ms step_avg:45.62ms
+step:1026/1490 train_time:46842ms step_avg:45.66ms
+step:1027/1490 train_time:46924ms step_avg:45.69ms
+step:1028/1490 train_time:47008ms step_avg:45.73ms
+step:1029/1490 train_time:47088ms step_avg:45.76ms
+step:1030/1490 train_time:47172ms step_avg:45.80ms
+step:1031/1490 train_time:47251ms step_avg:45.83ms
+step:1032/1490 train_time:47334ms step_avg:45.87ms
+step:1033/1490 train_time:47413ms step_avg:45.90ms
+step:1034/1490 train_time:47497ms step_avg:45.94ms
+step:1035/1490 train_time:47576ms step_avg:45.97ms
+step:1036/1490 train_time:47659ms step_avg:46.00ms
+step:1037/1490 train_time:47737ms step_avg:46.03ms
+step:1038/1490 train_time:47822ms step_avg:46.07ms
+step:1039/1490 train_time:47900ms step_avg:46.10ms
+step:1040/1490 train_time:47986ms step_avg:46.14ms
+step:1041/1490 train_time:48066ms step_avg:46.17ms
+step:1042/1490 train_time:48151ms step_avg:46.21ms
+step:1043/1490 train_time:48230ms step_avg:46.24ms
+step:1044/1490 train_time:48313ms step_avg:46.28ms
+step:1045/1490 train_time:48392ms step_avg:46.31ms
+step:1046/1490 train_time:48477ms step_avg:46.35ms
+step:1047/1490 train_time:48556ms step_avg:46.38ms
+step:1048/1490 train_time:48639ms step_avg:46.41ms
+step:1049/1490 train_time:48718ms step_avg:46.44ms
+step:1050/1490 train_time:48802ms step_avg:46.48ms
+step:1051/1490 train_time:48882ms step_avg:46.51ms
+step:1052/1490 train_time:48966ms step_avg:46.55ms
+step:1053/1490 train_time:49046ms step_avg:46.58ms
+step:1054/1490 train_time:49130ms step_avg:46.61ms
+step:1055/1490 train_time:49209ms step_avg:46.64ms
+step:1056/1490 train_time:49294ms step_avg:46.68ms
+step:1057/1490 train_time:49374ms step_avg:46.71ms
+step:1058/1490 train_time:49457ms step_avg:46.75ms
+step:1059/1490 train_time:49536ms step_avg:46.78ms
+step:1060/1490 train_time:49620ms step_avg:46.81ms
+step:1061/1490 train_time:49699ms step_avg:46.84ms
+step:1062/1490 train_time:49784ms step_avg:46.88ms
+step:1063/1490 train_time:49863ms step_avg:46.91ms
+step:1064/1490 train_time:49946ms step_avg:46.94ms
+step:1065/1490 train_time:50025ms step_avg:46.97ms
+step:1066/1490 train_time:50109ms step_avg:47.01ms
+step:1067/1490 train_time:50188ms step_avg:47.04ms
+step:1068/1490 train_time:50273ms step_avg:47.07ms
+step:1069/1490 train_time:50351ms step_avg:47.10ms
+step:1070/1490 train_time:50436ms step_avg:47.14ms
+step:1071/1490 train_time:50516ms step_avg:47.17ms
+step:1072/1490 train_time:50600ms step_avg:47.20ms
+step:1073/1490 train_time:50679ms step_avg:47.23ms
+step:1074/1490 train_time:50762ms step_avg:47.26ms
+step:1075/1490 train_time:50840ms step_avg:47.29ms
+step:1076/1490 train_time:50924ms step_avg:47.33ms
+step:1077/1490 train_time:51004ms step_avg:47.36ms
+step:1078/1490 train_time:51089ms step_avg:47.39ms
+step:1079/1490 train_time:51168ms step_avg:47.42ms
+step:1080/1490 train_time:51252ms step_avg:47.46ms
+step:1081/1490 train_time:51331ms step_avg:47.48ms
+step:1082/1490 train_time:51417ms step_avg:47.52ms
+step:1083/1490 train_time:51496ms step_avg:47.55ms
+step:1084/1490 train_time:51580ms step_avg:47.58ms
+step:1085/1490 train_time:51659ms step_avg:47.61ms
+step:1086/1490 train_time:51744ms step_avg:47.65ms
+step:1087/1490 train_time:51824ms step_avg:47.68ms
+step:1088/1490 train_time:51907ms step_avg:47.71ms
+step:1089/1490 train_time:51987ms step_avg:47.74ms
+step:1090/1490 train_time:52071ms step_avg:47.77ms
+step:1091/1490 train_time:52150ms step_avg:47.80ms
+step:1092/1490 train_time:52234ms step_avg:47.83ms
+step:1093/1490 train_time:52314ms step_avg:47.86ms
+step:1094/1490 train_time:52399ms step_avg:47.90ms
+step:1095/1490 train_time:52478ms step_avg:47.92ms
+step:1096/1490 train_time:52561ms step_avg:47.96ms
+step:1097/1490 train_time:52640ms step_avg:47.99ms
+step:1098/1490 train_time:52725ms step_avg:48.02ms
+step:1099/1490 train_time:52804ms step_avg:48.05ms
+step:1100/1490 train_time:52888ms step_avg:48.08ms
+step:1101/1490 train_time:52968ms step_avg:48.11ms
+step:1102/1490 train_time:53051ms step_avg:48.14ms
+step:1103/1490 train_time:53131ms step_avg:48.17ms
+step:1104/1490 train_time:53215ms step_avg:48.20ms
+step:1105/1490 train_time:53294ms step_avg:48.23ms
+step:1106/1490 train_time:53378ms step_avg:48.26ms
+step:1107/1490 train_time:53457ms step_avg:48.29ms
+step:1108/1490 train_time:53542ms step_avg:48.32ms
+step:1109/1490 train_time:53620ms step_avg:48.35ms
+step:1110/1490 train_time:53705ms step_avg:48.38ms
+step:1111/1490 train_time:53784ms step_avg:48.41ms
+step:1112/1490 train_time:53867ms step_avg:48.44ms
+step:1113/1490 train_time:53946ms step_avg:48.47ms
+step:1114/1490 train_time:54030ms step_avg:48.50ms
+step:1115/1490 train_time:54109ms step_avg:48.53ms
+step:1116/1490 train_time:54194ms step_avg:48.56ms
+step:1117/1490 train_time:54273ms step_avg:48.59ms
+step:1118/1490 train_time:54358ms step_avg:48.62ms
+step:1119/1490 train_time:54437ms step_avg:48.65ms
+step:1120/1490 train_time:54522ms step_avg:48.68ms
+step:1121/1490 train_time:54599ms step_avg:48.71ms
+step:1122/1490 train_time:54684ms step_avg:48.74ms
+step:1123/1490 train_time:54764ms step_avg:48.77ms
+step:1124/1490 train_time:54847ms step_avg:48.80ms
+step:1125/1490 train_time:54926ms step_avg:48.82ms
+step:1126/1490 train_time:55011ms step_avg:48.86ms
+step:1127/1490 train_time:55091ms step_avg:48.88ms
+step:1128/1490 train_time:55175ms step_avg:48.91ms
+step:1129/1490 train_time:55253ms step_avg:48.94ms
+step:1130/1490 train_time:55338ms step_avg:48.97ms
+step:1131/1490 train_time:55418ms step_avg:49.00ms
+step:1132/1490 train_time:55502ms step_avg:49.03ms
+step:1133/1490 train_time:55580ms step_avg:49.06ms
+step:1134/1490 train_time:55666ms step_avg:49.09ms
+step:1135/1490 train_time:55744ms step_avg:49.11ms
+step:1136/1490 train_time:55827ms step_avg:49.14ms
+step:1137/1490 train_time:55906ms step_avg:49.17ms
+step:1138/1490 train_time:55994ms step_avg:49.20ms
+step:1139/1490 train_time:56071ms step_avg:49.23ms
+step:1140/1490 train_time:56155ms step_avg:49.26ms
+step:1141/1490 train_time:56234ms step_avg:49.28ms
+step:1142/1490 train_time:56319ms step_avg:49.32ms
+step:1143/1490 train_time:56398ms step_avg:49.34ms
+step:1144/1490 train_time:56482ms step_avg:49.37ms
+step:1145/1490 train_time:56561ms step_avg:49.40ms
+step:1146/1490 train_time:56644ms step_avg:49.43ms
+step:1147/1490 train_time:56724ms step_avg:49.45ms
+step:1148/1490 train_time:56807ms step_avg:49.48ms
+step:1149/1490 train_time:56887ms step_avg:49.51ms
+step:1150/1490 train_time:56972ms step_avg:49.54ms
+step:1151/1490 train_time:57051ms step_avg:49.57ms
+step:1152/1490 train_time:57134ms step_avg:49.60ms
+step:1153/1490 train_time:57215ms step_avg:49.62ms
+step:1154/1490 train_time:57300ms step_avg:49.65ms
+step:1155/1490 train_time:57379ms step_avg:49.68ms
+step:1156/1490 train_time:57464ms step_avg:49.71ms
+step:1157/1490 train_time:57542ms step_avg:49.73ms
+step:1158/1490 train_time:57626ms step_avg:49.76ms
+step:1159/1490 train_time:57706ms step_avg:49.79ms
+step:1160/1490 train_time:57790ms step_avg:49.82ms
+step:1161/1490 train_time:57868ms step_avg:49.84ms
+step:1162/1490 train_time:57951ms step_avg:49.87ms
+step:1163/1490 train_time:58031ms step_avg:49.90ms
+step:1164/1490 train_time:58114ms step_avg:49.93ms
+step:1165/1490 train_time:58195ms step_avg:49.95ms
+step:1166/1490 train_time:58280ms step_avg:49.98ms
+step:1167/1490 train_time:58360ms step_avg:50.01ms
+step:1168/1490 train_time:58443ms step_avg:50.04ms
+step:1169/1490 train_time:58523ms step_avg:50.06ms
+step:1170/1490 train_time:58607ms step_avg:50.09ms
+step:1171/1490 train_time:58687ms step_avg:50.12ms
+step:1172/1490 train_time:58771ms step_avg:50.15ms
+step:1173/1490 train_time:58849ms step_avg:50.17ms
+step:1174/1490 train_time:58934ms step_avg:50.20ms
+step:1175/1490 train_time:59013ms step_avg:50.22ms
+step:1176/1490 train_time:59097ms step_avg:50.25ms
+step:1177/1490 train_time:59176ms step_avg:50.28ms
+step:1178/1490 train_time:59259ms step_avg:50.30ms
+step:1179/1490 train_time:59338ms step_avg:50.33ms
+step:1180/1490 train_time:59423ms step_avg:50.36ms
+step:1181/1490 train_time:59502ms step_avg:50.38ms
+step:1182/1490 train_time:59586ms step_avg:50.41ms
+step:1183/1490 train_time:59666ms step_avg:50.44ms
+step:1184/1490 train_time:59749ms step_avg:50.46ms
+step:1185/1490 train_time:59827ms step_avg:50.49ms
+step:1186/1490 train_time:59914ms step_avg:50.52ms
+step:1187/1490 train_time:59991ms step_avg:50.54ms
+step:1188/1490 train_time:60077ms step_avg:50.57ms
+step:1189/1490 train_time:60157ms step_avg:50.59ms
+step:1190/1490 train_time:60240ms step_avg:50.62ms
+step:1191/1490 train_time:60319ms step_avg:50.65ms
+step:1192/1490 train_time:60404ms step_avg:50.67ms
+step:1193/1490 train_time:60483ms step_avg:50.70ms
+step:1194/1490 train_time:60566ms step_avg:50.73ms
+step:1195/1490 train_time:60645ms step_avg:50.75ms
+step:1196/1490 train_time:60729ms step_avg:50.78ms
+step:1197/1490 train_time:60809ms step_avg:50.80ms
+step:1198/1490 train_time:60894ms step_avg:50.83ms
+step:1199/1490 train_time:60974ms step_avg:50.85ms
+step:1200/1490 train_time:61058ms step_avg:50.88ms
+step:1201/1490 train_time:61137ms step_avg:50.91ms
+step:1202/1490 train_time:61221ms step_avg:50.93ms
+step:1203/1490 train_time:61300ms step_avg:50.96ms
+step:1204/1490 train_time:61384ms step_avg:50.98ms
+step:1205/1490 train_time:61463ms step_avg:51.01ms
+step:1206/1490 train_time:61546ms step_avg:51.03ms
+step:1207/1490 train_time:61625ms step_avg:51.06ms
+step:1208/1490 train_time:61709ms step_avg:51.08ms
+step:1209/1490 train_time:61789ms step_avg:51.11ms
+step:1210/1490 train_time:61874ms step_avg:51.14ms
+step:1211/1490 train_time:61954ms step_avg:51.16ms
+step:1212/1490 train_time:62038ms step_avg:51.19ms
+step:1213/1490 train_time:62117ms step_avg:51.21ms
+step:1214/1490 train_time:62203ms step_avg:51.24ms
+step:1215/1490 train_time:62282ms step_avg:51.26ms
+step:1216/1490 train_time:62365ms step_avg:51.29ms
+step:1217/1490 train_time:62443ms step_avg:51.31ms
+step:1218/1490 train_time:62527ms step_avg:51.34ms
+step:1219/1490 train_time:62607ms step_avg:51.36ms
+step:1220/1490 train_time:62691ms step_avg:51.39ms
+step:1221/1490 train_time:62771ms step_avg:51.41ms
+step:1222/1490 train_time:62854ms step_avg:51.44ms
+step:1223/1490 train_time:62933ms step_avg:51.46ms
+step:1224/1490 train_time:63017ms step_avg:51.48ms
+step:1225/1490 train_time:63096ms step_avg:51.51ms
+step:1226/1490 train_time:63181ms step_avg:51.53ms
+step:1227/1490 train_time:63259ms step_avg:51.56ms
+step:1228/1490 train_time:63343ms step_avg:51.58ms
+step:1229/1490 train_time:63422ms step_avg:51.60ms
+step:1230/1490 train_time:63506ms step_avg:51.63ms
+step:1231/1490 train_time:63586ms step_avg:51.65ms
+step:1232/1490 train_time:63670ms step_avg:51.68ms
+step:1233/1490 train_time:63750ms step_avg:51.70ms
+step:1234/1490 train_time:63833ms step_avg:51.73ms
+step:1235/1490 train_time:63912ms step_avg:51.75ms
+step:1236/1490 train_time:63997ms step_avg:51.78ms
+step:1237/1490 train_time:64078ms step_avg:51.80ms
+step:1238/1490 train_time:64161ms step_avg:51.83ms
+step:1239/1490 train_time:64239ms step_avg:51.85ms
+step:1240/1490 train_time:64327ms step_avg:51.88ms
+step:1241/1490 train_time:64404ms step_avg:51.90ms
+step:1242/1490 train_time:64488ms step_avg:51.92ms
+step:1243/1490 train_time:64567ms step_avg:51.94ms
+step:1244/1490 train_time:64650ms step_avg:51.97ms
+step:1245/1490 train_time:64729ms step_avg:51.99ms
+step:1246/1490 train_time:64813ms step_avg:52.02ms
+step:1247/1490 train_time:64895ms step_avg:52.04ms
+step:1248/1490 train_time:64979ms step_avg:52.07ms
+step:1249/1490 train_time:65058ms step_avg:52.09ms
+step:1250/1490 train_time:65142ms step_avg:52.11ms
+step:1250/1490 val_loss:3.3710 train_time:65239ms step_avg:52.19ms
+step:1251/1490 train_time:65258ms step_avg:52.16ms
+step:1252/1490 train_time:65311ms step_avg:52.17ms
+step:1253/1490 train_time:65394ms step_avg:52.19ms
+step:1254/1490 train_time:65480ms step_avg:52.22ms
+step:1255/1490 train_time:65560ms step_avg:52.24ms
+step:1256/1490 train_time:65644ms step_avg:52.26ms
+step:1257/1490 train_time:65722ms step_avg:52.28ms
+step:1258/1490 train_time:65806ms step_avg:52.31ms
+step:1259/1490 train_time:65885ms step_avg:52.33ms
+step:1260/1490 train_time:65967ms step_avg:52.36ms
+step:1261/1490 train_time:66045ms step_avg:52.38ms
+step:1262/1490 train_time:66129ms step_avg:52.40ms
+step:1263/1490 train_time:66208ms step_avg:52.42ms
+step:1264/1490 train_time:66294ms step_avg:52.45ms
+step:1265/1490 train_time:66374ms step_avg:52.47ms
+step:1266/1490 train_time:66459ms step_avg:52.50ms
+step:1267/1490 train_time:66540ms step_avg:52.52ms
+step:1268/1490 train_time:66624ms step_avg:52.54ms
+step:1269/1490 train_time:66703ms step_avg:52.56ms
+step:1270/1490 train_time:66787ms step_avg:52.59ms
+step:1271/1490 train_time:66864ms step_avg:52.61ms
+step:1272/1490 train_time:66947ms step_avg:52.63ms
+step:1273/1490 train_time:67024ms step_avg:52.65ms
+step:1274/1490 train_time:67108ms step_avg:52.68ms
+step:1275/1490 train_time:67186ms step_avg:52.70ms
+step:1276/1490 train_time:67271ms step_avg:52.72ms
+step:1277/1490 train_time:67350ms step_avg:52.74ms
+step:1278/1490 train_time:67435ms step_avg:52.77ms
+step:1279/1490 train_time:67517ms step_avg:52.79ms
+step:1280/1490 train_time:67602ms step_avg:52.81ms
+step:1281/1490 train_time:67682ms step_avg:52.84ms
+step:1282/1490 train_time:67766ms step_avg:52.86ms
+step:1283/1490 train_time:67845ms step_avg:52.88ms
+step:1284/1490 train_time:67929ms step_avg:52.90ms
+step:1285/1490 train_time:68006ms step_avg:52.92ms
+step:1286/1490 train_time:68089ms step_avg:52.95ms
+step:1287/1490 train_time:68168ms step_avg:52.97ms
+step:1288/1490 train_time:68253ms step_avg:52.99ms
+step:1289/1490 train_time:68334ms step_avg:53.01ms
+step:1290/1490 train_time:68417ms step_avg:53.04ms
+step:1291/1490 train_time:68498ms step_avg:53.06ms
+step:1292/1490 train_time:68582ms step_avg:53.08ms
+step:1293/1490 train_time:68662ms step_avg:53.10ms
+step:1294/1490 train_time:68748ms step_avg:53.13ms
+step:1295/1490 train_time:68827ms step_avg:53.15ms
+step:1296/1490 train_time:68911ms step_avg:53.17ms
+step:1297/1490 train_time:68990ms step_avg:53.19ms
+step:1298/1490 train_time:69074ms step_avg:53.22ms
+step:1299/1490 train_time:69152ms step_avg:53.23ms
+step:1300/1490 train_time:69235ms step_avg:53.26ms
+step:1301/1490 train_time:69316ms step_avg:53.28ms
+step:1302/1490 train_time:69400ms step_avg:53.30ms
+step:1303/1490 train_time:69479ms step_avg:53.32ms
+step:1304/1490 train_time:69563ms step_avg:53.35ms
+step:1305/1490 train_time:69642ms step_avg:53.37ms
+step:1306/1490 train_time:69727ms step_avg:53.39ms
+step:1307/1490 train_time:69807ms step_avg:53.41ms
+step:1308/1490 train_time:69892ms step_avg:53.43ms
+step:1309/1490 train_time:69970ms step_avg:53.45ms
+step:1310/1490 train_time:70054ms step_avg:53.48ms
+step:1311/1490 train_time:70133ms step_avg:53.50ms
+step:1312/1490 train_time:70216ms step_avg:53.52ms
+step:1313/1490 train_time:70296ms step_avg:53.54ms
+step:1314/1490 train_time:70380ms step_avg:53.56ms
+step:1315/1490 train_time:70457ms step_avg:53.58ms
+step:1316/1490 train_time:70543ms step_avg:53.60ms
+step:1317/1490 train_time:70623ms step_avg:53.62ms
+step:1318/1490 train_time:70709ms step_avg:53.65ms
+step:1319/1490 train_time:70789ms step_avg:53.67ms
+step:1320/1490 train_time:70872ms step_avg:53.69ms
+step:1321/1490 train_time:70950ms step_avg:53.71ms
+step:1322/1490 train_time:71036ms step_avg:53.73ms
+step:1323/1490 train_time:71115ms step_avg:53.75ms
+step:1324/1490 train_time:71198ms step_avg:53.78ms
+step:1325/1490 train_time:71277ms step_avg:53.79ms
+step:1326/1490 train_time:71360ms step_avg:53.82ms
+step:1327/1490 train_time:71440ms step_avg:53.84ms
+step:1328/1490 train_time:71525ms step_avg:53.86ms
+step:1329/1490 train_time:71605ms step_avg:53.88ms
+step:1330/1490 train_time:71689ms step_avg:53.90ms
+step:1331/1490 train_time:71768ms step_avg:53.92ms
+step:1332/1490 train_time:71851ms step_avg:53.94ms
+step:1333/1490 train_time:71929ms step_avg:53.96ms
+step:1334/1490 train_time:72013ms step_avg:53.98ms
+step:1335/1490 train_time:72091ms step_avg:54.00ms
+step:1336/1490 train_time:72176ms step_avg:54.02ms
+step:1337/1490 train_time:72255ms step_avg:54.04ms
+step:1338/1490 train_time:72339ms step_avg:54.06ms
+step:1339/1490 train_time:72417ms step_avg:54.08ms
+step:1340/1490 train_time:72502ms step_avg:54.11ms
+step:1341/1490 train_time:72584ms step_avg:54.13ms
+step:1342/1490 train_time:72667ms step_avg:54.15ms
+step:1343/1490 train_time:72746ms step_avg:54.17ms
+step:1344/1490 train_time:72831ms step_avg:54.19ms
+step:1345/1490 train_time:72910ms step_avg:54.21ms
+step:1346/1490 train_time:72994ms step_avg:54.23ms
+step:1347/1490 train_time:73072ms step_avg:54.25ms
+step:1348/1490 train_time:73155ms step_avg:54.27ms
+step:1349/1490 train_time:73234ms step_avg:54.29ms
+step:1350/1490 train_time:73318ms step_avg:54.31ms
+step:1351/1490 train_time:73398ms step_avg:54.33ms
+step:1352/1490 train_time:73482ms step_avg:54.35ms
+step:1353/1490 train_time:73562ms step_avg:54.37ms
+step:1354/1490 train_time:73647ms step_avg:54.39ms
+step:1355/1490 train_time:73727ms step_avg:54.41ms
+step:1356/1490 train_time:73811ms step_avg:54.43ms
+step:1357/1490 train_time:73889ms step_avg:54.45ms
+step:1358/1490 train_time:73974ms step_avg:54.47ms
+step:1359/1490 train_time:74053ms step_avg:54.49ms
+step:1360/1490 train_time:74137ms step_avg:54.51ms
+step:1361/1490 train_time:74217ms step_avg:54.53ms
+step:1362/1490 train_time:74301ms step_avg:54.55ms
+step:1363/1490 train_time:74381ms step_avg:54.57ms
+step:1364/1490 train_time:74465ms step_avg:54.59ms
+step:1365/1490 train_time:74545ms step_avg:54.61ms
+step:1366/1490 train_time:74629ms step_avg:54.63ms
+step:1367/1490 train_time:74708ms step_avg:54.65ms
+step:1368/1490 train_time:74793ms step_avg:54.67ms
+step:1369/1490 train_time:74871ms step_avg:54.69ms
+step:1370/1490 train_time:74955ms step_avg:54.71ms
+step:1371/1490 train_time:75035ms step_avg:54.73ms
+step:1372/1490 train_time:75117ms step_avg:54.75ms
+step:1373/1490 train_time:75196ms step_avg:54.77ms
+step:1374/1490 train_time:75282ms step_avg:54.79ms
+step:1375/1490 train_time:75361ms step_avg:54.81ms
+step:1376/1490 train_time:75445ms step_avg:54.83ms
+step:1377/1490 train_time:75524ms step_avg:54.85ms
+step:1378/1490 train_time:75607ms step_avg:54.87ms
+step:1379/1490 train_time:75688ms step_avg:54.89ms
+step:1380/1490 train_time:75771ms step_avg:54.91ms
+step:1381/1490 train_time:75849ms step_avg:54.92ms
+step:1382/1490 train_time:75935ms step_avg:54.95ms
+step:1383/1490 train_time:76015ms step_avg:54.96ms
+step:1384/1490 train_time:76098ms step_avg:54.98ms
+step:1385/1490 train_time:76177ms step_avg:55.00ms
+step:1386/1490 train_time:76260ms step_avg:55.02ms
+step:1387/1490 train_time:76339ms step_avg:55.04ms
+step:1388/1490 train_time:76425ms step_avg:55.06ms
+step:1389/1490 train_time:76505ms step_avg:55.08ms
+step:1390/1490 train_time:76591ms step_avg:55.10ms
+step:1391/1490 train_time:76669ms step_avg:55.12ms
+step:1392/1490 train_time:76753ms step_avg:55.14ms
+step:1393/1490 train_time:76833ms step_avg:55.16ms
+step:1394/1490 train_time:76917ms step_avg:55.18ms
+step:1395/1490 train_time:76996ms step_avg:55.19ms
+step:1396/1490 train_time:77080ms step_avg:55.22ms
+step:1397/1490 train_time:77158ms step_avg:55.23ms
+step:1398/1490 train_time:77241ms step_avg:55.25ms
+step:1399/1490 train_time:77321ms step_avg:55.27ms
+step:1400/1490 train_time:77405ms step_avg:55.29ms
+step:1401/1490 train_time:77486ms step_avg:55.31ms
+step:1402/1490 train_time:77570ms step_avg:55.33ms
+step:1403/1490 train_time:77649ms step_avg:55.34ms
+step:1404/1490 train_time:77733ms step_avg:55.37ms
+step:1405/1490 train_time:77812ms step_avg:55.38ms
+step:1406/1490 train_time:77895ms step_avg:55.40ms
+step:1407/1490 train_time:77973ms step_avg:55.42ms
+step:1408/1490 train_time:78056ms step_avg:55.44ms
+step:1409/1490 train_time:78136ms step_avg:55.45ms
+step:1410/1490 train_time:78220ms step_avg:55.48ms
+step:1411/1490 train_time:78300ms step_avg:55.49ms
+step:1412/1490 train_time:78386ms step_avg:55.51ms
+step:1413/1490 train_time:78466ms step_avg:55.53ms
+step:1414/1490 train_time:78550ms step_avg:55.55ms
+step:1415/1490 train_time:78629ms step_avg:55.57ms
+step:1416/1490 train_time:78712ms step_avg:55.59ms
+step:1417/1490 train_time:78790ms step_avg:55.60ms
+step:1418/1490 train_time:78873ms step_avg:55.62ms
+step:1419/1490 train_time:78951ms step_avg:55.64ms
+step:1420/1490 train_time:79034ms step_avg:55.66ms
+step:1421/1490 train_time:79114ms step_avg:55.67ms
+step:1422/1490 train_time:79200ms step_avg:55.70ms
+step:1423/1490 train_time:79280ms step_avg:55.71ms
+step:1424/1490 train_time:79363ms step_avg:55.73ms
+step:1425/1490 train_time:79443ms step_avg:55.75ms
+step:1426/1490 train_time:79529ms step_avg:55.77ms
+step:1427/1490 train_time:79609ms step_avg:55.79ms
+step:1428/1490 train_time:79693ms step_avg:55.81ms
+step:1429/1490 train_time:79770ms step_avg:55.82ms
+step:1430/1490 train_time:79854ms step_avg:55.84ms
+step:1431/1490 train_time:79934ms step_avg:55.86ms
+step:1432/1490 train_time:80017ms step_avg:55.88ms
+step:1433/1490 train_time:80096ms step_avg:55.89ms
+step:1434/1490 train_time:80182ms step_avg:55.91ms
+step:1435/1490 train_time:80260ms step_avg:55.93ms
+step:1436/1490 train_time:80343ms step_avg:55.95ms
+step:1437/1490 train_time:80423ms step_avg:55.97ms
+step:1438/1490 train_time:80510ms step_avg:55.99ms
+step:1439/1490 train_time:80589ms step_avg:56.00ms
+step:1440/1490 train_time:80674ms step_avg:56.02ms
+step:1441/1490 train_time:80753ms step_avg:56.04ms
+step:1442/1490 train_time:80836ms step_avg:56.06ms
+step:1443/1490 train_time:80915ms step_avg:56.07ms
+step:1444/1490 train_time:80998ms step_avg:56.09ms
+step:1445/1490 train_time:81076ms step_avg:56.11ms
+step:1446/1490 train_time:81160ms step_avg:56.13ms
+step:1447/1490 train_time:81239ms step_avg:56.14ms
+step:1448/1490 train_time:81323ms step_avg:56.16ms
+step:1449/1490 train_time:81402ms step_avg:56.18ms
+step:1450/1490 train_time:81488ms step_avg:56.20ms
+step:1451/1490 train_time:81572ms step_avg:56.22ms
+step:1452/1490 train_time:81657ms step_avg:56.24ms
+step:1453/1490 train_time:81738ms step_avg:56.25ms
+step:1454/1490 train_time:81822ms step_avg:56.27ms
+step:1455/1490 train_time:81901ms step_avg:56.29ms
+step:1456/1490 train_time:81985ms step_avg:56.31ms
+step:1457/1490 train_time:82064ms step_avg:56.32ms
+step:1458/1490 train_time:82148ms step_avg:56.34ms
+step:1459/1490 train_time:82227ms step_avg:56.36ms
+step:1460/1490 train_time:82311ms step_avg:56.38ms
+step:1461/1490 train_time:82391ms step_avg:56.39ms
+step:1462/1490 train_time:82476ms step_avg:56.41ms
+step:1463/1490 train_time:82556ms step_avg:56.43ms
+step:1464/1490 train_time:82641ms step_avg:56.45ms
+step:1465/1490 train_time:82721ms step_avg:56.47ms
+step:1466/1490 train_time:82807ms step_avg:56.48ms
+step:1467/1490 train_time:82886ms step_avg:56.50ms
+step:1468/1490 train_time:82969ms step_avg:56.52ms
+step:1469/1490 train_time:83047ms step_avg:56.53ms
+step:1470/1490 train_time:83132ms step_avg:56.55ms
+step:1471/1490 train_time:83212ms step_avg:56.57ms
+step:1472/1490 train_time:83297ms step_avg:56.59ms
+step:1473/1490 train_time:83377ms step_avg:56.60ms
+step:1474/1490 train_time:83461ms step_avg:56.62ms
+step:1475/1490 train_time:83541ms step_avg:56.64ms
+step:1476/1490 train_time:83626ms step_avg:56.66ms
+step:1477/1490 train_time:83706ms step_avg:56.67ms
+step:1478/1490 train_time:83790ms step_avg:56.69ms
+step:1479/1490 train_time:83868ms step_avg:56.71ms
+step:1480/1490 train_time:83953ms step_avg:56.73ms
+step:1481/1490 train_time:84033ms step_avg:56.74ms
+step:1482/1490 train_time:84117ms step_avg:56.76ms
+step:1483/1490 train_time:84196ms step_avg:56.77ms
+step:1484/1490 train_time:84280ms step_avg:56.79ms
+step:1485/1490 train_time:84359ms step_avg:56.81ms
+step:1486/1490 train_time:84444ms step_avg:56.83ms
+step:1487/1490 train_time:84524ms step_avg:56.84ms
+step:1488/1490 train_time:84609ms step_avg:56.86ms
+step:1489/1490 train_time:84689ms step_avg:56.88ms
+step:1490/1490 train_time:84773ms step_avg:56.89ms
+step:1490/1490 val_loss:3.2784 train_time:84870ms step_avg:56.96ms
+peak memory allocated: 30949 MiB reserved: 46586 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/43e34e1c-a9c4-4de5-a86b-5ea59c227867.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/43e34e1c-a9c4-4de5-a86b-5ea59c227867.txt
@@ -1,0 +1,4571 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 12:52:18 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   31C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8296 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:81ms step_avg:81.34ms
+step:2/1490 train_time:105ms step_avg:52.73ms
+step:3/1490 train_time:124ms step_avg:41.33ms
+step:4/1490 train_time:158ms step_avg:39.57ms
+step:5/1490 train_time:185ms step_avg:36.98ms
+step:6/1490 train_time:220ms step_avg:36.59ms
+step:7/1490 train_time:246ms step_avg:35.17ms
+step:8/1490 train_time:281ms step_avg:35.08ms
+step:9/1490 train_time:308ms step_avg:34.21ms
+step:10/1490 train_time:342ms step_avg:34.21ms
+step:11/1490 train_time:370ms step_avg:33.60ms
+step:12/1490 train_time:404ms step_avg:33.65ms
+step:13/1490 train_time:431ms step_avg:33.19ms
+step:14/1490 train_time:466ms step_avg:33.25ms
+step:15/1490 train_time:493ms step_avg:32.87ms
+step:16/1490 train_time:527ms step_avg:32.96ms
+step:17/1490 train_time:555ms step_avg:32.63ms
+step:18/1490 train_time:589ms step_avg:32.74ms
+step:19/1490 train_time:617ms step_avg:32.47ms
+step:20/1490 train_time:651ms step_avg:32.55ms
+step:21/1490 train_time:678ms step_avg:32.31ms
+step:22/1490 train_time:712ms step_avg:32.38ms
+step:23/1490 train_time:740ms step_avg:32.18ms
+step:24/1490 train_time:775ms step_avg:32.27ms
+step:25/1490 train_time:802ms step_avg:32.08ms
+step:26/1490 train_time:837ms step_avg:32.18ms
+step:27/1490 train_time:864ms step_avg:32.00ms
+step:28/1490 train_time:898ms step_avg:32.08ms
+step:29/1490 train_time:926ms step_avg:31.93ms
+step:30/1490 train_time:960ms step_avg:32.00ms
+step:31/1490 train_time:988ms step_avg:31.88ms
+step:32/1490 train_time:1023ms step_avg:31.97ms
+step:33/1490 train_time:1051ms step_avg:31.85ms
+step:34/1490 train_time:1086ms step_avg:31.93ms
+step:35/1490 train_time:1114ms step_avg:31.82ms
+step:36/1490 train_time:1148ms step_avg:31.89ms
+step:37/1490 train_time:1178ms step_avg:31.84ms
+step:38/1490 train_time:1210ms step_avg:31.84ms
+step:39/1490 train_time:1238ms step_avg:31.74ms
+step:40/1490 train_time:1272ms step_avg:31.80ms
+step:41/1490 train_time:1300ms step_avg:31.70ms
+step:42/1490 train_time:1334ms step_avg:31.77ms
+step:43/1490 train_time:1362ms step_avg:31.67ms
+step:44/1490 train_time:1396ms step_avg:31.73ms
+step:45/1490 train_time:1424ms step_avg:31.65ms
+step:46/1490 train_time:1458ms step_avg:31.70ms
+step:47/1490 train_time:1486ms step_avg:31.62ms
+step:48/1490 train_time:1520ms step_avg:31.67ms
+step:49/1490 train_time:1547ms step_avg:31.58ms
+step:50/1490 train_time:1582ms step_avg:31.64ms
+step:51/1490 train_time:1610ms step_avg:31.56ms
+step:52/1490 train_time:1644ms step_avg:31.61ms
+step:53/1490 train_time:1672ms step_avg:31.54ms
+step:54/1490 train_time:1706ms step_avg:31.59ms
+step:55/1490 train_time:1733ms step_avg:31.51ms
+step:56/1490 train_time:1767ms step_avg:31.56ms
+step:57/1490 train_time:1795ms step_avg:31.49ms
+step:58/1490 train_time:1830ms step_avg:31.55ms
+step:59/1490 train_time:1857ms step_avg:31.47ms
+step:60/1490 train_time:1891ms step_avg:31.52ms
+step:61/1490 train_time:1919ms step_avg:31.46ms
+step:62/1490 train_time:1953ms step_avg:31.51ms
+step:63/1490 train_time:1981ms step_avg:31.44ms
+step:64/1490 train_time:2015ms step_avg:31.49ms
+step:65/1490 train_time:2043ms step_avg:31.42ms
+step:66/1490 train_time:2077ms step_avg:31.48ms
+step:67/1490 train_time:2105ms step_avg:31.42ms
+step:68/1490 train_time:2140ms step_avg:31.47ms
+step:69/1490 train_time:2167ms step_avg:31.41ms
+step:70/1490 train_time:2202ms step_avg:31.45ms
+step:71/1490 train_time:2230ms step_avg:31.40ms
+step:72/1490 train_time:2264ms step_avg:31.44ms
+step:73/1490 train_time:2292ms step_avg:31.40ms
+step:74/1490 train_time:2326ms step_avg:31.43ms
+step:75/1490 train_time:2354ms step_avg:31.38ms
+step:76/1490 train_time:2388ms step_avg:31.42ms
+step:77/1490 train_time:2415ms step_avg:31.37ms
+step:78/1490 train_time:2450ms step_avg:31.41ms
+step:79/1490 train_time:2478ms step_avg:31.36ms
+step:80/1490 train_time:2512ms step_avg:31.41ms
+step:81/1490 train_time:2540ms step_avg:31.36ms
+step:82/1490 train_time:2575ms step_avg:31.40ms
+step:83/1490 train_time:2602ms step_avg:31.35ms
+step:84/1490 train_time:2637ms step_avg:31.39ms
+step:85/1490 train_time:2664ms step_avg:31.35ms
+step:86/1490 train_time:2699ms step_avg:31.38ms
+step:87/1490 train_time:2726ms step_avg:31.34ms
+step:88/1490 train_time:2760ms step_avg:31.37ms
+step:89/1490 train_time:2788ms step_avg:31.33ms
+step:90/1490 train_time:2822ms step_avg:31.36ms
+step:91/1490 train_time:2850ms step_avg:31.32ms
+step:92/1490 train_time:2884ms step_avg:31.35ms
+step:93/1490 train_time:2911ms step_avg:31.31ms
+step:94/1490 train_time:2946ms step_avg:31.35ms
+step:95/1490 train_time:2973ms step_avg:31.29ms
+step:96/1490 train_time:3007ms step_avg:31.32ms
+step:97/1490 train_time:3035ms step_avg:31.29ms
+step:98/1490 train_time:3069ms step_avg:31.32ms
+step:99/1490 train_time:3097ms step_avg:31.28ms
+step:100/1490 train_time:3131ms step_avg:31.31ms
+step:101/1490 train_time:3159ms step_avg:31.27ms
+step:102/1490 train_time:3193ms step_avg:31.31ms
+step:103/1490 train_time:3221ms step_avg:31.27ms
+step:104/1490 train_time:3255ms step_avg:31.30ms
+step:105/1490 train_time:3283ms step_avg:31.26ms
+step:106/1490 train_time:3317ms step_avg:31.30ms
+step:107/1490 train_time:3345ms step_avg:31.26ms
+step:108/1490 train_time:3379ms step_avg:31.29ms
+step:109/1490 train_time:3407ms step_avg:31.26ms
+step:110/1490 train_time:3441ms step_avg:31.28ms
+step:111/1490 train_time:3469ms step_avg:31.25ms
+step:112/1490 train_time:3503ms step_avg:31.28ms
+step:113/1490 train_time:3531ms step_avg:31.25ms
+step:114/1490 train_time:3565ms step_avg:31.27ms
+step:115/1490 train_time:3593ms step_avg:31.24ms
+step:116/1490 train_time:3627ms step_avg:31.27ms
+step:117/1490 train_time:3654ms step_avg:31.23ms
+step:118/1490 train_time:3689ms step_avg:31.26ms
+step:119/1490 train_time:3716ms step_avg:31.23ms
+step:120/1490 train_time:3751ms step_avg:31.26ms
+step:121/1490 train_time:3778ms step_avg:31.22ms
+step:122/1490 train_time:3813ms step_avg:31.25ms
+step:123/1490 train_time:3840ms step_avg:31.22ms
+step:124/1490 train_time:3875ms step_avg:31.25ms
+step:125/1490 train_time:3902ms step_avg:31.22ms
+step:126/1490 train_time:3936ms step_avg:31.24ms
+step:127/1490 train_time:3964ms step_avg:31.21ms
+step:128/1490 train_time:3998ms step_avg:31.24ms
+step:129/1490 train_time:4026ms step_avg:31.21ms
+step:130/1490 train_time:4060ms step_avg:31.23ms
+step:131/1490 train_time:4087ms step_avg:31.20ms
+step:132/1490 train_time:4121ms step_avg:31.22ms
+step:133/1490 train_time:4149ms step_avg:31.19ms
+step:134/1490 train_time:4183ms step_avg:31.22ms
+step:135/1490 train_time:4211ms step_avg:31.19ms
+step:136/1490 train_time:4245ms step_avg:31.21ms
+step:137/1490 train_time:4272ms step_avg:31.18ms
+step:138/1490 train_time:4306ms step_avg:31.20ms
+step:139/1490 train_time:4334ms step_avg:31.18ms
+step:140/1490 train_time:4368ms step_avg:31.20ms
+step:141/1490 train_time:4396ms step_avg:31.18ms
+step:142/1490 train_time:4431ms step_avg:31.20ms
+step:143/1490 train_time:4458ms step_avg:31.18ms
+step:144/1490 train_time:4493ms step_avg:31.20ms
+step:145/1490 train_time:4520ms step_avg:31.17ms
+step:146/1490 train_time:4555ms step_avg:31.20ms
+step:147/1490 train_time:4582ms step_avg:31.17ms
+step:148/1490 train_time:4617ms step_avg:31.19ms
+step:149/1490 train_time:4644ms step_avg:31.17ms
+step:150/1490 train_time:4678ms step_avg:31.19ms
+step:151/1490 train_time:4706ms step_avg:31.17ms
+step:152/1490 train_time:4740ms step_avg:31.18ms
+step:153/1490 train_time:4768ms step_avg:31.16ms
+step:154/1490 train_time:4802ms step_avg:31.18ms
+step:155/1490 train_time:4829ms step_avg:31.16ms
+step:156/1490 train_time:4864ms step_avg:31.18ms
+step:157/1490 train_time:4891ms step_avg:31.16ms
+step:158/1490 train_time:4925ms step_avg:31.17ms
+step:159/1490 train_time:4953ms step_avg:31.15ms
+step:160/1490 train_time:4987ms step_avg:31.17ms
+step:161/1490 train_time:5015ms step_avg:31.15ms
+step:162/1490 train_time:5049ms step_avg:31.17ms
+step:163/1490 train_time:5077ms step_avg:31.14ms
+step:164/1490 train_time:5111ms step_avg:31.17ms
+step:165/1490 train_time:5139ms step_avg:31.14ms
+step:166/1490 train_time:5173ms step_avg:31.16ms
+step:167/1490 train_time:5201ms step_avg:31.14ms
+step:168/1490 train_time:5235ms step_avg:31.16ms
+step:169/1490 train_time:5262ms step_avg:31.14ms
+step:170/1490 train_time:5297ms step_avg:31.16ms
+step:171/1490 train_time:5324ms step_avg:31.14ms
+step:172/1490 train_time:5359ms step_avg:31.16ms
+step:173/1490 train_time:5387ms step_avg:31.14ms
+step:174/1490 train_time:5421ms step_avg:31.15ms
+step:175/1490 train_time:5449ms step_avg:31.13ms
+step:176/1490 train_time:5483ms step_avg:31.15ms
+step:177/1490 train_time:5510ms step_avg:31.13ms
+step:178/1490 train_time:5544ms step_avg:31.15ms
+step:179/1490 train_time:5572ms step_avg:31.13ms
+step:180/1490 train_time:5606ms step_avg:31.15ms
+step:181/1490 train_time:5634ms step_avg:31.12ms
+step:182/1490 train_time:5668ms step_avg:31.14ms
+step:183/1490 train_time:5695ms step_avg:31.12ms
+step:184/1490 train_time:5730ms step_avg:31.14ms
+step:185/1490 train_time:5757ms step_avg:31.12ms
+step:186/1490 train_time:5791ms step_avg:31.14ms
+step:187/1490 train_time:5819ms step_avg:31.12ms
+step:188/1490 train_time:5853ms step_avg:31.13ms
+step:189/1490 train_time:5880ms step_avg:31.11ms
+step:190/1490 train_time:5915ms step_avg:31.13ms
+step:191/1490 train_time:5942ms step_avg:31.11ms
+step:192/1490 train_time:5976ms step_avg:31.13ms
+step:193/1490 train_time:6004ms step_avg:31.11ms
+step:194/1490 train_time:6038ms step_avg:31.12ms
+step:195/1490 train_time:6066ms step_avg:31.11ms
+step:196/1490 train_time:6100ms step_avg:31.12ms
+step:197/1490 train_time:6127ms step_avg:31.10ms
+step:198/1490 train_time:6161ms step_avg:31.12ms
+step:199/1490 train_time:6189ms step_avg:31.10ms
+step:200/1490 train_time:6223ms step_avg:31.12ms
+step:201/1490 train_time:6251ms step_avg:31.10ms
+step:202/1490 train_time:6285ms step_avg:31.11ms
+step:203/1490 train_time:6312ms step_avg:31.10ms
+step:204/1490 train_time:6346ms step_avg:31.11ms
+step:205/1490 train_time:6374ms step_avg:31.09ms
+step:206/1490 train_time:6408ms step_avg:31.11ms
+step:207/1490 train_time:6436ms step_avg:31.09ms
+step:208/1490 train_time:6470ms step_avg:31.11ms
+step:209/1490 train_time:6498ms step_avg:31.09ms
+step:210/1490 train_time:6533ms step_avg:31.11ms
+step:211/1490 train_time:6560ms step_avg:31.09ms
+step:212/1490 train_time:6594ms step_avg:31.10ms
+step:213/1490 train_time:6621ms step_avg:31.09ms
+step:214/1490 train_time:6656ms step_avg:31.10ms
+step:215/1490 train_time:6684ms step_avg:31.09ms
+step:216/1490 train_time:6718ms step_avg:31.10ms
+step:217/1490 train_time:6745ms step_avg:31.08ms
+step:218/1490 train_time:6780ms step_avg:31.10ms
+step:219/1490 train_time:6807ms step_avg:31.08ms
+step:220/1490 train_time:6842ms step_avg:31.10ms
+step:221/1490 train_time:6870ms step_avg:31.08ms
+step:222/1490 train_time:6904ms step_avg:31.10ms
+step:223/1490 train_time:6931ms step_avg:31.08ms
+step:224/1490 train_time:6965ms step_avg:31.10ms
+step:225/1490 train_time:6993ms step_avg:31.08ms
+step:226/1490 train_time:7027ms step_avg:31.09ms
+step:227/1490 train_time:7054ms step_avg:31.08ms
+step:228/1490 train_time:7088ms step_avg:31.09ms
+step:229/1490 train_time:7116ms step_avg:31.07ms
+step:230/1490 train_time:7150ms step_avg:31.09ms
+step:231/1490 train_time:7178ms step_avg:31.07ms
+step:232/1490 train_time:7212ms step_avg:31.09ms
+step:233/1490 train_time:7239ms step_avg:31.07ms
+step:234/1490 train_time:7274ms step_avg:31.08ms
+step:235/1490 train_time:7301ms step_avg:31.07ms
+step:236/1490 train_time:7335ms step_avg:31.08ms
+step:237/1490 train_time:7363ms step_avg:31.07ms
+step:238/1490 train_time:7397ms step_avg:31.08ms
+step:239/1490 train_time:7424ms step_avg:31.06ms
+step:240/1490 train_time:7458ms step_avg:31.08ms
+step:241/1490 train_time:7486ms step_avg:31.06ms
+step:242/1490 train_time:7520ms step_avg:31.08ms
+step:243/1490 train_time:7548ms step_avg:31.06ms
+step:244/1490 train_time:7582ms step_avg:31.07ms
+step:245/1490 train_time:7611ms step_avg:31.07ms
+step:246/1490 train_time:7644ms step_avg:31.07ms
+step:247/1490 train_time:7671ms step_avg:31.06ms
+step:248/1490 train_time:7705ms step_avg:31.07ms
+step:249/1490 train_time:7733ms step_avg:31.05ms
+step:250/1490 train_time:7767ms step_avg:31.07ms
+step:250/1490 val_loss:4.5143 train_time:7806ms step_avg:31.22ms
+step:251/1490 train_time:7823ms step_avg:31.17ms
+step:252/1490 train_time:7842ms step_avg:31.12ms
+step:253/1490 train_time:7858ms step_avg:31.06ms
+step:254/1490 train_time:7893ms step_avg:31.08ms
+step:255/1490 train_time:7922ms step_avg:31.07ms
+step:256/1490 train_time:7958ms step_avg:31.09ms
+step:257/1490 train_time:7986ms step_avg:31.07ms
+step:258/1490 train_time:8020ms step_avg:31.09ms
+step:259/1490 train_time:8048ms step_avg:31.07ms
+step:260/1490 train_time:8082ms step_avg:31.09ms
+step:261/1490 train_time:8110ms step_avg:31.07ms
+step:262/1490 train_time:8144ms step_avg:31.08ms
+step:263/1490 train_time:8171ms step_avg:31.07ms
+step:264/1490 train_time:8206ms step_avg:31.08ms
+step:265/1490 train_time:8233ms step_avg:31.07ms
+step:266/1490 train_time:8268ms step_avg:31.08ms
+step:267/1490 train_time:8295ms step_avg:31.07ms
+step:268/1490 train_time:8329ms step_avg:31.08ms
+step:269/1490 train_time:8356ms step_avg:31.06ms
+step:270/1490 train_time:8390ms step_avg:31.07ms
+step:271/1490 train_time:8418ms step_avg:31.06ms
+step:272/1490 train_time:8452ms step_avg:31.07ms
+step:273/1490 train_time:8479ms step_avg:31.06ms
+step:274/1490 train_time:8513ms step_avg:31.07ms
+step:275/1490 train_time:8540ms step_avg:31.06ms
+step:276/1490 train_time:8574ms step_avg:31.07ms
+step:277/1490 train_time:8602ms step_avg:31.05ms
+step:278/1490 train_time:8635ms step_avg:31.06ms
+step:279/1490 train_time:8663ms step_avg:31.05ms
+step:280/1490 train_time:8697ms step_avg:31.06ms
+step:281/1490 train_time:8724ms step_avg:31.05ms
+step:282/1490 train_time:8758ms step_avg:31.06ms
+step:283/1490 train_time:8785ms step_avg:31.04ms
+step:284/1490 train_time:8820ms step_avg:31.06ms
+step:285/1490 train_time:8847ms step_avg:31.04ms
+step:286/1490 train_time:8882ms step_avg:31.06ms
+step:287/1490 train_time:8910ms step_avg:31.04ms
+step:288/1490 train_time:8944ms step_avg:31.06ms
+step:289/1490 train_time:8972ms step_avg:31.04ms
+step:290/1490 train_time:9006ms step_avg:31.06ms
+step:291/1490 train_time:9033ms step_avg:31.04ms
+step:292/1490 train_time:9068ms step_avg:31.05ms
+step:293/1490 train_time:9095ms step_avg:31.04ms
+step:294/1490 train_time:9130ms step_avg:31.05ms
+step:295/1490 train_time:9157ms step_avg:31.04ms
+step:296/1490 train_time:9192ms step_avg:31.05ms
+step:297/1490 train_time:9219ms step_avg:31.04ms
+step:298/1490 train_time:9253ms step_avg:31.05ms
+step:299/1490 train_time:9281ms step_avg:31.04ms
+step:300/1490 train_time:9315ms step_avg:31.05ms
+step:301/1490 train_time:9342ms step_avg:31.04ms
+step:302/1490 train_time:9376ms step_avg:31.05ms
+step:303/1490 train_time:9404ms step_avg:31.04ms
+step:304/1490 train_time:9437ms step_avg:31.04ms
+step:305/1490 train_time:9465ms step_avg:31.03ms
+step:306/1490 train_time:9499ms step_avg:31.04ms
+step:307/1490 train_time:9526ms step_avg:31.03ms
+step:308/1490 train_time:9560ms step_avg:31.04ms
+step:309/1490 train_time:9588ms step_avg:31.03ms
+step:310/1490 train_time:9622ms step_avg:31.04ms
+step:311/1490 train_time:9650ms step_avg:31.03ms
+step:312/1490 train_time:9684ms step_avg:31.04ms
+step:313/1490 train_time:9711ms step_avg:31.03ms
+step:314/1490 train_time:9745ms step_avg:31.04ms
+step:315/1490 train_time:9772ms step_avg:31.02ms
+step:316/1490 train_time:9807ms step_avg:31.03ms
+step:317/1490 train_time:9834ms step_avg:31.02ms
+step:318/1490 train_time:9868ms step_avg:31.03ms
+step:319/1490 train_time:9896ms step_avg:31.02ms
+step:320/1490 train_time:9930ms step_avg:31.03ms
+step:321/1490 train_time:9958ms step_avg:31.02ms
+step:322/1490 train_time:9992ms step_avg:31.03ms
+step:323/1490 train_time:10020ms step_avg:31.02ms
+step:324/1490 train_time:10054ms step_avg:31.03ms
+step:325/1490 train_time:10082ms step_avg:31.02ms
+step:326/1490 train_time:10116ms step_avg:31.03ms
+step:327/1490 train_time:10143ms step_avg:31.02ms
+step:328/1490 train_time:10177ms step_avg:31.03ms
+step:329/1490 train_time:10205ms step_avg:31.02ms
+step:330/1490 train_time:10239ms step_avg:31.03ms
+step:331/1490 train_time:10269ms step_avg:31.02ms
+step:332/1490 train_time:10301ms step_avg:31.03ms
+step:333/1490 train_time:10328ms step_avg:31.01ms
+step:334/1490 train_time:10362ms step_avg:31.03ms
+step:335/1490 train_time:10390ms step_avg:31.01ms
+step:336/1490 train_time:10424ms step_avg:31.02ms
+step:337/1490 train_time:10452ms step_avg:31.01ms
+step:338/1490 train_time:10486ms step_avg:31.02ms
+step:339/1490 train_time:10513ms step_avg:31.01ms
+step:340/1490 train_time:10547ms step_avg:31.02ms
+step:341/1490 train_time:10574ms step_avg:31.01ms
+step:342/1490 train_time:10608ms step_avg:31.02ms
+step:343/1490 train_time:10636ms step_avg:31.01ms
+step:344/1490 train_time:10670ms step_avg:31.02ms
+step:345/1490 train_time:10698ms step_avg:31.01ms
+step:346/1490 train_time:10731ms step_avg:31.02ms
+step:347/1490 train_time:10759ms step_avg:31.01ms
+step:348/1490 train_time:10794ms step_avg:31.02ms
+step:349/1490 train_time:10821ms step_avg:31.00ms
+step:350/1490 train_time:10854ms step_avg:31.01ms
+step:351/1490 train_time:10882ms step_avg:31.00ms
+step:352/1490 train_time:10916ms step_avg:31.01ms
+step:353/1490 train_time:10943ms step_avg:31.00ms
+step:354/1490 train_time:11090ms step_avg:31.33ms
+step:355/1490 train_time:11105ms step_avg:31.28ms
+step:356/1490 train_time:11123ms step_avg:31.24ms
+step:357/1490 train_time:11143ms step_avg:31.21ms
+step:358/1490 train_time:11176ms step_avg:31.22ms
+step:359/1490 train_time:11204ms step_avg:31.21ms
+step:360/1490 train_time:11238ms step_avg:31.22ms
+step:361/1490 train_time:11265ms step_avg:31.20ms
+step:362/1490 train_time:11299ms step_avg:31.21ms
+step:363/1490 train_time:11326ms step_avg:31.20ms
+step:364/1490 train_time:11360ms step_avg:31.21ms
+step:365/1490 train_time:11387ms step_avg:31.20ms
+step:366/1490 train_time:11422ms step_avg:31.21ms
+step:367/1490 train_time:11448ms step_avg:31.19ms
+step:368/1490 train_time:11482ms step_avg:31.20ms
+step:369/1490 train_time:11509ms step_avg:31.19ms
+step:370/1490 train_time:11544ms step_avg:31.20ms
+step:371/1490 train_time:11571ms step_avg:31.19ms
+step:372/1490 train_time:11605ms step_avg:31.19ms
+step:373/1490 train_time:11632ms step_avg:31.19ms
+step:374/1490 train_time:11666ms step_avg:31.19ms
+step:375/1490 train_time:11693ms step_avg:31.18ms
+step:376/1490 train_time:11727ms step_avg:31.19ms
+step:377/1490 train_time:11755ms step_avg:31.18ms
+step:378/1490 train_time:11789ms step_avg:31.19ms
+step:379/1490 train_time:11816ms step_avg:31.18ms
+step:380/1490 train_time:11850ms step_avg:31.19ms
+step:381/1490 train_time:11878ms step_avg:31.17ms
+step:382/1490 train_time:11912ms step_avg:31.18ms
+step:383/1490 train_time:11939ms step_avg:31.17ms
+step:384/1490 train_time:11974ms step_avg:31.18ms
+step:385/1490 train_time:12002ms step_avg:31.17ms
+step:386/1490 train_time:12037ms step_avg:31.18ms
+step:387/1490 train_time:12065ms step_avg:31.18ms
+step:388/1490 train_time:12100ms step_avg:31.19ms
+step:389/1490 train_time:12127ms step_avg:31.18ms
+step:390/1490 train_time:12163ms step_avg:31.19ms
+step:391/1490 train_time:12190ms step_avg:31.18ms
+step:392/1490 train_time:12224ms step_avg:31.18ms
+step:393/1490 train_time:12252ms step_avg:31.18ms
+step:394/1490 train_time:12286ms step_avg:31.18ms
+step:395/1490 train_time:12313ms step_avg:31.17ms
+step:396/1490 train_time:12348ms step_avg:31.18ms
+step:397/1490 train_time:12375ms step_avg:31.17ms
+step:398/1490 train_time:12409ms step_avg:31.18ms
+step:399/1490 train_time:12437ms step_avg:31.17ms
+step:400/1490 train_time:12471ms step_avg:31.18ms
+step:401/1490 train_time:12498ms step_avg:31.17ms
+step:402/1490 train_time:12532ms step_avg:31.17ms
+step:403/1490 train_time:12560ms step_avg:31.17ms
+step:404/1490 train_time:12594ms step_avg:31.17ms
+step:405/1490 train_time:12621ms step_avg:31.16ms
+step:406/1490 train_time:12656ms step_avg:31.17ms
+step:407/1490 train_time:12682ms step_avg:31.16ms
+step:408/1490 train_time:12717ms step_avg:31.17ms
+step:409/1490 train_time:12744ms step_avg:31.16ms
+step:410/1490 train_time:12778ms step_avg:31.17ms
+step:411/1490 train_time:12805ms step_avg:31.16ms
+step:412/1490 train_time:12839ms step_avg:31.16ms
+step:413/1490 train_time:12866ms step_avg:31.15ms
+step:414/1490 train_time:12901ms step_avg:31.16ms
+step:415/1490 train_time:12928ms step_avg:31.15ms
+step:416/1490 train_time:12963ms step_avg:31.16ms
+step:417/1490 train_time:12990ms step_avg:31.15ms
+step:418/1490 train_time:13024ms step_avg:31.16ms
+step:419/1490 train_time:13052ms step_avg:31.15ms
+step:420/1490 train_time:13086ms step_avg:31.16ms
+step:421/1490 train_time:13114ms step_avg:31.15ms
+step:422/1490 train_time:13148ms step_avg:31.16ms
+step:423/1490 train_time:13176ms step_avg:31.15ms
+step:424/1490 train_time:13210ms step_avg:31.16ms
+step:425/1490 train_time:13238ms step_avg:31.15ms
+step:426/1490 train_time:13272ms step_avg:31.15ms
+step:427/1490 train_time:13299ms step_avg:31.15ms
+step:428/1490 train_time:13333ms step_avg:31.15ms
+step:429/1490 train_time:13360ms step_avg:31.14ms
+step:430/1490 train_time:13395ms step_avg:31.15ms
+step:431/1490 train_time:13422ms step_avg:31.14ms
+step:432/1490 train_time:13456ms step_avg:31.15ms
+step:433/1490 train_time:13484ms step_avg:31.14ms
+step:434/1490 train_time:13518ms step_avg:31.15ms
+step:435/1490 train_time:13545ms step_avg:31.14ms
+step:436/1490 train_time:13579ms step_avg:31.15ms
+step:437/1490 train_time:13606ms step_avg:31.14ms
+step:438/1490 train_time:13641ms step_avg:31.14ms
+step:439/1490 train_time:13668ms step_avg:31.14ms
+step:440/1490 train_time:13703ms step_avg:31.14ms
+step:441/1490 train_time:13730ms step_avg:31.13ms
+step:442/1490 train_time:13764ms step_avg:31.14ms
+step:443/1490 train_time:13791ms step_avg:31.13ms
+step:444/1490 train_time:13826ms step_avg:31.14ms
+step:445/1490 train_time:13853ms step_avg:31.13ms
+step:446/1490 train_time:13887ms step_avg:31.14ms
+step:447/1490 train_time:13915ms step_avg:31.13ms
+step:448/1490 train_time:13949ms step_avg:31.14ms
+step:449/1490 train_time:13977ms step_avg:31.13ms
+step:450/1490 train_time:14011ms step_avg:31.14ms
+step:451/1490 train_time:14038ms step_avg:31.13ms
+step:452/1490 train_time:14073ms step_avg:31.13ms
+step:453/1490 train_time:14100ms step_avg:31.13ms
+step:454/1490 train_time:14135ms step_avg:31.13ms
+step:455/1490 train_time:14162ms step_avg:31.12ms
+step:456/1490 train_time:14196ms step_avg:31.13ms
+step:457/1490 train_time:14223ms step_avg:31.12ms
+step:458/1490 train_time:14257ms step_avg:31.13ms
+step:459/1490 train_time:14284ms step_avg:31.12ms
+step:460/1490 train_time:14319ms step_avg:31.13ms
+step:461/1490 train_time:14347ms step_avg:31.12ms
+step:462/1490 train_time:14381ms step_avg:31.13ms
+step:463/1490 train_time:14409ms step_avg:31.12ms
+step:464/1490 train_time:14443ms step_avg:31.13ms
+step:465/1490 train_time:14470ms step_avg:31.12ms
+step:466/1490 train_time:14505ms step_avg:31.13ms
+step:467/1490 train_time:14532ms step_avg:31.12ms
+step:468/1490 train_time:14566ms step_avg:31.12ms
+step:469/1490 train_time:14593ms step_avg:31.12ms
+step:470/1490 train_time:14628ms step_avg:31.12ms
+step:471/1490 train_time:14655ms step_avg:31.11ms
+step:472/1490 train_time:14689ms step_avg:31.12ms
+step:473/1490 train_time:14717ms step_avg:31.11ms
+step:474/1490 train_time:14751ms step_avg:31.12ms
+step:475/1490 train_time:14779ms step_avg:31.11ms
+step:476/1490 train_time:14817ms step_avg:31.13ms
+step:477/1490 train_time:14840ms step_avg:31.11ms
+step:478/1490 train_time:14875ms step_avg:31.12ms
+step:479/1490 train_time:14902ms step_avg:31.11ms
+step:480/1490 train_time:14936ms step_avg:31.12ms
+step:481/1490 train_time:14963ms step_avg:31.11ms
+step:482/1490 train_time:14997ms step_avg:31.11ms
+step:483/1490 train_time:15024ms step_avg:31.11ms
+step:484/1490 train_time:15061ms step_avg:31.12ms
+step:485/1490 train_time:15114ms step_avg:31.16ms
+step:486/1490 train_time:15171ms step_avg:31.22ms
+step:487/1490 train_time:15225ms step_avg:31.26ms
+step:488/1490 train_time:15284ms step_avg:31.32ms
+step:489/1490 train_time:15337ms step_avg:31.36ms
+step:490/1490 train_time:15396ms step_avg:31.42ms
+step:491/1490 train_time:15449ms step_avg:31.46ms
+step:492/1490 train_time:15507ms step_avg:31.52ms
+step:493/1490 train_time:15561ms step_avg:31.56ms
+step:494/1490 train_time:15619ms step_avg:31.62ms
+step:495/1490 train_time:15673ms step_avg:31.66ms
+step:496/1490 train_time:15732ms step_avg:31.72ms
+step:497/1490 train_time:15786ms step_avg:31.76ms
+step:498/1490 train_time:15846ms step_avg:31.82ms
+step:499/1490 train_time:15900ms step_avg:31.86ms
+step:500/1490 train_time:15958ms step_avg:31.92ms
+step:500/1490 val_loss:4.2354 train_time:16026ms step_avg:32.05ms
+step:501/1490 train_time:16045ms step_avg:32.03ms
+step:502/1490 train_time:16072ms step_avg:32.02ms
+step:503/1490 train_time:16128ms step_avg:32.06ms
+step:504/1490 train_time:16194ms step_avg:32.13ms
+step:505/1490 train_time:16248ms step_avg:32.17ms
+step:506/1490 train_time:16307ms step_avg:32.23ms
+step:507/1490 train_time:16360ms step_avg:32.27ms
+step:508/1490 train_time:16418ms step_avg:32.32ms
+step:509/1490 train_time:16470ms step_avg:32.36ms
+step:510/1490 train_time:16529ms step_avg:32.41ms
+step:511/1490 train_time:16581ms step_avg:32.45ms
+step:512/1490 train_time:16639ms step_avg:32.50ms
+step:513/1490 train_time:16692ms step_avg:32.54ms
+step:514/1490 train_time:16751ms step_avg:32.59ms
+step:515/1490 train_time:16803ms step_avg:32.63ms
+step:516/1490 train_time:16861ms step_avg:32.68ms
+step:517/1490 train_time:16913ms step_avg:32.71ms
+step:518/1490 train_time:16972ms step_avg:32.76ms
+step:519/1490 train_time:17026ms step_avg:32.81ms
+step:520/1490 train_time:17087ms step_avg:32.86ms
+step:521/1490 train_time:17143ms step_avg:32.90ms
+step:522/1490 train_time:17204ms step_avg:32.96ms
+step:523/1490 train_time:17258ms step_avg:33.00ms
+step:524/1490 train_time:17316ms step_avg:33.05ms
+step:525/1490 train_time:17370ms step_avg:33.09ms
+step:526/1490 train_time:17429ms step_avg:33.13ms
+step:527/1490 train_time:17482ms step_avg:33.17ms
+step:528/1490 train_time:17540ms step_avg:33.22ms
+step:529/1490 train_time:17592ms step_avg:33.26ms
+step:530/1490 train_time:17650ms step_avg:33.30ms
+step:531/1490 train_time:17702ms step_avg:33.34ms
+step:532/1490 train_time:17761ms step_avg:33.39ms
+step:533/1490 train_time:17814ms step_avg:33.42ms
+step:534/1490 train_time:17872ms step_avg:33.47ms
+step:535/1490 train_time:17925ms step_avg:33.51ms
+step:536/1490 train_time:17985ms step_avg:33.55ms
+step:537/1490 train_time:18040ms step_avg:33.59ms
+step:538/1490 train_time:18099ms step_avg:33.64ms
+step:539/1490 train_time:18152ms step_avg:33.68ms
+step:540/1490 train_time:18211ms step_avg:33.72ms
+step:541/1490 train_time:18264ms step_avg:33.76ms
+step:542/1490 train_time:18324ms step_avg:33.81ms
+step:543/1490 train_time:18378ms step_avg:33.85ms
+step:544/1490 train_time:18436ms step_avg:33.89ms
+step:545/1490 train_time:18490ms step_avg:33.93ms
+step:546/1490 train_time:18549ms step_avg:33.97ms
+step:547/1490 train_time:18602ms step_avg:34.01ms
+step:548/1490 train_time:18661ms step_avg:34.05ms
+step:549/1490 train_time:18714ms step_avg:34.09ms
+step:550/1490 train_time:18772ms step_avg:34.13ms
+step:551/1490 train_time:18825ms step_avg:34.17ms
+step:552/1490 train_time:18883ms step_avg:34.21ms
+step:553/1490 train_time:18937ms step_avg:34.24ms
+step:554/1490 train_time:18996ms step_avg:34.29ms
+step:555/1490 train_time:19050ms step_avg:34.32ms
+step:556/1490 train_time:19110ms step_avg:34.37ms
+step:557/1490 train_time:19164ms step_avg:34.41ms
+step:558/1490 train_time:19223ms step_avg:34.45ms
+step:559/1490 train_time:19276ms step_avg:34.48ms
+step:560/1490 train_time:19335ms step_avg:34.53ms
+step:561/1490 train_time:19388ms step_avg:34.56ms
+step:562/1490 train_time:19447ms step_avg:34.60ms
+step:563/1490 train_time:19501ms step_avg:34.64ms
+step:564/1490 train_time:19560ms step_avg:34.68ms
+step:565/1490 train_time:19613ms step_avg:34.71ms
+step:566/1490 train_time:19672ms step_avg:34.76ms
+step:567/1490 train_time:19725ms step_avg:34.79ms
+step:568/1490 train_time:19784ms step_avg:34.83ms
+step:569/1490 train_time:19837ms step_avg:34.86ms
+step:570/1490 train_time:19895ms step_avg:34.90ms
+step:571/1490 train_time:19948ms step_avg:34.94ms
+step:572/1490 train_time:20008ms step_avg:34.98ms
+step:573/1490 train_time:20061ms step_avg:35.01ms
+step:574/1490 train_time:20120ms step_avg:35.05ms
+step:575/1490 train_time:20173ms step_avg:35.08ms
+step:576/1490 train_time:20233ms step_avg:35.13ms
+step:577/1490 train_time:20286ms step_avg:35.16ms
+step:578/1490 train_time:20345ms step_avg:35.20ms
+step:579/1490 train_time:20399ms step_avg:35.23ms
+step:580/1490 train_time:20457ms step_avg:35.27ms
+step:581/1490 train_time:20510ms step_avg:35.30ms
+step:582/1490 train_time:20570ms step_avg:35.34ms
+step:583/1490 train_time:20623ms step_avg:35.37ms
+step:584/1490 train_time:20682ms step_avg:35.41ms
+step:585/1490 train_time:20735ms step_avg:35.44ms
+step:586/1490 train_time:20793ms step_avg:35.48ms
+step:587/1490 train_time:20846ms step_avg:35.51ms
+step:588/1490 train_time:20907ms step_avg:35.56ms
+step:589/1490 train_time:20959ms step_avg:35.58ms
+step:590/1490 train_time:21017ms step_avg:35.62ms
+step:591/1490 train_time:21071ms step_avg:35.65ms
+step:592/1490 train_time:21130ms step_avg:35.69ms
+step:593/1490 train_time:21183ms step_avg:35.72ms
+step:594/1490 train_time:21242ms step_avg:35.76ms
+step:595/1490 train_time:21295ms step_avg:35.79ms
+step:596/1490 train_time:21354ms step_avg:35.83ms
+step:597/1490 train_time:21407ms step_avg:35.86ms
+step:598/1490 train_time:21465ms step_avg:35.90ms
+step:599/1490 train_time:21518ms step_avg:35.92ms
+step:600/1490 train_time:21577ms step_avg:35.96ms
+step:601/1490 train_time:21631ms step_avg:35.99ms
+step:602/1490 train_time:21689ms step_avg:36.03ms
+step:603/1490 train_time:21742ms step_avg:36.06ms
+step:604/1490 train_time:21802ms step_avg:36.10ms
+step:605/1490 train_time:21855ms step_avg:36.12ms
+step:606/1490 train_time:21913ms step_avg:36.16ms
+step:607/1490 train_time:21966ms step_avg:36.19ms
+step:608/1490 train_time:22025ms step_avg:36.23ms
+step:609/1490 train_time:22078ms step_avg:36.25ms
+step:610/1490 train_time:22137ms step_avg:36.29ms
+step:611/1490 train_time:22190ms step_avg:36.32ms
+step:612/1490 train_time:22249ms step_avg:36.35ms
+step:613/1490 train_time:22303ms step_avg:36.38ms
+step:614/1490 train_time:22362ms step_avg:36.42ms
+step:615/1490 train_time:22416ms step_avg:36.45ms
+step:616/1490 train_time:22474ms step_avg:36.48ms
+step:617/1490 train_time:22529ms step_avg:36.51ms
+step:618/1490 train_time:22587ms step_avg:36.55ms
+step:619/1490 train_time:22640ms step_avg:36.58ms
+step:620/1490 train_time:22699ms step_avg:36.61ms
+step:621/1490 train_time:22752ms step_avg:36.64ms
+step:622/1490 train_time:22812ms step_avg:36.67ms
+step:623/1490 train_time:22865ms step_avg:36.70ms
+step:624/1490 train_time:22923ms step_avg:36.74ms
+step:625/1490 train_time:22977ms step_avg:36.76ms
+step:626/1490 train_time:23034ms step_avg:36.80ms
+step:627/1490 train_time:23088ms step_avg:36.82ms
+step:628/1490 train_time:23147ms step_avg:36.86ms
+step:629/1490 train_time:23201ms step_avg:36.89ms
+step:630/1490 train_time:23260ms step_avg:36.92ms
+step:631/1490 train_time:23313ms step_avg:36.95ms
+step:632/1490 train_time:23372ms step_avg:36.98ms
+step:633/1490 train_time:23425ms step_avg:37.01ms
+step:634/1490 train_time:23483ms step_avg:37.04ms
+step:635/1490 train_time:23538ms step_avg:37.07ms
+step:636/1490 train_time:23596ms step_avg:37.10ms
+step:637/1490 train_time:23648ms step_avg:37.12ms
+step:638/1490 train_time:23708ms step_avg:37.16ms
+step:639/1490 train_time:23762ms step_avg:37.19ms
+step:640/1490 train_time:23820ms step_avg:37.22ms
+step:641/1490 train_time:23873ms step_avg:37.24ms
+step:642/1490 train_time:23932ms step_avg:37.28ms
+step:643/1490 train_time:23985ms step_avg:37.30ms
+step:644/1490 train_time:24045ms step_avg:37.34ms
+step:645/1490 train_time:24098ms step_avg:37.36ms
+step:646/1490 train_time:24157ms step_avg:37.39ms
+step:647/1490 train_time:24210ms step_avg:37.42ms
+step:648/1490 train_time:24269ms step_avg:37.45ms
+step:649/1490 train_time:24323ms step_avg:37.48ms
+step:650/1490 train_time:24382ms step_avg:37.51ms
+step:651/1490 train_time:24435ms step_avg:37.53ms
+step:652/1490 train_time:24493ms step_avg:37.57ms
+step:653/1490 train_time:24547ms step_avg:37.59ms
+step:654/1490 train_time:24605ms step_avg:37.62ms
+step:655/1490 train_time:24658ms step_avg:37.65ms
+step:656/1490 train_time:24717ms step_avg:37.68ms
+step:657/1490 train_time:24770ms step_avg:37.70ms
+step:658/1490 train_time:24829ms step_avg:37.73ms
+step:659/1490 train_time:24883ms step_avg:37.76ms
+step:660/1490 train_time:24941ms step_avg:37.79ms
+step:661/1490 train_time:24993ms step_avg:37.81ms
+step:662/1490 train_time:25052ms step_avg:37.84ms
+step:663/1490 train_time:25105ms step_avg:37.87ms
+step:664/1490 train_time:25164ms step_avg:37.90ms
+step:665/1490 train_time:25218ms step_avg:37.92ms
+step:666/1490 train_time:25276ms step_avg:37.95ms
+step:667/1490 train_time:25330ms step_avg:37.98ms
+step:668/1490 train_time:25389ms step_avg:38.01ms
+step:669/1490 train_time:25442ms step_avg:38.03ms
+step:670/1490 train_time:25502ms step_avg:38.06ms
+step:671/1490 train_time:25554ms step_avg:38.08ms
+step:672/1490 train_time:25613ms step_avg:38.12ms
+step:673/1490 train_time:25667ms step_avg:38.14ms
+step:674/1490 train_time:25726ms step_avg:38.17ms
+step:675/1490 train_time:25779ms step_avg:38.19ms
+step:676/1490 train_time:25837ms step_avg:38.22ms
+step:677/1490 train_time:25890ms step_avg:38.24ms
+step:678/1490 train_time:25949ms step_avg:38.27ms
+step:679/1490 train_time:26002ms step_avg:38.30ms
+step:680/1490 train_time:26061ms step_avg:38.33ms
+step:681/1490 train_time:26114ms step_avg:38.35ms
+step:682/1490 train_time:26173ms step_avg:38.38ms
+step:683/1490 train_time:26226ms step_avg:38.40ms
+step:684/1490 train_time:26285ms step_avg:38.43ms
+step:685/1490 train_time:26339ms step_avg:38.45ms
+step:686/1490 train_time:26397ms step_avg:38.48ms
+step:687/1490 train_time:26450ms step_avg:38.50ms
+step:688/1490 train_time:26510ms step_avg:38.53ms
+step:689/1490 train_time:26563ms step_avg:38.55ms
+step:690/1490 train_time:26622ms step_avg:38.58ms
+step:691/1490 train_time:26676ms step_avg:38.60ms
+step:692/1490 train_time:26734ms step_avg:38.63ms
+step:693/1490 train_time:26788ms step_avg:38.65ms
+step:694/1490 train_time:26846ms step_avg:38.68ms
+step:695/1490 train_time:26901ms step_avg:38.71ms
+step:696/1490 train_time:26959ms step_avg:38.73ms
+step:697/1490 train_time:27012ms step_avg:38.76ms
+step:698/1490 train_time:27071ms step_avg:38.78ms
+step:699/1490 train_time:27125ms step_avg:38.81ms
+step:700/1490 train_time:27184ms step_avg:38.83ms
+step:701/1490 train_time:27236ms step_avg:38.85ms
+step:702/1490 train_time:27295ms step_avg:38.88ms
+step:703/1490 train_time:27348ms step_avg:38.90ms
+step:704/1490 train_time:27408ms step_avg:38.93ms
+step:705/1490 train_time:27461ms step_avg:38.95ms
+step:706/1490 train_time:27519ms step_avg:38.98ms
+step:707/1490 train_time:27573ms step_avg:39.00ms
+step:708/1490 train_time:27632ms step_avg:39.03ms
+step:709/1490 train_time:27685ms step_avg:39.05ms
+step:710/1490 train_time:27744ms step_avg:39.08ms
+step:711/1490 train_time:27798ms step_avg:39.10ms
+step:712/1490 train_time:27856ms step_avg:39.12ms
+step:713/1490 train_time:27910ms step_avg:39.15ms
+step:714/1490 train_time:27970ms step_avg:39.17ms
+step:715/1490 train_time:28023ms step_avg:39.19ms
+step:716/1490 train_time:28081ms step_avg:39.22ms
+step:717/1490 train_time:28134ms step_avg:39.24ms
+step:718/1490 train_time:28193ms step_avg:39.27ms
+step:719/1490 train_time:28247ms step_avg:39.29ms
+step:720/1490 train_time:28305ms step_avg:39.31ms
+step:721/1490 train_time:28358ms step_avg:39.33ms
+step:722/1490 train_time:28417ms step_avg:39.36ms
+step:723/1490 train_time:28470ms step_avg:39.38ms
+step:724/1490 train_time:28529ms step_avg:39.41ms
+step:725/1490 train_time:28582ms step_avg:39.42ms
+step:726/1490 train_time:28642ms step_avg:39.45ms
+step:727/1490 train_time:28695ms step_avg:39.47ms
+step:728/1490 train_time:28754ms step_avg:39.50ms
+step:729/1490 train_time:28808ms step_avg:39.52ms
+step:730/1490 train_time:28866ms step_avg:39.54ms
+step:731/1490 train_time:28920ms step_avg:39.56ms
+step:732/1490 train_time:28978ms step_avg:39.59ms
+step:733/1490 train_time:29031ms step_avg:39.61ms
+step:734/1490 train_time:29090ms step_avg:39.63ms
+step:735/1490 train_time:29143ms step_avg:39.65ms
+step:736/1490 train_time:29202ms step_avg:39.68ms
+step:737/1490 train_time:29255ms step_avg:39.69ms
+step:738/1490 train_time:29314ms step_avg:39.72ms
+step:739/1490 train_time:29366ms step_avg:39.74ms
+step:740/1490 train_time:29425ms step_avg:39.76ms
+step:741/1490 train_time:29479ms step_avg:39.78ms
+step:742/1490 train_time:29537ms step_avg:39.81ms
+step:743/1490 train_time:29590ms step_avg:39.82ms
+step:744/1490 train_time:29650ms step_avg:39.85ms
+step:745/1490 train_time:29703ms step_avg:39.87ms
+step:746/1490 train_time:29761ms step_avg:39.89ms
+step:747/1490 train_time:29816ms step_avg:39.91ms
+step:748/1490 train_time:29874ms step_avg:39.94ms
+step:749/1490 train_time:29929ms step_avg:39.96ms
+step:750/1490 train_time:29987ms step_avg:39.98ms
+step:750/1490 val_loss:3.8009 train_time:30054ms step_avg:40.07ms
+step:751/1490 train_time:30076ms step_avg:40.05ms
+step:752/1490 train_time:30101ms step_avg:40.03ms
+step:753/1490 train_time:30158ms step_avg:40.05ms
+step:754/1490 train_time:30220ms step_avg:40.08ms
+step:755/1490 train_time:30273ms step_avg:40.10ms
+step:756/1490 train_time:30333ms step_avg:40.12ms
+step:757/1490 train_time:30386ms step_avg:40.14ms
+step:758/1490 train_time:30444ms step_avg:40.16ms
+step:759/1490 train_time:30498ms step_avg:40.18ms
+step:760/1490 train_time:30556ms step_avg:40.21ms
+step:761/1490 train_time:30608ms step_avg:40.22ms
+step:762/1490 train_time:30666ms step_avg:40.24ms
+step:763/1490 train_time:30719ms step_avg:40.26ms
+step:764/1490 train_time:30777ms step_avg:40.28ms
+step:765/1490 train_time:30829ms step_avg:40.30ms
+step:766/1490 train_time:30887ms step_avg:40.32ms
+step:767/1490 train_time:30940ms step_avg:40.34ms
+step:768/1490 train_time:30998ms step_avg:40.36ms
+step:769/1490 train_time:31052ms step_avg:40.38ms
+step:770/1490 train_time:31112ms step_avg:40.41ms
+step:771/1490 train_time:31167ms step_avg:40.42ms
+step:772/1490 train_time:31227ms step_avg:40.45ms
+step:773/1490 train_time:31282ms step_avg:40.47ms
+step:774/1490 train_time:31340ms step_avg:40.49ms
+step:775/1490 train_time:31394ms step_avg:40.51ms
+step:776/1490 train_time:31452ms step_avg:40.53ms
+step:777/1490 train_time:31505ms step_avg:40.55ms
+step:778/1490 train_time:31564ms step_avg:40.57ms
+step:779/1490 train_time:31617ms step_avg:40.59ms
+step:780/1490 train_time:31675ms step_avg:40.61ms
+step:781/1490 train_time:31728ms step_avg:40.63ms
+step:782/1490 train_time:31786ms step_avg:40.65ms
+step:783/1490 train_time:31840ms step_avg:40.66ms
+step:784/1490 train_time:31898ms step_avg:40.69ms
+step:785/1490 train_time:31950ms step_avg:40.70ms
+step:786/1490 train_time:32008ms step_avg:40.72ms
+step:787/1490 train_time:32063ms step_avg:40.74ms
+step:788/1490 train_time:32122ms step_avg:40.76ms
+step:789/1490 train_time:32176ms step_avg:40.78ms
+step:790/1490 train_time:32236ms step_avg:40.80ms
+step:791/1490 train_time:32289ms step_avg:40.82ms
+step:792/1490 train_time:32348ms step_avg:40.84ms
+step:793/1490 train_time:32402ms step_avg:40.86ms
+step:794/1490 train_time:32461ms step_avg:40.88ms
+step:795/1490 train_time:32515ms step_avg:40.90ms
+step:796/1490 train_time:32573ms step_avg:40.92ms
+step:797/1490 train_time:32626ms step_avg:40.94ms
+step:798/1490 train_time:32684ms step_avg:40.96ms
+step:799/1490 train_time:32738ms step_avg:40.97ms
+step:800/1490 train_time:32796ms step_avg:40.99ms
+step:801/1490 train_time:32848ms step_avg:41.01ms
+step:802/1490 train_time:32907ms step_avg:41.03ms
+step:803/1490 train_time:32960ms step_avg:41.05ms
+step:804/1490 train_time:33018ms step_avg:41.07ms
+step:805/1490 train_time:33072ms step_avg:41.08ms
+step:806/1490 train_time:33131ms step_avg:41.11ms
+step:807/1490 train_time:33184ms step_avg:41.12ms
+step:808/1490 train_time:33244ms step_avg:41.14ms
+step:809/1490 train_time:33297ms step_avg:41.16ms
+step:810/1490 train_time:33356ms step_avg:41.18ms
+step:811/1490 train_time:33409ms step_avg:41.20ms
+step:812/1490 train_time:33468ms step_avg:41.22ms
+step:813/1490 train_time:33522ms step_avg:41.23ms
+step:814/1490 train_time:33580ms step_avg:41.25ms
+step:815/1490 train_time:33634ms step_avg:41.27ms
+step:816/1490 train_time:33692ms step_avg:41.29ms
+step:817/1490 train_time:33746ms step_avg:41.30ms
+step:818/1490 train_time:33804ms step_avg:41.33ms
+step:819/1490 train_time:33857ms step_avg:41.34ms
+step:820/1490 train_time:33916ms step_avg:41.36ms
+step:821/1490 train_time:33969ms step_avg:41.38ms
+step:822/1490 train_time:34028ms step_avg:41.40ms
+step:823/1490 train_time:34081ms step_avg:41.41ms
+step:824/1490 train_time:34140ms step_avg:41.43ms
+step:825/1490 train_time:34193ms step_avg:41.45ms
+step:826/1490 train_time:34251ms step_avg:41.47ms
+step:827/1490 train_time:34304ms step_avg:41.48ms
+step:828/1490 train_time:34364ms step_avg:41.50ms
+step:829/1490 train_time:34418ms step_avg:41.52ms
+step:830/1490 train_time:34477ms step_avg:41.54ms
+step:831/1490 train_time:34530ms step_avg:41.55ms
+step:832/1490 train_time:34588ms step_avg:41.57ms
+step:833/1490 train_time:34642ms step_avg:41.59ms
+step:834/1490 train_time:34701ms step_avg:41.61ms
+step:835/1490 train_time:34754ms step_avg:41.62ms
+step:836/1490 train_time:34813ms step_avg:41.64ms
+step:837/1490 train_time:34866ms step_avg:41.66ms
+step:838/1490 train_time:34925ms step_avg:41.68ms
+step:839/1490 train_time:34978ms step_avg:41.69ms
+step:840/1490 train_time:35036ms step_avg:41.71ms
+step:841/1490 train_time:35089ms step_avg:41.72ms
+step:842/1490 train_time:35148ms step_avg:41.74ms
+step:843/1490 train_time:35202ms step_avg:41.76ms
+step:844/1490 train_time:35261ms step_avg:41.78ms
+step:845/1490 train_time:35315ms step_avg:41.79ms
+step:846/1490 train_time:35373ms step_avg:41.81ms
+step:847/1490 train_time:35427ms step_avg:41.83ms
+step:848/1490 train_time:35486ms step_avg:41.85ms
+step:849/1490 train_time:35540ms step_avg:41.86ms
+step:850/1490 train_time:35598ms step_avg:41.88ms
+step:851/1490 train_time:35651ms step_avg:41.89ms
+step:852/1490 train_time:35709ms step_avg:41.91ms
+step:853/1490 train_time:35764ms step_avg:41.93ms
+step:854/1490 train_time:35823ms step_avg:41.95ms
+step:855/1490 train_time:35876ms step_avg:41.96ms
+step:856/1490 train_time:35934ms step_avg:41.98ms
+step:857/1490 train_time:35989ms step_avg:41.99ms
+step:858/1490 train_time:36047ms step_avg:42.01ms
+step:859/1490 train_time:36100ms step_avg:42.03ms
+step:860/1490 train_time:36159ms step_avg:42.05ms
+step:861/1490 train_time:36212ms step_avg:42.06ms
+step:862/1490 train_time:36271ms step_avg:42.08ms
+step:863/1490 train_time:36324ms step_avg:42.09ms
+step:864/1490 train_time:36382ms step_avg:42.11ms
+step:865/1490 train_time:36436ms step_avg:42.12ms
+step:866/1490 train_time:36495ms step_avg:42.14ms
+step:867/1490 train_time:36547ms step_avg:42.15ms
+step:868/1490 train_time:36607ms step_avg:42.17ms
+step:869/1490 train_time:36660ms step_avg:42.19ms
+step:870/1490 train_time:36718ms step_avg:42.21ms
+step:871/1490 train_time:36772ms step_avg:42.22ms
+step:872/1490 train_time:36831ms step_avg:42.24ms
+step:873/1490 train_time:36884ms step_avg:42.25ms
+step:874/1490 train_time:36943ms step_avg:42.27ms
+step:875/1490 train_time:36996ms step_avg:42.28ms
+step:876/1490 train_time:37053ms step_avg:42.30ms
+step:877/1490 train_time:37106ms step_avg:42.31ms
+step:878/1490 train_time:37166ms step_avg:42.33ms
+step:879/1490 train_time:37219ms step_avg:42.34ms
+step:880/1490 train_time:37277ms step_avg:42.36ms
+step:881/1490 train_time:37331ms step_avg:42.37ms
+step:882/1490 train_time:37389ms step_avg:42.39ms
+step:883/1490 train_time:37443ms step_avg:42.40ms
+step:884/1490 train_time:37502ms step_avg:42.42ms
+step:885/1490 train_time:37556ms step_avg:42.44ms
+step:886/1490 train_time:37614ms step_avg:42.45ms
+step:887/1490 train_time:37667ms step_avg:42.47ms
+step:888/1490 train_time:37727ms step_avg:42.48ms
+step:889/1490 train_time:37779ms step_avg:42.50ms
+step:890/1490 train_time:37838ms step_avg:42.52ms
+step:891/1490 train_time:37891ms step_avg:42.53ms
+step:892/1490 train_time:37950ms step_avg:42.54ms
+step:893/1490 train_time:38003ms step_avg:42.56ms
+step:894/1490 train_time:38061ms step_avg:42.57ms
+step:895/1490 train_time:38115ms step_avg:42.59ms
+step:896/1490 train_time:38173ms step_avg:42.60ms
+step:897/1490 train_time:38226ms step_avg:42.61ms
+step:898/1490 train_time:38285ms step_avg:42.63ms
+step:899/1490 train_time:38340ms step_avg:42.65ms
+step:900/1490 train_time:38399ms step_avg:42.67ms
+step:901/1490 train_time:38453ms step_avg:42.68ms
+step:902/1490 train_time:38511ms step_avg:42.70ms
+step:903/1490 train_time:38565ms step_avg:42.71ms
+step:904/1490 train_time:38625ms step_avg:42.73ms
+step:905/1490 train_time:38677ms step_avg:42.74ms
+step:906/1490 train_time:38737ms step_avg:42.76ms
+step:907/1490 train_time:38789ms step_avg:42.77ms
+step:908/1490 train_time:38848ms step_avg:42.78ms
+step:909/1490 train_time:38901ms step_avg:42.80ms
+step:910/1490 train_time:38960ms step_avg:42.81ms
+step:911/1490 train_time:39013ms step_avg:42.82ms
+step:912/1490 train_time:39072ms step_avg:42.84ms
+step:913/1490 train_time:39126ms step_avg:42.85ms
+step:914/1490 train_time:39184ms step_avg:42.87ms
+step:915/1490 train_time:39237ms step_avg:42.88ms
+step:916/1490 train_time:39295ms step_avg:42.90ms
+step:917/1490 train_time:39348ms step_avg:42.91ms
+step:918/1490 train_time:39407ms step_avg:42.93ms
+step:919/1490 train_time:39460ms step_avg:42.94ms
+step:920/1490 train_time:39520ms step_avg:42.96ms
+step:921/1490 train_time:39574ms step_avg:42.97ms
+step:922/1490 train_time:39632ms step_avg:42.98ms
+step:923/1490 train_time:39686ms step_avg:43.00ms
+step:924/1490 train_time:39745ms step_avg:43.01ms
+step:925/1490 train_time:39798ms step_avg:43.02ms
+step:926/1490 train_time:39856ms step_avg:43.04ms
+step:927/1490 train_time:39909ms step_avg:43.05ms
+step:928/1490 train_time:39968ms step_avg:43.07ms
+step:929/1490 train_time:40021ms step_avg:43.08ms
+step:930/1490 train_time:40080ms step_avg:43.10ms
+step:931/1490 train_time:40133ms step_avg:43.11ms
+step:932/1490 train_time:40192ms step_avg:43.12ms
+step:933/1490 train_time:40245ms step_avg:43.14ms
+step:934/1490 train_time:40304ms step_avg:43.15ms
+step:935/1490 train_time:40357ms step_avg:43.16ms
+step:936/1490 train_time:40416ms step_avg:43.18ms
+step:937/1490 train_time:40469ms step_avg:43.19ms
+step:938/1490 train_time:40528ms step_avg:43.21ms
+step:939/1490 train_time:40580ms step_avg:43.22ms
+step:940/1490 train_time:40639ms step_avg:43.23ms
+step:941/1490 train_time:40693ms step_avg:43.24ms
+step:942/1490 train_time:40751ms step_avg:43.26ms
+step:943/1490 train_time:40804ms step_avg:43.27ms
+step:944/1490 train_time:40863ms step_avg:43.29ms
+step:945/1490 train_time:40918ms step_avg:43.30ms
+step:946/1490 train_time:40977ms step_avg:43.32ms
+step:947/1490 train_time:41030ms step_avg:43.33ms
+step:948/1490 train_time:41088ms step_avg:43.34ms
+step:949/1490 train_time:41141ms step_avg:43.35ms
+step:950/1490 train_time:41201ms step_avg:43.37ms
+step:951/1490 train_time:41255ms step_avg:43.38ms
+step:952/1490 train_time:41313ms step_avg:43.40ms
+step:953/1490 train_time:41366ms step_avg:43.41ms
+step:954/1490 train_time:41425ms step_avg:43.42ms
+step:955/1490 train_time:41478ms step_avg:43.43ms
+step:956/1490 train_time:41537ms step_avg:43.45ms
+step:957/1490 train_time:41590ms step_avg:43.46ms
+step:958/1490 train_time:41649ms step_avg:43.47ms
+step:959/1490 train_time:41702ms step_avg:43.48ms
+step:960/1490 train_time:41761ms step_avg:43.50ms
+step:961/1490 train_time:41815ms step_avg:43.51ms
+step:962/1490 train_time:41873ms step_avg:43.53ms
+step:963/1490 train_time:41926ms step_avg:43.54ms
+step:964/1490 train_time:41985ms step_avg:43.55ms
+step:965/1490 train_time:42038ms step_avg:43.56ms
+step:966/1490 train_time:42096ms step_avg:43.58ms
+step:967/1490 train_time:42149ms step_avg:43.59ms
+step:968/1490 train_time:42212ms step_avg:43.61ms
+step:969/1490 train_time:42290ms step_avg:43.64ms
+step:970/1490 train_time:42373ms step_avg:43.68ms
+step:971/1490 train_time:42453ms step_avg:43.72ms
+step:972/1490 train_time:42537ms step_avg:43.76ms
+step:973/1490 train_time:42616ms step_avg:43.80ms
+step:974/1490 train_time:42700ms step_avg:43.84ms
+step:975/1490 train_time:42778ms step_avg:43.88ms
+step:976/1490 train_time:42864ms step_avg:43.92ms
+step:977/1490 train_time:42943ms step_avg:43.95ms
+step:978/1490 train_time:43028ms step_avg:44.00ms
+step:979/1490 train_time:43106ms step_avg:44.03ms
+step:980/1490 train_time:43191ms step_avg:44.07ms
+step:981/1490 train_time:43270ms step_avg:44.11ms
+step:982/1490 train_time:43355ms step_avg:44.15ms
+step:983/1490 train_time:43433ms step_avg:44.18ms
+step:984/1490 train_time:43516ms step_avg:44.22ms
+step:985/1490 train_time:43596ms step_avg:44.26ms
+step:986/1490 train_time:43681ms step_avg:44.30ms
+step:987/1490 train_time:43759ms step_avg:44.34ms
+step:988/1490 train_time:43844ms step_avg:44.38ms
+step:989/1490 train_time:43922ms step_avg:44.41ms
+step:990/1490 train_time:44006ms step_avg:44.45ms
+step:991/1490 train_time:44087ms step_avg:44.49ms
+step:992/1490 train_time:44172ms step_avg:44.53ms
+step:993/1490 train_time:44251ms step_avg:44.56ms
+step:994/1490 train_time:44336ms step_avg:44.60ms
+step:995/1490 train_time:44414ms step_avg:44.64ms
+step:996/1490 train_time:44498ms step_avg:44.68ms
+step:997/1490 train_time:44578ms step_avg:44.71ms
+step:998/1490 train_time:44663ms step_avg:44.75ms
+step:999/1490 train_time:44743ms step_avg:44.79ms
+step:1000/1490 train_time:44827ms step_avg:44.83ms
+step:1000/1490 val_loss:3.5199 train_time:44923ms step_avg:44.92ms
+step:1001/1490 train_time:44941ms step_avg:44.90ms
+step:1002/1490 train_time:44994ms step_avg:44.90ms
+step:1003/1490 train_time:45077ms step_avg:44.94ms
+step:1004/1490 train_time:45165ms step_avg:44.98ms
+step:1005/1490 train_time:45243ms step_avg:45.02ms
+step:1006/1490 train_time:45326ms step_avg:45.06ms
+step:1007/1490 train_time:45405ms step_avg:45.09ms
+step:1008/1490 train_time:45490ms step_avg:45.13ms
+step:1009/1490 train_time:45567ms step_avg:45.16ms
+step:1010/1490 train_time:45650ms step_avg:45.20ms
+step:1011/1490 train_time:45729ms step_avg:45.23ms
+step:1012/1490 train_time:45812ms step_avg:45.27ms
+step:1013/1490 train_time:45893ms step_avg:45.30ms
+step:1014/1490 train_time:45978ms step_avg:45.34ms
+step:1015/1490 train_time:46058ms step_avg:45.38ms
+step:1016/1490 train_time:46145ms step_avg:45.42ms
+step:1017/1490 train_time:46224ms step_avg:45.45ms
+step:1018/1490 train_time:46309ms step_avg:45.49ms
+step:1019/1490 train_time:46387ms step_avg:45.52ms
+step:1020/1490 train_time:46471ms step_avg:45.56ms
+step:1021/1490 train_time:46550ms step_avg:45.59ms
+step:1022/1490 train_time:46633ms step_avg:45.63ms
+step:1023/1490 train_time:46710ms step_avg:45.66ms
+step:1024/1490 train_time:46795ms step_avg:45.70ms
+step:1025/1490 train_time:46875ms step_avg:45.73ms
+step:1026/1490 train_time:46959ms step_avg:45.77ms
+step:1027/1490 train_time:47038ms step_avg:45.80ms
+step:1028/1490 train_time:47124ms step_avg:45.84ms
+step:1029/1490 train_time:47205ms step_avg:45.87ms
+step:1030/1490 train_time:47289ms step_avg:45.91ms
+step:1031/1490 train_time:47367ms step_avg:45.94ms
+step:1032/1490 train_time:47451ms step_avg:45.98ms
+step:1033/1490 train_time:47529ms step_avg:46.01ms
+step:1034/1490 train_time:47612ms step_avg:46.05ms
+step:1035/1490 train_time:47691ms step_avg:46.08ms
+step:1036/1490 train_time:47774ms step_avg:46.11ms
+step:1037/1490 train_time:47854ms step_avg:46.15ms
+step:1038/1490 train_time:47937ms step_avg:46.18ms
+step:1039/1490 train_time:48016ms step_avg:46.21ms
+step:1040/1490 train_time:48101ms step_avg:46.25ms
+step:1041/1490 train_time:48181ms step_avg:46.28ms
+step:1042/1490 train_time:48266ms step_avg:46.32ms
+step:1043/1490 train_time:48345ms step_avg:46.35ms
+step:1044/1490 train_time:48429ms step_avg:46.39ms
+step:1045/1490 train_time:48508ms step_avg:46.42ms
+step:1046/1490 train_time:48591ms step_avg:46.45ms
+step:1047/1490 train_time:48670ms step_avg:46.49ms
+step:1048/1490 train_time:48753ms step_avg:46.52ms
+step:1049/1490 train_time:48832ms step_avg:46.55ms
+step:1050/1490 train_time:48917ms step_avg:46.59ms
+step:1051/1490 train_time:48997ms step_avg:46.62ms
+step:1052/1490 train_time:49083ms step_avg:46.66ms
+step:1053/1490 train_time:49162ms step_avg:46.69ms
+step:1054/1490 train_time:49248ms step_avg:46.72ms
+step:1055/1490 train_time:49324ms step_avg:46.75ms
+step:1056/1490 train_time:49408ms step_avg:46.79ms
+step:1057/1490 train_time:49486ms step_avg:46.82ms
+step:1058/1490 train_time:49570ms step_avg:46.85ms
+step:1059/1490 train_time:49651ms step_avg:46.88ms
+step:1060/1490 train_time:49734ms step_avg:46.92ms
+step:1061/1490 train_time:49813ms step_avg:46.95ms
+step:1062/1490 train_time:49899ms step_avg:46.99ms
+step:1063/1490 train_time:49978ms step_avg:47.02ms
+step:1064/1490 train_time:50063ms step_avg:47.05ms
+step:1065/1490 train_time:50142ms step_avg:47.08ms
+step:1066/1490 train_time:50225ms step_avg:47.12ms
+step:1067/1490 train_time:50305ms step_avg:47.15ms
+step:1068/1490 train_time:50390ms step_avg:47.18ms
+step:1069/1490 train_time:50468ms step_avg:47.21ms
+step:1070/1490 train_time:50554ms step_avg:47.25ms
+step:1071/1490 train_time:50631ms step_avg:47.27ms
+step:1072/1490 train_time:50715ms step_avg:47.31ms
+step:1073/1490 train_time:50795ms step_avg:47.34ms
+step:1074/1490 train_time:50880ms step_avg:47.37ms
+step:1075/1490 train_time:50959ms step_avg:47.40ms
+step:1076/1490 train_time:51042ms step_avg:47.44ms
+step:1077/1490 train_time:51121ms step_avg:47.47ms
+step:1078/1490 train_time:51205ms step_avg:47.50ms
+step:1079/1490 train_time:51284ms step_avg:47.53ms
+step:1080/1490 train_time:51368ms step_avg:47.56ms
+step:1081/1490 train_time:51446ms step_avg:47.59ms
+step:1082/1490 train_time:51530ms step_avg:47.62ms
+step:1083/1490 train_time:51609ms step_avg:47.65ms
+step:1084/1490 train_time:51697ms step_avg:47.69ms
+step:1085/1490 train_time:51776ms step_avg:47.72ms
+step:1086/1490 train_time:51860ms step_avg:47.75ms
+step:1087/1490 train_time:51938ms step_avg:47.78ms
+step:1088/1490 train_time:52023ms step_avg:47.82ms
+step:1089/1490 train_time:52102ms step_avg:47.84ms
+step:1090/1490 train_time:52186ms step_avg:47.88ms
+step:1091/1490 train_time:52265ms step_avg:47.91ms
+step:1092/1490 train_time:52350ms step_avg:47.94ms
+step:1093/1490 train_time:52430ms step_avg:47.97ms
+step:1094/1490 train_time:52514ms step_avg:48.00ms
+step:1095/1490 train_time:52592ms step_avg:48.03ms
+step:1096/1490 train_time:52677ms step_avg:48.06ms
+step:1097/1490 train_time:52757ms step_avg:48.09ms
+step:1098/1490 train_time:52842ms step_avg:48.13ms
+step:1099/1490 train_time:52920ms step_avg:48.15ms
+step:1100/1490 train_time:53004ms step_avg:48.19ms
+step:1101/1490 train_time:53082ms step_avg:48.21ms
+step:1102/1490 train_time:53166ms step_avg:48.25ms
+step:1103/1490 train_time:53245ms step_avg:48.27ms
+step:1104/1490 train_time:53329ms step_avg:48.31ms
+step:1105/1490 train_time:53408ms step_avg:48.33ms
+step:1106/1490 train_time:53492ms step_avg:48.37ms
+step:1107/1490 train_time:53571ms step_avg:48.39ms
+step:1108/1490 train_time:53656ms step_avg:48.43ms
+step:1109/1490 train_time:53737ms step_avg:48.46ms
+step:1110/1490 train_time:53821ms step_avg:48.49ms
+step:1111/1490 train_time:53899ms step_avg:48.51ms
+step:1112/1490 train_time:53984ms step_avg:48.55ms
+step:1113/1490 train_time:54064ms step_avg:48.57ms
+step:1114/1490 train_time:54147ms step_avg:48.61ms
+step:1115/1490 train_time:54225ms step_avg:48.63ms
+step:1116/1490 train_time:54309ms step_avg:48.66ms
+step:1117/1490 train_time:54388ms step_avg:48.69ms
+step:1118/1490 train_time:54473ms step_avg:48.72ms
+step:1119/1490 train_time:54553ms step_avg:48.75ms
+step:1120/1490 train_time:54638ms step_avg:48.78ms
+step:1121/1490 train_time:54717ms step_avg:48.81ms
+step:1122/1490 train_time:54801ms step_avg:48.84ms
+step:1123/1490 train_time:54880ms step_avg:48.87ms
+step:1124/1490 train_time:54963ms step_avg:48.90ms
+step:1125/1490 train_time:55042ms step_avg:48.93ms
+step:1126/1490 train_time:55126ms step_avg:48.96ms
+step:1127/1490 train_time:55206ms step_avg:48.98ms
+step:1128/1490 train_time:55290ms step_avg:49.02ms
+step:1129/1490 train_time:55369ms step_avg:49.04ms
+step:1130/1490 train_time:55454ms step_avg:49.07ms
+step:1131/1490 train_time:55533ms step_avg:49.10ms
+step:1132/1490 train_time:55617ms step_avg:49.13ms
+step:1133/1490 train_time:55697ms step_avg:49.16ms
+step:1134/1490 train_time:55781ms step_avg:49.19ms
+step:1135/1490 train_time:55860ms step_avg:49.22ms
+step:1136/1490 train_time:55944ms step_avg:49.25ms
+step:1137/1490 train_time:56022ms step_avg:49.27ms
+step:1138/1490 train_time:56106ms step_avg:49.30ms
+step:1139/1490 train_time:56186ms step_avg:49.33ms
+step:1140/1490 train_time:56271ms step_avg:49.36ms
+step:1141/1490 train_time:56351ms step_avg:49.39ms
+step:1142/1490 train_time:56435ms step_avg:49.42ms
+step:1143/1490 train_time:56515ms step_avg:49.44ms
+step:1144/1490 train_time:56599ms step_avg:49.47ms
+step:1145/1490 train_time:56678ms step_avg:49.50ms
+step:1146/1490 train_time:56763ms step_avg:49.53ms
+step:1147/1490 train_time:56843ms step_avg:49.56ms
+step:1148/1490 train_time:56925ms step_avg:49.59ms
+step:1149/1490 train_time:57004ms step_avg:49.61ms
+step:1150/1490 train_time:57088ms step_avg:49.64ms
+step:1151/1490 train_time:57166ms step_avg:49.67ms
+step:1152/1490 train_time:57252ms step_avg:49.70ms
+step:1153/1490 train_time:57330ms step_avg:49.72ms
+step:1154/1490 train_time:57414ms step_avg:49.75ms
+step:1155/1490 train_time:57495ms step_avg:49.78ms
+step:1156/1490 train_time:57580ms step_avg:49.81ms
+step:1157/1490 train_time:57658ms step_avg:49.83ms
+step:1158/1490 train_time:57742ms step_avg:49.86ms
+step:1159/1490 train_time:57821ms step_avg:49.89ms
+step:1160/1490 train_time:57905ms step_avg:49.92ms
+step:1161/1490 train_time:57984ms step_avg:49.94ms
+step:1162/1490 train_time:58069ms step_avg:49.97ms
+step:1163/1490 train_time:58150ms step_avg:50.00ms
+step:1164/1490 train_time:58233ms step_avg:50.03ms
+step:1165/1490 train_time:58311ms step_avg:50.05ms
+step:1166/1490 train_time:58398ms step_avg:50.08ms
+step:1167/1490 train_time:58477ms step_avg:50.11ms
+step:1168/1490 train_time:58562ms step_avg:50.14ms
+step:1169/1490 train_time:58641ms step_avg:50.16ms
+step:1170/1490 train_time:58725ms step_avg:50.19ms
+step:1171/1490 train_time:58806ms step_avg:50.22ms
+step:1172/1490 train_time:58889ms step_avg:50.25ms
+step:1173/1490 train_time:58967ms step_avg:50.27ms
+step:1174/1490 train_time:59052ms step_avg:50.30ms
+step:1175/1490 train_time:59130ms step_avg:50.32ms
+step:1176/1490 train_time:59215ms step_avg:50.35ms
+step:1177/1490 train_time:59295ms step_avg:50.38ms
+step:1178/1490 train_time:59380ms step_avg:50.41ms
+step:1179/1490 train_time:59459ms step_avg:50.43ms
+step:1180/1490 train_time:59543ms step_avg:50.46ms
+step:1181/1490 train_time:59623ms step_avg:50.48ms
+step:1182/1490 train_time:59707ms step_avg:50.51ms
+step:1183/1490 train_time:59787ms step_avg:50.54ms
+step:1184/1490 train_time:59871ms step_avg:50.57ms
+step:1185/1490 train_time:59950ms step_avg:50.59ms
+step:1186/1490 train_time:60034ms step_avg:50.62ms
+step:1187/1490 train_time:60113ms step_avg:50.64ms
+step:1188/1490 train_time:60197ms step_avg:50.67ms
+step:1189/1490 train_time:60276ms step_avg:50.69ms
+step:1190/1490 train_time:60361ms step_avg:50.72ms
+step:1191/1490 train_time:60440ms step_avg:50.75ms
+step:1192/1490 train_time:60523ms step_avg:50.77ms
+step:1193/1490 train_time:60602ms step_avg:50.80ms
+step:1194/1490 train_time:60686ms step_avg:50.83ms
+step:1195/1490 train_time:60765ms step_avg:50.85ms
+step:1196/1490 train_time:60850ms step_avg:50.88ms
+step:1197/1490 train_time:60930ms step_avg:50.90ms
+step:1198/1490 train_time:61014ms step_avg:50.93ms
+step:1199/1490 train_time:61093ms step_avg:50.95ms
+step:1200/1490 train_time:61178ms step_avg:50.98ms
+step:1201/1490 train_time:61258ms step_avg:51.01ms
+step:1202/1490 train_time:61342ms step_avg:51.03ms
+step:1203/1490 train_time:61419ms step_avg:51.06ms
+step:1204/1490 train_time:61504ms step_avg:51.08ms
+step:1205/1490 train_time:61583ms step_avg:51.11ms
+step:1206/1490 train_time:61666ms step_avg:51.13ms
+step:1207/1490 train_time:61746ms step_avg:51.16ms
+step:1208/1490 train_time:61831ms step_avg:51.18ms
+step:1209/1490 train_time:61910ms step_avg:51.21ms
+step:1210/1490 train_time:61995ms step_avg:51.24ms
+step:1211/1490 train_time:62075ms step_avg:51.26ms
+step:1212/1490 train_time:62159ms step_avg:51.29ms
+step:1213/1490 train_time:62238ms step_avg:51.31ms
+step:1214/1490 train_time:62321ms step_avg:51.34ms
+step:1215/1490 train_time:62400ms step_avg:51.36ms
+step:1216/1490 train_time:62485ms step_avg:51.39ms
+step:1217/1490 train_time:62564ms step_avg:51.41ms
+step:1218/1490 train_time:62647ms step_avg:51.43ms
+step:1219/1490 train_time:62726ms step_avg:51.46ms
+step:1220/1490 train_time:62809ms step_avg:51.48ms
+step:1221/1490 train_time:62889ms step_avg:51.51ms
+step:1222/1490 train_time:62973ms step_avg:51.53ms
+step:1223/1490 train_time:63053ms step_avg:51.56ms
+step:1224/1490 train_time:63137ms step_avg:51.58ms
+step:1225/1490 train_time:63216ms step_avg:51.61ms
+step:1226/1490 train_time:63301ms step_avg:51.63ms
+step:1227/1490 train_time:63379ms step_avg:51.65ms
+step:1228/1490 train_time:63463ms step_avg:51.68ms
+step:1229/1490 train_time:63541ms step_avg:51.70ms
+step:1230/1490 train_time:63624ms step_avg:51.73ms
+step:1231/1490 train_time:63704ms step_avg:51.75ms
+step:1232/1490 train_time:63787ms step_avg:51.78ms
+step:1233/1490 train_time:63867ms step_avg:51.80ms
+step:1234/1490 train_time:63952ms step_avg:51.83ms
+step:1235/1490 train_time:64031ms step_avg:51.85ms
+step:1236/1490 train_time:64115ms step_avg:51.87ms
+step:1237/1490 train_time:64196ms step_avg:51.90ms
+step:1238/1490 train_time:64280ms step_avg:51.92ms
+step:1239/1490 train_time:64359ms step_avg:51.94ms
+step:1240/1490 train_time:64443ms step_avg:51.97ms
+step:1241/1490 train_time:64522ms step_avg:51.99ms
+step:1242/1490 train_time:64606ms step_avg:52.02ms
+step:1243/1490 train_time:64685ms step_avg:52.04ms
+step:1244/1490 train_time:64768ms step_avg:52.06ms
+step:1245/1490 train_time:64847ms step_avg:52.09ms
+step:1246/1490 train_time:64930ms step_avg:52.11ms
+step:1247/1490 train_time:65010ms step_avg:52.13ms
+step:1248/1490 train_time:65097ms step_avg:52.16ms
+step:1249/1490 train_time:65176ms step_avg:52.18ms
+step:1250/1490 train_time:65260ms step_avg:52.21ms
+step:1250/1490 val_loss:3.3743 train_time:65356ms step_avg:52.28ms
+step:1251/1490 train_time:65374ms step_avg:52.26ms
+step:1252/1490 train_time:65429ms step_avg:52.26ms
+step:1253/1490 train_time:65513ms step_avg:52.28ms
+step:1254/1490 train_time:65599ms step_avg:52.31ms
+step:1255/1490 train_time:65678ms step_avg:52.33ms
+step:1256/1490 train_time:65762ms step_avg:52.36ms
+step:1257/1490 train_time:65839ms step_avg:52.38ms
+step:1258/1490 train_time:65924ms step_avg:52.40ms
+step:1259/1490 train_time:66002ms step_avg:52.42ms
+step:1260/1490 train_time:66085ms step_avg:52.45ms
+step:1261/1490 train_time:66163ms step_avg:52.47ms
+step:1262/1490 train_time:66246ms step_avg:52.49ms
+step:1263/1490 train_time:66324ms step_avg:52.51ms
+step:1264/1490 train_time:66410ms step_avg:52.54ms
+step:1265/1490 train_time:66490ms step_avg:52.56ms
+step:1266/1490 train_time:66578ms step_avg:52.59ms
+step:1267/1490 train_time:66658ms step_avg:52.61ms
+step:1268/1490 train_time:66741ms step_avg:52.64ms
+step:1269/1490 train_time:66819ms step_avg:52.65ms
+step:1270/1490 train_time:66903ms step_avg:52.68ms
+step:1271/1490 train_time:66982ms step_avg:52.70ms
+step:1272/1490 train_time:67065ms step_avg:52.72ms
+step:1273/1490 train_time:67142ms step_avg:52.74ms
+step:1274/1490 train_time:67226ms step_avg:52.77ms
+step:1275/1490 train_time:67305ms step_avg:52.79ms
+step:1276/1490 train_time:67390ms step_avg:52.81ms
+step:1277/1490 train_time:67470ms step_avg:52.84ms
+step:1278/1490 train_time:67555ms step_avg:52.86ms
+step:1279/1490 train_time:67635ms step_avg:52.88ms
+step:1280/1490 train_time:67719ms step_avg:52.91ms
+step:1281/1490 train_time:67798ms step_avg:52.93ms
+step:1282/1490 train_time:67883ms step_avg:52.95ms
+step:1283/1490 train_time:67961ms step_avg:52.97ms
+step:1284/1490 train_time:68045ms step_avg:52.99ms
+step:1285/1490 train_time:68122ms step_avg:53.01ms
+step:1286/1490 train_time:68207ms step_avg:53.04ms
+step:1287/1490 train_time:68286ms step_avg:53.06ms
+step:1288/1490 train_time:68372ms step_avg:53.08ms
+step:1289/1490 train_time:68452ms step_avg:53.10ms
+step:1290/1490 train_time:68536ms step_avg:53.13ms
+step:1291/1490 train_time:68616ms step_avg:53.15ms
+step:1292/1490 train_time:68699ms step_avg:53.17ms
+step:1293/1490 train_time:68780ms step_avg:53.19ms
+step:1294/1490 train_time:68864ms step_avg:53.22ms
+step:1295/1490 train_time:68943ms step_avg:53.24ms
+step:1296/1490 train_time:69026ms step_avg:53.26ms
+step:1297/1490 train_time:69104ms step_avg:53.28ms
+step:1298/1490 train_time:69188ms step_avg:53.30ms
+step:1299/1490 train_time:69266ms step_avg:53.32ms
+step:1300/1490 train_time:69351ms step_avg:53.35ms
+step:1301/1490 train_time:69430ms step_avg:53.37ms
+step:1302/1490 train_time:69516ms step_avg:53.39ms
+step:1303/1490 train_time:69595ms step_avg:53.41ms
+step:1304/1490 train_time:69679ms step_avg:53.43ms
+step:1305/1490 train_time:69758ms step_avg:53.45ms
+step:1306/1490 train_time:69841ms step_avg:53.48ms
+step:1307/1490 train_time:69921ms step_avg:53.50ms
+step:1308/1490 train_time:70004ms step_avg:53.52ms
+step:1309/1490 train_time:70083ms step_avg:53.54ms
+step:1310/1490 train_time:70167ms step_avg:53.56ms
+step:1311/1490 train_time:70245ms step_avg:53.58ms
+step:1312/1490 train_time:70330ms step_avg:53.61ms
+step:1313/1490 train_time:70410ms step_avg:53.63ms
+step:1314/1490 train_time:70493ms step_avg:53.65ms
+step:1315/1490 train_time:70571ms step_avg:53.67ms
+step:1316/1490 train_time:70656ms step_avg:53.69ms
+step:1317/1490 train_time:70735ms step_avg:53.71ms
+step:1318/1490 train_time:70819ms step_avg:53.73ms
+step:1319/1490 train_time:70899ms step_avg:53.75ms
+step:1320/1490 train_time:70984ms step_avg:53.78ms
+step:1321/1490 train_time:71063ms step_avg:53.79ms
+step:1322/1490 train_time:71147ms step_avg:53.82ms
+step:1323/1490 train_time:71226ms step_avg:53.84ms
+step:1324/1490 train_time:71311ms step_avg:53.86ms
+step:1325/1490 train_time:71390ms step_avg:53.88ms
+step:1326/1490 train_time:71475ms step_avg:53.90ms
+step:1327/1490 train_time:71554ms step_avg:53.92ms
+step:1328/1490 train_time:71637ms step_avg:53.94ms
+step:1329/1490 train_time:71716ms step_avg:53.96ms
+step:1330/1490 train_time:71800ms step_avg:53.98ms
+step:1331/1490 train_time:71880ms step_avg:54.00ms
+step:1332/1490 train_time:71965ms step_avg:54.03ms
+step:1333/1490 train_time:72044ms step_avg:54.05ms
+step:1334/1490 train_time:72128ms step_avg:54.07ms
+step:1335/1490 train_time:72207ms step_avg:54.09ms
+step:1336/1490 train_time:72292ms step_avg:54.11ms
+step:1337/1490 train_time:72370ms step_avg:54.13ms
+step:1338/1490 train_time:72454ms step_avg:54.15ms
+step:1339/1490 train_time:72533ms step_avg:54.17ms
+step:1340/1490 train_time:72617ms step_avg:54.19ms
+step:1341/1490 train_time:72696ms step_avg:54.21ms
+step:1342/1490 train_time:72780ms step_avg:54.23ms
+step:1343/1490 train_time:72860ms step_avg:54.25ms
+step:1344/1490 train_time:72943ms step_avg:54.27ms
+step:1345/1490 train_time:73022ms step_avg:54.29ms
+step:1346/1490 train_time:73108ms step_avg:54.31ms
+step:1347/1490 train_time:73187ms step_avg:54.33ms
+step:1348/1490 train_time:73272ms step_avg:54.36ms
+step:1349/1490 train_time:73350ms step_avg:54.37ms
+step:1350/1490 train_time:73435ms step_avg:54.40ms
+step:1351/1490 train_time:73514ms step_avg:54.41ms
+step:1352/1490 train_time:73597ms step_avg:54.44ms
+step:1353/1490 train_time:73676ms step_avg:54.45ms
+step:1354/1490 train_time:73760ms step_avg:54.48ms
+step:1355/1490 train_time:73839ms step_avg:54.49ms
+step:1356/1490 train_time:73924ms step_avg:54.52ms
+step:1357/1490 train_time:74003ms step_avg:54.53ms
+step:1358/1490 train_time:74087ms step_avg:54.56ms
+step:1359/1490 train_time:74167ms step_avg:54.57ms
+step:1360/1490 train_time:74252ms step_avg:54.60ms
+step:1361/1490 train_time:74330ms step_avg:54.61ms
+step:1362/1490 train_time:74415ms step_avg:54.64ms
+step:1363/1490 train_time:74494ms step_avg:54.65ms
+step:1364/1490 train_time:74578ms step_avg:54.68ms
+step:1365/1490 train_time:74658ms step_avg:54.69ms
+step:1366/1490 train_time:74740ms step_avg:54.71ms
+step:1367/1490 train_time:74819ms step_avg:54.73ms
+step:1368/1490 train_time:74904ms step_avg:54.75ms
+step:1369/1490 train_time:74984ms step_avg:54.77ms
+step:1370/1490 train_time:75070ms step_avg:54.80ms
+step:1371/1490 train_time:75148ms step_avg:54.81ms
+step:1372/1490 train_time:75232ms step_avg:54.83ms
+step:1373/1490 train_time:75312ms step_avg:54.85ms
+step:1374/1490 train_time:75396ms step_avg:54.87ms
+step:1375/1490 train_time:75473ms step_avg:54.89ms
+step:1376/1490 train_time:75557ms step_avg:54.91ms
+step:1377/1490 train_time:75635ms step_avg:54.93ms
+step:1378/1490 train_time:75720ms step_avg:54.95ms
+step:1379/1490 train_time:75799ms step_avg:54.97ms
+step:1380/1490 train_time:75884ms step_avg:54.99ms
+step:1381/1490 train_time:75963ms step_avg:55.01ms
+step:1382/1490 train_time:76047ms step_avg:55.03ms
+step:1383/1490 train_time:76126ms step_avg:55.04ms
+step:1384/1490 train_time:76210ms step_avg:55.07ms
+step:1385/1490 train_time:76291ms step_avg:55.08ms
+step:1386/1490 train_time:76375ms step_avg:55.10ms
+step:1387/1490 train_time:76452ms step_avg:55.12ms
+step:1388/1490 train_time:76536ms step_avg:55.14ms
+step:1389/1490 train_time:76616ms step_avg:55.16ms
+step:1390/1490 train_time:76700ms step_avg:55.18ms
+step:1391/1490 train_time:76778ms step_avg:55.20ms
+step:1392/1490 train_time:76864ms step_avg:55.22ms
+step:1393/1490 train_time:76942ms step_avg:55.23ms
+step:1394/1490 train_time:77026ms step_avg:55.26ms
+step:1395/1490 train_time:77105ms step_avg:55.27ms
+step:1396/1490 train_time:77189ms step_avg:55.29ms
+step:1397/1490 train_time:77269ms step_avg:55.31ms
+step:1398/1490 train_time:77353ms step_avg:55.33ms
+step:1399/1490 train_time:77431ms step_avg:55.35ms
+step:1400/1490 train_time:77516ms step_avg:55.37ms
+step:1401/1490 train_time:77595ms step_avg:55.39ms
+step:1402/1490 train_time:77678ms step_avg:55.41ms
+step:1403/1490 train_time:77758ms step_avg:55.42ms
+step:1404/1490 train_time:77842ms step_avg:55.44ms
+step:1405/1490 train_time:77920ms step_avg:55.46ms
+step:1406/1490 train_time:78005ms step_avg:55.48ms
+step:1407/1490 train_time:78086ms step_avg:55.50ms
+step:1408/1490 train_time:78172ms step_avg:55.52ms
+step:1409/1490 train_time:78250ms step_avg:55.54ms
+step:1410/1490 train_time:78336ms step_avg:55.56ms
+step:1411/1490 train_time:78415ms step_avg:55.57ms
+step:1412/1490 train_time:78498ms step_avg:55.59ms
+step:1413/1490 train_time:78578ms step_avg:55.61ms
+step:1414/1490 train_time:78662ms step_avg:55.63ms
+step:1415/1490 train_time:78739ms step_avg:55.65ms
+step:1416/1490 train_time:78823ms step_avg:55.67ms
+step:1417/1490 train_time:78902ms step_avg:55.68ms
+step:1418/1490 train_time:78987ms step_avg:55.70ms
+step:1419/1490 train_time:79068ms step_avg:55.72ms
+step:1420/1490 train_time:79152ms step_avg:55.74ms
+step:1421/1490 train_time:79230ms step_avg:55.76ms
+step:1422/1490 train_time:79315ms step_avg:55.78ms
+step:1423/1490 train_time:79393ms step_avg:55.79ms
+step:1424/1490 train_time:79478ms step_avg:55.81ms
+step:1425/1490 train_time:79558ms step_avg:55.83ms
+step:1426/1490 train_time:79642ms step_avg:55.85ms
+step:1427/1490 train_time:79720ms step_avg:55.87ms
+step:1428/1490 train_time:79804ms step_avg:55.89ms
+step:1429/1490 train_time:79883ms step_avg:55.90ms
+step:1430/1490 train_time:79968ms step_avg:55.92ms
+step:1431/1490 train_time:80048ms step_avg:55.94ms
+step:1432/1490 train_time:80131ms step_avg:55.96ms
+step:1433/1490 train_time:80211ms step_avg:55.97ms
+step:1434/1490 train_time:80296ms step_avg:55.99ms
+step:1435/1490 train_time:80373ms step_avg:56.01ms
+step:1436/1490 train_time:80458ms step_avg:56.03ms
+step:1437/1490 train_time:80537ms step_avg:56.05ms
+step:1438/1490 train_time:80621ms step_avg:56.06ms
+step:1439/1490 train_time:80699ms step_avg:56.08ms
+step:1440/1490 train_time:80784ms step_avg:56.10ms
+step:1441/1490 train_time:80863ms step_avg:56.12ms
+step:1442/1490 train_time:80947ms step_avg:56.14ms
+step:1443/1490 train_time:81028ms step_avg:56.15ms
+step:1444/1490 train_time:81111ms step_avg:56.17ms
+step:1445/1490 train_time:81190ms step_avg:56.19ms
+step:1446/1490 train_time:81275ms step_avg:56.21ms
+step:1447/1490 train_time:81353ms step_avg:56.22ms
+step:1448/1490 train_time:81436ms step_avg:56.24ms
+step:1449/1490 train_time:81515ms step_avg:56.26ms
+step:1450/1490 train_time:81598ms step_avg:56.27ms
+step:1451/1490 train_time:81680ms step_avg:56.29ms
+step:1452/1490 train_time:81769ms step_avg:56.31ms
+step:1453/1490 train_time:81847ms step_avg:56.33ms
+step:1454/1490 train_time:81931ms step_avg:56.35ms
+step:1455/1490 train_time:82011ms step_avg:56.36ms
+step:1456/1490 train_time:82095ms step_avg:56.38ms
+step:1457/1490 train_time:82175ms step_avg:56.40ms
+step:1458/1490 train_time:82259ms step_avg:56.42ms
+step:1459/1490 train_time:82339ms step_avg:56.43ms
+step:1460/1490 train_time:82424ms step_avg:56.45ms
+step:1461/1490 train_time:82503ms step_avg:56.47ms
+step:1462/1490 train_time:82588ms step_avg:56.49ms
+step:1463/1490 train_time:82668ms step_avg:56.51ms
+step:1464/1490 train_time:82751ms step_avg:56.52ms
+step:1465/1490 train_time:82831ms step_avg:56.54ms
+step:1466/1490 train_time:82915ms step_avg:56.56ms
+step:1467/1490 train_time:82995ms step_avg:56.57ms
+step:1468/1490 train_time:83080ms step_avg:56.59ms
+step:1469/1490 train_time:83160ms step_avg:56.61ms
+step:1470/1490 train_time:83244ms step_avg:56.63ms
+step:1471/1490 train_time:83323ms step_avg:56.64ms
+step:1472/1490 train_time:83407ms step_avg:56.66ms
+step:1473/1490 train_time:83489ms step_avg:56.68ms
+step:1474/1490 train_time:83573ms step_avg:56.70ms
+step:1475/1490 train_time:83652ms step_avg:56.71ms
+step:1476/1490 train_time:83735ms step_avg:56.73ms
+step:1477/1490 train_time:83813ms step_avg:56.75ms
+step:1478/1490 train_time:83899ms step_avg:56.77ms
+step:1479/1490 train_time:83980ms step_avg:56.78ms
+step:1480/1490 train_time:84064ms step_avg:56.80ms
+step:1481/1490 train_time:84144ms step_avg:56.82ms
+step:1482/1490 train_time:84227ms step_avg:56.83ms
+step:1483/1490 train_time:84306ms step_avg:56.85ms
+step:1484/1490 train_time:84391ms step_avg:56.87ms
+step:1485/1490 train_time:84470ms step_avg:56.88ms
+step:1486/1490 train_time:84555ms step_avg:56.90ms
+step:1487/1490 train_time:84633ms step_avg:56.92ms
+step:1488/1490 train_time:84718ms step_avg:56.93ms
+step:1489/1490 train_time:84797ms step_avg:56.95ms
+step:1490/1490 train_time:84880ms step_avg:56.97ms
+step:1490/1490 val_loss:3.2805 train_time:84977ms step_avg:57.03ms
+peak memory allocated: 30949 MiB reserved: 46586 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/49e25392-15a4-449a-a406-6b7c489e2815.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/49e25392-15a4-449a-a406-6b7c489e2815.txt
@@ -1,0 +1,4571 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 12:45:26 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   30C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   31C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   32C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   29C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   30C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   30C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8314 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:82ms step_avg:82.36ms
+step:2/1490 train_time:109ms step_avg:54.40ms
+step:3/1490 train_time:128ms step_avg:42.54ms
+step:4/1490 train_time:148ms step_avg:37.02ms
+step:5/1490 train_time:169ms step_avg:33.78ms
+step:6/1490 train_time:203ms step_avg:33.85ms
+step:7/1490 train_time:230ms step_avg:32.85ms
+step:8/1490 train_time:264ms step_avg:33.05ms
+step:9/1490 train_time:292ms step_avg:32.40ms
+step:10/1490 train_time:326ms step_avg:32.64ms
+step:11/1490 train_time:353ms step_avg:32.13ms
+step:12/1490 train_time:388ms step_avg:32.34ms
+step:13/1490 train_time:415ms step_avg:31.94ms
+step:14/1490 train_time:450ms step_avg:32.12ms
+step:15/1490 train_time:477ms step_avg:31.83ms
+step:16/1490 train_time:512ms step_avg:31.99ms
+step:17/1490 train_time:539ms step_avg:31.69ms
+step:18/1490 train_time:573ms step_avg:31.85ms
+step:19/1490 train_time:601ms step_avg:31.61ms
+step:20/1490 train_time:635ms step_avg:31.75ms
+step:21/1490 train_time:662ms step_avg:31.53ms
+step:22/1490 train_time:697ms step_avg:31.66ms
+step:23/1490 train_time:724ms step_avg:31.47ms
+step:24/1490 train_time:759ms step_avg:31.61ms
+step:25/1490 train_time:786ms step_avg:31.42ms
+step:26/1490 train_time:820ms step_avg:31.53ms
+step:27/1490 train_time:847ms step_avg:31.37ms
+step:28/1490 train_time:881ms step_avg:31.48ms
+step:29/1490 train_time:909ms step_avg:31.33ms
+step:30/1490 train_time:943ms step_avg:31.44ms
+step:31/1490 train_time:970ms step_avg:31.30ms
+step:32/1490 train_time:1005ms step_avg:31.42ms
+step:33/1490 train_time:1033ms step_avg:31.31ms
+step:34/1490 train_time:1069ms step_avg:31.44ms
+step:35/1490 train_time:1096ms step_avg:31.30ms
+step:36/1490 train_time:1130ms step_avg:31.39ms
+step:37/1490 train_time:1158ms step_avg:31.29ms
+step:38/1490 train_time:1192ms step_avg:31.38ms
+step:39/1490 train_time:1220ms step_avg:31.28ms
+step:40/1490 train_time:1254ms step_avg:31.36ms
+step:41/1490 train_time:1282ms step_avg:31.26ms
+step:42/1490 train_time:1316ms step_avg:31.34ms
+step:43/1490 train_time:1344ms step_avg:31.25ms
+step:44/1490 train_time:1378ms step_avg:31.32ms
+step:45/1490 train_time:1406ms step_avg:31.24ms
+step:46/1490 train_time:1440ms step_avg:31.31ms
+step:47/1490 train_time:1468ms step_avg:31.23ms
+step:48/1490 train_time:1502ms step_avg:31.30ms
+step:49/1490 train_time:1530ms step_avg:31.21ms
+step:50/1490 train_time:1564ms step_avg:31.28ms
+step:51/1490 train_time:1591ms step_avg:31.20ms
+step:52/1490 train_time:1626ms step_avg:31.27ms
+step:53/1490 train_time:1653ms step_avg:31.19ms
+step:54/1490 train_time:1688ms step_avg:31.26ms
+step:55/1490 train_time:1716ms step_avg:31.19ms
+step:56/1490 train_time:1750ms step_avg:31.25ms
+step:57/1490 train_time:1777ms step_avg:31.18ms
+step:58/1490 train_time:1812ms step_avg:31.23ms
+step:59/1490 train_time:1839ms step_avg:31.17ms
+step:60/1490 train_time:1873ms step_avg:31.22ms
+step:61/1490 train_time:1900ms step_avg:31.15ms
+step:62/1490 train_time:1935ms step_avg:31.21ms
+step:63/1490 train_time:1962ms step_avg:31.14ms
+step:64/1490 train_time:1996ms step_avg:31.19ms
+step:65/1490 train_time:2024ms step_avg:31.13ms
+step:66/1490 train_time:2058ms step_avg:31.18ms
+step:67/1490 train_time:2085ms step_avg:31.12ms
+step:68/1490 train_time:2119ms step_avg:31.17ms
+step:69/1490 train_time:2147ms step_avg:31.12ms
+step:70/1490 train_time:2181ms step_avg:31.16ms
+step:71/1490 train_time:2209ms step_avg:31.11ms
+step:72/1490 train_time:2243ms step_avg:31.16ms
+step:73/1490 train_time:2271ms step_avg:31.11ms
+step:74/1490 train_time:2305ms step_avg:31.15ms
+step:75/1490 train_time:2333ms step_avg:31.10ms
+step:76/1490 train_time:2367ms step_avg:31.14ms
+step:77/1490 train_time:2395ms step_avg:31.10ms
+step:78/1490 train_time:2429ms step_avg:31.14ms
+step:79/1490 train_time:2457ms step_avg:31.10ms
+step:80/1490 train_time:2491ms step_avg:31.14ms
+step:81/1490 train_time:2519ms step_avg:31.09ms
+step:82/1490 train_time:2553ms step_avg:31.13ms
+step:83/1490 train_time:2580ms step_avg:31.09ms
+step:84/1490 train_time:2615ms step_avg:31.13ms
+step:85/1490 train_time:2642ms step_avg:31.08ms
+step:86/1490 train_time:2676ms step_avg:31.12ms
+step:87/1490 train_time:2704ms step_avg:31.08ms
+step:88/1490 train_time:2738ms step_avg:31.12ms
+step:89/1490 train_time:2766ms step_avg:31.08ms
+step:90/1490 train_time:2800ms step_avg:31.11ms
+step:91/1490 train_time:2827ms step_avg:31.07ms
+step:92/1490 train_time:2862ms step_avg:31.10ms
+step:93/1490 train_time:2889ms step_avg:31.07ms
+step:94/1490 train_time:2924ms step_avg:31.11ms
+step:95/1490 train_time:2951ms step_avg:31.07ms
+step:96/1490 train_time:2986ms step_avg:31.11ms
+step:97/1490 train_time:3013ms step_avg:31.06ms
+step:98/1490 train_time:3048ms step_avg:31.10ms
+step:99/1490 train_time:3075ms step_avg:31.06ms
+step:100/1490 train_time:3110ms step_avg:31.10ms
+step:101/1490 train_time:3137ms step_avg:31.06ms
+step:102/1490 train_time:3172ms step_avg:31.09ms
+step:103/1490 train_time:3199ms step_avg:31.06ms
+step:104/1490 train_time:3234ms step_avg:31.09ms
+step:105/1490 train_time:3261ms step_avg:31.06ms
+step:106/1490 train_time:3295ms step_avg:31.09ms
+step:107/1490 train_time:3323ms step_avg:31.05ms
+step:108/1490 train_time:3357ms step_avg:31.08ms
+step:109/1490 train_time:3384ms step_avg:31.05ms
+step:110/1490 train_time:3419ms step_avg:31.08ms
+step:111/1490 train_time:3446ms step_avg:31.05ms
+step:112/1490 train_time:3481ms step_avg:31.08ms
+step:113/1490 train_time:3508ms step_avg:31.05ms
+step:114/1490 train_time:3543ms step_avg:31.08ms
+step:115/1490 train_time:3570ms step_avg:31.05ms
+step:116/1490 train_time:3605ms step_avg:31.07ms
+step:117/1490 train_time:3632ms step_avg:31.04ms
+step:118/1490 train_time:3666ms step_avg:31.07ms
+step:119/1490 train_time:3693ms step_avg:31.04ms
+step:120/1490 train_time:3729ms step_avg:31.08ms
+step:121/1490 train_time:3755ms step_avg:31.04ms
+step:122/1490 train_time:3790ms step_avg:31.07ms
+step:123/1490 train_time:3817ms step_avg:31.04ms
+step:124/1490 train_time:3852ms step_avg:31.06ms
+step:125/1490 train_time:3879ms step_avg:31.03ms
+step:126/1490 train_time:3914ms step_avg:31.06ms
+step:127/1490 train_time:3941ms step_avg:31.03ms
+step:128/1490 train_time:3975ms step_avg:31.06ms
+step:129/1490 train_time:4003ms step_avg:31.03ms
+step:130/1490 train_time:4037ms step_avg:31.05ms
+step:131/1490 train_time:4064ms step_avg:31.03ms
+step:132/1490 train_time:4098ms step_avg:31.05ms
+step:133/1490 train_time:4126ms step_avg:31.02ms
+step:134/1490 train_time:4160ms step_avg:31.04ms
+step:135/1490 train_time:4187ms step_avg:31.02ms
+step:136/1490 train_time:4222ms step_avg:31.04ms
+step:137/1490 train_time:4249ms step_avg:31.02ms
+step:138/1490 train_time:4284ms step_avg:31.04ms
+step:139/1490 train_time:4311ms step_avg:31.02ms
+step:140/1490 train_time:4346ms step_avg:31.04ms
+step:141/1490 train_time:4373ms step_avg:31.01ms
+step:142/1490 train_time:4407ms step_avg:31.04ms
+step:143/1490 train_time:4435ms step_avg:31.01ms
+step:144/1490 train_time:4469ms step_avg:31.04ms
+step:145/1490 train_time:4497ms step_avg:31.01ms
+step:146/1490 train_time:4531ms step_avg:31.03ms
+step:147/1490 train_time:4559ms step_avg:31.01ms
+step:148/1490 train_time:4593ms step_avg:31.04ms
+step:149/1490 train_time:4621ms step_avg:31.01ms
+step:150/1490 train_time:4655ms step_avg:31.03ms
+step:151/1490 train_time:4683ms step_avg:31.01ms
+step:152/1490 train_time:4717ms step_avg:31.03ms
+step:153/1490 train_time:4744ms step_avg:31.01ms
+step:154/1490 train_time:4779ms step_avg:31.03ms
+step:155/1490 train_time:4806ms step_avg:31.01ms
+step:156/1490 train_time:4840ms step_avg:31.03ms
+step:157/1490 train_time:4868ms step_avg:31.00ms
+step:158/1490 train_time:4902ms step_avg:31.03ms
+step:159/1490 train_time:4930ms step_avg:31.01ms
+step:160/1490 train_time:4964ms step_avg:31.03ms
+step:161/1490 train_time:4992ms step_avg:31.00ms
+step:162/1490 train_time:5027ms step_avg:31.03ms
+step:163/1490 train_time:5053ms step_avg:31.00ms
+step:164/1490 train_time:5088ms step_avg:31.02ms
+step:165/1490 train_time:5115ms step_avg:31.00ms
+step:166/1490 train_time:5149ms step_avg:31.02ms
+step:167/1490 train_time:5177ms step_avg:31.00ms
+step:168/1490 train_time:5211ms step_avg:31.02ms
+step:169/1490 train_time:5239ms step_avg:31.00ms
+step:170/1490 train_time:5273ms step_avg:31.02ms
+step:171/1490 train_time:5300ms step_avg:30.99ms
+step:172/1490 train_time:5334ms step_avg:31.01ms
+step:173/1490 train_time:5361ms step_avg:30.99ms
+step:174/1490 train_time:5396ms step_avg:31.01ms
+step:175/1490 train_time:5423ms step_avg:30.99ms
+step:176/1490 train_time:5457ms step_avg:31.00ms
+step:177/1490 train_time:5484ms step_avg:30.98ms
+step:178/1490 train_time:5518ms step_avg:31.00ms
+step:179/1490 train_time:5546ms step_avg:30.98ms
+step:180/1490 train_time:5580ms step_avg:31.00ms
+step:181/1490 train_time:5607ms step_avg:30.98ms
+step:182/1490 train_time:5642ms step_avg:31.00ms
+step:183/1490 train_time:5669ms step_avg:30.98ms
+step:184/1490 train_time:5704ms step_avg:31.00ms
+step:185/1490 train_time:5731ms step_avg:30.98ms
+step:186/1490 train_time:5765ms step_avg:31.00ms
+step:187/1490 train_time:5792ms step_avg:30.98ms
+step:188/1490 train_time:5827ms step_avg:31.00ms
+step:189/1490 train_time:5854ms step_avg:30.97ms
+step:190/1490 train_time:5889ms step_avg:30.99ms
+step:191/1490 train_time:5916ms step_avg:30.97ms
+step:192/1490 train_time:5951ms step_avg:31.00ms
+step:193/1490 train_time:5977ms step_avg:30.97ms
+step:194/1490 train_time:6012ms step_avg:30.99ms
+step:195/1490 train_time:6039ms step_avg:30.97ms
+step:196/1490 train_time:6073ms step_avg:30.99ms
+step:197/1490 train_time:6101ms step_avg:30.97ms
+step:198/1490 train_time:6135ms step_avg:30.98ms
+step:199/1490 train_time:6162ms step_avg:30.97ms
+step:200/1490 train_time:6197ms step_avg:30.98ms
+step:201/1490 train_time:6224ms step_avg:30.97ms
+step:202/1490 train_time:6258ms step_avg:30.98ms
+step:203/1490 train_time:6286ms step_avg:30.97ms
+step:204/1490 train_time:6320ms step_avg:30.98ms
+step:205/1490 train_time:6348ms step_avg:30.96ms
+step:206/1490 train_time:6382ms step_avg:30.98ms
+step:207/1490 train_time:6409ms step_avg:30.96ms
+step:208/1490 train_time:6444ms step_avg:30.98ms
+step:209/1490 train_time:6471ms step_avg:30.96ms
+step:210/1490 train_time:6505ms step_avg:30.98ms
+step:211/1490 train_time:6533ms step_avg:30.96ms
+step:212/1490 train_time:6567ms step_avg:30.98ms
+step:213/1490 train_time:6594ms step_avg:30.96ms
+step:214/1490 train_time:6629ms step_avg:30.98ms
+step:215/1490 train_time:6657ms step_avg:30.96ms
+step:216/1490 train_time:6691ms step_avg:30.98ms
+step:217/1490 train_time:6718ms step_avg:30.96ms
+step:218/1490 train_time:6752ms step_avg:30.97ms
+step:219/1490 train_time:6780ms step_avg:30.96ms
+step:220/1490 train_time:6814ms step_avg:30.97ms
+step:221/1490 train_time:6841ms step_avg:30.96ms
+step:222/1490 train_time:6876ms step_avg:30.97ms
+step:223/1490 train_time:6903ms step_avg:30.96ms
+step:224/1490 train_time:6938ms step_avg:30.97ms
+step:225/1490 train_time:6965ms step_avg:30.96ms
+step:226/1490 train_time:6999ms step_avg:30.97ms
+step:227/1490 train_time:7026ms step_avg:30.95ms
+step:228/1490 train_time:7061ms step_avg:30.97ms
+step:229/1490 train_time:7088ms step_avg:30.95ms
+step:230/1490 train_time:7122ms step_avg:30.97ms
+step:231/1490 train_time:7150ms step_avg:30.95ms
+step:232/1490 train_time:7184ms step_avg:30.97ms
+step:233/1490 train_time:7212ms step_avg:30.95ms
+step:234/1490 train_time:7246ms step_avg:30.97ms
+step:235/1490 train_time:7273ms step_avg:30.95ms
+step:236/1490 train_time:7308ms step_avg:30.97ms
+step:237/1490 train_time:7335ms step_avg:30.95ms
+step:238/1490 train_time:7369ms step_avg:30.96ms
+step:239/1490 train_time:7396ms step_avg:30.95ms
+step:240/1490 train_time:7431ms step_avg:30.96ms
+step:241/1490 train_time:7459ms step_avg:30.95ms
+step:242/1490 train_time:7493ms step_avg:30.96ms
+step:243/1490 train_time:7520ms step_avg:30.95ms
+step:244/1490 train_time:7555ms step_avg:30.96ms
+step:245/1490 train_time:7582ms step_avg:30.95ms
+step:246/1490 train_time:7616ms step_avg:30.96ms
+step:247/1490 train_time:7644ms step_avg:30.95ms
+step:248/1490 train_time:7678ms step_avg:30.96ms
+step:249/1490 train_time:7705ms step_avg:30.94ms
+step:250/1490 train_time:7739ms step_avg:30.96ms
+step:250/1490 val_loss:4.5226 train_time:7778ms step_avg:31.11ms
+step:251/1490 train_time:7801ms step_avg:31.08ms
+step:252/1490 train_time:7822ms step_avg:31.04ms
+step:253/1490 train_time:7837ms step_avg:30.98ms
+step:254/1490 train_time:7867ms step_avg:30.97ms
+step:255/1490 train_time:7895ms step_avg:30.96ms
+step:256/1490 train_time:7931ms step_avg:30.98ms
+step:257/1490 train_time:7959ms step_avg:30.97ms
+step:258/1490 train_time:7994ms step_avg:30.98ms
+step:259/1490 train_time:8021ms step_avg:30.97ms
+step:260/1490 train_time:8056ms step_avg:30.98ms
+step:261/1490 train_time:8083ms step_avg:30.97ms
+step:262/1490 train_time:8118ms step_avg:30.98ms
+step:263/1490 train_time:8145ms step_avg:30.97ms
+step:264/1490 train_time:8179ms step_avg:30.98ms
+step:265/1490 train_time:8206ms step_avg:30.97ms
+step:266/1490 train_time:8241ms step_avg:30.98ms
+step:267/1490 train_time:8268ms step_avg:30.97ms
+step:268/1490 train_time:8303ms step_avg:30.98ms
+step:269/1490 train_time:8330ms step_avg:30.97ms
+step:270/1490 train_time:8364ms step_avg:30.98ms
+step:271/1490 train_time:8391ms step_avg:30.96ms
+step:272/1490 train_time:8425ms step_avg:30.98ms
+step:273/1490 train_time:8453ms step_avg:30.96ms
+step:274/1490 train_time:8487ms step_avg:30.97ms
+step:275/1490 train_time:8514ms step_avg:30.96ms
+step:276/1490 train_time:8548ms step_avg:30.97ms
+step:277/1490 train_time:8575ms step_avg:30.96ms
+step:278/1490 train_time:8609ms step_avg:30.97ms
+step:279/1490 train_time:8636ms step_avg:30.96ms
+step:280/1490 train_time:8670ms step_avg:30.97ms
+step:281/1490 train_time:8697ms step_avg:30.95ms
+step:282/1490 train_time:8731ms step_avg:30.96ms
+step:283/1490 train_time:8759ms step_avg:30.95ms
+step:284/1490 train_time:8793ms step_avg:30.96ms
+step:285/1490 train_time:8820ms step_avg:30.95ms
+step:286/1490 train_time:8855ms step_avg:30.96ms
+step:287/1490 train_time:8882ms step_avg:30.95ms
+step:288/1490 train_time:8917ms step_avg:30.96ms
+step:289/1490 train_time:8945ms step_avg:30.95ms
+step:290/1490 train_time:8979ms step_avg:30.96ms
+step:291/1490 train_time:9007ms step_avg:30.95ms
+step:292/1490 train_time:9041ms step_avg:30.96ms
+step:293/1490 train_time:9069ms step_avg:30.95ms
+step:294/1490 train_time:9103ms step_avg:30.96ms
+step:295/1490 train_time:9131ms step_avg:30.95ms
+step:296/1490 train_time:9165ms step_avg:30.96ms
+step:297/1490 train_time:9193ms step_avg:30.95ms
+step:298/1490 train_time:9227ms step_avg:30.96ms
+step:299/1490 train_time:9254ms step_avg:30.95ms
+step:300/1490 train_time:9288ms step_avg:30.96ms
+step:301/1490 train_time:9316ms step_avg:30.95ms
+step:302/1490 train_time:9350ms step_avg:30.96ms
+step:303/1490 train_time:9377ms step_avg:30.95ms
+step:304/1490 train_time:9411ms step_avg:30.96ms
+step:305/1490 train_time:9439ms step_avg:30.95ms
+step:306/1490 train_time:9473ms step_avg:30.96ms
+step:307/1490 train_time:9500ms step_avg:30.95ms
+step:308/1490 train_time:9534ms step_avg:30.96ms
+step:309/1490 train_time:9562ms step_avg:30.95ms
+step:310/1490 train_time:9597ms step_avg:30.96ms
+step:311/1490 train_time:9624ms step_avg:30.94ms
+step:312/1490 train_time:9658ms step_avg:30.96ms
+step:313/1490 train_time:9685ms step_avg:30.94ms
+step:314/1490 train_time:9720ms step_avg:30.95ms
+step:315/1490 train_time:9747ms step_avg:30.94ms
+step:316/1490 train_time:9781ms step_avg:30.95ms
+step:317/1490 train_time:9809ms step_avg:30.94ms
+step:318/1490 train_time:9843ms step_avg:30.95ms
+step:319/1490 train_time:9870ms step_avg:30.94ms
+step:320/1490 train_time:9905ms step_avg:30.95ms
+step:321/1490 train_time:9932ms step_avg:30.94ms
+step:322/1490 train_time:9966ms step_avg:30.95ms
+step:323/1490 train_time:9993ms step_avg:30.94ms
+step:324/1490 train_time:10027ms step_avg:30.95ms
+step:325/1490 train_time:10055ms step_avg:30.94ms
+step:326/1490 train_time:10089ms step_avg:30.95ms
+step:327/1490 train_time:10116ms step_avg:30.94ms
+step:328/1490 train_time:10150ms step_avg:30.95ms
+step:329/1490 train_time:10178ms step_avg:30.94ms
+step:330/1490 train_time:10212ms step_avg:30.95ms
+step:331/1490 train_time:10239ms step_avg:30.93ms
+step:332/1490 train_time:10273ms step_avg:30.94ms
+step:333/1490 train_time:10300ms step_avg:30.93ms
+step:334/1490 train_time:10334ms step_avg:30.94ms
+step:335/1490 train_time:10362ms step_avg:30.93ms
+step:336/1490 train_time:10397ms step_avg:30.94ms
+step:337/1490 train_time:10424ms step_avg:30.93ms
+step:338/1490 train_time:10458ms step_avg:30.94ms
+step:339/1490 train_time:10485ms step_avg:30.93ms
+step:340/1490 train_time:10520ms step_avg:30.94ms
+step:341/1490 train_time:10547ms step_avg:30.93ms
+step:342/1490 train_time:10581ms step_avg:30.94ms
+step:343/1490 train_time:10609ms step_avg:30.93ms
+step:344/1490 train_time:10643ms step_avg:30.94ms
+step:345/1490 train_time:10670ms step_avg:30.93ms
+step:346/1490 train_time:10705ms step_avg:30.94ms
+step:347/1490 train_time:10732ms step_avg:30.93ms
+step:348/1490 train_time:10766ms step_avg:30.94ms
+step:349/1490 train_time:10793ms step_avg:30.93ms
+step:350/1490 train_time:10827ms step_avg:30.93ms
+step:351/1490 train_time:10855ms step_avg:30.93ms
+step:352/1490 train_time:10889ms step_avg:30.93ms
+step:353/1490 train_time:10916ms step_avg:30.92ms
+step:354/1490 train_time:10951ms step_avg:30.93ms
+step:355/1490 train_time:10978ms step_avg:30.92ms
+step:356/1490 train_time:11012ms step_avg:30.93ms
+step:357/1490 train_time:11039ms step_avg:30.92ms
+step:358/1490 train_time:11074ms step_avg:30.93ms
+step:359/1490 train_time:11101ms step_avg:30.92ms
+step:360/1490 train_time:11135ms step_avg:30.93ms
+step:361/1490 train_time:11163ms step_avg:30.92ms
+step:362/1490 train_time:11197ms step_avg:30.93ms
+step:363/1490 train_time:11224ms step_avg:30.92ms
+step:364/1490 train_time:11259ms step_avg:30.93ms
+step:365/1490 train_time:11285ms step_avg:30.92ms
+step:366/1490 train_time:11320ms step_avg:30.93ms
+step:367/1490 train_time:11347ms step_avg:30.92ms
+step:368/1490 train_time:11382ms step_avg:30.93ms
+step:369/1490 train_time:11409ms step_avg:30.92ms
+step:370/1490 train_time:11444ms step_avg:30.93ms
+step:371/1490 train_time:11471ms step_avg:30.92ms
+step:372/1490 train_time:11506ms step_avg:30.93ms
+step:373/1490 train_time:11533ms step_avg:30.92ms
+step:374/1490 train_time:11567ms step_avg:30.93ms
+step:375/1490 train_time:11594ms step_avg:30.92ms
+step:376/1490 train_time:11628ms step_avg:30.93ms
+step:377/1490 train_time:11656ms step_avg:30.92ms
+step:378/1490 train_time:11690ms step_avg:30.93ms
+step:379/1490 train_time:11717ms step_avg:30.92ms
+step:380/1490 train_time:11752ms step_avg:30.93ms
+step:381/1490 train_time:11779ms step_avg:30.92ms
+step:382/1490 train_time:11813ms step_avg:30.93ms
+step:383/1490 train_time:11841ms step_avg:30.92ms
+step:384/1490 train_time:11875ms step_avg:30.92ms
+step:385/1490 train_time:11902ms step_avg:30.91ms
+step:386/1490 train_time:11937ms step_avg:30.92ms
+step:387/1490 train_time:11964ms step_avg:30.91ms
+step:388/1490 train_time:11998ms step_avg:30.92ms
+step:389/1490 train_time:12025ms step_avg:30.91ms
+step:390/1490 train_time:12060ms step_avg:30.92ms
+step:391/1490 train_time:12087ms step_avg:30.91ms
+step:392/1490 train_time:12121ms step_avg:30.92ms
+step:393/1490 train_time:12148ms step_avg:30.91ms
+step:394/1490 train_time:12183ms step_avg:30.92ms
+step:395/1490 train_time:12211ms step_avg:30.91ms
+step:396/1490 train_time:12245ms step_avg:30.92ms
+step:397/1490 train_time:12272ms step_avg:30.91ms
+step:398/1490 train_time:12306ms step_avg:30.92ms
+step:399/1490 train_time:12333ms step_avg:30.91ms
+step:400/1490 train_time:12368ms step_avg:30.92ms
+step:401/1490 train_time:12395ms step_avg:30.91ms
+step:402/1490 train_time:12429ms step_avg:30.92ms
+step:403/1490 train_time:12457ms step_avg:30.91ms
+step:404/1490 train_time:12491ms step_avg:30.92ms
+step:405/1490 train_time:12518ms step_avg:30.91ms
+step:406/1490 train_time:12552ms step_avg:30.92ms
+step:407/1490 train_time:12580ms step_avg:30.91ms
+step:408/1490 train_time:12614ms step_avg:30.92ms
+step:409/1490 train_time:12642ms step_avg:30.91ms
+step:410/1490 train_time:12677ms step_avg:30.92ms
+step:411/1490 train_time:12704ms step_avg:30.91ms
+step:412/1490 train_time:12738ms step_avg:30.92ms
+step:413/1490 train_time:12765ms step_avg:30.91ms
+step:414/1490 train_time:12800ms step_avg:30.92ms
+step:415/1490 train_time:12827ms step_avg:30.91ms
+step:416/1490 train_time:12862ms step_avg:30.92ms
+step:417/1490 train_time:12889ms step_avg:30.91ms
+step:418/1490 train_time:12924ms step_avg:30.92ms
+step:419/1490 train_time:12951ms step_avg:30.91ms
+step:420/1490 train_time:12986ms step_avg:30.92ms
+step:421/1490 train_time:13013ms step_avg:30.91ms
+step:422/1490 train_time:13047ms step_avg:30.92ms
+step:423/1490 train_time:13074ms step_avg:30.91ms
+step:424/1490 train_time:13108ms step_avg:30.92ms
+step:425/1490 train_time:13136ms step_avg:30.91ms
+step:426/1490 train_time:13170ms step_avg:30.92ms
+step:427/1490 train_time:13197ms step_avg:30.91ms
+step:428/1490 train_time:13231ms step_avg:30.91ms
+step:429/1490 train_time:13259ms step_avg:30.91ms
+step:430/1490 train_time:13293ms step_avg:30.91ms
+step:431/1490 train_time:13321ms step_avg:30.91ms
+step:432/1490 train_time:13355ms step_avg:30.91ms
+step:433/1490 train_time:13383ms step_avg:30.91ms
+step:434/1490 train_time:13417ms step_avg:30.91ms
+step:435/1490 train_time:13444ms step_avg:30.91ms
+step:436/1490 train_time:13479ms step_avg:30.91ms
+step:437/1490 train_time:13506ms step_avg:30.91ms
+step:438/1490 train_time:13540ms step_avg:30.91ms
+step:439/1490 train_time:13567ms step_avg:30.91ms
+step:440/1490 train_time:13602ms step_avg:30.91ms
+step:441/1490 train_time:13629ms step_avg:30.90ms
+step:442/1490 train_time:13663ms step_avg:30.91ms
+step:443/1490 train_time:13691ms step_avg:30.90ms
+step:444/1490 train_time:13725ms step_avg:30.91ms
+step:445/1490 train_time:13753ms step_avg:30.90ms
+step:446/1490 train_time:13787ms step_avg:30.91ms
+step:447/1490 train_time:13814ms step_avg:30.90ms
+step:448/1490 train_time:13848ms step_avg:30.91ms
+step:449/1490 train_time:13876ms step_avg:30.90ms
+step:450/1490 train_time:13910ms step_avg:30.91ms
+step:451/1490 train_time:13937ms step_avg:30.90ms
+step:452/1490 train_time:13972ms step_avg:30.91ms
+step:453/1490 train_time:13999ms step_avg:30.90ms
+step:454/1490 train_time:14033ms step_avg:30.91ms
+step:455/1490 train_time:14061ms step_avg:30.90ms
+step:456/1490 train_time:14095ms step_avg:30.91ms
+step:457/1490 train_time:14122ms step_avg:30.90ms
+step:458/1490 train_time:14157ms step_avg:30.91ms
+step:459/1490 train_time:14184ms step_avg:30.90ms
+step:460/1490 train_time:14218ms step_avg:30.91ms
+step:461/1490 train_time:14245ms step_avg:30.90ms
+step:462/1490 train_time:14280ms step_avg:30.91ms
+step:463/1490 train_time:14307ms step_avg:30.90ms
+step:464/1490 train_time:14341ms step_avg:30.91ms
+step:465/1490 train_time:14369ms step_avg:30.90ms
+step:466/1490 train_time:14403ms step_avg:30.91ms
+step:467/1490 train_time:14430ms step_avg:30.90ms
+step:468/1490 train_time:14464ms step_avg:30.91ms
+step:469/1490 train_time:14491ms step_avg:30.90ms
+step:470/1490 train_time:14526ms step_avg:30.91ms
+step:471/1490 train_time:14553ms step_avg:30.90ms
+step:472/1490 train_time:14587ms step_avg:30.90ms
+step:473/1490 train_time:14615ms step_avg:30.90ms
+step:474/1490 train_time:14649ms step_avg:30.90ms
+step:475/1490 train_time:14676ms step_avg:30.90ms
+step:476/1490 train_time:14710ms step_avg:30.90ms
+step:477/1490 train_time:14738ms step_avg:30.90ms
+step:478/1490 train_time:14773ms step_avg:30.91ms
+step:479/1490 train_time:14799ms step_avg:30.90ms
+step:480/1490 train_time:14833ms step_avg:30.90ms
+step:481/1490 train_time:14860ms step_avg:30.89ms
+step:482/1490 train_time:14895ms step_avg:30.90ms
+step:483/1490 train_time:14922ms step_avg:30.89ms
+step:484/1490 train_time:14959ms step_avg:30.91ms
+step:485/1490 train_time:15012ms step_avg:30.95ms
+step:486/1490 train_time:15069ms step_avg:31.01ms
+step:487/1490 train_time:15122ms step_avg:31.05ms
+step:488/1490 train_time:15181ms step_avg:31.11ms
+step:489/1490 train_time:15234ms step_avg:31.15ms
+step:490/1490 train_time:15292ms step_avg:31.21ms
+step:491/1490 train_time:15346ms step_avg:31.25ms
+step:492/1490 train_time:15405ms step_avg:31.31ms
+step:493/1490 train_time:15459ms step_avg:31.36ms
+step:494/1490 train_time:15518ms step_avg:31.41ms
+step:495/1490 train_time:15571ms step_avg:31.46ms
+step:496/1490 train_time:15630ms step_avg:31.51ms
+step:497/1490 train_time:15684ms step_avg:31.56ms
+step:498/1490 train_time:15743ms step_avg:31.61ms
+step:499/1490 train_time:15796ms step_avg:31.66ms
+step:500/1490 train_time:15854ms step_avg:31.71ms
+step:500/1490 val_loss:4.2275 train_time:15922ms step_avg:31.84ms
+step:501/1490 train_time:15940ms step_avg:31.82ms
+step:502/1490 train_time:15968ms step_avg:31.81ms
+step:503/1490 train_time:16024ms step_avg:31.86ms
+step:504/1490 train_time:16088ms step_avg:31.92ms
+step:505/1490 train_time:16142ms step_avg:31.96ms
+step:506/1490 train_time:16201ms step_avg:32.02ms
+step:507/1490 train_time:16253ms step_avg:32.06ms
+step:508/1490 train_time:16311ms step_avg:32.11ms
+step:509/1490 train_time:16365ms step_avg:32.15ms
+step:510/1490 train_time:16423ms step_avg:32.20ms
+step:511/1490 train_time:16476ms step_avg:32.24ms
+step:512/1490 train_time:16533ms step_avg:32.29ms
+step:513/1490 train_time:16587ms step_avg:32.33ms
+step:514/1490 train_time:16645ms step_avg:32.38ms
+step:515/1490 train_time:16699ms step_avg:32.42ms
+step:516/1490 train_time:16756ms step_avg:32.47ms
+step:517/1490 train_time:16809ms step_avg:32.51ms
+step:518/1490 train_time:16868ms step_avg:32.56ms
+step:519/1490 train_time:16921ms step_avg:32.60ms
+step:520/1490 train_time:16981ms step_avg:32.66ms
+step:521/1490 train_time:17036ms step_avg:32.70ms
+step:522/1490 train_time:17095ms step_avg:32.75ms
+step:523/1490 train_time:17149ms step_avg:32.79ms
+step:524/1490 train_time:17209ms step_avg:32.84ms
+step:525/1490 train_time:17263ms step_avg:32.88ms
+step:526/1490 train_time:17322ms step_avg:32.93ms
+step:527/1490 train_time:17376ms step_avg:32.97ms
+step:528/1490 train_time:17434ms step_avg:33.02ms
+step:529/1490 train_time:17487ms step_avg:33.06ms
+step:530/1490 train_time:17545ms step_avg:33.10ms
+step:531/1490 train_time:17597ms step_avg:33.14ms
+step:532/1490 train_time:17655ms step_avg:33.19ms
+step:533/1490 train_time:17708ms step_avg:33.22ms
+step:534/1490 train_time:17767ms step_avg:33.27ms
+step:535/1490 train_time:17820ms step_avg:33.31ms
+step:536/1490 train_time:17879ms step_avg:33.36ms
+step:537/1490 train_time:17932ms step_avg:33.39ms
+step:538/1490 train_time:17991ms step_avg:33.44ms
+step:539/1490 train_time:18046ms step_avg:33.48ms
+step:540/1490 train_time:18106ms step_avg:33.53ms
+step:541/1490 train_time:18160ms step_avg:33.57ms
+step:542/1490 train_time:18219ms step_avg:33.61ms
+step:543/1490 train_time:18272ms step_avg:33.65ms
+step:544/1490 train_time:18331ms step_avg:33.70ms
+step:545/1490 train_time:18384ms step_avg:33.73ms
+step:546/1490 train_time:18442ms step_avg:33.78ms
+step:547/1490 train_time:18496ms step_avg:33.81ms
+step:548/1490 train_time:18554ms step_avg:33.86ms
+step:549/1490 train_time:18606ms step_avg:33.89ms
+step:550/1490 train_time:18665ms step_avg:33.94ms
+step:551/1490 train_time:18718ms step_avg:33.97ms
+step:552/1490 train_time:18776ms step_avg:34.01ms
+step:553/1490 train_time:18829ms step_avg:34.05ms
+step:554/1490 train_time:18888ms step_avg:34.09ms
+step:555/1490 train_time:18941ms step_avg:34.13ms
+step:556/1490 train_time:19001ms step_avg:34.17ms
+step:557/1490 train_time:19054ms step_avg:34.21ms
+step:558/1490 train_time:19113ms step_avg:34.25ms
+step:559/1490 train_time:19167ms step_avg:34.29ms
+step:560/1490 train_time:19226ms step_avg:34.33ms
+step:561/1490 train_time:19279ms step_avg:34.37ms
+step:562/1490 train_time:19337ms step_avg:34.41ms
+step:563/1490 train_time:19390ms step_avg:34.44ms
+step:564/1490 train_time:19449ms step_avg:34.48ms
+step:565/1490 train_time:19503ms step_avg:34.52ms
+step:566/1490 train_time:19561ms step_avg:34.56ms
+step:567/1490 train_time:19614ms step_avg:34.59ms
+step:568/1490 train_time:19672ms step_avg:34.63ms
+step:569/1490 train_time:19724ms step_avg:34.67ms
+step:570/1490 train_time:19784ms step_avg:34.71ms
+step:571/1490 train_time:19837ms step_avg:34.74ms
+step:572/1490 train_time:19895ms step_avg:34.78ms
+step:573/1490 train_time:19949ms step_avg:34.81ms
+step:574/1490 train_time:20009ms step_avg:34.86ms
+step:575/1490 train_time:20062ms step_avg:34.89ms
+step:576/1490 train_time:20122ms step_avg:34.93ms
+step:577/1490 train_time:20175ms step_avg:34.97ms
+step:578/1490 train_time:20234ms step_avg:35.01ms
+step:579/1490 train_time:20288ms step_avg:35.04ms
+step:580/1490 train_time:20346ms step_avg:35.08ms
+step:581/1490 train_time:20399ms step_avg:35.11ms
+step:582/1490 train_time:20458ms step_avg:35.15ms
+step:583/1490 train_time:20510ms step_avg:35.18ms
+step:584/1490 train_time:20569ms step_avg:35.22ms
+step:585/1490 train_time:20622ms step_avg:35.25ms
+step:586/1490 train_time:20680ms step_avg:35.29ms
+step:587/1490 train_time:20734ms step_avg:35.32ms
+step:588/1490 train_time:20792ms step_avg:35.36ms
+step:589/1490 train_time:20845ms step_avg:35.39ms
+step:590/1490 train_time:20904ms step_avg:35.43ms
+step:591/1490 train_time:20958ms step_avg:35.46ms
+step:592/1490 train_time:21016ms step_avg:35.50ms
+step:593/1490 train_time:21070ms step_avg:35.53ms
+step:594/1490 train_time:21129ms step_avg:35.57ms
+step:595/1490 train_time:21183ms step_avg:35.60ms
+step:596/1490 train_time:21242ms step_avg:35.64ms
+step:597/1490 train_time:21296ms step_avg:35.67ms
+step:598/1490 train_time:21354ms step_avg:35.71ms
+step:599/1490 train_time:21408ms step_avg:35.74ms
+step:600/1490 train_time:21467ms step_avg:35.78ms
+step:601/1490 train_time:21521ms step_avg:35.81ms
+step:602/1490 train_time:21578ms step_avg:35.84ms
+step:603/1490 train_time:21631ms step_avg:35.87ms
+step:604/1490 train_time:21690ms step_avg:35.91ms
+step:605/1490 train_time:21743ms step_avg:35.94ms
+step:606/1490 train_time:21801ms step_avg:35.98ms
+step:607/1490 train_time:21855ms step_avg:36.00ms
+step:608/1490 train_time:21913ms step_avg:36.04ms
+step:609/1490 train_time:21967ms step_avg:36.07ms
+step:610/1490 train_time:22026ms step_avg:36.11ms
+step:611/1490 train_time:22080ms step_avg:36.14ms
+step:612/1490 train_time:22139ms step_avg:36.17ms
+step:613/1490 train_time:22193ms step_avg:36.20ms
+step:614/1490 train_time:22251ms step_avg:36.24ms
+step:615/1490 train_time:22305ms step_avg:36.27ms
+step:616/1490 train_time:22364ms step_avg:36.31ms
+step:617/1490 train_time:22418ms step_avg:36.33ms
+step:618/1490 train_time:22477ms step_avg:36.37ms
+step:619/1490 train_time:22530ms step_avg:36.40ms
+step:620/1490 train_time:22589ms step_avg:36.43ms
+step:621/1490 train_time:22642ms step_avg:36.46ms
+step:622/1490 train_time:22701ms step_avg:36.50ms
+step:623/1490 train_time:22753ms step_avg:36.52ms
+step:624/1490 train_time:22812ms step_avg:36.56ms
+step:625/1490 train_time:22866ms step_avg:36.58ms
+step:626/1490 train_time:22924ms step_avg:36.62ms
+step:627/1490 train_time:22977ms step_avg:36.65ms
+step:628/1490 train_time:23036ms step_avg:36.68ms
+step:629/1490 train_time:23090ms step_avg:36.71ms
+step:630/1490 train_time:23148ms step_avg:36.74ms
+step:631/1490 train_time:23201ms step_avg:36.77ms
+step:632/1490 train_time:23261ms step_avg:36.81ms
+step:633/1490 train_time:23314ms step_avg:36.83ms
+step:634/1490 train_time:23373ms step_avg:36.87ms
+step:635/1490 train_time:23426ms step_avg:36.89ms
+step:636/1490 train_time:23485ms step_avg:36.93ms
+step:637/1490 train_time:23539ms step_avg:36.95ms
+step:638/1490 train_time:23597ms step_avg:36.99ms
+step:639/1490 train_time:23649ms step_avg:37.01ms
+step:640/1490 train_time:23709ms step_avg:37.05ms
+step:641/1490 train_time:23762ms step_avg:37.07ms
+step:642/1490 train_time:23820ms step_avg:37.10ms
+step:643/1490 train_time:23873ms step_avg:37.13ms
+step:644/1490 train_time:23932ms step_avg:37.16ms
+step:645/1490 train_time:23985ms step_avg:37.19ms
+step:646/1490 train_time:24044ms step_avg:37.22ms
+step:647/1490 train_time:24098ms step_avg:37.25ms
+step:648/1490 train_time:24156ms step_avg:37.28ms
+step:649/1490 train_time:24209ms step_avg:37.30ms
+step:650/1490 train_time:24268ms step_avg:37.34ms
+step:651/1490 train_time:24322ms step_avg:37.36ms
+step:652/1490 train_time:24380ms step_avg:37.39ms
+step:653/1490 train_time:24433ms step_avg:37.42ms
+step:654/1490 train_time:24492ms step_avg:37.45ms
+step:655/1490 train_time:24545ms step_avg:37.47ms
+step:656/1490 train_time:24603ms step_avg:37.51ms
+step:657/1490 train_time:24657ms step_avg:37.53ms
+step:658/1490 train_time:24715ms step_avg:37.56ms
+step:659/1490 train_time:24769ms step_avg:37.59ms
+step:660/1490 train_time:24827ms step_avg:37.62ms
+step:661/1490 train_time:24881ms step_avg:37.64ms
+step:662/1490 train_time:24938ms step_avg:37.67ms
+step:663/1490 train_time:24992ms step_avg:37.70ms
+step:664/1490 train_time:25051ms step_avg:37.73ms
+step:665/1490 train_time:25104ms step_avg:37.75ms
+step:666/1490 train_time:25163ms step_avg:37.78ms
+step:667/1490 train_time:25217ms step_avg:37.81ms
+step:668/1490 train_time:25276ms step_avg:37.84ms
+step:669/1490 train_time:25329ms step_avg:37.86ms
+step:670/1490 train_time:25388ms step_avg:37.89ms
+step:671/1490 train_time:25441ms step_avg:37.91ms
+step:672/1490 train_time:25500ms step_avg:37.95ms
+step:673/1490 train_time:25553ms step_avg:37.97ms
+step:674/1490 train_time:25611ms step_avg:38.00ms
+step:675/1490 train_time:25664ms step_avg:38.02ms
+step:676/1490 train_time:25722ms step_avg:38.05ms
+step:677/1490 train_time:25775ms step_avg:38.07ms
+step:678/1490 train_time:25833ms step_avg:38.10ms
+step:679/1490 train_time:25887ms step_avg:38.13ms
+step:680/1490 train_time:25946ms step_avg:38.16ms
+step:681/1490 train_time:25999ms step_avg:38.18ms
+step:682/1490 train_time:26058ms step_avg:38.21ms
+step:683/1490 train_time:26111ms step_avg:38.23ms
+step:684/1490 train_time:26170ms step_avg:38.26ms
+step:685/1490 train_time:26223ms step_avg:38.28ms
+step:686/1490 train_time:26282ms step_avg:38.31ms
+step:687/1490 train_time:26335ms step_avg:38.33ms
+step:688/1490 train_time:26393ms step_avg:38.36ms
+step:689/1490 train_time:26447ms step_avg:38.38ms
+step:690/1490 train_time:26505ms step_avg:38.41ms
+step:691/1490 train_time:26560ms step_avg:38.44ms
+step:692/1490 train_time:26618ms step_avg:38.47ms
+step:693/1490 train_time:26671ms step_avg:38.49ms
+step:694/1490 train_time:26730ms step_avg:38.52ms
+step:695/1490 train_time:26783ms step_avg:38.54ms
+step:696/1490 train_time:26842ms step_avg:38.57ms
+step:697/1490 train_time:26895ms step_avg:38.59ms
+step:698/1490 train_time:26953ms step_avg:38.61ms
+step:699/1490 train_time:27006ms step_avg:38.64ms
+step:700/1490 train_time:27066ms step_avg:38.67ms
+step:701/1490 train_time:27119ms step_avg:38.69ms
+step:702/1490 train_time:27177ms step_avg:38.71ms
+step:703/1490 train_time:27230ms step_avg:38.73ms
+step:704/1490 train_time:27289ms step_avg:38.76ms
+step:705/1490 train_time:27342ms step_avg:38.78ms
+step:706/1490 train_time:27402ms step_avg:38.81ms
+step:707/1490 train_time:27455ms step_avg:38.83ms
+step:708/1490 train_time:27514ms step_avg:38.86ms
+step:709/1490 train_time:27567ms step_avg:38.88ms
+step:710/1490 train_time:27630ms step_avg:38.92ms
+step:711/1490 train_time:27680ms step_avg:38.93ms
+step:712/1490 train_time:27738ms step_avg:38.96ms
+step:713/1490 train_time:27792ms step_avg:38.98ms
+step:714/1490 train_time:27850ms step_avg:39.01ms
+step:715/1490 train_time:27903ms step_avg:39.03ms
+step:716/1490 train_time:27963ms step_avg:39.05ms
+step:717/1490 train_time:28016ms step_avg:39.07ms
+step:718/1490 train_time:28074ms step_avg:39.10ms
+step:719/1490 train_time:28127ms step_avg:39.12ms
+step:720/1490 train_time:28186ms step_avg:39.15ms
+step:721/1490 train_time:28239ms step_avg:39.17ms
+step:722/1490 train_time:28297ms step_avg:39.19ms
+step:723/1490 train_time:28351ms step_avg:39.21ms
+step:724/1490 train_time:28410ms step_avg:39.24ms
+step:725/1490 train_time:28464ms step_avg:39.26ms
+step:726/1490 train_time:28523ms step_avg:39.29ms
+step:727/1490 train_time:28576ms step_avg:39.31ms
+step:728/1490 train_time:28635ms step_avg:39.33ms
+step:729/1490 train_time:28688ms step_avg:39.35ms
+step:730/1490 train_time:28747ms step_avg:39.38ms
+step:731/1490 train_time:28800ms step_avg:39.40ms
+step:732/1490 train_time:28859ms step_avg:39.43ms
+step:733/1490 train_time:28912ms step_avg:39.44ms
+step:734/1490 train_time:28971ms step_avg:39.47ms
+step:735/1490 train_time:29024ms step_avg:39.49ms
+step:736/1490 train_time:29082ms step_avg:39.51ms
+step:737/1490 train_time:29136ms step_avg:39.53ms
+step:738/1490 train_time:29194ms step_avg:39.56ms
+step:739/1490 train_time:29247ms step_avg:39.58ms
+step:740/1490 train_time:29306ms step_avg:39.60ms
+step:741/1490 train_time:29360ms step_avg:39.62ms
+step:742/1490 train_time:29418ms step_avg:39.65ms
+step:743/1490 train_time:29472ms step_avg:39.67ms
+step:744/1490 train_time:29530ms step_avg:39.69ms
+step:745/1490 train_time:29584ms step_avg:39.71ms
+step:746/1490 train_time:29642ms step_avg:39.73ms
+step:747/1490 train_time:29696ms step_avg:39.75ms
+step:748/1490 train_time:29754ms step_avg:39.78ms
+step:749/1490 train_time:29808ms step_avg:39.80ms
+step:750/1490 train_time:29867ms step_avg:39.82ms
+step:750/1490 val_loss:3.8015 train_time:29934ms step_avg:39.91ms
+step:751/1490 train_time:29954ms step_avg:39.88ms
+step:752/1490 train_time:29981ms step_avg:39.87ms
+step:753/1490 train_time:30038ms step_avg:39.89ms
+step:754/1490 train_time:30099ms step_avg:39.92ms
+step:755/1490 train_time:30152ms step_avg:39.94ms
+step:756/1490 train_time:30212ms step_avg:39.96ms
+step:757/1490 train_time:30265ms step_avg:39.98ms
+step:758/1490 train_time:30324ms step_avg:40.00ms
+step:759/1490 train_time:30377ms step_avg:40.02ms
+step:760/1490 train_time:30435ms step_avg:40.05ms
+step:761/1490 train_time:30488ms step_avg:40.06ms
+step:762/1490 train_time:30546ms step_avg:40.09ms
+step:763/1490 train_time:30599ms step_avg:40.10ms
+step:764/1490 train_time:30656ms step_avg:40.13ms
+step:765/1490 train_time:30710ms step_avg:40.14ms
+step:766/1490 train_time:30768ms step_avg:40.17ms
+step:767/1490 train_time:30820ms step_avg:40.18ms
+step:768/1490 train_time:30879ms step_avg:40.21ms
+step:769/1490 train_time:30932ms step_avg:40.22ms
+step:770/1490 train_time:30993ms step_avg:40.25ms
+step:771/1490 train_time:31047ms step_avg:40.27ms
+step:772/1490 train_time:31108ms step_avg:40.29ms
+step:773/1490 train_time:31162ms step_avg:40.31ms
+step:774/1490 train_time:31220ms step_avg:40.34ms
+step:775/1490 train_time:31273ms step_avg:40.35ms
+step:776/1490 train_time:31332ms step_avg:40.38ms
+step:777/1490 train_time:31386ms step_avg:40.39ms
+step:778/1490 train_time:31443ms step_avg:40.42ms
+step:779/1490 train_time:31497ms step_avg:40.43ms
+step:780/1490 train_time:31555ms step_avg:40.45ms
+step:781/1490 train_time:31607ms step_avg:40.47ms
+step:782/1490 train_time:31666ms step_avg:40.49ms
+step:783/1490 train_time:31719ms step_avg:40.51ms
+step:784/1490 train_time:31778ms step_avg:40.53ms
+step:785/1490 train_time:31831ms step_avg:40.55ms
+step:786/1490 train_time:31889ms step_avg:40.57ms
+step:787/1490 train_time:31942ms step_avg:40.59ms
+step:788/1490 train_time:32002ms step_avg:40.61ms
+step:789/1490 train_time:32056ms step_avg:40.63ms
+step:790/1490 train_time:32116ms step_avg:40.65ms
+step:791/1490 train_time:32170ms step_avg:40.67ms
+step:792/1490 train_time:32229ms step_avg:40.69ms
+step:793/1490 train_time:32283ms step_avg:40.71ms
+step:794/1490 train_time:32342ms step_avg:40.73ms
+step:795/1490 train_time:32395ms step_avg:40.75ms
+step:796/1490 train_time:32453ms step_avg:40.77ms
+step:797/1490 train_time:32506ms step_avg:40.79ms
+step:798/1490 train_time:32564ms step_avg:40.81ms
+step:799/1490 train_time:32617ms step_avg:40.82ms
+step:800/1490 train_time:32674ms step_avg:40.84ms
+step:801/1490 train_time:32727ms step_avg:40.86ms
+step:802/1490 train_time:32787ms step_avg:40.88ms
+step:803/1490 train_time:32841ms step_avg:40.90ms
+step:804/1490 train_time:32899ms step_avg:40.92ms
+step:805/1490 train_time:32952ms step_avg:40.93ms
+step:806/1490 train_time:33011ms step_avg:40.96ms
+step:807/1490 train_time:33065ms step_avg:40.97ms
+step:808/1490 train_time:33124ms step_avg:40.99ms
+step:809/1490 train_time:33178ms step_avg:41.01ms
+step:810/1490 train_time:33236ms step_avg:41.03ms
+step:811/1490 train_time:33289ms step_avg:41.05ms
+step:812/1490 train_time:33349ms step_avg:41.07ms
+step:813/1490 train_time:33402ms step_avg:41.08ms
+step:814/1490 train_time:33460ms step_avg:41.11ms
+step:815/1490 train_time:33513ms step_avg:41.12ms
+step:816/1490 train_time:33572ms step_avg:41.14ms
+step:817/1490 train_time:33625ms step_avg:41.16ms
+step:818/1490 train_time:33685ms step_avg:41.18ms
+step:819/1490 train_time:33738ms step_avg:41.19ms
+step:820/1490 train_time:33796ms step_avg:41.21ms
+step:821/1490 train_time:33849ms step_avg:41.23ms
+step:822/1490 train_time:33908ms step_avg:41.25ms
+step:823/1490 train_time:33961ms step_avg:41.26ms
+step:824/1490 train_time:34020ms step_avg:41.29ms
+step:825/1490 train_time:34073ms step_avg:41.30ms
+step:826/1490 train_time:34132ms step_avg:41.32ms
+step:827/1490 train_time:34186ms step_avg:41.34ms
+step:828/1490 train_time:34244ms step_avg:41.36ms
+step:829/1490 train_time:34299ms step_avg:41.37ms
+step:830/1490 train_time:34357ms step_avg:41.39ms
+step:831/1490 train_time:34411ms step_avg:41.41ms
+step:832/1490 train_time:34469ms step_avg:41.43ms
+step:833/1490 train_time:34522ms step_avg:41.44ms
+step:834/1490 train_time:34581ms step_avg:41.46ms
+step:835/1490 train_time:34634ms step_avg:41.48ms
+step:836/1490 train_time:34693ms step_avg:41.50ms
+step:837/1490 train_time:34745ms step_avg:41.51ms
+step:838/1490 train_time:34803ms step_avg:41.53ms
+step:839/1490 train_time:34857ms step_avg:41.55ms
+step:840/1490 train_time:34915ms step_avg:41.57ms
+step:841/1490 train_time:34969ms step_avg:41.58ms
+step:842/1490 train_time:35028ms step_avg:41.60ms
+step:843/1490 train_time:35081ms step_avg:41.61ms
+step:844/1490 train_time:35140ms step_avg:41.64ms
+step:845/1490 train_time:35194ms step_avg:41.65ms
+step:846/1490 train_time:35252ms step_avg:41.67ms
+step:847/1490 train_time:35306ms step_avg:41.68ms
+step:848/1490 train_time:35365ms step_avg:41.70ms
+step:849/1490 train_time:35417ms step_avg:41.72ms
+step:850/1490 train_time:35476ms step_avg:41.74ms
+step:851/1490 train_time:35529ms step_avg:41.75ms
+step:852/1490 train_time:35588ms step_avg:41.77ms
+step:853/1490 train_time:35641ms step_avg:41.78ms
+step:854/1490 train_time:35699ms step_avg:41.80ms
+step:855/1490 train_time:35752ms step_avg:41.81ms
+step:856/1490 train_time:35810ms step_avg:41.83ms
+step:857/1490 train_time:35863ms step_avg:41.85ms
+step:858/1490 train_time:35922ms step_avg:41.87ms
+step:859/1490 train_time:35975ms step_avg:41.88ms
+step:860/1490 train_time:36034ms step_avg:41.90ms
+step:861/1490 train_time:36087ms step_avg:41.91ms
+step:862/1490 train_time:36146ms step_avg:41.93ms
+step:863/1490 train_time:36201ms step_avg:41.95ms
+step:864/1490 train_time:36260ms step_avg:41.97ms
+step:865/1490 train_time:36313ms step_avg:41.98ms
+step:866/1490 train_time:36372ms step_avg:42.00ms
+step:867/1490 train_time:36424ms step_avg:42.01ms
+step:868/1490 train_time:36483ms step_avg:42.03ms
+step:869/1490 train_time:36536ms step_avg:42.04ms
+step:870/1490 train_time:36595ms step_avg:42.06ms
+step:871/1490 train_time:36648ms step_avg:42.08ms
+step:872/1490 train_time:36707ms step_avg:42.10ms
+step:873/1490 train_time:36760ms step_avg:42.11ms
+step:874/1490 train_time:36818ms step_avg:42.13ms
+step:875/1490 train_time:36871ms step_avg:42.14ms
+step:876/1490 train_time:36930ms step_avg:42.16ms
+step:877/1490 train_time:36984ms step_avg:42.17ms
+step:878/1490 train_time:37043ms step_avg:42.19ms
+step:879/1490 train_time:37096ms step_avg:42.20ms
+step:880/1490 train_time:37154ms step_avg:42.22ms
+step:881/1490 train_time:37208ms step_avg:42.23ms
+step:882/1490 train_time:37267ms step_avg:42.25ms
+step:883/1490 train_time:37321ms step_avg:42.27ms
+step:884/1490 train_time:37379ms step_avg:42.28ms
+step:885/1490 train_time:37432ms step_avg:42.30ms
+step:886/1490 train_time:37491ms step_avg:42.31ms
+step:887/1490 train_time:37544ms step_avg:42.33ms
+step:888/1490 train_time:37603ms step_avg:42.35ms
+step:889/1490 train_time:37656ms step_avg:42.36ms
+step:890/1490 train_time:37715ms step_avg:42.38ms
+step:891/1490 train_time:37768ms step_avg:42.39ms
+step:892/1490 train_time:37827ms step_avg:42.41ms
+step:893/1490 train_time:37880ms step_avg:42.42ms
+step:894/1490 train_time:37938ms step_avg:42.44ms
+step:895/1490 train_time:37991ms step_avg:42.45ms
+step:896/1490 train_time:38050ms step_avg:42.47ms
+step:897/1490 train_time:38103ms step_avg:42.48ms
+step:898/1490 train_time:38163ms step_avg:42.50ms
+step:899/1490 train_time:38216ms step_avg:42.51ms
+step:900/1490 train_time:38275ms step_avg:42.53ms
+step:901/1490 train_time:38329ms step_avg:42.54ms
+step:902/1490 train_time:38388ms step_avg:42.56ms
+step:903/1490 train_time:38441ms step_avg:42.57ms
+step:904/1490 train_time:38500ms step_avg:42.59ms
+step:905/1490 train_time:38553ms step_avg:42.60ms
+step:906/1490 train_time:38611ms step_avg:42.62ms
+step:907/1490 train_time:38664ms step_avg:42.63ms
+step:908/1490 train_time:38723ms step_avg:42.65ms
+step:909/1490 train_time:38777ms step_avg:42.66ms
+step:910/1490 train_time:38835ms step_avg:42.68ms
+step:911/1490 train_time:38889ms step_avg:42.69ms
+step:912/1490 train_time:38948ms step_avg:42.71ms
+step:913/1490 train_time:39001ms step_avg:42.72ms
+step:914/1490 train_time:39059ms step_avg:42.73ms
+step:915/1490 train_time:39112ms step_avg:42.75ms
+step:916/1490 train_time:39171ms step_avg:42.76ms
+step:917/1490 train_time:39225ms step_avg:42.78ms
+step:918/1490 train_time:39284ms step_avg:42.79ms
+step:919/1490 train_time:39337ms step_avg:42.80ms
+step:920/1490 train_time:39395ms step_avg:42.82ms
+step:921/1490 train_time:39448ms step_avg:42.83ms
+step:922/1490 train_time:39507ms step_avg:42.85ms
+step:923/1490 train_time:39561ms step_avg:42.86ms
+step:924/1490 train_time:39619ms step_avg:42.88ms
+step:925/1490 train_time:39672ms step_avg:42.89ms
+step:926/1490 train_time:39730ms step_avg:42.91ms
+step:927/1490 train_time:39783ms step_avg:42.92ms
+step:928/1490 train_time:39842ms step_avg:42.93ms
+step:929/1490 train_time:39895ms step_avg:42.94ms
+step:930/1490 train_time:39953ms step_avg:42.96ms
+step:931/1490 train_time:40008ms step_avg:42.97ms
+step:932/1490 train_time:40067ms step_avg:42.99ms
+step:933/1490 train_time:40120ms step_avg:43.00ms
+step:934/1490 train_time:40178ms step_avg:43.02ms
+step:935/1490 train_time:40231ms step_avg:43.03ms
+step:936/1490 train_time:40290ms step_avg:43.05ms
+step:937/1490 train_time:40343ms step_avg:43.06ms
+step:938/1490 train_time:40402ms step_avg:43.07ms
+step:939/1490 train_time:40456ms step_avg:43.08ms
+step:940/1490 train_time:40514ms step_avg:43.10ms
+step:941/1490 train_time:40567ms step_avg:43.11ms
+step:942/1490 train_time:40626ms step_avg:43.13ms
+step:943/1490 train_time:40679ms step_avg:43.14ms
+step:944/1490 train_time:40738ms step_avg:43.15ms
+step:945/1490 train_time:40790ms step_avg:43.16ms
+step:946/1490 train_time:40849ms step_avg:43.18ms
+step:947/1490 train_time:40901ms step_avg:43.19ms
+step:948/1490 train_time:40960ms step_avg:43.21ms
+step:949/1490 train_time:41013ms step_avg:43.22ms
+step:950/1490 train_time:41072ms step_avg:43.23ms
+step:951/1490 train_time:41125ms step_avg:43.24ms
+step:952/1490 train_time:41185ms step_avg:43.26ms
+step:953/1490 train_time:41238ms step_avg:43.27ms
+step:954/1490 train_time:41296ms step_avg:43.29ms
+step:955/1490 train_time:41349ms step_avg:43.30ms
+step:956/1490 train_time:41408ms step_avg:43.31ms
+step:957/1490 train_time:41461ms step_avg:43.32ms
+step:958/1490 train_time:41520ms step_avg:43.34ms
+step:959/1490 train_time:41573ms step_avg:43.35ms
+step:960/1490 train_time:41632ms step_avg:43.37ms
+step:961/1490 train_time:41685ms step_avg:43.38ms
+step:962/1490 train_time:41743ms step_avg:43.39ms
+step:963/1490 train_time:41796ms step_avg:43.40ms
+step:964/1490 train_time:41855ms step_avg:43.42ms
+step:965/1490 train_time:41909ms step_avg:43.43ms
+step:966/1490 train_time:41968ms step_avg:43.45ms
+step:967/1490 train_time:42020ms step_avg:43.45ms
+step:968/1490 train_time:42082ms step_avg:43.47ms
+step:969/1490 train_time:42161ms step_avg:43.51ms
+step:970/1490 train_time:42245ms step_avg:43.55ms
+step:971/1490 train_time:42325ms step_avg:43.59ms
+step:972/1490 train_time:42409ms step_avg:43.63ms
+step:973/1490 train_time:42487ms step_avg:43.67ms
+step:974/1490 train_time:42571ms step_avg:43.71ms
+step:975/1490 train_time:42651ms step_avg:43.74ms
+step:976/1490 train_time:42734ms step_avg:43.79ms
+step:977/1490 train_time:42813ms step_avg:43.82ms
+step:978/1490 train_time:42896ms step_avg:43.86ms
+step:979/1490 train_time:42974ms step_avg:43.90ms
+step:980/1490 train_time:43058ms step_avg:43.94ms
+step:981/1490 train_time:43138ms step_avg:43.97ms
+step:982/1490 train_time:43222ms step_avg:44.01ms
+step:983/1490 train_time:43301ms step_avg:44.05ms
+step:984/1490 train_time:43385ms step_avg:44.09ms
+step:985/1490 train_time:43465ms step_avg:44.13ms
+step:986/1490 train_time:43550ms step_avg:44.17ms
+step:987/1490 train_time:43631ms step_avg:44.21ms
+step:988/1490 train_time:43714ms step_avg:44.25ms
+step:989/1490 train_time:43793ms step_avg:44.28ms
+step:990/1490 train_time:43877ms step_avg:44.32ms
+step:991/1490 train_time:43956ms step_avg:44.36ms
+step:992/1490 train_time:44040ms step_avg:44.39ms
+step:993/1490 train_time:44120ms step_avg:44.43ms
+step:994/1490 train_time:44205ms step_avg:44.47ms
+step:995/1490 train_time:44283ms step_avg:44.51ms
+step:996/1490 train_time:44367ms step_avg:44.55ms
+step:997/1490 train_time:44446ms step_avg:44.58ms
+step:998/1490 train_time:44530ms step_avg:44.62ms
+step:999/1490 train_time:44611ms step_avg:44.66ms
+step:1000/1490 train_time:44694ms step_avg:44.69ms
+step:1000/1490 val_loss:3.5152 train_time:44790ms step_avg:44.79ms
+step:1001/1490 train_time:44811ms step_avg:44.77ms
+step:1002/1490 train_time:44862ms step_avg:44.77ms
+step:1003/1490 train_time:44944ms step_avg:44.81ms
+step:1004/1490 train_time:45031ms step_avg:44.85ms
+step:1005/1490 train_time:45112ms step_avg:44.89ms
+step:1006/1490 train_time:45195ms step_avg:44.93ms
+step:1007/1490 train_time:45274ms step_avg:44.96ms
+step:1008/1490 train_time:45357ms step_avg:45.00ms
+step:1009/1490 train_time:45434ms step_avg:45.03ms
+step:1010/1490 train_time:45518ms step_avg:45.07ms
+step:1011/1490 train_time:45595ms step_avg:45.10ms
+step:1012/1490 train_time:45678ms step_avg:45.14ms
+step:1013/1490 train_time:45758ms step_avg:45.17ms
+step:1014/1490 train_time:45844ms step_avg:45.21ms
+step:1015/1490 train_time:45926ms step_avg:45.25ms
+step:1016/1490 train_time:46011ms step_avg:45.29ms
+step:1017/1490 train_time:46090ms step_avg:45.32ms
+step:1018/1490 train_time:46179ms step_avg:45.36ms
+step:1019/1490 train_time:46253ms step_avg:45.39ms
+step:1020/1490 train_time:46337ms step_avg:45.43ms
+step:1021/1490 train_time:46415ms step_avg:45.46ms
+step:1022/1490 train_time:46499ms step_avg:45.50ms
+step:1023/1490 train_time:46577ms step_avg:45.53ms
+step:1024/1490 train_time:46661ms step_avg:45.57ms
+step:1025/1490 train_time:46739ms step_avg:45.60ms
+step:1026/1490 train_time:46824ms step_avg:45.64ms
+step:1027/1490 train_time:46903ms step_avg:45.67ms
+step:1028/1490 train_time:46989ms step_avg:45.71ms
+step:1029/1490 train_time:47069ms step_avg:45.74ms
+step:1030/1490 train_time:47152ms step_avg:45.78ms
+step:1031/1490 train_time:47232ms step_avg:45.81ms
+step:1032/1490 train_time:47316ms step_avg:45.85ms
+step:1033/1490 train_time:47394ms step_avg:45.88ms
+step:1034/1490 train_time:47477ms step_avg:45.92ms
+step:1035/1490 train_time:47555ms step_avg:45.95ms
+step:1036/1490 train_time:47640ms step_avg:45.98ms
+step:1037/1490 train_time:47719ms step_avg:46.02ms
+step:1038/1490 train_time:47802ms step_avg:46.05ms
+step:1039/1490 train_time:47882ms step_avg:46.08ms
+step:1040/1490 train_time:47968ms step_avg:46.12ms
+step:1041/1490 train_time:48046ms step_avg:46.15ms
+step:1042/1490 train_time:48130ms step_avg:46.19ms
+step:1043/1490 train_time:48209ms step_avg:46.22ms
+step:1044/1490 train_time:48294ms step_avg:46.26ms
+step:1045/1490 train_time:48372ms step_avg:46.29ms
+step:1046/1490 train_time:48455ms step_avg:46.32ms
+step:1047/1490 train_time:48534ms step_avg:46.36ms
+step:1048/1490 train_time:48618ms step_avg:46.39ms
+step:1049/1490 train_time:48696ms step_avg:46.42ms
+step:1050/1490 train_time:48782ms step_avg:46.46ms
+step:1051/1490 train_time:48862ms step_avg:46.49ms
+step:1052/1490 train_time:48946ms step_avg:46.53ms
+step:1053/1490 train_time:49025ms step_avg:46.56ms
+step:1054/1490 train_time:49109ms step_avg:46.59ms
+step:1055/1490 train_time:49188ms step_avg:46.62ms
+step:1056/1490 train_time:49272ms step_avg:46.66ms
+step:1057/1490 train_time:49351ms step_avg:46.69ms
+step:1058/1490 train_time:49436ms step_avg:46.73ms
+step:1059/1490 train_time:49515ms step_avg:46.76ms
+step:1060/1490 train_time:49598ms step_avg:46.79ms
+step:1061/1490 train_time:49678ms step_avg:46.82ms
+step:1062/1490 train_time:49764ms step_avg:46.86ms
+step:1063/1490 train_time:49843ms step_avg:46.89ms
+step:1064/1490 train_time:49928ms step_avg:46.92ms
+step:1065/1490 train_time:50007ms step_avg:46.95ms
+step:1066/1490 train_time:50091ms step_avg:46.99ms
+step:1067/1490 train_time:50171ms step_avg:47.02ms
+step:1068/1490 train_time:50255ms step_avg:47.06ms
+step:1069/1490 train_time:50333ms step_avg:47.08ms
+step:1070/1490 train_time:50417ms step_avg:47.12ms
+step:1071/1490 train_time:50495ms step_avg:47.15ms
+step:1072/1490 train_time:50579ms step_avg:47.18ms
+step:1073/1490 train_time:50659ms step_avg:47.21ms
+step:1074/1490 train_time:50744ms step_avg:47.25ms
+step:1075/1490 train_time:50823ms step_avg:47.28ms
+step:1076/1490 train_time:50907ms step_avg:47.31ms
+step:1077/1490 train_time:50985ms step_avg:47.34ms
+step:1078/1490 train_time:51070ms step_avg:47.38ms
+step:1079/1490 train_time:51149ms step_avg:47.40ms
+step:1080/1490 train_time:51232ms step_avg:47.44ms
+step:1081/1490 train_time:51311ms step_avg:47.47ms
+step:1082/1490 train_time:51395ms step_avg:47.50ms
+step:1083/1490 train_time:51475ms step_avg:47.53ms
+step:1084/1490 train_time:51559ms step_avg:47.56ms
+step:1085/1490 train_time:51639ms step_avg:47.59ms
+step:1086/1490 train_time:51723ms step_avg:47.63ms
+step:1087/1490 train_time:51802ms step_avg:47.66ms
+step:1088/1490 train_time:51886ms step_avg:47.69ms
+step:1089/1490 train_time:51965ms step_avg:47.72ms
+step:1090/1490 train_time:52049ms step_avg:47.75ms
+step:1091/1490 train_time:52126ms step_avg:47.78ms
+step:1092/1490 train_time:52210ms step_avg:47.81ms
+step:1093/1490 train_time:52289ms step_avg:47.84ms
+step:1094/1490 train_time:52374ms step_avg:47.87ms
+step:1095/1490 train_time:52453ms step_avg:47.90ms
+step:1096/1490 train_time:52538ms step_avg:47.94ms
+step:1097/1490 train_time:52619ms step_avg:47.97ms
+step:1098/1490 train_time:52703ms step_avg:48.00ms
+step:1099/1490 train_time:52783ms step_avg:48.03ms
+step:1100/1490 train_time:52868ms step_avg:48.06ms
+step:1101/1490 train_time:52947ms step_avg:48.09ms
+step:1102/1490 train_time:53031ms step_avg:48.12ms
+step:1103/1490 train_time:53110ms step_avg:48.15ms
+step:1104/1490 train_time:53194ms step_avg:48.18ms
+step:1105/1490 train_time:53272ms step_avg:48.21ms
+step:1106/1490 train_time:53356ms step_avg:48.24ms
+step:1107/1490 train_time:53436ms step_avg:48.27ms
+step:1108/1490 train_time:53521ms step_avg:48.30ms
+step:1109/1490 train_time:53600ms step_avg:48.33ms
+step:1110/1490 train_time:53684ms step_avg:48.36ms
+step:1111/1490 train_time:53765ms step_avg:48.39ms
+step:1112/1490 train_time:53849ms step_avg:48.43ms
+step:1113/1490 train_time:53929ms step_avg:48.45ms
+step:1114/1490 train_time:54012ms step_avg:48.48ms
+step:1115/1490 train_time:54090ms step_avg:48.51ms
+step:1116/1490 train_time:54174ms step_avg:48.54ms
+step:1117/1490 train_time:54253ms step_avg:48.57ms
+step:1118/1490 train_time:54337ms step_avg:48.60ms
+step:1119/1490 train_time:54417ms step_avg:48.63ms
+step:1120/1490 train_time:54501ms step_avg:48.66ms
+step:1121/1490 train_time:54580ms step_avg:48.69ms
+step:1122/1490 train_time:54665ms step_avg:48.72ms
+step:1123/1490 train_time:54744ms step_avg:48.75ms
+step:1124/1490 train_time:54829ms step_avg:48.78ms
+step:1125/1490 train_time:54906ms step_avg:48.81ms
+step:1126/1490 train_time:54990ms step_avg:48.84ms
+step:1127/1490 train_time:55069ms step_avg:48.86ms
+step:1128/1490 train_time:55152ms step_avg:48.89ms
+step:1129/1490 train_time:55231ms step_avg:48.92ms
+step:1130/1490 train_time:55315ms step_avg:48.95ms
+step:1131/1490 train_time:55395ms step_avg:48.98ms
+step:1132/1490 train_time:55478ms step_avg:49.01ms
+step:1133/1490 train_time:55558ms step_avg:49.04ms
+step:1134/1490 train_time:55644ms step_avg:49.07ms
+step:1135/1490 train_time:55722ms step_avg:49.09ms
+step:1136/1490 train_time:55806ms step_avg:49.12ms
+step:1137/1490 train_time:55883ms step_avg:49.15ms
+step:1138/1490 train_time:55969ms step_avg:49.18ms
+step:1139/1490 train_time:56048ms step_avg:49.21ms
+step:1140/1490 train_time:56133ms step_avg:49.24ms
+step:1141/1490 train_time:56212ms step_avg:49.27ms
+step:1142/1490 train_time:56295ms step_avg:49.30ms
+step:1143/1490 train_time:56374ms step_avg:49.32ms
+step:1144/1490 train_time:56460ms step_avg:49.35ms
+step:1145/1490 train_time:56540ms step_avg:49.38ms
+step:1146/1490 train_time:56625ms step_avg:49.41ms
+step:1147/1490 train_time:56703ms step_avg:49.44ms
+step:1148/1490 train_time:56787ms step_avg:49.47ms
+step:1149/1490 train_time:56868ms step_avg:49.49ms
+step:1150/1490 train_time:56951ms step_avg:49.52ms
+step:1151/1490 train_time:57030ms step_avg:49.55ms
+step:1152/1490 train_time:57115ms step_avg:49.58ms
+step:1153/1490 train_time:57193ms step_avg:49.60ms
+step:1154/1490 train_time:57278ms step_avg:49.63ms
+step:1155/1490 train_time:57357ms step_avg:49.66ms
+step:1156/1490 train_time:57442ms step_avg:49.69ms
+step:1157/1490 train_time:57522ms step_avg:49.72ms
+step:1158/1490 train_time:57605ms step_avg:49.75ms
+step:1159/1490 train_time:57684ms step_avg:49.77ms
+step:1160/1490 train_time:57769ms step_avg:49.80ms
+step:1161/1490 train_time:57849ms step_avg:49.83ms
+step:1162/1490 train_time:57933ms step_avg:49.86ms
+step:1163/1490 train_time:58011ms step_avg:49.88ms
+step:1164/1490 train_time:58094ms step_avg:49.91ms
+step:1165/1490 train_time:58174ms step_avg:49.93ms
+step:1166/1490 train_time:58259ms step_avg:49.96ms
+step:1167/1490 train_time:58338ms step_avg:49.99ms
+step:1168/1490 train_time:58424ms step_avg:50.02ms
+step:1169/1490 train_time:58502ms step_avg:50.04ms
+step:1170/1490 train_time:58586ms step_avg:50.07ms
+step:1171/1490 train_time:58666ms step_avg:50.10ms
+step:1172/1490 train_time:58750ms step_avg:50.13ms
+step:1173/1490 train_time:58829ms step_avg:50.15ms
+step:1174/1490 train_time:58913ms step_avg:50.18ms
+step:1175/1490 train_time:58992ms step_avg:50.21ms
+step:1176/1490 train_time:59076ms step_avg:50.23ms
+step:1177/1490 train_time:59155ms step_avg:50.26ms
+step:1178/1490 train_time:59240ms step_avg:50.29ms
+step:1179/1490 train_time:59319ms step_avg:50.31ms
+step:1180/1490 train_time:59404ms step_avg:50.34ms
+step:1181/1490 train_time:59483ms step_avg:50.37ms
+step:1182/1490 train_time:59569ms step_avg:50.40ms
+step:1183/1490 train_time:59648ms step_avg:50.42ms
+step:1184/1490 train_time:59732ms step_avg:50.45ms
+step:1185/1490 train_time:59811ms step_avg:50.47ms
+step:1186/1490 train_time:59895ms step_avg:50.50ms
+step:1187/1490 train_time:59973ms step_avg:50.52ms
+step:1188/1490 train_time:60057ms step_avg:50.55ms
+step:1189/1490 train_time:60137ms step_avg:50.58ms
+step:1190/1490 train_time:60223ms step_avg:50.61ms
+step:1191/1490 train_time:60300ms step_avg:50.63ms
+step:1192/1490 train_time:60383ms step_avg:50.66ms
+step:1193/1490 train_time:60462ms step_avg:50.68ms
+step:1194/1490 train_time:60548ms step_avg:50.71ms
+step:1195/1490 train_time:60628ms step_avg:50.73ms
+step:1196/1490 train_time:60711ms step_avg:50.76ms
+step:1197/1490 train_time:60789ms step_avg:50.78ms
+step:1198/1490 train_time:60873ms step_avg:50.81ms
+step:1199/1490 train_time:60952ms step_avg:50.84ms
+step:1200/1490 train_time:61038ms step_avg:50.86ms
+step:1201/1490 train_time:61117ms step_avg:50.89ms
+step:1202/1490 train_time:61201ms step_avg:50.92ms
+step:1203/1490 train_time:61280ms step_avg:50.94ms
+step:1204/1490 train_time:61365ms step_avg:50.97ms
+step:1205/1490 train_time:61444ms step_avg:50.99ms
+step:1206/1490 train_time:61528ms step_avg:51.02ms
+step:1207/1490 train_time:61607ms step_avg:51.04ms
+step:1208/1490 train_time:61691ms step_avg:51.07ms
+step:1209/1490 train_time:61771ms step_avg:51.09ms
+step:1210/1490 train_time:61854ms step_avg:51.12ms
+step:1211/1490 train_time:61935ms step_avg:51.14ms
+step:1212/1490 train_time:62019ms step_avg:51.17ms
+step:1213/1490 train_time:62099ms step_avg:51.19ms
+step:1214/1490 train_time:62183ms step_avg:51.22ms
+step:1215/1490 train_time:62263ms step_avg:51.24ms
+step:1216/1490 train_time:62347ms step_avg:51.27ms
+step:1217/1490 train_time:62424ms step_avg:51.29ms
+step:1218/1490 train_time:62508ms step_avg:51.32ms
+step:1219/1490 train_time:62587ms step_avg:51.34ms
+step:1220/1490 train_time:62670ms step_avg:51.37ms
+step:1221/1490 train_time:62749ms step_avg:51.39ms
+step:1222/1490 train_time:62833ms step_avg:51.42ms
+step:1223/1490 train_time:62912ms step_avg:51.44ms
+step:1224/1490 train_time:62997ms step_avg:51.47ms
+step:1225/1490 train_time:63076ms step_avg:51.49ms
+step:1226/1490 train_time:63161ms step_avg:51.52ms
+step:1227/1490 train_time:63241ms step_avg:51.54ms
+step:1228/1490 train_time:63324ms step_avg:51.57ms
+step:1229/1490 train_time:63403ms step_avg:51.59ms
+step:1230/1490 train_time:63487ms step_avg:51.62ms
+step:1231/1490 train_time:63566ms step_avg:51.64ms
+step:1232/1490 train_time:63650ms step_avg:51.66ms
+step:1233/1490 train_time:63728ms step_avg:51.69ms
+step:1234/1490 train_time:63812ms step_avg:51.71ms
+step:1235/1490 train_time:63890ms step_avg:51.73ms
+step:1236/1490 train_time:63975ms step_avg:51.76ms
+step:1237/1490 train_time:64055ms step_avg:51.78ms
+step:1238/1490 train_time:64140ms step_avg:51.81ms
+step:1239/1490 train_time:64220ms step_avg:51.83ms
+step:1240/1490 train_time:64303ms step_avg:51.86ms
+step:1241/1490 train_time:64382ms step_avg:51.88ms
+step:1242/1490 train_time:64467ms step_avg:51.91ms
+step:1243/1490 train_time:64547ms step_avg:51.93ms
+step:1244/1490 train_time:64631ms step_avg:51.95ms
+step:1245/1490 train_time:64710ms step_avg:51.98ms
+step:1246/1490 train_time:64792ms step_avg:52.00ms
+step:1247/1490 train_time:64871ms step_avg:52.02ms
+step:1248/1490 train_time:64957ms step_avg:52.05ms
+step:1249/1490 train_time:65036ms step_avg:52.07ms
+step:1250/1490 train_time:65121ms step_avg:52.10ms
+step:1250/1490 val_loss:3.3696 train_time:65217ms step_avg:52.17ms
+step:1251/1490 train_time:65235ms step_avg:52.15ms
+step:1252/1490 train_time:65289ms step_avg:52.15ms
+step:1253/1490 train_time:65370ms step_avg:52.17ms
+step:1254/1490 train_time:65457ms step_avg:52.20ms
+step:1255/1490 train_time:65535ms step_avg:52.22ms
+step:1256/1490 train_time:65620ms step_avg:52.25ms
+step:1257/1490 train_time:65698ms step_avg:52.27ms
+step:1258/1490 train_time:65781ms step_avg:52.29ms
+step:1259/1490 train_time:65858ms step_avg:52.31ms
+step:1260/1490 train_time:65941ms step_avg:52.33ms
+step:1261/1490 train_time:66018ms step_avg:52.35ms
+step:1262/1490 train_time:66101ms step_avg:52.38ms
+step:1263/1490 train_time:66180ms step_avg:52.40ms
+step:1264/1490 train_time:66266ms step_avg:52.43ms
+step:1265/1490 train_time:66351ms step_avg:52.45ms
+step:1266/1490 train_time:66436ms step_avg:52.48ms
+step:1267/1490 train_time:66515ms step_avg:52.50ms
+step:1268/1490 train_time:66599ms step_avg:52.52ms
+step:1269/1490 train_time:66678ms step_avg:52.54ms
+step:1270/1490 train_time:66762ms step_avg:52.57ms
+step:1271/1490 train_time:66841ms step_avg:52.59ms
+step:1272/1490 train_time:66924ms step_avg:52.61ms
+step:1273/1490 train_time:67001ms step_avg:52.63ms
+step:1274/1490 train_time:67084ms step_avg:52.66ms
+step:1275/1490 train_time:67162ms step_avg:52.68ms
+step:1276/1490 train_time:67249ms step_avg:52.70ms
+step:1277/1490 train_time:67329ms step_avg:52.72ms
+step:1278/1490 train_time:67415ms step_avg:52.75ms
+step:1279/1490 train_time:67494ms step_avg:52.77ms
+step:1280/1490 train_time:67580ms step_avg:52.80ms
+step:1281/1490 train_time:67658ms step_avg:52.82ms
+step:1282/1490 train_time:67743ms step_avg:52.84ms
+step:1283/1490 train_time:67820ms step_avg:52.86ms
+step:1284/1490 train_time:67904ms step_avg:52.88ms
+step:1285/1490 train_time:67983ms step_avg:52.90ms
+step:1286/1490 train_time:68066ms step_avg:52.93ms
+step:1287/1490 train_time:68145ms step_avg:52.95ms
+step:1288/1490 train_time:68230ms step_avg:52.97ms
+step:1289/1490 train_time:68310ms step_avg:52.99ms
+step:1290/1490 train_time:68395ms step_avg:53.02ms
+step:1291/1490 train_time:68474ms step_avg:53.04ms
+step:1292/1490 train_time:68559ms step_avg:53.06ms
+step:1293/1490 train_time:68639ms step_avg:53.08ms
+step:1294/1490 train_time:68722ms step_avg:53.11ms
+step:1295/1490 train_time:68800ms step_avg:53.13ms
+step:1296/1490 train_time:68883ms step_avg:53.15ms
+step:1297/1490 train_time:68962ms step_avg:53.17ms
+step:1298/1490 train_time:69045ms step_avg:53.19ms
+step:1299/1490 train_time:69125ms step_avg:53.21ms
+step:1300/1490 train_time:69210ms step_avg:53.24ms
+step:1301/1490 train_time:69291ms step_avg:53.26ms
+step:1302/1490 train_time:69376ms step_avg:53.28ms
+step:1303/1490 train_time:69455ms step_avg:53.30ms
+step:1304/1490 train_time:69540ms step_avg:53.33ms
+step:1305/1490 train_time:69618ms step_avg:53.35ms
+step:1306/1490 train_time:69702ms step_avg:53.37ms
+step:1307/1490 train_time:69782ms step_avg:53.39ms
+step:1308/1490 train_time:69866ms step_avg:53.41ms
+step:1309/1490 train_time:69944ms step_avg:53.43ms
+step:1310/1490 train_time:70028ms step_avg:53.46ms
+step:1311/1490 train_time:70107ms step_avg:53.48ms
+step:1312/1490 train_time:70191ms step_avg:53.50ms
+step:1313/1490 train_time:70272ms step_avg:53.52ms
+step:1314/1490 train_time:70356ms step_avg:53.54ms
+step:1315/1490 train_time:70435ms step_avg:53.56ms
+step:1316/1490 train_time:70520ms step_avg:53.59ms
+step:1317/1490 train_time:70599ms step_avg:53.61ms
+step:1318/1490 train_time:70683ms step_avg:53.63ms
+step:1319/1490 train_time:70762ms step_avg:53.65ms
+step:1320/1490 train_time:70848ms step_avg:53.67ms
+step:1321/1490 train_time:70927ms step_avg:53.69ms
+step:1322/1490 train_time:71010ms step_avg:53.71ms
+step:1323/1490 train_time:71088ms step_avg:53.73ms
+step:1324/1490 train_time:71174ms step_avg:53.76ms
+step:1325/1490 train_time:71254ms step_avg:53.78ms
+step:1326/1490 train_time:71339ms step_avg:53.80ms
+step:1327/1490 train_time:71419ms step_avg:53.82ms
+step:1328/1490 train_time:71503ms step_avg:53.84ms
+step:1329/1490 train_time:71582ms step_avg:53.86ms
+step:1330/1490 train_time:71665ms step_avg:53.88ms
+step:1331/1490 train_time:71745ms step_avg:53.90ms
+step:1332/1490 train_time:71830ms step_avg:53.93ms
+step:1333/1490 train_time:71908ms step_avg:53.94ms
+step:1334/1490 train_time:71992ms step_avg:53.97ms
+step:1335/1490 train_time:72071ms step_avg:53.99ms
+step:1336/1490 train_time:72156ms step_avg:54.01ms
+step:1337/1490 train_time:72235ms step_avg:54.03ms
+step:1338/1490 train_time:72320ms step_avg:54.05ms
+step:1339/1490 train_time:72398ms step_avg:54.07ms
+step:1340/1490 train_time:72483ms step_avg:54.09ms
+step:1341/1490 train_time:72562ms step_avg:54.11ms
+step:1342/1490 train_time:72646ms step_avg:54.13ms
+step:1343/1490 train_time:72726ms step_avg:54.15ms
+step:1344/1490 train_time:72810ms step_avg:54.17ms
+step:1345/1490 train_time:72888ms step_avg:54.19ms
+step:1346/1490 train_time:72974ms step_avg:54.22ms
+step:1347/1490 train_time:73052ms step_avg:54.23ms
+step:1348/1490 train_time:73137ms step_avg:54.26ms
+step:1349/1490 train_time:73216ms step_avg:54.27ms
+step:1350/1490 train_time:73299ms step_avg:54.30ms
+step:1351/1490 train_time:73379ms step_avg:54.31ms
+step:1352/1490 train_time:73463ms step_avg:54.34ms
+step:1353/1490 train_time:73542ms step_avg:54.35ms
+step:1354/1490 train_time:73627ms step_avg:54.38ms
+step:1355/1490 train_time:73705ms step_avg:54.39ms
+step:1356/1490 train_time:73789ms step_avg:54.42ms
+step:1357/1490 train_time:73869ms step_avg:54.44ms
+step:1358/1490 train_time:73953ms step_avg:54.46ms
+step:1359/1490 train_time:74032ms step_avg:54.48ms
+step:1360/1490 train_time:74116ms step_avg:54.50ms
+step:1361/1490 train_time:74194ms step_avg:54.51ms
+step:1362/1490 train_time:74279ms step_avg:54.54ms
+step:1363/1490 train_time:74358ms step_avg:54.55ms
+step:1364/1490 train_time:74442ms step_avg:54.58ms
+step:1365/1490 train_time:74522ms step_avg:54.60ms
+step:1366/1490 train_time:74607ms step_avg:54.62ms
+step:1367/1490 train_time:74686ms step_avg:54.64ms
+step:1368/1490 train_time:74771ms step_avg:54.66ms
+step:1369/1490 train_time:74850ms step_avg:54.68ms
+step:1370/1490 train_time:74935ms step_avg:54.70ms
+step:1371/1490 train_time:75014ms step_avg:54.71ms
+step:1372/1490 train_time:75097ms step_avg:54.74ms
+step:1373/1490 train_time:75176ms step_avg:54.75ms
+step:1374/1490 train_time:75259ms step_avg:54.77ms
+step:1375/1490 train_time:75337ms step_avg:54.79ms
+step:1376/1490 train_time:75421ms step_avg:54.81ms
+step:1377/1490 train_time:75500ms step_avg:54.83ms
+step:1378/1490 train_time:75583ms step_avg:54.85ms
+step:1379/1490 train_time:75664ms step_avg:54.87ms
+step:1380/1490 train_time:75750ms step_avg:54.89ms
+step:1381/1490 train_time:75829ms step_avg:54.91ms
+step:1382/1490 train_time:75913ms step_avg:54.93ms
+step:1383/1490 train_time:75993ms step_avg:54.95ms
+step:1384/1490 train_time:76078ms step_avg:54.97ms
+step:1385/1490 train_time:76156ms step_avg:54.99ms
+step:1386/1490 train_time:76241ms step_avg:55.01ms
+step:1387/1490 train_time:76318ms step_avg:55.02ms
+step:1388/1490 train_time:76403ms step_avg:55.05ms
+step:1389/1490 train_time:76483ms step_avg:55.06ms
+step:1390/1490 train_time:76567ms step_avg:55.08ms
+step:1391/1490 train_time:76646ms step_avg:55.10ms
+step:1392/1490 train_time:76730ms step_avg:55.12ms
+step:1393/1490 train_time:76808ms step_avg:55.14ms
+step:1394/1490 train_time:76893ms step_avg:55.16ms
+step:1395/1490 train_time:76973ms step_avg:55.18ms
+step:1396/1490 train_time:77057ms step_avg:55.20ms
+step:1397/1490 train_time:77136ms step_avg:55.22ms
+step:1398/1490 train_time:77220ms step_avg:55.24ms
+step:1399/1490 train_time:77300ms step_avg:55.25ms
+step:1400/1490 train_time:77383ms step_avg:55.27ms
+step:1401/1490 train_time:77461ms step_avg:55.29ms
+step:1402/1490 train_time:77547ms step_avg:55.31ms
+step:1403/1490 train_time:77627ms step_avg:55.33ms
+step:1404/1490 train_time:77711ms step_avg:55.35ms
+step:1405/1490 train_time:77790ms step_avg:55.37ms
+step:1406/1490 train_time:77874ms step_avg:55.39ms
+step:1407/1490 train_time:77954ms step_avg:55.40ms
+step:1408/1490 train_time:78038ms step_avg:55.43ms
+step:1409/1490 train_time:78117ms step_avg:55.44ms
+step:1410/1490 train_time:78200ms step_avg:55.46ms
+step:1411/1490 train_time:78280ms step_avg:55.48ms
+step:1412/1490 train_time:78362ms step_avg:55.50ms
+step:1413/1490 train_time:78442ms step_avg:55.51ms
+step:1414/1490 train_time:78528ms step_avg:55.54ms
+step:1415/1490 train_time:78607ms step_avg:55.55ms
+step:1416/1490 train_time:78691ms step_avg:55.57ms
+step:1417/1490 train_time:78772ms step_avg:55.59ms
+step:1418/1490 train_time:78855ms step_avg:55.61ms
+step:1419/1490 train_time:78934ms step_avg:55.63ms
+step:1420/1490 train_time:79017ms step_avg:55.65ms
+step:1421/1490 train_time:79095ms step_avg:55.66ms
+step:1422/1490 train_time:79181ms step_avg:55.68ms
+step:1423/1490 train_time:79260ms step_avg:55.70ms
+step:1424/1490 train_time:79343ms step_avg:55.72ms
+step:1425/1490 train_time:79423ms step_avg:55.74ms
+step:1426/1490 train_time:79506ms step_avg:55.75ms
+step:1427/1490 train_time:79586ms step_avg:55.77ms
+step:1428/1490 train_time:79670ms step_avg:55.79ms
+step:1429/1490 train_time:79750ms step_avg:55.81ms
+step:1430/1490 train_time:79835ms step_avg:55.83ms
+step:1431/1490 train_time:79914ms step_avg:55.85ms
+step:1432/1490 train_time:79998ms step_avg:55.86ms
+step:1433/1490 train_time:80077ms step_avg:55.88ms
+step:1434/1490 train_time:80161ms step_avg:55.90ms
+step:1435/1490 train_time:80239ms step_avg:55.92ms
+step:1436/1490 train_time:80324ms step_avg:55.94ms
+step:1437/1490 train_time:80402ms step_avg:55.95ms
+step:1438/1490 train_time:80486ms step_avg:55.97ms
+step:1439/1490 train_time:80566ms step_avg:55.99ms
+step:1440/1490 train_time:80651ms step_avg:56.01ms
+step:1441/1490 train_time:80731ms step_avg:56.02ms
+step:1442/1490 train_time:80815ms step_avg:56.04ms
+step:1443/1490 train_time:80894ms step_avg:56.06ms
+step:1444/1490 train_time:80980ms step_avg:56.08ms
+step:1445/1490 train_time:81058ms step_avg:56.10ms
+step:1446/1490 train_time:81143ms step_avg:56.12ms
+step:1447/1490 train_time:81221ms step_avg:56.13ms
+step:1448/1490 train_time:81304ms step_avg:56.15ms
+step:1449/1490 train_time:81384ms step_avg:56.17ms
+step:1450/1490 train_time:81469ms step_avg:56.19ms
+step:1451/1490 train_time:81553ms step_avg:56.20ms
+step:1452/1490 train_time:81640ms step_avg:56.23ms
+step:1453/1490 train_time:81719ms step_avg:56.24ms
+step:1454/1490 train_time:81803ms step_avg:56.26ms
+step:1455/1490 train_time:81884ms step_avg:56.28ms
+step:1456/1490 train_time:81969ms step_avg:56.30ms
+step:1457/1490 train_time:82048ms step_avg:56.31ms
+step:1458/1490 train_time:82134ms step_avg:56.33ms
+step:1459/1490 train_time:82211ms step_avg:56.35ms
+step:1460/1490 train_time:82296ms step_avg:56.37ms
+step:1461/1490 train_time:82374ms step_avg:56.38ms
+step:1462/1490 train_time:82459ms step_avg:56.40ms
+step:1463/1490 train_time:82539ms step_avg:56.42ms
+step:1464/1490 train_time:82623ms step_avg:56.44ms
+step:1465/1490 train_time:82704ms step_avg:56.45ms
+step:1466/1490 train_time:82789ms step_avg:56.47ms
+step:1467/1490 train_time:82869ms step_avg:56.49ms
+step:1468/1490 train_time:82954ms step_avg:56.51ms
+step:1469/1490 train_time:83034ms step_avg:56.52ms
+step:1470/1490 train_time:83117ms step_avg:56.54ms
+step:1471/1490 train_time:83195ms step_avg:56.56ms
+step:1472/1490 train_time:83279ms step_avg:56.58ms
+step:1473/1490 train_time:83358ms step_avg:56.59ms
+step:1474/1490 train_time:83443ms step_avg:56.61ms
+step:1475/1490 train_time:83524ms step_avg:56.63ms
+step:1476/1490 train_time:83608ms step_avg:56.64ms
+step:1477/1490 train_time:83686ms step_avg:56.66ms
+step:1478/1490 train_time:83773ms step_avg:56.68ms
+step:1479/1490 train_time:83852ms step_avg:56.70ms
+step:1480/1490 train_time:83937ms step_avg:56.71ms
+step:1481/1490 train_time:84016ms step_avg:56.73ms
+step:1482/1490 train_time:84100ms step_avg:56.75ms
+step:1483/1490 train_time:84180ms step_avg:56.76ms
+step:1484/1490 train_time:84263ms step_avg:56.78ms
+step:1485/1490 train_time:84343ms step_avg:56.80ms
+step:1486/1490 train_time:84428ms step_avg:56.82ms
+step:1487/1490 train_time:84507ms step_avg:56.83ms
+step:1488/1490 train_time:84592ms step_avg:56.85ms
+step:1489/1490 train_time:84671ms step_avg:56.86ms
+step:1490/1490 train_time:84756ms step_avg:56.88ms
+step:1490/1490 val_loss:3.2776 train_time:84854ms step_avg:56.95ms
+peak memory allocated: 31276 MiB reserved: 46026 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/a868dddb-edaf-4140-99e1-bce57e553218.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/a868dddb-edaf-4140-99e1-bce57e553218.txt
@@ -1,0 +1,4571 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 13:01:13 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   31C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8312 train_time:0ms step_avg:0.06ms
+step:1/1490 train_time:83ms step_avg:82.66ms
+step:2/1490 train_time:107ms step_avg:53.26ms
+step:3/1490 train_time:124ms step_avg:41.22ms
+step:4/1490 train_time:144ms step_avg:36.01ms
+step:5/1490 train_time:171ms step_avg:34.14ms
+step:6/1490 train_time:206ms step_avg:34.32ms
+step:7/1490 train_time:233ms step_avg:33.23ms
+step:8/1490 train_time:267ms step_avg:33.37ms
+step:9/1490 train_time:294ms step_avg:32.69ms
+step:10/1490 train_time:329ms step_avg:32.86ms
+step:11/1490 train_time:356ms step_avg:32.35ms
+step:12/1490 train_time:390ms step_avg:32.53ms
+step:13/1490 train_time:421ms step_avg:32.39ms
+step:14/1490 train_time:452ms step_avg:32.32ms
+step:15/1490 train_time:479ms step_avg:31.96ms
+step:16/1490 train_time:514ms step_avg:32.10ms
+step:17/1490 train_time:541ms step_avg:31.81ms
+step:18/1490 train_time:575ms step_avg:31.95ms
+step:19/1490 train_time:603ms step_avg:31.72ms
+step:20/1490 train_time:637ms step_avg:31.86ms
+step:21/1490 train_time:665ms step_avg:31.64ms
+step:22/1490 train_time:699ms step_avg:31.79ms
+step:23/1490 train_time:727ms step_avg:31.59ms
+step:24/1490 train_time:761ms step_avg:31.69ms
+step:25/1490 train_time:788ms step_avg:31.52ms
+step:26/1490 train_time:824ms step_avg:31.68ms
+step:27/1490 train_time:850ms step_avg:31.46ms
+step:28/1490 train_time:884ms step_avg:31.57ms
+step:29/1490 train_time:911ms step_avg:31.43ms
+step:30/1490 train_time:946ms step_avg:31.53ms
+step:31/1490 train_time:973ms step_avg:31.40ms
+step:32/1490 train_time:1008ms step_avg:31.50ms
+step:33/1490 train_time:1037ms step_avg:31.42ms
+step:34/1490 train_time:1072ms step_avg:31.52ms
+step:35/1490 train_time:1100ms step_avg:31.42ms
+step:36/1490 train_time:1134ms step_avg:31.51ms
+step:37/1490 train_time:1162ms step_avg:31.40ms
+step:38/1490 train_time:1196ms step_avg:31.48ms
+step:39/1490 train_time:1224ms step_avg:31.38ms
+step:40/1490 train_time:1259ms step_avg:31.46ms
+step:41/1490 train_time:1286ms step_avg:31.36ms
+step:42/1490 train_time:1320ms step_avg:31.43ms
+step:43/1490 train_time:1348ms step_avg:31.34ms
+step:44/1490 train_time:1382ms step_avg:31.41ms
+step:45/1490 train_time:1410ms step_avg:31.33ms
+step:46/1490 train_time:1444ms step_avg:31.40ms
+step:47/1490 train_time:1472ms step_avg:31.33ms
+step:48/1490 train_time:1506ms step_avg:31.39ms
+step:49/1490 train_time:1534ms step_avg:31.31ms
+step:50/1490 train_time:1569ms step_avg:31.37ms
+step:51/1490 train_time:1596ms step_avg:31.29ms
+step:52/1490 train_time:1630ms step_avg:31.35ms
+step:53/1490 train_time:1658ms step_avg:31.28ms
+step:54/1490 train_time:1692ms step_avg:31.33ms
+step:55/1490 train_time:1720ms step_avg:31.27ms
+step:56/1490 train_time:1754ms step_avg:31.32ms
+step:57/1490 train_time:1781ms step_avg:31.25ms
+step:58/1490 train_time:1816ms step_avg:31.30ms
+step:59/1490 train_time:1843ms step_avg:31.24ms
+step:60/1490 train_time:1877ms step_avg:31.29ms
+step:61/1490 train_time:1905ms step_avg:31.23ms
+step:62/1490 train_time:1939ms step_avg:31.28ms
+step:63/1490 train_time:1967ms step_avg:31.22ms
+step:64/1490 train_time:2001ms step_avg:31.26ms
+step:65/1490 train_time:2028ms step_avg:31.21ms
+step:66/1490 train_time:2063ms step_avg:31.25ms
+step:67/1490 train_time:2091ms step_avg:31.20ms
+step:68/1490 train_time:2125ms step_avg:31.25ms
+step:69/1490 train_time:2153ms step_avg:31.20ms
+step:70/1490 train_time:2188ms step_avg:31.26ms
+step:71/1490 train_time:2215ms step_avg:31.19ms
+step:72/1490 train_time:2249ms step_avg:31.24ms
+step:73/1490 train_time:2277ms step_avg:31.19ms
+step:74/1490 train_time:2311ms step_avg:31.23ms
+step:75/1490 train_time:2339ms step_avg:31.19ms
+step:76/1490 train_time:2373ms step_avg:31.23ms
+step:77/1490 train_time:2401ms step_avg:31.18ms
+step:78/1490 train_time:2435ms step_avg:31.22ms
+step:79/1490 train_time:2462ms step_avg:31.17ms
+step:80/1490 train_time:2497ms step_avg:31.21ms
+step:81/1490 train_time:2525ms step_avg:31.17ms
+step:82/1490 train_time:2559ms step_avg:31.20ms
+step:83/1490 train_time:2586ms step_avg:31.16ms
+step:84/1490 train_time:2621ms step_avg:31.20ms
+step:85/1490 train_time:2648ms step_avg:31.16ms
+step:86/1490 train_time:2682ms step_avg:31.19ms
+step:87/1490 train_time:2710ms step_avg:31.15ms
+step:88/1490 train_time:2745ms step_avg:31.19ms
+step:89/1490 train_time:2772ms step_avg:31.15ms
+step:90/1490 train_time:2806ms step_avg:31.18ms
+step:91/1490 train_time:2834ms step_avg:31.15ms
+step:92/1490 train_time:2868ms step_avg:31.18ms
+step:93/1490 train_time:2896ms step_avg:31.14ms
+step:94/1490 train_time:2930ms step_avg:31.17ms
+step:95/1490 train_time:2958ms step_avg:31.13ms
+step:96/1490 train_time:2992ms step_avg:31.16ms
+step:97/1490 train_time:3019ms step_avg:31.13ms
+step:98/1490 train_time:3053ms step_avg:31.16ms
+step:99/1490 train_time:3081ms step_avg:31.12ms
+step:100/1490 train_time:3115ms step_avg:31.15ms
+step:101/1490 train_time:3142ms step_avg:31.11ms
+step:102/1490 train_time:3177ms step_avg:31.14ms
+step:103/1490 train_time:3204ms step_avg:31.11ms
+step:104/1490 train_time:3238ms step_avg:31.13ms
+step:105/1490 train_time:3266ms step_avg:31.10ms
+step:106/1490 train_time:3300ms step_avg:31.13ms
+step:107/1490 train_time:3327ms step_avg:31.10ms
+step:108/1490 train_time:3362ms step_avg:31.13ms
+step:109/1490 train_time:3389ms step_avg:31.09ms
+step:110/1490 train_time:3424ms step_avg:31.12ms
+step:111/1490 train_time:3451ms step_avg:31.09ms
+step:112/1490 train_time:3485ms step_avg:31.12ms
+step:113/1490 train_time:3513ms step_avg:31.09ms
+step:114/1490 train_time:3547ms step_avg:31.12ms
+step:115/1490 train_time:3575ms step_avg:31.09ms
+step:116/1490 train_time:3609ms step_avg:31.12ms
+step:117/1490 train_time:3637ms step_avg:31.08ms
+step:118/1490 train_time:3671ms step_avg:31.11ms
+step:119/1490 train_time:3699ms step_avg:31.08ms
+step:120/1490 train_time:3733ms step_avg:31.11ms
+step:121/1490 train_time:3760ms step_avg:31.08ms
+step:122/1490 train_time:3795ms step_avg:31.11ms
+step:123/1490 train_time:3822ms step_avg:31.08ms
+step:124/1490 train_time:3857ms step_avg:31.10ms
+step:125/1490 train_time:3884ms step_avg:31.08ms
+step:126/1490 train_time:3919ms step_avg:31.10ms
+step:127/1490 train_time:3946ms step_avg:31.07ms
+step:128/1490 train_time:3980ms step_avg:31.10ms
+step:129/1490 train_time:4008ms step_avg:31.07ms
+step:130/1490 train_time:4042ms step_avg:31.09ms
+step:131/1490 train_time:4070ms step_avg:31.06ms
+step:132/1490 train_time:4104ms step_avg:31.09ms
+step:133/1490 train_time:4132ms step_avg:31.07ms
+step:134/1490 train_time:4166ms step_avg:31.09ms
+step:135/1490 train_time:4194ms step_avg:31.06ms
+step:136/1490 train_time:4228ms step_avg:31.09ms
+step:137/1490 train_time:4255ms step_avg:31.06ms
+step:138/1490 train_time:4290ms step_avg:31.08ms
+step:139/1490 train_time:4317ms step_avg:31.06ms
+step:140/1490 train_time:4352ms step_avg:31.08ms
+step:141/1490 train_time:4379ms step_avg:31.06ms
+step:142/1490 train_time:4413ms step_avg:31.08ms
+step:143/1490 train_time:4441ms step_avg:31.05ms
+step:144/1490 train_time:4475ms step_avg:31.07ms
+step:145/1490 train_time:4502ms step_avg:31.05ms
+step:146/1490 train_time:4537ms step_avg:31.07ms
+step:147/1490 train_time:4565ms step_avg:31.05ms
+step:148/1490 train_time:4599ms step_avg:31.08ms
+step:149/1490 train_time:4627ms step_avg:31.05ms
+step:150/1490 train_time:4661ms step_avg:31.08ms
+step:151/1490 train_time:4689ms step_avg:31.05ms
+step:152/1490 train_time:4723ms step_avg:31.07ms
+step:153/1490 train_time:4751ms step_avg:31.05ms
+step:154/1490 train_time:4785ms step_avg:31.07ms
+step:155/1490 train_time:4813ms step_avg:31.05ms
+step:156/1490 train_time:4847ms step_avg:31.07ms
+step:157/1490 train_time:4874ms step_avg:31.05ms
+step:158/1490 train_time:4908ms step_avg:31.07ms
+step:159/1490 train_time:4936ms step_avg:31.05ms
+step:160/1490 train_time:4971ms step_avg:31.07ms
+step:161/1490 train_time:4998ms step_avg:31.05ms
+step:162/1490 train_time:5033ms step_avg:31.07ms
+step:163/1490 train_time:5060ms step_avg:31.04ms
+step:164/1490 train_time:5094ms step_avg:31.06ms
+step:165/1490 train_time:5122ms step_avg:31.04ms
+step:166/1490 train_time:5156ms step_avg:31.06ms
+step:167/1490 train_time:5184ms step_avg:31.04ms
+step:168/1490 train_time:5219ms step_avg:31.06ms
+step:169/1490 train_time:5246ms step_avg:31.04ms
+step:170/1490 train_time:5280ms step_avg:31.06ms
+step:171/1490 train_time:5307ms step_avg:31.04ms
+step:172/1490 train_time:5342ms step_avg:31.06ms
+step:173/1490 train_time:5369ms step_avg:31.04ms
+step:174/1490 train_time:5404ms step_avg:31.05ms
+step:175/1490 train_time:5432ms step_avg:31.04ms
+step:176/1490 train_time:5466ms step_avg:31.06ms
+step:177/1490 train_time:5493ms step_avg:31.04ms
+step:178/1490 train_time:5528ms step_avg:31.05ms
+step:179/1490 train_time:5555ms step_avg:31.03ms
+step:180/1490 train_time:5589ms step_avg:31.05ms
+step:181/1490 train_time:5617ms step_avg:31.03ms
+step:182/1490 train_time:5651ms step_avg:31.05ms
+step:183/1490 train_time:5678ms step_avg:31.03ms
+step:184/1490 train_time:5712ms step_avg:31.04ms
+step:185/1490 train_time:5740ms step_avg:31.03ms
+step:186/1490 train_time:5774ms step_avg:31.04ms
+step:187/1490 train_time:5801ms step_avg:31.02ms
+step:188/1490 train_time:5835ms step_avg:31.04ms
+step:189/1490 train_time:5863ms step_avg:31.02ms
+step:190/1490 train_time:5897ms step_avg:31.04ms
+step:191/1490 train_time:5925ms step_avg:31.02ms
+step:192/1490 train_time:5960ms step_avg:31.04ms
+step:193/1490 train_time:5986ms step_avg:31.02ms
+step:194/1490 train_time:6021ms step_avg:31.04ms
+step:195/1490 train_time:6048ms step_avg:31.02ms
+step:196/1490 train_time:6082ms step_avg:31.03ms
+step:197/1490 train_time:6128ms step_avg:31.11ms
+step:198/1490 train_time:6156ms step_avg:31.09ms
+step:199/1490 train_time:6183ms step_avg:31.07ms
+step:200/1490 train_time:6223ms step_avg:31.11ms
+step:201/1490 train_time:6237ms step_avg:31.03ms
+step:202/1490 train_time:6268ms step_avg:31.03ms
+step:203/1490 train_time:6295ms step_avg:31.01ms
+step:204/1490 train_time:6330ms step_avg:31.03ms
+step:205/1490 train_time:6357ms step_avg:31.01ms
+step:206/1490 train_time:6391ms step_avg:31.03ms
+step:207/1490 train_time:6419ms step_avg:31.01ms
+step:208/1490 train_time:6453ms step_avg:31.02ms
+step:209/1490 train_time:6480ms step_avg:31.01ms
+step:210/1490 train_time:6514ms step_avg:31.02ms
+step:211/1490 train_time:6542ms step_avg:31.00ms
+step:212/1490 train_time:6576ms step_avg:31.02ms
+step:213/1490 train_time:6603ms step_avg:31.00ms
+step:214/1490 train_time:6638ms step_avg:31.02ms
+step:215/1490 train_time:6665ms step_avg:31.00ms
+step:216/1490 train_time:6700ms step_avg:31.02ms
+step:217/1490 train_time:6727ms step_avg:31.00ms
+step:218/1490 train_time:6761ms step_avg:31.01ms
+step:219/1490 train_time:6789ms step_avg:31.00ms
+step:220/1490 train_time:6823ms step_avg:31.02ms
+step:221/1490 train_time:6851ms step_avg:31.00ms
+step:222/1490 train_time:6885ms step_avg:31.01ms
+step:223/1490 train_time:6913ms step_avg:31.00ms
+step:224/1490 train_time:6947ms step_avg:31.01ms
+step:225/1490 train_time:6975ms step_avg:31.00ms
+step:226/1490 train_time:7009ms step_avg:31.01ms
+step:227/1490 train_time:7036ms step_avg:31.00ms
+step:228/1490 train_time:7070ms step_avg:31.01ms
+step:229/1490 train_time:7098ms step_avg:30.99ms
+step:230/1490 train_time:7132ms step_avg:31.01ms
+step:231/1490 train_time:7159ms step_avg:30.99ms
+step:232/1490 train_time:7193ms step_avg:31.01ms
+step:233/1490 train_time:7220ms step_avg:30.99ms
+step:234/1490 train_time:7254ms step_avg:31.00ms
+step:235/1490 train_time:7282ms step_avg:30.99ms
+step:236/1490 train_time:7317ms step_avg:31.00ms
+step:237/1490 train_time:7344ms step_avg:30.99ms
+step:238/1490 train_time:7379ms step_avg:31.00ms
+step:239/1490 train_time:7406ms step_avg:30.99ms
+step:240/1490 train_time:7441ms step_avg:31.00ms
+step:241/1490 train_time:7468ms step_avg:30.99ms
+step:242/1490 train_time:7502ms step_avg:31.00ms
+step:243/1490 train_time:7529ms step_avg:30.99ms
+step:244/1490 train_time:7564ms step_avg:31.00ms
+step:245/1490 train_time:7591ms step_avg:30.98ms
+step:246/1490 train_time:7625ms step_avg:31.00ms
+step:247/1490 train_time:7652ms step_avg:30.98ms
+step:248/1490 train_time:7686ms step_avg:30.99ms
+step:249/1490 train_time:7714ms step_avg:30.98ms
+step:250/1490 train_time:7748ms step_avg:30.99ms
+step:250/1490 val_loss:4.5079 train_time:7788ms step_avg:31.15ms
+step:251/1490 train_time:7809ms step_avg:31.11ms
+step:252/1490 train_time:7828ms step_avg:31.06ms
+step:253/1490 train_time:7842ms step_avg:31.00ms
+step:254/1490 train_time:7878ms step_avg:31.02ms
+step:255/1490 train_time:7907ms step_avg:31.01ms
+step:256/1490 train_time:7943ms step_avg:31.03ms
+step:257/1490 train_time:7971ms step_avg:31.02ms
+step:258/1490 train_time:8005ms step_avg:31.03ms
+step:259/1490 train_time:8033ms step_avg:31.02ms
+step:260/1490 train_time:8067ms step_avg:31.03ms
+step:261/1490 train_time:8095ms step_avg:31.01ms
+step:262/1490 train_time:8129ms step_avg:31.03ms
+step:263/1490 train_time:8156ms step_avg:31.01ms
+step:264/1490 train_time:8190ms step_avg:31.02ms
+step:265/1490 train_time:8218ms step_avg:31.01ms
+step:266/1490 train_time:8252ms step_avg:31.02ms
+step:267/1490 train_time:8279ms step_avg:31.01ms
+step:268/1490 train_time:8313ms step_avg:31.02ms
+step:269/1490 train_time:8340ms step_avg:31.01ms
+step:270/1490 train_time:8375ms step_avg:31.02ms
+step:271/1490 train_time:8402ms step_avg:31.00ms
+step:272/1490 train_time:8436ms step_avg:31.01ms
+step:273/1490 train_time:8463ms step_avg:31.00ms
+step:274/1490 train_time:8497ms step_avg:31.01ms
+step:275/1490 train_time:8525ms step_avg:31.00ms
+step:276/1490 train_time:8559ms step_avg:31.01ms
+step:277/1490 train_time:8586ms step_avg:31.00ms
+step:278/1490 train_time:8620ms step_avg:31.01ms
+step:279/1490 train_time:8647ms step_avg:30.99ms
+step:280/1490 train_time:8681ms step_avg:31.00ms
+step:281/1490 train_time:8709ms step_avg:30.99ms
+step:282/1490 train_time:8743ms step_avg:31.00ms
+step:283/1490 train_time:8771ms step_avg:30.99ms
+step:284/1490 train_time:8805ms step_avg:31.00ms
+step:285/1490 train_time:8833ms step_avg:30.99ms
+step:286/1490 train_time:8867ms step_avg:31.01ms
+step:287/1490 train_time:8895ms step_avg:30.99ms
+step:288/1490 train_time:8929ms step_avg:31.00ms
+step:289/1490 train_time:8957ms step_avg:30.99ms
+step:290/1490 train_time:8991ms step_avg:31.00ms
+step:291/1490 train_time:9019ms step_avg:30.99ms
+step:292/1490 train_time:9054ms step_avg:31.01ms
+step:293/1490 train_time:9081ms step_avg:30.99ms
+step:294/1490 train_time:9116ms step_avg:31.01ms
+step:295/1490 train_time:9143ms step_avg:30.99ms
+step:296/1490 train_time:9177ms step_avg:31.00ms
+step:297/1490 train_time:9205ms step_avg:30.99ms
+step:298/1490 train_time:9239ms step_avg:31.00ms
+step:299/1490 train_time:9267ms step_avg:30.99ms
+step:300/1490 train_time:9301ms step_avg:31.00ms
+step:301/1490 train_time:9328ms step_avg:30.99ms
+step:302/1490 train_time:9362ms step_avg:31.00ms
+step:303/1490 train_time:9390ms step_avg:30.99ms
+step:304/1490 train_time:9424ms step_avg:31.00ms
+step:305/1490 train_time:9451ms step_avg:30.99ms
+step:306/1490 train_time:9485ms step_avg:31.00ms
+step:307/1490 train_time:9512ms step_avg:30.98ms
+step:308/1490 train_time:9546ms step_avg:30.99ms
+step:309/1490 train_time:9574ms step_avg:30.98ms
+step:310/1490 train_time:9608ms step_avg:30.99ms
+step:311/1490 train_time:9635ms step_avg:30.98ms
+step:312/1490 train_time:9670ms step_avg:30.99ms
+step:313/1490 train_time:9697ms step_avg:30.98ms
+step:314/1490 train_time:9731ms step_avg:30.99ms
+step:315/1490 train_time:9758ms step_avg:30.98ms
+step:316/1490 train_time:9792ms step_avg:30.99ms
+step:317/1490 train_time:9820ms step_avg:30.98ms
+step:318/1490 train_time:9855ms step_avg:30.99ms
+step:319/1490 train_time:9882ms step_avg:30.98ms
+step:320/1490 train_time:9916ms step_avg:30.99ms
+step:321/1490 train_time:9943ms step_avg:30.98ms
+step:322/1490 train_time:9978ms step_avg:30.99ms
+step:323/1490 train_time:10005ms step_avg:30.98ms
+step:324/1490 train_time:10039ms step_avg:30.99ms
+step:325/1490 train_time:10067ms step_avg:30.98ms
+step:326/1490 train_time:10102ms step_avg:30.99ms
+step:327/1490 train_time:10129ms step_avg:30.98ms
+step:328/1490 train_time:10163ms step_avg:30.99ms
+step:329/1490 train_time:10191ms step_avg:30.98ms
+step:330/1490 train_time:10225ms step_avg:30.99ms
+step:331/1490 train_time:10253ms step_avg:30.97ms
+step:332/1490 train_time:10287ms step_avg:30.98ms
+step:333/1490 train_time:10314ms step_avg:30.97ms
+step:334/1490 train_time:10348ms step_avg:30.98ms
+step:335/1490 train_time:10376ms step_avg:30.97ms
+step:336/1490 train_time:10410ms step_avg:30.98ms
+step:337/1490 train_time:10437ms step_avg:30.97ms
+step:338/1490 train_time:10471ms step_avg:30.98ms
+step:339/1490 train_time:10499ms step_avg:30.97ms
+step:340/1490 train_time:10533ms step_avg:30.98ms
+step:341/1490 train_time:10560ms step_avg:30.97ms
+step:342/1490 train_time:10594ms step_avg:30.98ms
+step:343/1490 train_time:10622ms step_avg:30.97ms
+step:344/1490 train_time:10656ms step_avg:30.98ms
+step:345/1490 train_time:10683ms step_avg:30.97ms
+step:346/1490 train_time:10717ms step_avg:30.97ms
+step:347/1490 train_time:10744ms step_avg:30.96ms
+step:348/1490 train_time:10779ms step_avg:30.97ms
+step:349/1490 train_time:10806ms step_avg:30.96ms
+step:350/1490 train_time:10840ms step_avg:30.97ms
+step:351/1490 train_time:10868ms step_avg:30.96ms
+step:352/1490 train_time:10902ms step_avg:30.97ms
+step:353/1490 train_time:10930ms step_avg:30.96ms
+step:354/1490 train_time:10964ms step_avg:30.97ms
+step:355/1490 train_time:10991ms step_avg:30.96ms
+step:356/1490 train_time:11025ms step_avg:30.97ms
+step:357/1490 train_time:11053ms step_avg:30.96ms
+step:358/1490 train_time:11087ms step_avg:30.97ms
+step:359/1490 train_time:11115ms step_avg:30.96ms
+step:360/1490 train_time:11149ms step_avg:30.97ms
+step:361/1490 train_time:11176ms step_avg:30.96ms
+step:362/1490 train_time:11211ms step_avg:30.97ms
+step:363/1490 train_time:11238ms step_avg:30.96ms
+step:364/1490 train_time:11272ms step_avg:30.97ms
+step:365/1490 train_time:11300ms step_avg:30.96ms
+step:366/1490 train_time:11334ms step_avg:30.97ms
+step:367/1490 train_time:11361ms step_avg:30.96ms
+step:368/1490 train_time:11395ms step_avg:30.97ms
+step:369/1490 train_time:11423ms step_avg:30.96ms
+step:370/1490 train_time:11456ms step_avg:30.96ms
+step:371/1490 train_time:11484ms step_avg:30.95ms
+step:372/1490 train_time:11518ms step_avg:30.96ms
+step:373/1490 train_time:11545ms step_avg:30.95ms
+step:374/1490 train_time:11580ms step_avg:30.96ms
+step:375/1490 train_time:11607ms step_avg:30.95ms
+step:376/1490 train_time:11641ms step_avg:30.96ms
+step:377/1490 train_time:11669ms step_avg:30.95ms
+step:378/1490 train_time:11703ms step_avg:30.96ms
+step:379/1490 train_time:11731ms step_avg:30.95ms
+step:380/1490 train_time:11765ms step_avg:30.96ms
+step:381/1490 train_time:11792ms step_avg:30.95ms
+step:382/1490 train_time:11826ms step_avg:30.96ms
+step:383/1490 train_time:11854ms step_avg:30.95ms
+step:384/1490 train_time:11888ms step_avg:30.96ms
+step:385/1490 train_time:11915ms step_avg:30.95ms
+step:386/1490 train_time:11949ms step_avg:30.96ms
+step:387/1490 train_time:11977ms step_avg:30.95ms
+step:388/1490 train_time:12011ms step_avg:30.96ms
+step:389/1490 train_time:12039ms step_avg:30.95ms
+step:390/1490 train_time:12073ms step_avg:30.96ms
+step:391/1490 train_time:12101ms step_avg:30.95ms
+step:392/1490 train_time:12135ms step_avg:30.96ms
+step:393/1490 train_time:12162ms step_avg:30.95ms
+step:394/1490 train_time:12196ms step_avg:30.96ms
+step:395/1490 train_time:12224ms step_avg:30.95ms
+step:396/1490 train_time:12258ms step_avg:30.95ms
+step:397/1490 train_time:12285ms step_avg:30.94ms
+step:398/1490 train_time:12319ms step_avg:30.95ms
+step:399/1490 train_time:12347ms step_avg:30.94ms
+step:400/1490 train_time:12381ms step_avg:30.95ms
+step:401/1490 train_time:12409ms step_avg:30.94ms
+step:402/1490 train_time:12443ms step_avg:30.95ms
+step:403/1490 train_time:12471ms step_avg:30.94ms
+step:404/1490 train_time:12505ms step_avg:30.95ms
+step:405/1490 train_time:12532ms step_avg:30.94ms
+step:406/1490 train_time:12566ms step_avg:30.95ms
+step:407/1490 train_time:12593ms step_avg:30.94ms
+step:408/1490 train_time:12628ms step_avg:30.95ms
+step:409/1490 train_time:12655ms step_avg:30.94ms
+step:410/1490 train_time:12689ms step_avg:30.95ms
+step:411/1490 train_time:12716ms step_avg:30.94ms
+step:412/1490 train_time:12750ms step_avg:30.95ms
+step:413/1490 train_time:12777ms step_avg:30.94ms
+step:414/1490 train_time:12811ms step_avg:30.95ms
+step:415/1490 train_time:12839ms step_avg:30.94ms
+step:416/1490 train_time:12874ms step_avg:30.95ms
+step:417/1490 train_time:12901ms step_avg:30.94ms
+step:418/1490 train_time:12935ms step_avg:30.95ms
+step:419/1490 train_time:12963ms step_avg:30.94ms
+step:420/1490 train_time:12997ms step_avg:30.95ms
+step:421/1490 train_time:13024ms step_avg:30.94ms
+step:422/1490 train_time:13059ms step_avg:30.94ms
+step:423/1490 train_time:13086ms step_avg:30.94ms
+step:424/1490 train_time:13121ms step_avg:30.95ms
+step:425/1490 train_time:13149ms step_avg:30.94ms
+step:426/1490 train_time:13183ms step_avg:30.95ms
+step:427/1490 train_time:13210ms step_avg:30.94ms
+step:428/1490 train_time:13244ms step_avg:30.94ms
+step:429/1490 train_time:13272ms step_avg:30.94ms
+step:430/1490 train_time:13306ms step_avg:30.94ms
+step:431/1490 train_time:13334ms step_avg:30.94ms
+step:432/1490 train_time:13368ms step_avg:30.94ms
+step:433/1490 train_time:13396ms step_avg:30.94ms
+step:434/1490 train_time:13429ms step_avg:30.94ms
+step:435/1490 train_time:13457ms step_avg:30.93ms
+step:436/1490 train_time:13491ms step_avg:30.94ms
+step:437/1490 train_time:13518ms step_avg:30.93ms
+step:438/1490 train_time:13552ms step_avg:30.94ms
+step:439/1490 train_time:13580ms step_avg:30.93ms
+step:440/1490 train_time:13614ms step_avg:30.94ms
+step:441/1490 train_time:13641ms step_avg:30.93ms
+step:442/1490 train_time:13675ms step_avg:30.94ms
+step:443/1490 train_time:13703ms step_avg:30.93ms
+step:444/1490 train_time:13737ms step_avg:30.94ms
+step:445/1490 train_time:13764ms step_avg:30.93ms
+step:446/1490 train_time:13798ms step_avg:30.94ms
+step:447/1490 train_time:13825ms step_avg:30.93ms
+step:448/1490 train_time:13861ms step_avg:30.94ms
+step:449/1490 train_time:13887ms step_avg:30.93ms
+step:450/1490 train_time:13921ms step_avg:30.94ms
+step:451/1490 train_time:13949ms step_avg:30.93ms
+step:452/1490 train_time:13983ms step_avg:30.94ms
+step:453/1490 train_time:14011ms step_avg:30.93ms
+step:454/1490 train_time:14045ms step_avg:30.94ms
+step:455/1490 train_time:14073ms step_avg:30.93ms
+step:456/1490 train_time:14107ms step_avg:30.94ms
+step:457/1490 train_time:14135ms step_avg:30.93ms
+step:458/1490 train_time:14168ms step_avg:30.94ms
+step:459/1490 train_time:14196ms step_avg:30.93ms
+step:460/1490 train_time:14230ms step_avg:30.93ms
+step:461/1490 train_time:14258ms step_avg:30.93ms
+step:462/1490 train_time:14291ms step_avg:30.93ms
+step:463/1490 train_time:14319ms step_avg:30.93ms
+step:464/1490 train_time:14354ms step_avg:30.93ms
+step:465/1490 train_time:14381ms step_avg:30.93ms
+step:466/1490 train_time:14415ms step_avg:30.93ms
+step:467/1490 train_time:14442ms step_avg:30.93ms
+step:468/1490 train_time:14477ms step_avg:30.93ms
+step:469/1490 train_time:14504ms step_avg:30.93ms
+step:470/1490 train_time:14538ms step_avg:30.93ms
+step:471/1490 train_time:14566ms step_avg:30.92ms
+step:472/1490 train_time:14600ms step_avg:30.93ms
+step:473/1490 train_time:14627ms step_avg:30.92ms
+step:474/1490 train_time:14661ms step_avg:30.93ms
+step:475/1490 train_time:14689ms step_avg:30.92ms
+step:476/1490 train_time:14723ms step_avg:30.93ms
+step:477/1490 train_time:14750ms step_avg:30.92ms
+step:478/1490 train_time:14784ms step_avg:30.93ms
+step:479/1490 train_time:14812ms step_avg:30.92ms
+step:480/1490 train_time:14846ms step_avg:30.93ms
+step:481/1490 train_time:14873ms step_avg:30.92ms
+step:482/1490 train_time:14908ms step_avg:30.93ms
+step:483/1490 train_time:14935ms step_avg:30.92ms
+step:484/1490 train_time:14972ms step_avg:30.93ms
+step:485/1490 train_time:15024ms step_avg:30.98ms
+step:486/1490 train_time:15083ms step_avg:31.03ms
+step:487/1490 train_time:15136ms step_avg:31.08ms
+step:488/1490 train_time:15196ms step_avg:31.14ms
+step:489/1490 train_time:15248ms step_avg:31.18ms
+step:490/1490 train_time:15324ms step_avg:31.27ms
+step:491/1490 train_time:15361ms step_avg:31.28ms
+step:492/1490 train_time:15419ms step_avg:31.34ms
+step:493/1490 train_time:15473ms step_avg:31.38ms
+step:494/1490 train_time:15531ms step_avg:31.44ms
+step:495/1490 train_time:15584ms step_avg:31.48ms
+step:496/1490 train_time:15643ms step_avg:31.54ms
+step:497/1490 train_time:15697ms step_avg:31.58ms
+step:498/1490 train_time:15756ms step_avg:31.64ms
+step:499/1490 train_time:15809ms step_avg:31.68ms
+step:500/1490 train_time:15869ms step_avg:31.74ms
+step:500/1490 val_loss:4.2454 train_time:15937ms step_avg:31.87ms
+step:501/1490 train_time:15956ms step_avg:31.85ms
+step:502/1490 train_time:15984ms step_avg:31.84ms
+step:503/1490 train_time:16039ms step_avg:31.89ms
+step:504/1490 train_time:16101ms step_avg:31.95ms
+step:505/1490 train_time:16156ms step_avg:31.99ms
+step:506/1490 train_time:16215ms step_avg:32.05ms
+step:507/1490 train_time:16268ms step_avg:32.09ms
+step:508/1490 train_time:16327ms step_avg:32.14ms
+step:509/1490 train_time:16380ms step_avg:32.18ms
+step:510/1490 train_time:16438ms step_avg:32.23ms
+step:511/1490 train_time:16491ms step_avg:32.27ms
+step:512/1490 train_time:16550ms step_avg:32.32ms
+step:513/1490 train_time:16602ms step_avg:32.36ms
+step:514/1490 train_time:16661ms step_avg:32.41ms
+step:515/1490 train_time:16714ms step_avg:32.46ms
+step:516/1490 train_time:16772ms step_avg:32.50ms
+step:517/1490 train_time:16825ms step_avg:32.54ms
+step:518/1490 train_time:16884ms step_avg:32.59ms
+step:519/1490 train_time:16938ms step_avg:32.64ms
+step:520/1490 train_time:16998ms step_avg:32.69ms
+step:521/1490 train_time:17053ms step_avg:32.73ms
+step:522/1490 train_time:17113ms step_avg:32.78ms
+step:523/1490 train_time:17166ms step_avg:32.82ms
+step:524/1490 train_time:17226ms step_avg:32.87ms
+step:525/1490 train_time:17279ms step_avg:32.91ms
+step:526/1490 train_time:17338ms step_avg:32.96ms
+step:527/1490 train_time:17392ms step_avg:33.00ms
+step:528/1490 train_time:17450ms step_avg:33.05ms
+step:529/1490 train_time:17503ms step_avg:33.09ms
+step:530/1490 train_time:17562ms step_avg:33.14ms
+step:531/1490 train_time:17614ms step_avg:33.17ms
+step:532/1490 train_time:17672ms step_avg:33.22ms
+step:533/1490 train_time:17725ms step_avg:33.26ms
+step:534/1490 train_time:17784ms step_avg:33.30ms
+step:535/1490 train_time:17837ms step_avg:33.34ms
+step:536/1490 train_time:17896ms step_avg:33.39ms
+step:537/1490 train_time:17949ms step_avg:33.42ms
+step:538/1490 train_time:18009ms step_avg:33.47ms
+step:539/1490 train_time:18063ms step_avg:33.51ms
+step:540/1490 train_time:18123ms step_avg:33.56ms
+step:541/1490 train_time:18176ms step_avg:33.60ms
+step:542/1490 train_time:18235ms step_avg:33.64ms
+step:543/1490 train_time:18289ms step_avg:33.68ms
+step:544/1490 train_time:18348ms step_avg:33.73ms
+step:545/1490 train_time:18400ms step_avg:33.76ms
+step:546/1490 train_time:18459ms step_avg:33.81ms
+step:547/1490 train_time:18513ms step_avg:33.84ms
+step:548/1490 train_time:18571ms step_avg:33.89ms
+step:549/1490 train_time:18624ms step_avg:33.92ms
+step:550/1490 train_time:18682ms step_avg:33.97ms
+step:551/1490 train_time:18735ms step_avg:34.00ms
+step:552/1490 train_time:18793ms step_avg:34.05ms
+step:553/1490 train_time:18847ms step_avg:34.08ms
+step:554/1490 train_time:18905ms step_avg:34.12ms
+step:555/1490 train_time:18960ms step_avg:34.16ms
+step:556/1490 train_time:19019ms step_avg:34.21ms
+step:557/1490 train_time:19072ms step_avg:34.24ms
+step:558/1490 train_time:19131ms step_avg:34.29ms
+step:559/1490 train_time:19184ms step_avg:34.32ms
+step:560/1490 train_time:19244ms step_avg:34.36ms
+step:561/1490 train_time:19298ms step_avg:34.40ms
+step:562/1490 train_time:19356ms step_avg:34.44ms
+step:563/1490 train_time:19409ms step_avg:34.47ms
+step:564/1490 train_time:19468ms step_avg:34.52ms
+step:565/1490 train_time:19521ms step_avg:34.55ms
+step:566/1490 train_time:19580ms step_avg:34.59ms
+step:567/1490 train_time:19633ms step_avg:34.63ms
+step:568/1490 train_time:19691ms step_avg:34.67ms
+step:569/1490 train_time:19745ms step_avg:34.70ms
+step:570/1490 train_time:19803ms step_avg:34.74ms
+step:571/1490 train_time:19856ms step_avg:34.77ms
+step:572/1490 train_time:19915ms step_avg:34.82ms
+step:573/1490 train_time:19969ms step_avg:34.85ms
+step:574/1490 train_time:20029ms step_avg:34.89ms
+step:575/1490 train_time:20082ms step_avg:34.93ms
+step:576/1490 train_time:20141ms step_avg:34.97ms
+step:577/1490 train_time:20195ms step_avg:35.00ms
+step:578/1490 train_time:20254ms step_avg:35.04ms
+step:579/1490 train_time:20307ms step_avg:35.07ms
+step:580/1490 train_time:20367ms step_avg:35.11ms
+step:581/1490 train_time:20420ms step_avg:35.15ms
+step:582/1490 train_time:20478ms step_avg:35.19ms
+step:583/1490 train_time:20531ms step_avg:35.22ms
+step:584/1490 train_time:20590ms step_avg:35.26ms
+step:585/1490 train_time:20643ms step_avg:35.29ms
+step:586/1490 train_time:20702ms step_avg:35.33ms
+step:587/1490 train_time:20755ms step_avg:35.36ms
+step:588/1490 train_time:20813ms step_avg:35.40ms
+step:589/1490 train_time:20867ms step_avg:35.43ms
+step:590/1490 train_time:20927ms step_avg:35.47ms
+step:591/1490 train_time:20980ms step_avg:35.50ms
+step:592/1490 train_time:21039ms step_avg:35.54ms
+step:593/1490 train_time:21092ms step_avg:35.57ms
+step:594/1490 train_time:21151ms step_avg:35.61ms
+step:595/1490 train_time:21205ms step_avg:35.64ms
+step:596/1490 train_time:21264ms step_avg:35.68ms
+step:597/1490 train_time:21318ms step_avg:35.71ms
+step:598/1490 train_time:21376ms step_avg:35.75ms
+step:599/1490 train_time:21430ms step_avg:35.78ms
+step:600/1490 train_time:21489ms step_avg:35.81ms
+step:601/1490 train_time:21542ms step_avg:35.84ms
+step:602/1490 train_time:21601ms step_avg:35.88ms
+step:603/1490 train_time:21654ms step_avg:35.91ms
+step:604/1490 train_time:21711ms step_avg:35.95ms
+step:605/1490 train_time:21765ms step_avg:35.97ms
+step:606/1490 train_time:21824ms step_avg:36.01ms
+step:607/1490 train_time:21877ms step_avg:36.04ms
+step:608/1490 train_time:21936ms step_avg:36.08ms
+step:609/1490 train_time:21990ms step_avg:36.11ms
+step:610/1490 train_time:22047ms step_avg:36.14ms
+step:611/1490 train_time:22101ms step_avg:36.17ms
+step:612/1490 train_time:22160ms step_avg:36.21ms
+step:613/1490 train_time:22214ms step_avg:36.24ms
+step:614/1490 train_time:22272ms step_avg:36.27ms
+step:615/1490 train_time:22326ms step_avg:36.30ms
+step:616/1490 train_time:22385ms step_avg:36.34ms
+step:617/1490 train_time:22438ms step_avg:36.37ms
+step:618/1490 train_time:22497ms step_avg:36.40ms
+step:619/1490 train_time:22549ms step_avg:36.43ms
+step:620/1490 train_time:22608ms step_avg:36.46ms
+step:621/1490 train_time:22661ms step_avg:36.49ms
+step:622/1490 train_time:22721ms step_avg:36.53ms
+step:623/1490 train_time:22773ms step_avg:36.55ms
+step:624/1490 train_time:22831ms step_avg:36.59ms
+step:625/1490 train_time:22885ms step_avg:36.62ms
+step:626/1490 train_time:22943ms step_avg:36.65ms
+step:627/1490 train_time:22997ms step_avg:36.68ms
+step:628/1490 train_time:23056ms step_avg:36.71ms
+step:629/1490 train_time:23110ms step_avg:36.74ms
+step:630/1490 train_time:23168ms step_avg:36.78ms
+step:631/1490 train_time:23223ms step_avg:36.80ms
+step:632/1490 train_time:23281ms step_avg:36.84ms
+step:633/1490 train_time:23335ms step_avg:36.86ms
+step:634/1490 train_time:23393ms step_avg:36.90ms
+step:635/1490 train_time:23447ms step_avg:36.92ms
+step:636/1490 train_time:23506ms step_avg:36.96ms
+step:637/1490 train_time:23559ms step_avg:36.98ms
+step:638/1490 train_time:23617ms step_avg:37.02ms
+step:639/1490 train_time:23670ms step_avg:37.04ms
+step:640/1490 train_time:23730ms step_avg:37.08ms
+step:641/1490 train_time:23782ms step_avg:37.10ms
+step:642/1490 train_time:23842ms step_avg:37.14ms
+step:643/1490 train_time:23895ms step_avg:37.16ms
+step:644/1490 train_time:23954ms step_avg:37.20ms
+step:645/1490 train_time:24006ms step_avg:37.22ms
+step:646/1490 train_time:24065ms step_avg:37.25ms
+step:647/1490 train_time:24119ms step_avg:37.28ms
+step:648/1490 train_time:24177ms step_avg:37.31ms
+step:649/1490 train_time:24231ms step_avg:37.34ms
+step:650/1490 train_time:24290ms step_avg:37.37ms
+step:651/1490 train_time:24344ms step_avg:37.39ms
+step:652/1490 train_time:24403ms step_avg:37.43ms
+step:653/1490 train_time:24456ms step_avg:37.45ms
+step:654/1490 train_time:24514ms step_avg:37.48ms
+step:655/1490 train_time:24568ms step_avg:37.51ms
+step:656/1490 train_time:24627ms step_avg:37.54ms
+step:657/1490 train_time:24680ms step_avg:37.56ms
+step:658/1490 train_time:24739ms step_avg:37.60ms
+step:659/1490 train_time:24791ms step_avg:37.62ms
+step:660/1490 train_time:24850ms step_avg:37.65ms
+step:661/1490 train_time:24903ms step_avg:37.68ms
+step:662/1490 train_time:24962ms step_avg:37.71ms
+step:663/1490 train_time:25016ms step_avg:37.73ms
+step:664/1490 train_time:25074ms step_avg:37.76ms
+step:665/1490 train_time:25128ms step_avg:37.79ms
+step:666/1490 train_time:25186ms step_avg:37.82ms
+step:667/1490 train_time:25240ms step_avg:37.84ms
+step:668/1490 train_time:25300ms step_avg:37.87ms
+step:669/1490 train_time:25353ms step_avg:37.90ms
+step:670/1490 train_time:25411ms step_avg:37.93ms
+step:671/1490 train_time:25465ms step_avg:37.95ms
+step:672/1490 train_time:25524ms step_avg:37.98ms
+step:673/1490 train_time:25577ms step_avg:38.00ms
+step:674/1490 train_time:25635ms step_avg:38.03ms
+step:675/1490 train_time:25688ms step_avg:38.06ms
+step:676/1490 train_time:25748ms step_avg:38.09ms
+step:677/1490 train_time:25801ms step_avg:38.11ms
+step:678/1490 train_time:25860ms step_avg:38.14ms
+step:679/1490 train_time:25913ms step_avg:38.16ms
+step:680/1490 train_time:25971ms step_avg:38.19ms
+step:681/1490 train_time:26024ms step_avg:38.21ms
+step:682/1490 train_time:26083ms step_avg:38.24ms
+step:683/1490 train_time:26137ms step_avg:38.27ms
+step:684/1490 train_time:26195ms step_avg:38.30ms
+step:685/1490 train_time:26248ms step_avg:38.32ms
+step:686/1490 train_time:26306ms step_avg:38.35ms
+step:687/1490 train_time:26360ms step_avg:38.37ms
+step:688/1490 train_time:26420ms step_avg:38.40ms
+step:689/1490 train_time:26473ms step_avg:38.42ms
+step:690/1490 train_time:26531ms step_avg:38.45ms
+step:691/1490 train_time:26585ms step_avg:38.47ms
+step:692/1490 train_time:26643ms step_avg:38.50ms
+step:693/1490 train_time:26698ms step_avg:38.52ms
+step:694/1490 train_time:26756ms step_avg:38.55ms
+step:695/1490 train_time:26809ms step_avg:38.57ms
+step:696/1490 train_time:26868ms step_avg:38.60ms
+step:697/1490 train_time:26921ms step_avg:38.62ms
+step:698/1490 train_time:26980ms step_avg:38.65ms
+step:699/1490 train_time:27033ms step_avg:38.67ms
+step:700/1490 train_time:27091ms step_avg:38.70ms
+step:701/1490 train_time:27144ms step_avg:38.72ms
+step:702/1490 train_time:27204ms step_avg:38.75ms
+step:703/1490 train_time:27257ms step_avg:38.77ms
+step:704/1490 train_time:27316ms step_avg:38.80ms
+step:705/1490 train_time:27369ms step_avg:38.82ms
+step:706/1490 train_time:27428ms step_avg:38.85ms
+step:707/1490 train_time:27482ms step_avg:38.87ms
+step:708/1490 train_time:27541ms step_avg:38.90ms
+step:709/1490 train_time:27594ms step_avg:38.92ms
+step:710/1490 train_time:27652ms step_avg:38.95ms
+step:711/1490 train_time:27705ms step_avg:38.97ms
+step:712/1490 train_time:27764ms step_avg:38.99ms
+step:713/1490 train_time:27818ms step_avg:39.01ms
+step:714/1490 train_time:27876ms step_avg:39.04ms
+step:715/1490 train_time:27930ms step_avg:39.06ms
+step:716/1490 train_time:27989ms step_avg:39.09ms
+step:717/1490 train_time:28043ms step_avg:39.11ms
+step:718/1490 train_time:28102ms step_avg:39.14ms
+step:719/1490 train_time:28155ms step_avg:39.16ms
+step:720/1490 train_time:28213ms step_avg:39.18ms
+step:721/1490 train_time:28266ms step_avg:39.20ms
+step:722/1490 train_time:28326ms step_avg:39.23ms
+step:723/1490 train_time:28379ms step_avg:39.25ms
+step:724/1490 train_time:28438ms step_avg:39.28ms
+step:725/1490 train_time:28491ms step_avg:39.30ms
+step:726/1490 train_time:28550ms step_avg:39.32ms
+step:727/1490 train_time:28603ms step_avg:39.34ms
+step:728/1490 train_time:28662ms step_avg:39.37ms
+step:729/1490 train_time:28715ms step_avg:39.39ms
+step:730/1490 train_time:28773ms step_avg:39.42ms
+step:731/1490 train_time:28827ms step_avg:39.44ms
+step:732/1490 train_time:28886ms step_avg:39.46ms
+step:733/1490 train_time:28939ms step_avg:39.48ms
+step:734/1490 train_time:28997ms step_avg:39.51ms
+step:735/1490 train_time:29050ms step_avg:39.52ms
+step:736/1490 train_time:29108ms step_avg:39.55ms
+step:737/1490 train_time:29162ms step_avg:39.57ms
+step:738/1490 train_time:29221ms step_avg:39.60ms
+step:739/1490 train_time:29275ms step_avg:39.61ms
+step:740/1490 train_time:29334ms step_avg:39.64ms
+step:741/1490 train_time:29387ms step_avg:39.66ms
+step:742/1490 train_time:29446ms step_avg:39.68ms
+step:743/1490 train_time:29499ms step_avg:39.70ms
+step:744/1490 train_time:29558ms step_avg:39.73ms
+step:745/1490 train_time:29611ms step_avg:39.75ms
+step:746/1490 train_time:29669ms step_avg:39.77ms
+step:747/1490 train_time:29723ms step_avg:39.79ms
+step:748/1490 train_time:29782ms step_avg:39.82ms
+step:749/1490 train_time:29835ms step_avg:39.83ms
+step:750/1490 train_time:29893ms step_avg:39.86ms
+step:750/1490 val_loss:3.8039 train_time:29961ms step_avg:39.95ms
+step:751/1490 train_time:29979ms step_avg:39.92ms
+step:752/1490 train_time:30009ms step_avg:39.91ms
+step:753/1490 train_time:30065ms step_avg:39.93ms
+step:754/1490 train_time:30126ms step_avg:39.96ms
+step:755/1490 train_time:30182ms step_avg:39.98ms
+step:756/1490 train_time:30242ms step_avg:40.00ms
+step:757/1490 train_time:30296ms step_avg:40.02ms
+step:758/1490 train_time:30354ms step_avg:40.04ms
+step:759/1490 train_time:30406ms step_avg:40.06ms
+step:760/1490 train_time:30465ms step_avg:40.09ms
+step:761/1490 train_time:30519ms step_avg:40.10ms
+step:762/1490 train_time:30577ms step_avg:40.13ms
+step:763/1490 train_time:30629ms step_avg:40.14ms
+step:764/1490 train_time:30687ms step_avg:40.17ms
+step:765/1490 train_time:30740ms step_avg:40.18ms
+step:766/1490 train_time:30798ms step_avg:40.21ms
+step:767/1490 train_time:30851ms step_avg:40.22ms
+step:768/1490 train_time:30908ms step_avg:40.25ms
+step:769/1490 train_time:30962ms step_avg:40.26ms
+step:770/1490 train_time:31023ms step_avg:40.29ms
+step:771/1490 train_time:31077ms step_avg:40.31ms
+step:772/1490 train_time:31136ms step_avg:40.33ms
+step:773/1490 train_time:31191ms step_avg:40.35ms
+step:774/1490 train_time:31251ms step_avg:40.38ms
+step:775/1490 train_time:31304ms step_avg:40.39ms
+step:776/1490 train_time:31362ms step_avg:40.42ms
+step:777/1490 train_time:31416ms step_avg:40.43ms
+step:778/1490 train_time:31474ms step_avg:40.45ms
+step:779/1490 train_time:31527ms step_avg:40.47ms
+step:780/1490 train_time:31585ms step_avg:40.49ms
+step:781/1490 train_time:31639ms step_avg:40.51ms
+step:782/1490 train_time:31697ms step_avg:40.53ms
+step:783/1490 train_time:31750ms step_avg:40.55ms
+step:784/1490 train_time:31808ms step_avg:40.57ms
+step:785/1490 train_time:31862ms step_avg:40.59ms
+step:786/1490 train_time:31920ms step_avg:40.61ms
+step:787/1490 train_time:31973ms step_avg:40.63ms
+step:788/1490 train_time:32031ms step_avg:40.65ms
+step:789/1490 train_time:32085ms step_avg:40.67ms
+step:790/1490 train_time:32146ms step_avg:40.69ms
+step:791/1490 train_time:32199ms step_avg:40.71ms
+step:792/1490 train_time:32257ms step_avg:40.73ms
+step:793/1490 train_time:32311ms step_avg:40.75ms
+step:794/1490 train_time:32370ms step_avg:40.77ms
+step:795/1490 train_time:32423ms step_avg:40.78ms
+step:796/1490 train_time:32482ms step_avg:40.81ms
+step:797/1490 train_time:32535ms step_avg:40.82ms
+step:798/1490 train_time:32594ms step_avg:40.84ms
+step:799/1490 train_time:32647ms step_avg:40.86ms
+step:800/1490 train_time:32705ms step_avg:40.88ms
+step:801/1490 train_time:32759ms step_avg:40.90ms
+step:802/1490 train_time:32817ms step_avg:40.92ms
+step:803/1490 train_time:32870ms step_avg:40.93ms
+step:804/1490 train_time:32929ms step_avg:40.96ms
+step:805/1490 train_time:32983ms step_avg:40.97ms
+step:806/1490 train_time:33042ms step_avg:40.99ms
+step:807/1490 train_time:33095ms step_avg:41.01ms
+step:808/1490 train_time:33154ms step_avg:41.03ms
+step:809/1490 train_time:33207ms step_avg:41.05ms
+step:810/1490 train_time:33267ms step_avg:41.07ms
+step:811/1490 train_time:33320ms step_avg:41.09ms
+step:812/1490 train_time:33379ms step_avg:41.11ms
+step:813/1490 train_time:33432ms step_avg:41.12ms
+step:814/1490 train_time:33491ms step_avg:41.14ms
+step:815/1490 train_time:33544ms step_avg:41.16ms
+step:816/1490 train_time:33603ms step_avg:41.18ms
+step:817/1490 train_time:33851ms step_avg:41.43ms
+step:818/1490 train_time:33879ms step_avg:41.42ms
+step:819/1490 train_time:33930ms step_avg:41.43ms
+step:820/1490 train_time:33988ms step_avg:41.45ms
+step:821/1490 train_time:34040ms step_avg:41.46ms
+step:822/1490 train_time:34099ms step_avg:41.48ms
+step:823/1490 train_time:34151ms step_avg:41.50ms
+step:824/1490 train_time:34209ms step_avg:41.52ms
+step:825/1490 train_time:34262ms step_avg:41.53ms
+step:826/1490 train_time:34320ms step_avg:41.55ms
+step:827/1490 train_time:34372ms step_avg:41.56ms
+step:828/1490 train_time:34430ms step_avg:41.58ms
+step:829/1490 train_time:34484ms step_avg:41.60ms
+step:830/1490 train_time:34542ms step_avg:41.62ms
+step:831/1490 train_time:34594ms step_avg:41.63ms
+step:832/1490 train_time:34652ms step_avg:41.65ms
+step:833/1490 train_time:34706ms step_avg:41.66ms
+step:834/1490 train_time:34770ms step_avg:41.69ms
+step:835/1490 train_time:34826ms step_avg:41.71ms
+step:836/1490 train_time:34885ms step_avg:41.73ms
+step:837/1490 train_time:34939ms step_avg:41.74ms
+step:838/1490 train_time:34997ms step_avg:41.76ms
+step:839/1490 train_time:35050ms step_avg:41.78ms
+step:840/1490 train_time:35109ms step_avg:41.80ms
+step:841/1490 train_time:35162ms step_avg:41.81ms
+step:842/1490 train_time:35220ms step_avg:41.83ms
+step:843/1490 train_time:35273ms step_avg:41.84ms
+step:844/1490 train_time:35330ms step_avg:41.86ms
+step:845/1490 train_time:35383ms step_avg:41.87ms
+step:846/1490 train_time:35441ms step_avg:41.89ms
+step:847/1490 train_time:35493ms step_avg:41.90ms
+step:848/1490 train_time:35551ms step_avg:41.92ms
+step:849/1490 train_time:35603ms step_avg:41.94ms
+step:850/1490 train_time:35663ms step_avg:41.96ms
+step:851/1490 train_time:35716ms step_avg:41.97ms
+step:852/1490 train_time:35775ms step_avg:41.99ms
+step:853/1490 train_time:35830ms step_avg:42.00ms
+step:854/1490 train_time:35889ms step_avg:42.03ms
+step:855/1490 train_time:35943ms step_avg:42.04ms
+step:856/1490 train_time:36002ms step_avg:42.06ms
+step:857/1490 train_time:36055ms step_avg:42.07ms
+step:858/1490 train_time:36114ms step_avg:42.09ms
+step:859/1490 train_time:36168ms step_avg:42.10ms
+step:860/1490 train_time:36226ms step_avg:42.12ms
+step:861/1490 train_time:36279ms step_avg:42.14ms
+step:862/1490 train_time:36337ms step_avg:42.15ms
+step:863/1490 train_time:36390ms step_avg:42.17ms
+step:864/1490 train_time:36449ms step_avg:42.19ms
+step:865/1490 train_time:36501ms step_avg:42.20ms
+step:866/1490 train_time:36559ms step_avg:42.22ms
+step:867/1490 train_time:36612ms step_avg:42.23ms
+step:868/1490 train_time:36671ms step_avg:42.25ms
+step:869/1490 train_time:36724ms step_avg:42.26ms
+step:870/1490 train_time:36784ms step_avg:42.28ms
+step:871/1490 train_time:36838ms step_avg:42.29ms
+step:872/1490 train_time:36897ms step_avg:42.31ms
+step:873/1490 train_time:36951ms step_avg:42.33ms
+step:874/1490 train_time:37009ms step_avg:42.34ms
+step:875/1490 train_time:37063ms step_avg:42.36ms
+step:876/1490 train_time:37122ms step_avg:42.38ms
+step:877/1490 train_time:37176ms step_avg:42.39ms
+step:878/1490 train_time:37234ms step_avg:42.41ms
+step:879/1490 train_time:37287ms step_avg:42.42ms
+step:880/1490 train_time:37345ms step_avg:42.44ms
+step:881/1490 train_time:37398ms step_avg:42.45ms
+step:882/1490 train_time:37457ms step_avg:42.47ms
+step:883/1490 train_time:37509ms step_avg:42.48ms
+step:884/1490 train_time:37568ms step_avg:42.50ms
+step:885/1490 train_time:37620ms step_avg:42.51ms
+step:886/1490 train_time:37678ms step_avg:42.53ms
+step:887/1490 train_time:37732ms step_avg:42.54ms
+step:888/1490 train_time:37791ms step_avg:42.56ms
+step:889/1490 train_time:37845ms step_avg:42.57ms
+step:890/1490 train_time:37904ms step_avg:42.59ms
+step:891/1490 train_time:37957ms step_avg:42.60ms
+step:892/1490 train_time:38015ms step_avg:42.62ms
+step:893/1490 train_time:38070ms step_avg:42.63ms
+step:894/1490 train_time:38128ms step_avg:42.65ms
+step:895/1490 train_time:38181ms step_avg:42.66ms
+step:896/1490 train_time:38240ms step_avg:42.68ms
+step:897/1490 train_time:38292ms step_avg:42.69ms
+step:898/1490 train_time:38352ms step_avg:42.71ms
+step:899/1490 train_time:38404ms step_avg:42.72ms
+step:900/1490 train_time:38463ms step_avg:42.74ms
+step:901/1490 train_time:38516ms step_avg:42.75ms
+step:902/1490 train_time:38574ms step_avg:42.76ms
+step:903/1490 train_time:38627ms step_avg:42.78ms
+step:904/1490 train_time:38686ms step_avg:42.79ms
+step:905/1490 train_time:38739ms step_avg:42.81ms
+step:906/1490 train_time:38797ms step_avg:42.82ms
+step:907/1490 train_time:38851ms step_avg:42.83ms
+step:908/1490 train_time:38910ms step_avg:42.85ms
+step:909/1490 train_time:38964ms step_avg:42.86ms
+step:910/1490 train_time:39023ms step_avg:42.88ms
+step:911/1490 train_time:39076ms step_avg:42.89ms
+step:912/1490 train_time:39134ms step_avg:42.91ms
+step:913/1490 train_time:39188ms step_avg:42.92ms
+step:914/1490 train_time:39247ms step_avg:42.94ms
+step:915/1490 train_time:39300ms step_avg:42.95ms
+step:916/1490 train_time:39358ms step_avg:42.97ms
+step:917/1490 train_time:39410ms step_avg:42.98ms
+step:918/1490 train_time:39469ms step_avg:42.99ms
+step:919/1490 train_time:39521ms step_avg:43.00ms
+step:920/1490 train_time:39580ms step_avg:43.02ms
+step:921/1490 train_time:39633ms step_avg:43.03ms
+step:922/1490 train_time:39692ms step_avg:43.05ms
+step:923/1490 train_time:39745ms step_avg:43.06ms
+step:924/1490 train_time:39805ms step_avg:43.08ms
+step:925/1490 train_time:39858ms step_avg:43.09ms
+step:926/1490 train_time:39916ms step_avg:43.11ms
+step:927/1490 train_time:39970ms step_avg:43.12ms
+step:928/1490 train_time:40028ms step_avg:43.13ms
+step:929/1490 train_time:40082ms step_avg:43.15ms
+step:930/1490 train_time:40141ms step_avg:43.16ms
+step:931/1490 train_time:40193ms step_avg:43.17ms
+step:932/1490 train_time:40252ms step_avg:43.19ms
+step:933/1490 train_time:40306ms step_avg:43.20ms
+step:934/1490 train_time:40364ms step_avg:43.22ms
+step:935/1490 train_time:40417ms step_avg:43.23ms
+step:936/1490 train_time:40475ms step_avg:43.24ms
+step:937/1490 train_time:40529ms step_avg:43.25ms
+step:938/1490 train_time:40588ms step_avg:43.27ms
+step:939/1490 train_time:40641ms step_avg:43.28ms
+step:940/1490 train_time:40699ms step_avg:43.30ms
+step:941/1490 train_time:40753ms step_avg:43.31ms
+step:942/1490 train_time:40812ms step_avg:43.32ms
+step:943/1490 train_time:40865ms step_avg:43.34ms
+step:944/1490 train_time:40924ms step_avg:43.35ms
+step:945/1490 train_time:40978ms step_avg:43.36ms
+step:946/1490 train_time:41035ms step_avg:43.38ms
+step:947/1490 train_time:41088ms step_avg:43.39ms
+step:948/1490 train_time:41148ms step_avg:43.41ms
+step:949/1490 train_time:41201ms step_avg:43.41ms
+step:950/1490 train_time:41259ms step_avg:43.43ms
+step:951/1490 train_time:41312ms step_avg:43.44ms
+step:952/1490 train_time:41371ms step_avg:43.46ms
+step:953/1490 train_time:41423ms step_avg:43.47ms
+step:954/1490 train_time:41483ms step_avg:43.48ms
+step:955/1490 train_time:41536ms step_avg:43.49ms
+step:956/1490 train_time:41594ms step_avg:43.51ms
+step:957/1490 train_time:41647ms step_avg:43.52ms
+step:958/1490 train_time:41706ms step_avg:43.53ms
+step:959/1490 train_time:41759ms step_avg:43.54ms
+step:960/1490 train_time:41817ms step_avg:43.56ms
+step:961/1490 train_time:41871ms step_avg:43.57ms
+step:962/1490 train_time:41930ms step_avg:43.59ms
+step:963/1490 train_time:41983ms step_avg:43.60ms
+step:964/1490 train_time:42041ms step_avg:43.61ms
+step:965/1490 train_time:42094ms step_avg:43.62ms
+step:966/1490 train_time:42153ms step_avg:43.64ms
+step:967/1490 train_time:42207ms step_avg:43.65ms
+step:968/1490 train_time:42269ms step_avg:43.67ms
+step:969/1490 train_time:42348ms step_avg:43.70ms
+step:970/1490 train_time:42431ms step_avg:43.74ms
+step:971/1490 train_time:42510ms step_avg:43.78ms
+step:972/1490 train_time:42595ms step_avg:43.82ms
+step:973/1490 train_time:42673ms step_avg:43.86ms
+step:974/1490 train_time:42757ms step_avg:43.90ms
+step:975/1490 train_time:42835ms step_avg:43.93ms
+step:976/1490 train_time:42921ms step_avg:43.98ms
+step:977/1490 train_time:42999ms step_avg:44.01ms
+step:978/1490 train_time:43084ms step_avg:44.05ms
+step:979/1490 train_time:43163ms step_avg:44.09ms
+step:980/1490 train_time:43247ms step_avg:44.13ms
+step:981/1490 train_time:43326ms step_avg:44.16ms
+step:982/1490 train_time:43409ms step_avg:44.20ms
+step:983/1490 train_time:43488ms step_avg:44.24ms
+step:984/1490 train_time:43572ms step_avg:44.28ms
+step:985/1490 train_time:43651ms step_avg:44.32ms
+step:986/1490 train_time:43735ms step_avg:44.36ms
+step:987/1490 train_time:43814ms step_avg:44.39ms
+step:988/1490 train_time:43899ms step_avg:44.43ms
+step:989/1490 train_time:43979ms step_avg:44.47ms
+step:990/1490 train_time:44062ms step_avg:44.51ms
+step:991/1490 train_time:44141ms step_avg:44.54ms
+step:992/1490 train_time:44225ms step_avg:44.58ms
+step:993/1490 train_time:44304ms step_avg:44.62ms
+step:994/1490 train_time:44387ms step_avg:44.66ms
+step:995/1490 train_time:44467ms step_avg:44.69ms
+step:996/1490 train_time:44551ms step_avg:44.73ms
+step:997/1490 train_time:44629ms step_avg:44.76ms
+step:998/1490 train_time:44715ms step_avg:44.80ms
+step:999/1490 train_time:44795ms step_avg:44.84ms
+step:1000/1490 train_time:44879ms step_avg:44.88ms
+step:1000/1490 val_loss:3.5189 train_time:44974ms step_avg:44.97ms
+step:1001/1490 train_time:44992ms step_avg:44.95ms
+step:1002/1490 train_time:45043ms step_avg:44.95ms
+step:1003/1490 train_time:45127ms step_avg:44.99ms
+step:1004/1490 train_time:45217ms step_avg:45.04ms
+step:1005/1490 train_time:45298ms step_avg:45.07ms
+step:1006/1490 train_time:45382ms step_avg:45.11ms
+step:1007/1490 train_time:45459ms step_avg:45.14ms
+step:1008/1490 train_time:45542ms step_avg:45.18ms
+step:1009/1490 train_time:45621ms step_avg:45.21ms
+step:1010/1490 train_time:45705ms step_avg:45.25ms
+step:1011/1490 train_time:45782ms step_avg:45.28ms
+step:1012/1490 train_time:45865ms step_avg:45.32ms
+step:1013/1490 train_time:45943ms step_avg:45.35ms
+step:1014/1490 train_time:46029ms step_avg:45.39ms
+step:1015/1490 train_time:46110ms step_avg:45.43ms
+step:1016/1490 train_time:46196ms step_avg:45.47ms
+step:1017/1490 train_time:46276ms step_avg:45.50ms
+step:1018/1490 train_time:46361ms step_avg:45.54ms
+step:1019/1490 train_time:46441ms step_avg:45.57ms
+step:1020/1490 train_time:46525ms step_avg:45.61ms
+step:1021/1490 train_time:46604ms step_avg:45.65ms
+step:1022/1490 train_time:46687ms step_avg:45.68ms
+step:1023/1490 train_time:46765ms step_avg:45.71ms
+step:1024/1490 train_time:46848ms step_avg:45.75ms
+step:1025/1490 train_time:46926ms step_avg:45.78ms
+step:1026/1490 train_time:47011ms step_avg:45.82ms
+step:1027/1490 train_time:47091ms step_avg:45.85ms
+step:1028/1490 train_time:47175ms step_avg:45.89ms
+step:1029/1490 train_time:47255ms step_avg:45.92ms
+step:1030/1490 train_time:47339ms step_avg:45.96ms
+step:1031/1490 train_time:47418ms step_avg:45.99ms
+step:1032/1490 train_time:47503ms step_avg:46.03ms
+step:1033/1490 train_time:47582ms step_avg:46.06ms
+step:1034/1490 train_time:47664ms step_avg:46.10ms
+step:1035/1490 train_time:47743ms step_avg:46.13ms
+step:1036/1490 train_time:47828ms step_avg:46.17ms
+step:1037/1490 train_time:47907ms step_avg:46.20ms
+step:1038/1490 train_time:47991ms step_avg:46.23ms
+step:1039/1490 train_time:48069ms step_avg:46.27ms
+step:1040/1490 train_time:48154ms step_avg:46.30ms
+step:1041/1490 train_time:48233ms step_avg:46.33ms
+step:1042/1490 train_time:48319ms step_avg:46.37ms
+step:1043/1490 train_time:48398ms step_avg:46.40ms
+step:1044/1490 train_time:48483ms step_avg:46.44ms
+step:1045/1490 train_time:48560ms step_avg:46.47ms
+step:1046/1490 train_time:48644ms step_avg:46.51ms
+step:1047/1490 train_time:48723ms step_avg:46.54ms
+step:1048/1490 train_time:48809ms step_avg:46.57ms
+step:1049/1490 train_time:48888ms step_avg:46.60ms
+step:1050/1490 train_time:48972ms step_avg:46.64ms
+step:1051/1490 train_time:49050ms step_avg:46.67ms
+step:1052/1490 train_time:49135ms step_avg:46.71ms
+step:1053/1490 train_time:49215ms step_avg:46.74ms
+step:1054/1490 train_time:49298ms step_avg:46.77ms
+step:1055/1490 train_time:49378ms step_avg:46.80ms
+step:1056/1490 train_time:49461ms step_avg:46.84ms
+step:1057/1490 train_time:49540ms step_avg:46.87ms
+step:1058/1490 train_time:49624ms step_avg:46.90ms
+step:1059/1490 train_time:49703ms step_avg:46.93ms
+step:1060/1490 train_time:49787ms step_avg:46.97ms
+step:1061/1490 train_time:49867ms step_avg:47.00ms
+step:1062/1490 train_time:49950ms step_avg:47.03ms
+step:1063/1490 train_time:50030ms step_avg:47.07ms
+step:1064/1490 train_time:50116ms step_avg:47.10ms
+step:1065/1490 train_time:50195ms step_avg:47.13ms
+step:1066/1490 train_time:50278ms step_avg:47.17ms
+step:1067/1490 train_time:50357ms step_avg:47.20ms
+step:1068/1490 train_time:50442ms step_avg:47.23ms
+step:1069/1490 train_time:50521ms step_avg:47.26ms
+step:1070/1490 train_time:50605ms step_avg:47.29ms
+step:1071/1490 train_time:50684ms step_avg:47.32ms
+step:1072/1490 train_time:50767ms step_avg:47.36ms
+step:1073/1490 train_time:50846ms step_avg:47.39ms
+step:1074/1490 train_time:50931ms step_avg:47.42ms
+step:1075/1490 train_time:51009ms step_avg:47.45ms
+step:1076/1490 train_time:51094ms step_avg:47.48ms
+step:1077/1490 train_time:51172ms step_avg:47.51ms
+step:1078/1490 train_time:51256ms step_avg:47.55ms
+step:1079/1490 train_time:51335ms step_avg:47.58ms
+step:1080/1490 train_time:51418ms step_avg:47.61ms
+step:1081/1490 train_time:51497ms step_avg:47.64ms
+step:1082/1490 train_time:51581ms step_avg:47.67ms
+step:1083/1490 train_time:51660ms step_avg:47.70ms
+step:1084/1490 train_time:51743ms step_avg:47.73ms
+step:1085/1490 train_time:51824ms step_avg:47.76ms
+step:1086/1490 train_time:51908ms step_avg:47.80ms
+step:1087/1490 train_time:51988ms step_avg:47.83ms
+step:1088/1490 train_time:52071ms step_avg:47.86ms
+step:1089/1490 train_time:52150ms step_avg:47.89ms
+step:1090/1490 train_time:52236ms step_avg:47.92ms
+step:1091/1490 train_time:52314ms step_avg:47.95ms
+step:1092/1490 train_time:52398ms step_avg:47.98ms
+step:1093/1490 train_time:52477ms step_avg:48.01ms
+step:1094/1490 train_time:52561ms step_avg:48.05ms
+step:1095/1490 train_time:52639ms step_avg:48.07ms
+step:1096/1490 train_time:52724ms step_avg:48.11ms
+step:1097/1490 train_time:52803ms step_avg:48.13ms
+step:1098/1490 train_time:52890ms step_avg:48.17ms
+step:1099/1490 train_time:52970ms step_avg:48.20ms
+step:1100/1490 train_time:53053ms step_avg:48.23ms
+step:1101/1490 train_time:53133ms step_avg:48.26ms
+step:1102/1490 train_time:53217ms step_avg:48.29ms
+step:1103/1490 train_time:53296ms step_avg:48.32ms
+step:1104/1490 train_time:53379ms step_avg:48.35ms
+step:1105/1490 train_time:53458ms step_avg:48.38ms
+step:1106/1490 train_time:53542ms step_avg:48.41ms
+step:1107/1490 train_time:53621ms step_avg:48.44ms
+step:1108/1490 train_time:53706ms step_avg:48.47ms
+step:1109/1490 train_time:53787ms step_avg:48.50ms
+step:1110/1490 train_time:53870ms step_avg:48.53ms
+step:1111/1490 train_time:53950ms step_avg:48.56ms
+step:1112/1490 train_time:54034ms step_avg:48.59ms
+step:1113/1490 train_time:54113ms step_avg:48.62ms
+step:1114/1490 train_time:54197ms step_avg:48.65ms
+step:1115/1490 train_time:54275ms step_avg:48.68ms
+step:1116/1490 train_time:54357ms step_avg:48.71ms
+step:1117/1490 train_time:54436ms step_avg:48.73ms
+step:1118/1490 train_time:54520ms step_avg:48.77ms
+step:1119/1490 train_time:54599ms step_avg:48.79ms
+step:1120/1490 train_time:54683ms step_avg:48.82ms
+step:1121/1490 train_time:54763ms step_avg:48.85ms
+step:1122/1490 train_time:54847ms step_avg:48.88ms
+step:1123/1490 train_time:54928ms step_avg:48.91ms
+step:1124/1490 train_time:55011ms step_avg:48.94ms
+step:1125/1490 train_time:55089ms step_avg:48.97ms
+step:1126/1490 train_time:55175ms step_avg:49.00ms
+step:1127/1490 train_time:55253ms step_avg:49.03ms
+step:1128/1490 train_time:55337ms step_avg:49.06ms
+step:1129/1490 train_time:55417ms step_avg:49.08ms
+step:1130/1490 train_time:55500ms step_avg:49.12ms
+step:1131/1490 train_time:55580ms step_avg:49.14ms
+step:1132/1490 train_time:55663ms step_avg:49.17ms
+step:1133/1490 train_time:55742ms step_avg:49.20ms
+step:1134/1490 train_time:55829ms step_avg:49.23ms
+step:1135/1490 train_time:55908ms step_avg:49.26ms
+step:1136/1490 train_time:55994ms step_avg:49.29ms
+step:1137/1490 train_time:56073ms step_avg:49.32ms
+step:1138/1490 train_time:56156ms step_avg:49.35ms
+step:1139/1490 train_time:56236ms step_avg:49.37ms
+step:1140/1490 train_time:56319ms step_avg:49.40ms
+step:1141/1490 train_time:56398ms step_avg:49.43ms
+step:1142/1490 train_time:56482ms step_avg:49.46ms
+step:1143/1490 train_time:56559ms step_avg:49.48ms
+step:1144/1490 train_time:56643ms step_avg:49.51ms
+step:1145/1490 train_time:56723ms step_avg:49.54ms
+step:1146/1490 train_time:56808ms step_avg:49.57ms
+step:1147/1490 train_time:56888ms step_avg:49.60ms
+step:1148/1490 train_time:56971ms step_avg:49.63ms
+step:1149/1490 train_time:57051ms step_avg:49.65ms
+step:1150/1490 train_time:57136ms step_avg:49.68ms
+step:1151/1490 train_time:57214ms step_avg:49.71ms
+step:1152/1490 train_time:57298ms step_avg:49.74ms
+step:1153/1490 train_time:57377ms step_avg:49.76ms
+step:1154/1490 train_time:57460ms step_avg:49.79ms
+step:1155/1490 train_time:57539ms step_avg:49.82ms
+step:1156/1490 train_time:57623ms step_avg:49.85ms
+step:1157/1490 train_time:57703ms step_avg:49.87ms
+step:1158/1490 train_time:57788ms step_avg:49.90ms
+step:1159/1490 train_time:57868ms step_avg:49.93ms
+step:1160/1490 train_time:57951ms step_avg:49.96ms
+step:1161/1490 train_time:58030ms step_avg:49.98ms
+step:1162/1490 train_time:58115ms step_avg:50.01ms
+step:1163/1490 train_time:58194ms step_avg:50.04ms
+step:1164/1490 train_time:58276ms step_avg:50.07ms
+step:1165/1490 train_time:58357ms step_avg:50.09ms
+step:1166/1490 train_time:58441ms step_avg:50.12ms
+step:1167/1490 train_time:58519ms step_avg:50.15ms
+step:1168/1490 train_time:58604ms step_avg:50.17ms
+step:1169/1490 train_time:58684ms step_avg:50.20ms
+step:1170/1490 train_time:58768ms step_avg:50.23ms
+step:1171/1490 train_time:58847ms step_avg:50.25ms
+step:1172/1490 train_time:58932ms step_avg:50.28ms
+step:1173/1490 train_time:59011ms step_avg:50.31ms
+step:1174/1490 train_time:59095ms step_avg:50.34ms
+step:1175/1490 train_time:59173ms step_avg:50.36ms
+step:1176/1490 train_time:59256ms step_avg:50.39ms
+step:1177/1490 train_time:59336ms step_avg:50.41ms
+step:1178/1490 train_time:59421ms step_avg:50.44ms
+step:1179/1490 train_time:59499ms step_avg:50.47ms
+step:1180/1490 train_time:59585ms step_avg:50.50ms
+step:1181/1490 train_time:59663ms step_avg:50.52ms
+step:1182/1490 train_time:59748ms step_avg:50.55ms
+step:1183/1490 train_time:59827ms step_avg:50.57ms
+step:1184/1490 train_time:59910ms step_avg:50.60ms
+step:1185/1490 train_time:59990ms step_avg:50.62ms
+step:1186/1490 train_time:60076ms step_avg:50.65ms
+step:1187/1490 train_time:60153ms step_avg:50.68ms
+step:1188/1490 train_time:60237ms step_avg:50.70ms
+step:1189/1490 train_time:60317ms step_avg:50.73ms
+step:1190/1490 train_time:60402ms step_avg:50.76ms
+step:1191/1490 train_time:60481ms step_avg:50.78ms
+step:1192/1490 train_time:60565ms step_avg:50.81ms
+step:1193/1490 train_time:60643ms step_avg:50.83ms
+step:1194/1490 train_time:60728ms step_avg:50.86ms
+step:1195/1490 train_time:60808ms step_avg:50.89ms
+step:1196/1490 train_time:60892ms step_avg:50.91ms
+step:1197/1490 train_time:60971ms step_avg:50.94ms
+step:1198/1490 train_time:61055ms step_avg:50.96ms
+step:1199/1490 train_time:61133ms step_avg:50.99ms
+step:1200/1490 train_time:61217ms step_avg:51.01ms
+step:1201/1490 train_time:61296ms step_avg:51.04ms
+step:1202/1490 train_time:61379ms step_avg:51.06ms
+step:1203/1490 train_time:61458ms step_avg:51.09ms
+step:1204/1490 train_time:61543ms step_avg:51.12ms
+step:1205/1490 train_time:61622ms step_avg:51.14ms
+step:1206/1490 train_time:61706ms step_avg:51.17ms
+step:1207/1490 train_time:61785ms step_avg:51.19ms
+step:1208/1490 train_time:61869ms step_avg:51.22ms
+step:1209/1490 train_time:61949ms step_avg:51.24ms
+step:1210/1490 train_time:62034ms step_avg:51.27ms
+step:1211/1490 train_time:62112ms step_avg:51.29ms
+step:1212/1490 train_time:62196ms step_avg:51.32ms
+step:1213/1490 train_time:62276ms step_avg:51.34ms
+step:1214/1490 train_time:62358ms step_avg:51.37ms
+step:1215/1490 train_time:62439ms step_avg:51.39ms
+step:1216/1490 train_time:62524ms step_avg:51.42ms
+step:1217/1490 train_time:62604ms step_avg:51.44ms
+step:1218/1490 train_time:62688ms step_avg:51.47ms
+step:1219/1490 train_time:62767ms step_avg:51.49ms
+step:1220/1490 train_time:62851ms step_avg:51.52ms
+step:1221/1490 train_time:62929ms step_avg:51.54ms
+step:1222/1490 train_time:63014ms step_avg:51.57ms
+step:1223/1490 train_time:63094ms step_avg:51.59ms
+step:1224/1490 train_time:63177ms step_avg:51.62ms
+step:1225/1490 train_time:63255ms step_avg:51.64ms
+step:1226/1490 train_time:63339ms step_avg:51.66ms
+step:1227/1490 train_time:63419ms step_avg:51.69ms
+step:1228/1490 train_time:63504ms step_avg:51.71ms
+step:1229/1490 train_time:63585ms step_avg:51.74ms
+step:1230/1490 train_time:63669ms step_avg:51.76ms
+step:1231/1490 train_time:63749ms step_avg:51.79ms
+step:1232/1490 train_time:63833ms step_avg:51.81ms
+step:1233/1490 train_time:63912ms step_avg:51.83ms
+step:1234/1490 train_time:63997ms step_avg:51.86ms
+step:1235/1490 train_time:64075ms step_avg:51.88ms
+step:1236/1490 train_time:64158ms step_avg:51.91ms
+step:1237/1490 train_time:64238ms step_avg:51.93ms
+step:1238/1490 train_time:64322ms step_avg:51.96ms
+step:1239/1490 train_time:64401ms step_avg:51.98ms
+step:1240/1490 train_time:64486ms step_avg:52.01ms
+step:1241/1490 train_time:64565ms step_avg:52.03ms
+step:1242/1490 train_time:64648ms step_avg:52.05ms
+step:1243/1490 train_time:64728ms step_avg:52.07ms
+step:1244/1490 train_time:64813ms step_avg:52.10ms
+step:1245/1490 train_time:64892ms step_avg:52.12ms
+step:1246/1490 train_time:64977ms step_avg:52.15ms
+step:1247/1490 train_time:65056ms step_avg:52.17ms
+step:1248/1490 train_time:65140ms step_avg:52.20ms
+step:1249/1490 train_time:65218ms step_avg:52.22ms
+step:1250/1490 train_time:65302ms step_avg:52.24ms
+step:1250/1490 val_loss:3.3718 train_time:65397ms step_avg:52.32ms
+step:1251/1490 train_time:65415ms step_avg:52.29ms
+step:1252/1490 train_time:65466ms step_avg:52.29ms
+step:1253/1490 train_time:65544ms step_avg:52.31ms
+step:1254/1490 train_time:65631ms step_avg:52.34ms
+step:1255/1490 train_time:65710ms step_avg:52.36ms
+step:1256/1490 train_time:65793ms step_avg:52.38ms
+step:1257/1490 train_time:65872ms step_avg:52.40ms
+step:1258/1490 train_time:65956ms step_avg:52.43ms
+step:1259/1490 train_time:66034ms step_avg:52.45ms
+step:1260/1490 train_time:66116ms step_avg:52.47ms
+step:1261/1490 train_time:66195ms step_avg:52.49ms
+step:1262/1490 train_time:66278ms step_avg:52.52ms
+step:1263/1490 train_time:66357ms step_avg:52.54ms
+step:1264/1490 train_time:66444ms step_avg:52.57ms
+step:1265/1490 train_time:66527ms step_avg:52.59ms
+step:1266/1490 train_time:66611ms step_avg:52.62ms
+step:1267/1490 train_time:66690ms step_avg:52.64ms
+step:1268/1490 train_time:66776ms step_avg:52.66ms
+step:1269/1490 train_time:66855ms step_avg:52.68ms
+step:1270/1490 train_time:66938ms step_avg:52.71ms
+step:1271/1490 train_time:67016ms step_avg:52.73ms
+step:1272/1490 train_time:67100ms step_avg:52.75ms
+step:1273/1490 train_time:67177ms step_avg:52.77ms
+step:1274/1490 train_time:67261ms step_avg:52.80ms
+step:1275/1490 train_time:67340ms step_avg:52.82ms
+step:1276/1490 train_time:67425ms step_avg:52.84ms
+step:1277/1490 train_time:67505ms step_avg:52.86ms
+step:1278/1490 train_time:67591ms step_avg:52.89ms
+step:1279/1490 train_time:67669ms step_avg:52.91ms
+step:1280/1490 train_time:67754ms step_avg:52.93ms
+step:1281/1490 train_time:67832ms step_avg:52.95ms
+step:1282/1490 train_time:67916ms step_avg:52.98ms
+step:1283/1490 train_time:67996ms step_avg:53.00ms
+step:1284/1490 train_time:68079ms step_avg:53.02ms
+step:1285/1490 train_time:68157ms step_avg:53.04ms
+step:1286/1490 train_time:68240ms step_avg:53.06ms
+step:1287/1490 train_time:68319ms step_avg:53.08ms
+step:1288/1490 train_time:68404ms step_avg:53.11ms
+step:1289/1490 train_time:68484ms step_avg:53.13ms
+step:1290/1490 train_time:68570ms step_avg:53.15ms
+step:1291/1490 train_time:68649ms step_avg:53.18ms
+step:1292/1490 train_time:68732ms step_avg:53.20ms
+step:1293/1490 train_time:68810ms step_avg:53.22ms
+step:1294/1490 train_time:68895ms step_avg:53.24ms
+step:1295/1490 train_time:68975ms step_avg:53.26ms
+step:1296/1490 train_time:69059ms step_avg:53.29ms
+step:1297/1490 train_time:69138ms step_avg:53.31ms
+step:1298/1490 train_time:69222ms step_avg:53.33ms
+step:1299/1490 train_time:69301ms step_avg:53.35ms
+step:1300/1490 train_time:69384ms step_avg:53.37ms
+step:1301/1490 train_time:69465ms step_avg:53.39ms
+step:1302/1490 train_time:69549ms step_avg:53.42ms
+step:1303/1490 train_time:69627ms step_avg:53.44ms
+step:1304/1490 train_time:69712ms step_avg:53.46ms
+step:1305/1490 train_time:69792ms step_avg:53.48ms
+step:1306/1490 train_time:69876ms step_avg:53.50ms
+step:1307/1490 train_time:69956ms step_avg:53.52ms
+step:1308/1490 train_time:70039ms step_avg:53.55ms
+step:1309/1490 train_time:70116ms step_avg:53.56ms
+step:1310/1490 train_time:70201ms step_avg:53.59ms
+step:1311/1490 train_time:70281ms step_avg:53.61ms
+step:1312/1490 train_time:70365ms step_avg:53.63ms
+step:1313/1490 train_time:70445ms step_avg:53.65ms
+step:1314/1490 train_time:70529ms step_avg:53.68ms
+step:1315/1490 train_time:70608ms step_avg:53.69ms
+step:1316/1490 train_time:70693ms step_avg:53.72ms
+step:1317/1490 train_time:70771ms step_avg:53.74ms
+step:1318/1490 train_time:70855ms step_avg:53.76ms
+step:1319/1490 train_time:70935ms step_avg:53.78ms
+step:1320/1490 train_time:71019ms step_avg:53.80ms
+step:1321/1490 train_time:71097ms step_avg:53.82ms
+step:1322/1490 train_time:71181ms step_avg:53.84ms
+step:1323/1490 train_time:71260ms step_avg:53.86ms
+step:1324/1490 train_time:71345ms step_avg:53.89ms
+step:1325/1490 train_time:71424ms step_avg:53.91ms
+step:1326/1490 train_time:71508ms step_avg:53.93ms
+step:1327/1490 train_time:71588ms step_avg:53.95ms
+step:1328/1490 train_time:71673ms step_avg:53.97ms
+step:1329/1490 train_time:71752ms step_avg:53.99ms
+step:1330/1490 train_time:71836ms step_avg:54.01ms
+step:1331/1490 train_time:71915ms step_avg:54.03ms
+step:1332/1490 train_time:72000ms step_avg:54.05ms
+step:1333/1490 train_time:72078ms step_avg:54.07ms
+step:1334/1490 train_time:72162ms step_avg:54.09ms
+step:1335/1490 train_time:72241ms step_avg:54.11ms
+step:1336/1490 train_time:72327ms step_avg:54.14ms
+step:1337/1490 train_time:72406ms step_avg:54.16ms
+step:1338/1490 train_time:72490ms step_avg:54.18ms
+step:1339/1490 train_time:72569ms step_avg:54.20ms
+step:1340/1490 train_time:72653ms step_avg:54.22ms
+step:1341/1490 train_time:72732ms step_avg:54.24ms
+step:1342/1490 train_time:72814ms step_avg:54.26ms
+step:1343/1490 train_time:72894ms step_avg:54.28ms
+step:1344/1490 train_time:72977ms step_avg:54.30ms
+step:1345/1490 train_time:73056ms step_avg:54.32ms
+step:1346/1490 train_time:73140ms step_avg:54.34ms
+step:1347/1490 train_time:73220ms step_avg:54.36ms
+step:1348/1490 train_time:73303ms step_avg:54.38ms
+step:1349/1490 train_time:73383ms step_avg:54.40ms
+step:1350/1490 train_time:73469ms step_avg:54.42ms
+step:1351/1490 train_time:73548ms step_avg:54.44ms
+step:1352/1490 train_time:73632ms step_avg:54.46ms
+step:1353/1490 train_time:73711ms step_avg:54.48ms
+step:1354/1490 train_time:73796ms step_avg:54.50ms
+step:1355/1490 train_time:73875ms step_avg:54.52ms
+step:1356/1490 train_time:73959ms step_avg:54.54ms
+step:1357/1490 train_time:74036ms step_avg:54.56ms
+step:1358/1490 train_time:74119ms step_avg:54.58ms
+step:1359/1490 train_time:74198ms step_avg:54.60ms
+step:1360/1490 train_time:74283ms step_avg:54.62ms
+step:1361/1490 train_time:74362ms step_avg:54.64ms
+step:1362/1490 train_time:74447ms step_avg:54.66ms
+step:1363/1490 train_time:74526ms step_avg:54.68ms
+step:1364/1490 train_time:74609ms step_avg:54.70ms
+step:1365/1490 train_time:74691ms step_avg:54.72ms
+step:1366/1490 train_time:74774ms step_avg:54.74ms
+step:1367/1490 train_time:74853ms step_avg:54.76ms
+step:1368/1490 train_time:74937ms step_avg:54.78ms
+step:1369/1490 train_time:75016ms step_avg:54.80ms
+step:1370/1490 train_time:75100ms step_avg:54.82ms
+step:1371/1490 train_time:75180ms step_avg:54.84ms
+step:1372/1490 train_time:75264ms step_avg:54.86ms
+step:1373/1490 train_time:75343ms step_avg:54.87ms
+step:1374/1490 train_time:75428ms step_avg:54.90ms
+step:1375/1490 train_time:75507ms step_avg:54.91ms
+step:1376/1490 train_time:75593ms step_avg:54.94ms
+step:1377/1490 train_time:75673ms step_avg:54.95ms
+step:1378/1490 train_time:75756ms step_avg:54.98ms
+step:1379/1490 train_time:75836ms step_avg:54.99ms
+step:1380/1490 train_time:75920ms step_avg:55.01ms
+step:1381/1490 train_time:75998ms step_avg:55.03ms
+step:1382/1490 train_time:76082ms step_avg:55.05ms
+step:1383/1490 train_time:76161ms step_avg:55.07ms
+step:1384/1490 train_time:76246ms step_avg:55.09ms
+step:1385/1490 train_time:76325ms step_avg:55.11ms
+step:1386/1490 train_time:76409ms step_avg:55.13ms
+step:1387/1490 train_time:76488ms step_avg:55.15ms
+step:1388/1490 train_time:76574ms step_avg:55.17ms
+step:1389/1490 train_time:76653ms step_avg:55.19ms
+step:1390/1490 train_time:76737ms step_avg:55.21ms
+step:1391/1490 train_time:76815ms step_avg:55.22ms
+step:1392/1490 train_time:76899ms step_avg:55.24ms
+step:1393/1490 train_time:76978ms step_avg:55.26ms
+step:1394/1490 train_time:77062ms step_avg:55.28ms
+step:1395/1490 train_time:77142ms step_avg:55.30ms
+step:1396/1490 train_time:77226ms step_avg:55.32ms
+step:1397/1490 train_time:77305ms step_avg:55.34ms
+step:1398/1490 train_time:77389ms step_avg:55.36ms
+step:1399/1490 train_time:77468ms step_avg:55.37ms
+step:1400/1490 train_time:77553ms step_avg:55.39ms
+step:1401/1490 train_time:77631ms step_avg:55.41ms
+step:1402/1490 train_time:77715ms step_avg:55.43ms
+step:1403/1490 train_time:77795ms step_avg:55.45ms
+step:1404/1490 train_time:77880ms step_avg:55.47ms
+step:1405/1490 train_time:77958ms step_avg:55.49ms
+step:1406/1490 train_time:78043ms step_avg:55.51ms
+step:1407/1490 train_time:78121ms step_avg:55.52ms
+step:1408/1490 train_time:78206ms step_avg:55.54ms
+step:1409/1490 train_time:78286ms step_avg:55.56ms
+step:1410/1490 train_time:78371ms step_avg:55.58ms
+step:1411/1490 train_time:78450ms step_avg:55.60ms
+step:1412/1490 train_time:78533ms step_avg:55.62ms
+step:1413/1490 train_time:78611ms step_avg:55.63ms
+step:1414/1490 train_time:78695ms step_avg:55.65ms
+step:1415/1490 train_time:78774ms step_avg:55.67ms
+step:1416/1490 train_time:78858ms step_avg:55.69ms
+step:1417/1490 train_time:78936ms step_avg:55.71ms
+step:1418/1490 train_time:79020ms step_avg:55.73ms
+step:1419/1490 train_time:79098ms step_avg:55.74ms
+step:1420/1490 train_time:79184ms step_avg:55.76ms
+step:1421/1490 train_time:79264ms step_avg:55.78ms
+step:1422/1490 train_time:79349ms step_avg:55.80ms
+step:1423/1490 train_time:79428ms step_avg:55.82ms
+step:1424/1490 train_time:79512ms step_avg:55.84ms
+step:1425/1490 train_time:79591ms step_avg:55.85ms
+step:1426/1490 train_time:79673ms step_avg:55.87ms
+step:1427/1490 train_time:79752ms step_avg:55.89ms
+step:1428/1490 train_time:79836ms step_avg:55.91ms
+step:1429/1490 train_time:79915ms step_avg:55.92ms
+step:1430/1490 train_time:80000ms step_avg:55.94ms
+step:1431/1490 train_time:80079ms step_avg:55.96ms
+step:1432/1490 train_time:80164ms step_avg:55.98ms
+step:1433/1490 train_time:80245ms step_avg:56.00ms
+step:1434/1490 train_time:80329ms step_avg:56.02ms
+step:1435/1490 train_time:80408ms step_avg:56.03ms
+step:1436/1490 train_time:80493ms step_avg:56.05ms
+step:1437/1490 train_time:80573ms step_avg:56.07ms
+step:1438/1490 train_time:80656ms step_avg:56.09ms
+step:1439/1490 train_time:80735ms step_avg:56.10ms
+step:1440/1490 train_time:80818ms step_avg:56.12ms
+step:1441/1490 train_time:80897ms step_avg:56.14ms
+step:1442/1490 train_time:80981ms step_avg:56.16ms
+step:1443/1490 train_time:81059ms step_avg:56.17ms
+step:1444/1490 train_time:81144ms step_avg:56.19ms
+step:1445/1490 train_time:81223ms step_avg:56.21ms
+step:1446/1490 train_time:81308ms step_avg:56.23ms
+step:1447/1490 train_time:81387ms step_avg:56.25ms
+step:1448/1490 train_time:81472ms step_avg:56.27ms
+step:1449/1490 train_time:81550ms step_avg:56.28ms
+step:1450/1490 train_time:81634ms step_avg:56.30ms
+step:1451/1490 train_time:81718ms step_avg:56.32ms
+step:1452/1490 train_time:81804ms step_avg:56.34ms
+step:1453/1490 train_time:81883ms step_avg:56.35ms
+step:1454/1490 train_time:81968ms step_avg:56.37ms
+step:1455/1490 train_time:82048ms step_avg:56.39ms
+step:1456/1490 train_time:82133ms step_avg:56.41ms
+step:1457/1490 train_time:82211ms step_avg:56.42ms
+step:1458/1490 train_time:82297ms step_avg:56.44ms
+step:1459/1490 train_time:82377ms step_avg:56.46ms
+step:1460/1490 train_time:82462ms step_avg:56.48ms
+step:1461/1490 train_time:82541ms step_avg:56.50ms
+step:1462/1490 train_time:82625ms step_avg:56.52ms
+step:1463/1490 train_time:82704ms step_avg:56.53ms
+step:1464/1490 train_time:82789ms step_avg:56.55ms
+step:1465/1490 train_time:82868ms step_avg:56.57ms
+step:1466/1490 train_time:82952ms step_avg:56.58ms
+step:1467/1490 train_time:83031ms step_avg:56.60ms
+step:1468/1490 train_time:83115ms step_avg:56.62ms
+step:1469/1490 train_time:83196ms step_avg:56.63ms
+step:1470/1490 train_time:83280ms step_avg:56.65ms
+step:1471/1490 train_time:83361ms step_avg:56.67ms
+step:1472/1490 train_time:83447ms step_avg:56.69ms
+step:1473/1490 train_time:83527ms step_avg:56.71ms
+step:1474/1490 train_time:83610ms step_avg:56.72ms
+step:1475/1490 train_time:83689ms step_avg:56.74ms
+step:1476/1490 train_time:83774ms step_avg:56.76ms
+step:1477/1490 train_time:83854ms step_avg:56.77ms
+step:1478/1490 train_time:83939ms step_avg:56.79ms
+step:1479/1490 train_time:84018ms step_avg:56.81ms
+step:1480/1490 train_time:84102ms step_avg:56.83ms
+step:1481/1490 train_time:84182ms step_avg:56.84ms
+step:1482/1490 train_time:84268ms step_avg:56.86ms
+step:1483/1490 train_time:84348ms step_avg:56.88ms
+step:1484/1490 train_time:84431ms step_avg:56.89ms
+step:1485/1490 train_time:84510ms step_avg:56.91ms
+step:1486/1490 train_time:84595ms step_avg:56.93ms
+step:1487/1490 train_time:84675ms step_avg:56.94ms
+step:1488/1490 train_time:84759ms step_avg:56.96ms
+step:1489/1490 train_time:84838ms step_avg:56.98ms
+step:1490/1490 train_time:84922ms step_avg:56.99ms
+step:1490/1490 val_loss:3.2788 train_time:85018ms step_avg:57.06ms
+peak memory allocated: 31295 MiB reserved: 43906 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/train_gpt.py
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/train_gpt.py
@@ -1,0 +1,2006 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(grad_chunk: torch.Tensor, momentum_buffer: torch.Tensor, momentum_t: torch.Tensor,
+                  split_baddbmm: bool = False):
+    """
+    Fused Nesterov momentum + Polar Express Sign Method.
+    Nesterov momentum is applied in FP32, then the result is cast to BF16 for polar express
+    orthogonalization, avoiding materialization of the FP32 intermediate between graph breaks.
+
+    Polar Express: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+
+    momentum_t is a 0-D CPU tensor to avoid triggering graph recompilations when the value changes.
+    """
+    # Nesterov momentum (in FP32)
+    momentum = momentum_t.to(grad_chunk.dtype)
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    g = grad_chunk.lerp_(momentum_buffer, momentum)
+
+    X = g.bfloat16()
+    is_tall = g.size(-2) > g.size(-1)
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    X = X.contiguous()
+
+    if is_tall:
+        # Tall: use Triton kernels with X^T @ X (small) and right multiplication
+        A = torch.empty((*X.shape[:-2], X.size(-1), X.size(-1)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            XB_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_XB = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XTX(X, out=A)  # A = X.T @ X
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b*A + c*(A@A)
+
+            # Referencing X twice causes pytorch to make a defensive copy,
+            # resulting in a cudaMemcpyAsync in baddbmm.
+            # For large matrices (i.e., the mlp weights), it's faster to split
+            # the operation into two kernels to avoid this.
+            if split_baddbmm:
+                XB_matmul(X, B, out=C)  # C = X @ B
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_XB(X, X, B, beta=a, out=C)  # C = a * X + X @ B
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+    else:
+        # Wide: use Triton kernels with X @ X^T (small) and left multiplication
+        A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+        B = torch.empty_like(A)
+        C = torch.empty_like(X)
+
+        # Select batched vs unbatched
+        if split_baddbmm:
+            BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+        else:
+            aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+        # Perform the iterations
+        for a, b, c in polar_express_coeffs:
+            XXT(X, out=A)  # A = X @ X.mT
+            ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+            if split_baddbmm:
+                BX_matmul(B, X, out=C)  # C = B @ X
+                C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+            else:
+                aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+            X, C = C, X  # Swap references to avoid unnecessary copies
+
+    return X
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+@torch.no_grad
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    rows_per_rank = N // world
+
+    # queue upload of indexes to gpu
+    send_idxes = send_idxes_buffer[:idxes_np.shape[0]]
+    send_idxes.copy_(torch.from_numpy(idxes_np))
+    send_idxes = send_idxes.to(device, non_blocking=True)
+
+    # calculate how many gradient rows we will send to every rank
+    insertion_points = np.searchsorted(
+        idxes_np,
+        np.arange(0, rows_per_rank * (world + 1), rows_per_rank, dtype=np.int32),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+    # zero-out own send-count - we won't send our own gradient rows to ourselves as it's a waste:
+    # in sparse_comms_merge_gradients, we'll use the slice of the gradient that already includes them as the base tensor
+    send_counts[rank] = 0
+
+    # remove indexes owned by our rank from the send list
+    send_idxes = torch.cat([send_idxes[: insertion_points[rank]], send_idxes[insertion_points[rank + 1] :]])
+
+    # share the send counts so that each rank will know how many rows
+    # to expect from every other rank
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(recv_counts, send_counts, async_op=True).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+@torch.no_grad
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    # cpu tensors, so these ops are cheap and don't force a host<->device sync
+    total_recv_count = recv_counts.sum().item()
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    # queue sharing of row indexes
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts, # list for sharing
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+@torch.compile
+@torch.no_grad
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    # gather the rows that we want to send
+    send_vals = grad[idxes]
+
+    d = grad.shape[1]
+
+    send_sizes = [i*d for i in send_counts]
+    recv_sizes = [i*d for i in recv_counts]
+
+    recv_vals = torch.empty(sum(recv_sizes), device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+@torch.no_grad
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+
+    grad.index_add_(0, recv_idx, recv_vals.view(-1, d))
+
+    # return the slice of the gradient for parameters our rank updates
+    return grad[rows_per_rank * rank : rows_per_rank * (rank + 1)].mul_((1 / world))
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda elf.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/triton_kernels.py
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251/triton_kernels.py
@@ -1,0 +1,1006 @@
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/4d2974f3-cd04-488b-92b1-6e1d695ac842.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/4d2974f3-cd04-488b-92b1-6e1d695ac842.txt
@@ -1,0 +1,4804 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 21:56:32 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8287 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:89ms step_avg:89.36ms
+step:2/1490 train_time:113ms step_avg:56.33ms
+step:3/1490 train_time:131ms step_avg:43.81ms
+step:4/1490 train_time:153ms step_avg:38.16ms
+step:5/1490 train_time:177ms step_avg:35.35ms
+step:6/1490 train_time:211ms step_avg:35.20ms
+step:7/1490 train_time:238ms step_avg:34.00ms
+step:8/1490 train_time:272ms step_avg:34.02ms
+step:9/1490 train_time:299ms step_avg:33.20ms
+step:10/1490 train_time:333ms step_avg:33.29ms
+step:11/1490 train_time:360ms step_avg:32.72ms
+step:12/1490 train_time:394ms step_avg:32.85ms
+step:13/1490 train_time:421ms step_avg:32.38ms
+step:14/1490 train_time:455ms step_avg:32.49ms
+step:15/1490 train_time:482ms step_avg:32.12ms
+step:16/1490 train_time:516ms step_avg:32.24ms
+step:17/1490 train_time:542ms step_avg:31.91ms
+step:18/1490 train_time:576ms step_avg:32.02ms
+step:19/1490 train_time:603ms step_avg:31.74ms
+step:20/1490 train_time:637ms step_avg:31.85ms
+step:21/1490 train_time:664ms step_avg:31.62ms
+step:22/1490 train_time:698ms step_avg:31.73ms
+step:23/1490 train_time:725ms step_avg:31.51ms
+step:24/1490 train_time:759ms step_avg:31.63ms
+step:25/1490 train_time:786ms step_avg:31.42ms
+step:26/1490 train_time:820ms step_avg:31.53ms
+step:27/1490 train_time:846ms step_avg:31.35ms
+step:28/1490 train_time:881ms step_avg:31.45ms
+step:29/1490 train_time:907ms step_avg:31.28ms
+step:30/1490 train_time:942ms step_avg:31.39ms
+step:31/1490 train_time:970ms step_avg:31.28ms
+step:32/1490 train_time:1005ms step_avg:31.42ms
+step:33/1490 train_time:1033ms step_avg:31.30ms
+step:34/1490 train_time:1068ms step_avg:31.40ms
+step:35/1490 train_time:1095ms step_avg:31.28ms
+step:36/1490 train_time:1130ms step_avg:31.38ms
+step:37/1490 train_time:1156ms step_avg:31.25ms
+step:38/1490 train_time:1191ms step_avg:31.33ms
+step:39/1490 train_time:1217ms step_avg:31.21ms
+step:40/1490 train_time:1251ms step_avg:31.29ms
+step:41/1490 train_time:1278ms step_avg:31.18ms
+step:42/1490 train_time:1312ms step_avg:31.24ms
+step:43/1490 train_time:1339ms step_avg:31.13ms
+step:44/1490 train_time:1372ms step_avg:31.19ms
+step:45/1490 train_time:1399ms step_avg:31.09ms
+step:46/1490 train_time:1433ms step_avg:31.15ms
+step:47/1490 train_time:1460ms step_avg:31.06ms
+step:48/1490 train_time:1494ms step_avg:31.12ms
+step:49/1490 train_time:1521ms step_avg:31.03ms
+step:50/1490 train_time:1555ms step_avg:31.09ms
+step:51/1490 train_time:1582ms step_avg:31.01ms
+step:52/1490 train_time:1616ms step_avg:31.07ms
+step:53/1490 train_time:1643ms step_avg:30.99ms
+step:54/1490 train_time:1677ms step_avg:31.05ms
+step:55/1490 train_time:1703ms step_avg:30.97ms
+step:56/1490 train_time:1738ms step_avg:31.03ms
+step:57/1490 train_time:1765ms step_avg:30.96ms
+step:58/1490 train_time:1798ms step_avg:31.01ms
+step:59/1490 train_time:1825ms step_avg:30.94ms
+step:60/1490 train_time:1859ms step_avg:30.99ms
+step:61/1490 train_time:1886ms step_avg:30.92ms
+step:62/1490 train_time:1920ms step_avg:30.97ms
+step:63/1490 train_time:1947ms step_avg:30.91ms
+step:64/1490 train_time:1982ms step_avg:30.96ms
+step:65/1490 train_time:2009ms step_avg:30.90ms
+step:66/1490 train_time:2043ms step_avg:30.96ms
+step:67/1490 train_time:2070ms step_avg:30.90ms
+step:68/1490 train_time:2105ms step_avg:30.95ms
+step:69/1490 train_time:2132ms step_avg:30.89ms
+step:70/1490 train_time:2166ms step_avg:30.95ms
+step:71/1490 train_time:2193ms step_avg:30.89ms
+step:72/1490 train_time:2227ms step_avg:30.93ms
+step:73/1490 train_time:2254ms step_avg:30.88ms
+step:74/1490 train_time:2288ms step_avg:30.92ms
+step:75/1490 train_time:2315ms step_avg:30.87ms
+step:76/1490 train_time:2349ms step_avg:30.91ms
+step:77/1490 train_time:2375ms step_avg:30.85ms
+step:78/1490 train_time:2409ms step_avg:30.89ms
+step:79/1490 train_time:2436ms step_avg:30.83ms
+step:80/1490 train_time:2470ms step_avg:30.87ms
+step:81/1490 train_time:2497ms step_avg:30.82ms
+step:82/1490 train_time:2531ms step_avg:30.86ms
+step:83/1490 train_time:2557ms step_avg:30.81ms
+step:84/1490 train_time:2591ms step_avg:30.85ms
+step:85/1490 train_time:2618ms step_avg:30.80ms
+step:86/1490 train_time:2652ms step_avg:30.83ms
+step:87/1490 train_time:2679ms step_avg:30.79ms
+step:88/1490 train_time:2713ms step_avg:30.82ms
+step:89/1490 train_time:2739ms step_avg:30.78ms
+step:90/1490 train_time:2773ms step_avg:30.81ms
+step:91/1490 train_time:2800ms step_avg:30.77ms
+step:92/1490 train_time:2834ms step_avg:30.80ms
+step:93/1490 train_time:2861ms step_avg:30.76ms
+step:94/1490 train_time:2895ms step_avg:30.79ms
+step:95/1490 train_time:2921ms step_avg:30.75ms
+step:96/1490 train_time:2955ms step_avg:30.79ms
+step:97/1490 train_time:2982ms step_avg:30.74ms
+step:98/1490 train_time:3016ms step_avg:30.78ms
+step:99/1490 train_time:3043ms step_avg:30.74ms
+step:100/1490 train_time:3078ms step_avg:30.78ms
+step:101/1490 train_time:3104ms step_avg:30.74ms
+step:102/1490 train_time:3139ms step_avg:30.77ms
+step:103/1490 train_time:3166ms step_avg:30.73ms
+step:104/1490 train_time:3200ms step_avg:30.77ms
+step:105/1490 train_time:3227ms step_avg:30.74ms
+step:106/1490 train_time:3262ms step_avg:30.77ms
+step:107/1490 train_time:3288ms step_avg:30.73ms
+step:108/1490 train_time:3323ms step_avg:30.77ms
+step:109/1490 train_time:3349ms step_avg:30.73ms
+step:110/1490 train_time:3384ms step_avg:30.76ms
+step:111/1490 train_time:3411ms step_avg:30.73ms
+step:112/1490 train_time:3445ms step_avg:30.76ms
+step:113/1490 train_time:3472ms step_avg:30.72ms
+step:114/1490 train_time:3506ms step_avg:30.75ms
+step:115/1490 train_time:3532ms step_avg:30.71ms
+step:116/1490 train_time:3567ms step_avg:30.75ms
+step:117/1490 train_time:3593ms step_avg:30.71ms
+step:118/1490 train_time:3627ms step_avg:30.74ms
+step:119/1490 train_time:3653ms step_avg:30.70ms
+step:120/1490 train_time:3687ms step_avg:30.73ms
+step:121/1490 train_time:3714ms step_avg:30.70ms
+step:122/1490 train_time:3748ms step_avg:30.72ms
+step:123/1490 train_time:3775ms step_avg:30.69ms
+step:124/1490 train_time:3808ms step_avg:30.71ms
+step:125/1490 train_time:3835ms step_avg:30.68ms
+step:126/1490 train_time:3869ms step_avg:30.71ms
+step:127/1490 train_time:3896ms step_avg:30.68ms
+step:128/1490 train_time:3930ms step_avg:30.70ms
+step:129/1490 train_time:3957ms step_avg:30.67ms
+step:130/1490 train_time:3990ms step_avg:30.70ms
+step:131/1490 train_time:4018ms step_avg:30.67ms
+step:132/1490 train_time:4052ms step_avg:30.69ms
+step:133/1490 train_time:4078ms step_avg:30.67ms
+step:134/1490 train_time:4112ms step_avg:30.69ms
+step:135/1490 train_time:4139ms step_avg:30.66ms
+step:136/1490 train_time:4173ms step_avg:30.68ms
+step:137/1490 train_time:4200ms step_avg:30.66ms
+step:138/1490 train_time:4234ms step_avg:30.68ms
+step:139/1490 train_time:4261ms step_avg:30.66ms
+step:140/1490 train_time:4295ms step_avg:30.68ms
+step:141/1490 train_time:4322ms step_avg:30.65ms
+step:142/1490 train_time:4356ms step_avg:30.68ms
+step:143/1490 train_time:4383ms step_avg:30.65ms
+step:144/1490 train_time:4417ms step_avg:30.67ms
+step:145/1490 train_time:4444ms step_avg:30.65ms
+step:146/1490 train_time:4478ms step_avg:30.67ms
+step:147/1490 train_time:4505ms step_avg:30.64ms
+step:148/1490 train_time:4539ms step_avg:30.67ms
+step:149/1490 train_time:4566ms step_avg:30.64ms
+step:150/1490 train_time:4600ms step_avg:30.67ms
+step:151/1490 train_time:4626ms step_avg:30.64ms
+step:152/1490 train_time:4661ms step_avg:30.66ms
+step:153/1490 train_time:4687ms step_avg:30.64ms
+step:154/1490 train_time:4722ms step_avg:30.66ms
+step:155/1490 train_time:4748ms step_avg:30.64ms
+step:156/1490 train_time:4783ms step_avg:30.66ms
+step:157/1490 train_time:4810ms step_avg:30.64ms
+step:158/1490 train_time:4844ms step_avg:30.66ms
+step:159/1490 train_time:4871ms step_avg:30.63ms
+step:160/1490 train_time:4905ms step_avg:30.65ms
+step:161/1490 train_time:4932ms step_avg:30.63ms
+step:162/1490 train_time:4965ms step_avg:30.65ms
+step:163/1490 train_time:4992ms step_avg:30.63ms
+step:164/1490 train_time:5026ms step_avg:30.65ms
+step:165/1490 train_time:5053ms step_avg:30.62ms
+step:166/1490 train_time:5087ms step_avg:30.64ms
+step:167/1490 train_time:5114ms step_avg:30.62ms
+step:168/1490 train_time:5148ms step_avg:30.64ms
+step:169/1490 train_time:5175ms step_avg:30.62ms
+step:170/1490 train_time:5209ms step_avg:30.64ms
+step:171/1490 train_time:5235ms step_avg:30.62ms
+step:172/1490 train_time:5269ms step_avg:30.64ms
+step:173/1490 train_time:5296ms step_avg:30.61ms
+step:174/1490 train_time:5330ms step_avg:30.63ms
+step:175/1490 train_time:5357ms step_avg:30.61ms
+step:176/1490 train_time:5390ms step_avg:30.63ms
+step:177/1490 train_time:5418ms step_avg:30.61ms
+step:178/1490 train_time:5451ms step_avg:30.63ms
+step:179/1490 train_time:5478ms step_avg:30.61ms
+step:180/1490 train_time:5512ms step_avg:30.62ms
+step:181/1490 train_time:5539ms step_avg:30.60ms
+step:182/1490 train_time:5573ms step_avg:30.62ms
+step:183/1490 train_time:5600ms step_avg:30.60ms
+step:184/1490 train_time:5634ms step_avg:30.62ms
+step:185/1490 train_time:5661ms step_avg:30.60ms
+step:186/1490 train_time:5695ms step_avg:30.62ms
+step:187/1490 train_time:5722ms step_avg:30.60ms
+step:188/1490 train_time:5755ms step_avg:30.61ms
+step:189/1490 train_time:5782ms step_avg:30.59ms
+step:190/1490 train_time:5817ms step_avg:30.61ms
+step:191/1490 train_time:5844ms step_avg:30.59ms
+step:192/1490 train_time:5878ms step_avg:30.61ms
+step:193/1490 train_time:5905ms step_avg:30.59ms
+step:194/1490 train_time:5939ms step_avg:30.61ms
+step:195/1490 train_time:5966ms step_avg:30.59ms
+step:196/1490 train_time:6000ms step_avg:30.61ms
+step:197/1490 train_time:6026ms step_avg:30.59ms
+step:198/1490 train_time:6061ms step_avg:30.61ms
+step:199/1490 train_time:6087ms step_avg:30.59ms
+step:200/1490 train_time:6122ms step_avg:30.61ms
+step:201/1490 train_time:6148ms step_avg:30.59ms
+step:202/1490 train_time:6183ms step_avg:30.61ms
+step:203/1490 train_time:6209ms step_avg:30.59ms
+step:204/1490 train_time:6244ms step_avg:30.61ms
+step:205/1490 train_time:6271ms step_avg:30.59ms
+step:206/1490 train_time:6305ms step_avg:30.61ms
+step:207/1490 train_time:6332ms step_avg:30.59ms
+step:208/1490 train_time:6366ms step_avg:30.60ms
+step:209/1490 train_time:6392ms step_avg:30.59ms
+step:210/1490 train_time:6426ms step_avg:30.60ms
+step:211/1490 train_time:6453ms step_avg:30.58ms
+step:212/1490 train_time:6487ms step_avg:30.60ms
+step:213/1490 train_time:6514ms step_avg:30.58ms
+step:214/1490 train_time:6548ms step_avg:30.60ms
+step:215/1490 train_time:6574ms step_avg:30.58ms
+step:216/1490 train_time:6608ms step_avg:30.59ms
+step:217/1490 train_time:6635ms step_avg:30.58ms
+step:218/1490 train_time:6669ms step_avg:30.59ms
+step:219/1490 train_time:6696ms step_avg:30.57ms
+step:220/1490 train_time:6730ms step_avg:30.59ms
+step:221/1490 train_time:6756ms step_avg:30.57ms
+step:222/1490 train_time:6790ms step_avg:30.59ms
+step:223/1490 train_time:6817ms step_avg:30.57ms
+step:224/1490 train_time:6851ms step_avg:30.58ms
+step:225/1490 train_time:6878ms step_avg:30.57ms
+step:226/1490 train_time:6911ms step_avg:30.58ms
+step:227/1490 train_time:6938ms step_avg:30.57ms
+step:228/1490 train_time:6972ms step_avg:30.58ms
+step:229/1490 train_time:6999ms step_avg:30.56ms
+step:230/1490 train_time:7033ms step_avg:30.58ms
+step:231/1490 train_time:7060ms step_avg:30.56ms
+step:232/1490 train_time:7094ms step_avg:30.58ms
+step:233/1490 train_time:7120ms step_avg:30.56ms
+step:234/1490 train_time:7154ms step_avg:30.57ms
+step:235/1490 train_time:7181ms step_avg:30.56ms
+step:236/1490 train_time:7215ms step_avg:30.57ms
+step:237/1490 train_time:7243ms step_avg:30.56ms
+step:238/1490 train_time:7277ms step_avg:30.57ms
+step:239/1490 train_time:7303ms step_avg:30.56ms
+step:240/1490 train_time:7338ms step_avg:30.57ms
+step:241/1490 train_time:7365ms step_avg:30.56ms
+step:242/1490 train_time:7399ms step_avg:30.57ms
+step:243/1490 train_time:7425ms step_avg:30.56ms
+step:244/1490 train_time:7459ms step_avg:30.57ms
+step:245/1490 train_time:7486ms step_avg:30.56ms
+step:246/1490 train_time:7520ms step_avg:30.57ms
+step:247/1490 train_time:7547ms step_avg:30.55ms
+step:248/1490 train_time:7581ms step_avg:30.57ms
+step:249/1490 train_time:7608ms step_avg:30.55ms
+step:250/1490 train_time:7642ms step_avg:30.57ms
+step:250/1490 val_loss:4.5254 train_time:7680ms step_avg:30.72ms
+step:251/1490 train_time:7699ms step_avg:30.67ms
+step:252/1490 train_time:7719ms step_avg:30.63ms
+step:253/1490 train_time:7736ms step_avg:30.58ms
+step:254/1490 train_time:7767ms step_avg:30.58ms
+step:255/1490 train_time:7795ms step_avg:30.57ms
+step:256/1490 train_time:7831ms step_avg:30.59ms
+step:257/1490 train_time:7859ms step_avg:30.58ms
+step:258/1490 train_time:7894ms step_avg:30.60ms
+step:259/1490 train_time:7921ms step_avg:30.58ms
+step:260/1490 train_time:7956ms step_avg:30.60ms
+step:261/1490 train_time:7983ms step_avg:30.58ms
+step:262/1490 train_time:8017ms step_avg:30.60ms
+step:263/1490 train_time:8043ms step_avg:30.58ms
+step:264/1490 train_time:8077ms step_avg:30.60ms
+step:265/1490 train_time:8104ms step_avg:30.58ms
+step:266/1490 train_time:8138ms step_avg:30.60ms
+step:267/1490 train_time:8165ms step_avg:30.58ms
+step:268/1490 train_time:8199ms step_avg:30.59ms
+step:269/1490 train_time:8226ms step_avg:30.58ms
+step:270/1490 train_time:8260ms step_avg:30.59ms
+step:271/1490 train_time:8286ms step_avg:30.58ms
+step:272/1490 train_time:8320ms step_avg:30.59ms
+step:273/1490 train_time:8347ms step_avg:30.58ms
+step:274/1490 train_time:8381ms step_avg:30.59ms
+step:275/1490 train_time:8407ms step_avg:30.57ms
+step:276/1490 train_time:8442ms step_avg:30.59ms
+step:277/1490 train_time:8468ms step_avg:30.57ms
+step:278/1490 train_time:8502ms step_avg:30.58ms
+step:279/1490 train_time:8529ms step_avg:30.57ms
+step:280/1490 train_time:8563ms step_avg:30.58ms
+step:281/1490 train_time:8590ms step_avg:30.57ms
+step:282/1490 train_time:8624ms step_avg:30.58ms
+step:283/1490 train_time:8650ms step_avg:30.57ms
+step:284/1490 train_time:8684ms step_avg:30.58ms
+step:285/1490 train_time:8711ms step_avg:30.56ms
+step:286/1490 train_time:8745ms step_avg:30.58ms
+step:287/1490 train_time:8772ms step_avg:30.57ms
+step:288/1490 train_time:8806ms step_avg:30.58ms
+step:289/1490 train_time:8834ms step_avg:30.57ms
+step:290/1490 train_time:8868ms step_avg:30.58ms
+step:291/1490 train_time:8895ms step_avg:30.57ms
+step:292/1490 train_time:8930ms step_avg:30.58ms
+step:293/1490 train_time:8957ms step_avg:30.57ms
+step:294/1490 train_time:8992ms step_avg:30.58ms
+step:295/1490 train_time:9018ms step_avg:30.57ms
+step:296/1490 train_time:9053ms step_avg:30.58ms
+step:297/1490 train_time:9080ms step_avg:30.57ms
+step:298/1490 train_time:9114ms step_avg:30.58ms
+step:299/1490 train_time:9141ms step_avg:30.57ms
+step:300/1490 train_time:9175ms step_avg:30.58ms
+step:301/1490 train_time:9202ms step_avg:30.57ms
+step:302/1490 train_time:9236ms step_avg:30.58ms
+step:303/1490 train_time:9263ms step_avg:30.57ms
+step:304/1490 train_time:9297ms step_avg:30.58ms
+step:305/1490 train_time:9323ms step_avg:30.57ms
+step:306/1490 train_time:9357ms step_avg:30.58ms
+step:307/1490 train_time:9384ms step_avg:30.57ms
+step:308/1490 train_time:9418ms step_avg:30.58ms
+step:309/1490 train_time:9444ms step_avg:30.56ms
+step:310/1490 train_time:9479ms step_avg:30.58ms
+step:311/1490 train_time:9506ms step_avg:30.56ms
+step:312/1490 train_time:9541ms step_avg:30.58ms
+step:313/1490 train_time:9567ms step_avg:30.56ms
+step:314/1490 train_time:9600ms step_avg:30.57ms
+step:315/1490 train_time:9627ms step_avg:30.56ms
+step:316/1490 train_time:9661ms step_avg:30.57ms
+step:317/1490 train_time:9688ms step_avg:30.56ms
+step:318/1490 train_time:9722ms step_avg:30.57ms
+step:319/1490 train_time:9749ms step_avg:30.56ms
+step:320/1490 train_time:9783ms step_avg:30.57ms
+step:321/1490 train_time:9810ms step_avg:30.56ms
+step:322/1490 train_time:9844ms step_avg:30.57ms
+step:323/1490 train_time:9871ms step_avg:30.56ms
+step:324/1490 train_time:9905ms step_avg:30.57ms
+step:325/1490 train_time:9932ms step_avg:30.56ms
+step:326/1490 train_time:9966ms step_avg:30.57ms
+step:327/1490 train_time:9993ms step_avg:30.56ms
+step:328/1490 train_time:10026ms step_avg:30.57ms
+step:329/1490 train_time:10054ms step_avg:30.56ms
+step:330/1490 train_time:10088ms step_avg:30.57ms
+step:331/1490 train_time:10115ms step_avg:30.56ms
+step:332/1490 train_time:10149ms step_avg:30.57ms
+step:333/1490 train_time:10176ms step_avg:30.56ms
+step:334/1490 train_time:10210ms step_avg:30.57ms
+step:335/1490 train_time:10237ms step_avg:30.56ms
+step:336/1490 train_time:10271ms step_avg:30.57ms
+step:337/1490 train_time:10298ms step_avg:30.56ms
+step:338/1490 train_time:10332ms step_avg:30.57ms
+step:339/1490 train_time:10359ms step_avg:30.56ms
+step:340/1490 train_time:10393ms step_avg:30.57ms
+step:341/1490 train_time:10420ms step_avg:30.56ms
+step:342/1490 train_time:10454ms step_avg:30.57ms
+step:343/1490 train_time:10481ms step_avg:30.56ms
+step:344/1490 train_time:10515ms step_avg:30.57ms
+step:345/1490 train_time:10542ms step_avg:30.56ms
+step:346/1490 train_time:10576ms step_avg:30.57ms
+step:347/1490 train_time:10602ms step_avg:30.55ms
+step:348/1490 train_time:10637ms step_avg:30.57ms
+step:349/1490 train_time:10664ms step_avg:30.55ms
+step:350/1490 train_time:10697ms step_avg:30.56ms
+step:351/1490 train_time:10724ms step_avg:30.55ms
+step:352/1490 train_time:10758ms step_avg:30.56ms
+step:353/1490 train_time:10785ms step_avg:30.55ms
+step:354/1490 train_time:10819ms step_avg:30.56ms
+step:355/1490 train_time:10846ms step_avg:30.55ms
+step:356/1490 train_time:10881ms step_avg:30.56ms
+step:357/1490 train_time:10908ms step_avg:30.55ms
+step:358/1490 train_time:10942ms step_avg:30.56ms
+step:359/1490 train_time:10969ms step_avg:30.55ms
+step:360/1490 train_time:11003ms step_avg:30.56ms
+step:361/1490 train_time:11030ms step_avg:30.55ms
+step:362/1490 train_time:11063ms step_avg:30.56ms
+step:363/1490 train_time:11090ms step_avg:30.55ms
+step:364/1490 train_time:11124ms step_avg:30.56ms
+step:365/1490 train_time:11151ms step_avg:30.55ms
+step:366/1490 train_time:11185ms step_avg:30.56ms
+step:367/1490 train_time:11212ms step_avg:30.55ms
+step:368/1490 train_time:11246ms step_avg:30.56ms
+step:369/1490 train_time:11273ms step_avg:30.55ms
+step:370/1490 train_time:11307ms step_avg:30.56ms
+step:371/1490 train_time:11334ms step_avg:30.55ms
+step:372/1490 train_time:11367ms step_avg:30.56ms
+step:373/1490 train_time:11394ms step_avg:30.55ms
+step:374/1490 train_time:11428ms step_avg:30.56ms
+step:375/1490 train_time:11455ms step_avg:30.55ms
+step:376/1490 train_time:11489ms step_avg:30.56ms
+step:377/1490 train_time:11516ms step_avg:30.55ms
+step:378/1490 train_time:11550ms step_avg:30.55ms
+step:379/1490 train_time:11577ms step_avg:30.55ms
+step:380/1490 train_time:11611ms step_avg:30.55ms
+step:381/1490 train_time:11638ms step_avg:30.55ms
+step:382/1490 train_time:11672ms step_avg:30.56ms
+step:383/1490 train_time:11700ms step_avg:30.55ms
+step:384/1490 train_time:11734ms step_avg:30.56ms
+step:385/1490 train_time:11761ms step_avg:30.55ms
+step:386/1490 train_time:11795ms step_avg:30.56ms
+step:387/1490 train_time:11822ms step_avg:30.55ms
+step:388/1490 train_time:11856ms step_avg:30.56ms
+step:389/1490 train_time:11883ms step_avg:30.55ms
+step:390/1490 train_time:11917ms step_avg:30.56ms
+step:391/1490 train_time:11943ms step_avg:30.55ms
+step:392/1490 train_time:11978ms step_avg:30.56ms
+step:393/1490 train_time:12005ms step_avg:30.55ms
+step:394/1490 train_time:12039ms step_avg:30.56ms
+step:395/1490 train_time:12066ms step_avg:30.55ms
+step:396/1490 train_time:12100ms step_avg:30.56ms
+step:397/1490 train_time:12128ms step_avg:30.55ms
+step:398/1490 train_time:12162ms step_avg:30.56ms
+step:399/1490 train_time:12188ms step_avg:30.55ms
+step:400/1490 train_time:12222ms step_avg:30.56ms
+step:401/1490 train_time:12249ms step_avg:30.55ms
+step:402/1490 train_time:12283ms step_avg:30.56ms
+step:403/1490 train_time:12311ms step_avg:30.55ms
+step:404/1490 train_time:12345ms step_avg:30.56ms
+step:405/1490 train_time:12372ms step_avg:30.55ms
+step:406/1490 train_time:12406ms step_avg:30.56ms
+step:407/1490 train_time:12433ms step_avg:30.55ms
+step:408/1490 train_time:12467ms step_avg:30.56ms
+step:409/1490 train_time:12494ms step_avg:30.55ms
+step:410/1490 train_time:12527ms step_avg:30.55ms
+step:411/1490 train_time:12554ms step_avg:30.55ms
+step:412/1490 train_time:12588ms step_avg:30.55ms
+step:413/1490 train_time:12615ms step_avg:30.54ms
+step:414/1490 train_time:12648ms step_avg:30.55ms
+step:415/1490 train_time:12675ms step_avg:30.54ms
+step:416/1490 train_time:12709ms step_avg:30.55ms
+step:417/1490 train_time:12736ms step_avg:30.54ms
+step:418/1490 train_time:12771ms step_avg:30.55ms
+step:419/1490 train_time:12798ms step_avg:30.54ms
+step:420/1490 train_time:12831ms step_avg:30.55ms
+step:421/1490 train_time:12859ms step_avg:30.54ms
+step:422/1490 train_time:12893ms step_avg:30.55ms
+step:423/1490 train_time:12919ms step_avg:30.54ms
+step:424/1490 train_time:12954ms step_avg:30.55ms
+step:425/1490 train_time:12981ms step_avg:30.54ms
+step:426/1490 train_time:13015ms step_avg:30.55ms
+step:427/1490 train_time:13042ms step_avg:30.54ms
+step:428/1490 train_time:13076ms step_avg:30.55ms
+step:429/1490 train_time:13103ms step_avg:30.54ms
+step:430/1490 train_time:13137ms step_avg:30.55ms
+step:431/1490 train_time:13164ms step_avg:30.54ms
+step:432/1490 train_time:13198ms step_avg:30.55ms
+step:433/1490 train_time:13225ms step_avg:30.54ms
+step:434/1490 train_time:13259ms step_avg:30.55ms
+step:435/1490 train_time:13287ms step_avg:30.54ms
+step:436/1490 train_time:13321ms step_avg:30.55ms
+step:437/1490 train_time:13348ms step_avg:30.54ms
+step:438/1490 train_time:13382ms step_avg:30.55ms
+step:439/1490 train_time:13409ms step_avg:30.54ms
+step:440/1490 train_time:13443ms step_avg:30.55ms
+step:441/1490 train_time:13470ms step_avg:30.54ms
+step:442/1490 train_time:13504ms step_avg:30.55ms
+step:443/1490 train_time:13531ms step_avg:30.54ms
+step:444/1490 train_time:13565ms step_avg:30.55ms
+step:445/1490 train_time:13592ms step_avg:30.54ms
+step:446/1490 train_time:13626ms step_avg:30.55ms
+step:447/1490 train_time:13653ms step_avg:30.54ms
+step:448/1490 train_time:13687ms step_avg:30.55ms
+step:449/1490 train_time:13714ms step_avg:30.54ms
+step:450/1490 train_time:13747ms step_avg:30.55ms
+step:451/1490 train_time:13774ms step_avg:30.54ms
+step:452/1490 train_time:13808ms step_avg:30.55ms
+step:453/1490 train_time:13835ms step_avg:30.54ms
+step:454/1490 train_time:13869ms step_avg:30.55ms
+step:455/1490 train_time:13896ms step_avg:30.54ms
+step:456/1490 train_time:13930ms step_avg:30.55ms
+step:457/1490 train_time:13957ms step_avg:30.54ms
+step:458/1490 train_time:13991ms step_avg:30.55ms
+step:459/1490 train_time:14018ms step_avg:30.54ms
+step:460/1490 train_time:14051ms step_avg:30.55ms
+step:461/1490 train_time:14078ms step_avg:30.54ms
+step:462/1490 train_time:14113ms step_avg:30.55ms
+step:463/1490 train_time:14140ms step_avg:30.54ms
+step:464/1490 train_time:14175ms step_avg:30.55ms
+step:465/1490 train_time:14201ms step_avg:30.54ms
+step:466/1490 train_time:14236ms step_avg:30.55ms
+step:467/1490 train_time:14263ms step_avg:30.54ms
+step:468/1490 train_time:14297ms step_avg:30.55ms
+step:469/1490 train_time:14324ms step_avg:30.54ms
+step:470/1490 train_time:14358ms step_avg:30.55ms
+step:471/1490 train_time:14385ms step_avg:30.54ms
+step:472/1490 train_time:14419ms step_avg:30.55ms
+step:473/1490 train_time:14447ms step_avg:30.54ms
+step:474/1490 train_time:14481ms step_avg:30.55ms
+step:475/1490 train_time:14508ms step_avg:30.54ms
+step:476/1490 train_time:14542ms step_avg:30.55ms
+step:477/1490 train_time:14569ms step_avg:30.54ms
+step:478/1490 train_time:14603ms step_avg:30.55ms
+step:479/1490 train_time:14630ms step_avg:30.54ms
+step:480/1490 train_time:14664ms step_avg:30.55ms
+step:481/1490 train_time:14691ms step_avg:30.54ms
+step:482/1490 train_time:14725ms step_avg:30.55ms
+step:483/1490 train_time:14752ms step_avg:30.54ms
+step:484/1490 train_time:14788ms step_avg:30.55ms
+step:485/1490 train_time:14839ms step_avg:30.60ms
+step:486/1490 train_time:14897ms step_avg:30.65ms
+step:487/1490 train_time:14950ms step_avg:30.70ms
+step:488/1490 train_time:15009ms step_avg:30.76ms
+step:489/1490 train_time:15062ms step_avg:30.80ms
+step:490/1490 train_time:15120ms step_avg:30.86ms
+step:491/1490 train_time:15173ms step_avg:30.90ms
+step:492/1490 train_time:15232ms step_avg:30.96ms
+step:493/1490 train_time:15284ms step_avg:31.00ms
+step:494/1490 train_time:15344ms step_avg:31.06ms
+step:495/1490 train_time:15396ms step_avg:31.10ms
+step:496/1490 train_time:15455ms step_avg:31.16ms
+step:497/1490 train_time:15509ms step_avg:31.20ms
+step:498/1490 train_time:15567ms step_avg:31.26ms
+step:499/1490 train_time:15620ms step_avg:31.30ms
+step:500/1490 train_time:15679ms step_avg:31.36ms
+step:500/1490 val_loss:4.2357 train_time:15746ms step_avg:31.49ms
+step:501/1490 train_time:15767ms step_avg:31.47ms
+step:502/1490 train_time:15792ms step_avg:31.46ms
+step:503/1490 train_time:15850ms step_avg:31.51ms
+step:504/1490 train_time:15909ms step_avg:31.57ms
+step:505/1490 train_time:15962ms step_avg:31.61ms
+step:506/1490 train_time:16022ms step_avg:31.66ms
+step:507/1490 train_time:16075ms step_avg:31.71ms
+step:508/1490 train_time:16133ms step_avg:31.76ms
+step:509/1490 train_time:16186ms step_avg:31.80ms
+step:510/1490 train_time:16244ms step_avg:31.85ms
+step:511/1490 train_time:16296ms step_avg:31.89ms
+step:512/1490 train_time:16354ms step_avg:31.94ms
+step:513/1490 train_time:16407ms step_avg:31.98ms
+step:514/1490 train_time:16464ms step_avg:32.03ms
+step:515/1490 train_time:16517ms step_avg:32.07ms
+step:516/1490 train_time:16574ms step_avg:32.12ms
+step:517/1490 train_time:16627ms step_avg:32.16ms
+step:518/1490 train_time:16685ms step_avg:32.21ms
+step:519/1490 train_time:16738ms step_avg:32.25ms
+step:520/1490 train_time:16798ms step_avg:32.30ms
+step:521/1490 train_time:16853ms step_avg:32.35ms
+step:522/1490 train_time:16913ms step_avg:32.40ms
+step:523/1490 train_time:16966ms step_avg:32.44ms
+step:524/1490 train_time:17025ms step_avg:32.49ms
+step:525/1490 train_time:17078ms step_avg:32.53ms
+step:526/1490 train_time:17137ms step_avg:32.58ms
+step:527/1490 train_time:17190ms step_avg:32.62ms
+step:528/1490 train_time:17247ms step_avg:32.66ms
+step:529/1490 train_time:17300ms step_avg:32.70ms
+step:530/1490 train_time:17358ms step_avg:32.75ms
+step:531/1490 train_time:17411ms step_avg:32.79ms
+step:532/1490 train_time:17468ms step_avg:32.84ms
+step:533/1490 train_time:17522ms step_avg:32.87ms
+step:534/1490 train_time:17580ms step_avg:32.92ms
+step:535/1490 train_time:17633ms step_avg:32.96ms
+step:536/1490 train_time:17691ms step_avg:33.01ms
+step:537/1490 train_time:17744ms step_avg:33.04ms
+step:538/1490 train_time:17803ms step_avg:33.09ms
+step:539/1490 train_time:17857ms step_avg:33.13ms
+step:540/1490 train_time:17916ms step_avg:33.18ms
+step:541/1490 train_time:17970ms step_avg:33.22ms
+step:542/1490 train_time:18029ms step_avg:33.26ms
+step:543/1490 train_time:18081ms step_avg:33.30ms
+step:544/1490 train_time:18141ms step_avg:33.35ms
+step:545/1490 train_time:18193ms step_avg:33.38ms
+step:546/1490 train_time:18251ms step_avg:33.43ms
+step:547/1490 train_time:18303ms step_avg:33.46ms
+step:548/1490 train_time:18362ms step_avg:33.51ms
+step:549/1490 train_time:18415ms step_avg:33.54ms
+step:550/1490 train_time:18474ms step_avg:33.59ms
+step:551/1490 train_time:18527ms step_avg:33.62ms
+step:552/1490 train_time:18584ms step_avg:33.67ms
+step:553/1490 train_time:18637ms step_avg:33.70ms
+step:554/1490 train_time:18695ms step_avg:33.75ms
+step:555/1490 train_time:18749ms step_avg:33.78ms
+step:556/1490 train_time:18807ms step_avg:33.83ms
+step:557/1490 train_time:18861ms step_avg:33.86ms
+step:558/1490 train_time:18921ms step_avg:33.91ms
+step:559/1490 train_time:18974ms step_avg:33.94ms
+step:560/1490 train_time:19032ms step_avg:33.99ms
+step:561/1490 train_time:19085ms step_avg:34.02ms
+step:562/1490 train_time:19144ms step_avg:34.06ms
+step:563/1490 train_time:19197ms step_avg:34.10ms
+step:564/1490 train_time:19256ms step_avg:34.14ms
+step:565/1490 train_time:19308ms step_avg:34.17ms
+step:566/1490 train_time:19366ms step_avg:34.22ms
+step:567/1490 train_time:19420ms step_avg:34.25ms
+step:568/1490 train_time:19478ms step_avg:34.29ms
+step:569/1490 train_time:19530ms step_avg:34.32ms
+step:570/1490 train_time:19587ms step_avg:34.36ms
+step:571/1490 train_time:19641ms step_avg:34.40ms
+step:572/1490 train_time:19700ms step_avg:34.44ms
+step:573/1490 train_time:19753ms step_avg:34.47ms
+step:574/1490 train_time:19811ms step_avg:34.51ms
+step:575/1490 train_time:19865ms step_avg:34.55ms
+step:576/1490 train_time:19923ms step_avg:34.59ms
+step:577/1490 train_time:19976ms step_avg:34.62ms
+step:578/1490 train_time:20035ms step_avg:34.66ms
+step:579/1490 train_time:20088ms step_avg:34.69ms
+step:580/1490 train_time:20146ms step_avg:34.73ms
+step:581/1490 train_time:20199ms step_avg:34.77ms
+step:582/1490 train_time:20258ms step_avg:34.81ms
+step:583/1490 train_time:20311ms step_avg:34.84ms
+step:584/1490 train_time:20369ms step_avg:34.88ms
+step:585/1490 train_time:20423ms step_avg:34.91ms
+step:586/1490 train_time:20481ms step_avg:34.95ms
+step:587/1490 train_time:20533ms step_avg:34.98ms
+step:588/1490 train_time:20591ms step_avg:35.02ms
+step:589/1490 train_time:20645ms step_avg:35.05ms
+step:590/1490 train_time:20703ms step_avg:35.09ms
+step:591/1490 train_time:20757ms step_avg:35.12ms
+step:592/1490 train_time:20816ms step_avg:35.16ms
+step:593/1490 train_time:20870ms step_avg:35.19ms
+step:594/1490 train_time:20928ms step_avg:35.23ms
+step:595/1490 train_time:20981ms step_avg:35.26ms
+step:596/1490 train_time:21040ms step_avg:35.30ms
+step:597/1490 train_time:21094ms step_avg:35.33ms
+step:598/1490 train_time:21151ms step_avg:35.37ms
+step:599/1490 train_time:21204ms step_avg:35.40ms
+step:600/1490 train_time:21262ms step_avg:35.44ms
+step:601/1490 train_time:21316ms step_avg:35.47ms
+step:602/1490 train_time:21375ms step_avg:35.51ms
+step:603/1490 train_time:21428ms step_avg:35.54ms
+step:604/1490 train_time:21485ms step_avg:35.57ms
+step:605/1490 train_time:21539ms step_avg:35.60ms
+step:606/1490 train_time:21597ms step_avg:35.64ms
+step:607/1490 train_time:21650ms step_avg:35.67ms
+step:608/1490 train_time:21708ms step_avg:35.70ms
+step:609/1490 train_time:21761ms step_avg:35.73ms
+step:610/1490 train_time:21821ms step_avg:35.77ms
+step:611/1490 train_time:21874ms step_avg:35.80ms
+step:612/1490 train_time:21931ms step_avg:35.84ms
+step:613/1490 train_time:21984ms step_avg:35.86ms
+step:614/1490 train_time:22042ms step_avg:35.90ms
+step:615/1490 train_time:22095ms step_avg:35.93ms
+step:616/1490 train_time:22154ms step_avg:35.96ms
+step:617/1490 train_time:22208ms step_avg:35.99ms
+step:618/1490 train_time:22266ms step_avg:36.03ms
+step:619/1490 train_time:22320ms step_avg:36.06ms
+step:620/1490 train_time:22379ms step_avg:36.09ms
+step:621/1490 train_time:22431ms step_avg:36.12ms
+step:622/1490 train_time:22488ms step_avg:36.16ms
+step:623/1490 train_time:22542ms step_avg:36.18ms
+step:624/1490 train_time:22600ms step_avg:36.22ms
+step:625/1490 train_time:22653ms step_avg:36.25ms
+step:626/1490 train_time:22711ms step_avg:36.28ms
+step:627/1490 train_time:22765ms step_avg:36.31ms
+step:628/1490 train_time:22823ms step_avg:36.34ms
+step:629/1490 train_time:22876ms step_avg:36.37ms
+step:630/1490 train_time:22935ms step_avg:36.40ms
+step:631/1490 train_time:22988ms step_avg:36.43ms
+step:632/1490 train_time:23046ms step_avg:36.47ms
+step:633/1490 train_time:23099ms step_avg:36.49ms
+step:634/1490 train_time:23158ms step_avg:36.53ms
+step:635/1490 train_time:23211ms step_avg:36.55ms
+step:636/1490 train_time:23269ms step_avg:36.59ms
+step:637/1490 train_time:23322ms step_avg:36.61ms
+step:638/1490 train_time:23381ms step_avg:36.65ms
+step:639/1490 train_time:23434ms step_avg:36.67ms
+step:640/1490 train_time:23492ms step_avg:36.71ms
+step:641/1490 train_time:23544ms step_avg:36.73ms
+step:642/1490 train_time:23603ms step_avg:36.76ms
+step:643/1490 train_time:23656ms step_avg:36.79ms
+step:644/1490 train_time:23715ms step_avg:36.82ms
+step:645/1490 train_time:23769ms step_avg:36.85ms
+step:646/1490 train_time:23826ms step_avg:36.88ms
+step:647/1490 train_time:23880ms step_avg:36.91ms
+step:648/1490 train_time:23938ms step_avg:36.94ms
+step:649/1490 train_time:23991ms step_avg:36.97ms
+step:650/1490 train_time:24049ms step_avg:37.00ms
+step:651/1490 train_time:24102ms step_avg:37.02ms
+step:652/1490 train_time:24161ms step_avg:37.06ms
+step:653/1490 train_time:24214ms step_avg:37.08ms
+step:654/1490 train_time:24273ms step_avg:37.11ms
+step:655/1490 train_time:24326ms step_avg:37.14ms
+step:656/1490 train_time:24384ms step_avg:37.17ms
+step:657/1490 train_time:24437ms step_avg:37.19ms
+step:658/1490 train_time:24495ms step_avg:37.23ms
+step:659/1490 train_time:24549ms step_avg:37.25ms
+step:660/1490 train_time:24607ms step_avg:37.28ms
+step:661/1490 train_time:24661ms step_avg:37.31ms
+step:662/1490 train_time:24719ms step_avg:37.34ms
+step:663/1490 train_time:24772ms step_avg:37.36ms
+step:664/1490 train_time:24830ms step_avg:37.39ms
+step:665/1490 train_time:24883ms step_avg:37.42ms
+step:666/1490 train_time:24941ms step_avg:37.45ms
+step:667/1490 train_time:24994ms step_avg:37.47ms
+step:668/1490 train_time:25053ms step_avg:37.50ms
+step:669/1490 train_time:25106ms step_avg:37.53ms
+step:670/1490 train_time:25164ms step_avg:37.56ms
+step:671/1490 train_time:25217ms step_avg:37.58ms
+step:672/1490 train_time:25275ms step_avg:37.61ms
+step:673/1490 train_time:25329ms step_avg:37.64ms
+step:674/1490 train_time:25386ms step_avg:37.66ms
+step:675/1490 train_time:25440ms step_avg:37.69ms
+step:676/1490 train_time:25498ms step_avg:37.72ms
+step:677/1490 train_time:25552ms step_avg:37.74ms
+step:678/1490 train_time:25609ms step_avg:37.77ms
+step:679/1490 train_time:25662ms step_avg:37.79ms
+step:680/1490 train_time:25721ms step_avg:37.82ms
+step:681/1490 train_time:25774ms step_avg:37.85ms
+step:682/1490 train_time:25833ms step_avg:37.88ms
+step:683/1490 train_time:25885ms step_avg:37.90ms
+step:684/1490 train_time:25943ms step_avg:37.93ms
+step:685/1490 train_time:25997ms step_avg:37.95ms
+step:686/1490 train_time:26055ms step_avg:37.98ms
+step:687/1490 train_time:26109ms step_avg:38.00ms
+step:688/1490 train_time:26166ms step_avg:38.03ms
+step:689/1490 train_time:26220ms step_avg:38.06ms
+step:690/1490 train_time:26278ms step_avg:38.08ms
+step:691/1490 train_time:26331ms step_avg:38.11ms
+step:692/1490 train_time:26388ms step_avg:38.13ms
+step:693/1490 train_time:26442ms step_avg:38.16ms
+step:694/1490 train_time:26500ms step_avg:38.19ms
+step:695/1490 train_time:26554ms step_avg:38.21ms
+step:696/1490 train_time:26612ms step_avg:38.24ms
+step:697/1490 train_time:26665ms step_avg:38.26ms
+step:698/1490 train_time:26725ms step_avg:38.29ms
+step:699/1490 train_time:26777ms step_avg:38.31ms
+step:700/1490 train_time:26835ms step_avg:38.34ms
+step:701/1490 train_time:26889ms step_avg:38.36ms
+step:702/1490 train_time:26947ms step_avg:38.39ms
+step:703/1490 train_time:27000ms step_avg:38.41ms
+step:704/1490 train_time:27059ms step_avg:38.44ms
+step:705/1490 train_time:27112ms step_avg:38.46ms
+step:706/1490 train_time:27171ms step_avg:38.49ms
+step:707/1490 train_time:27223ms step_avg:38.50ms
+step:708/1490 train_time:27281ms step_avg:38.53ms
+step:709/1490 train_time:27335ms step_avg:38.55ms
+step:710/1490 train_time:27393ms step_avg:38.58ms
+step:711/1490 train_time:27445ms step_avg:38.60ms
+step:712/1490 train_time:27504ms step_avg:38.63ms
+step:713/1490 train_time:27558ms step_avg:38.65ms
+step:714/1490 train_time:27617ms step_avg:38.68ms
+step:715/1490 train_time:27670ms step_avg:38.70ms
+step:716/1490 train_time:27728ms step_avg:38.73ms
+step:717/1490 train_time:27781ms step_avg:38.75ms
+step:718/1490 train_time:27839ms step_avg:38.77ms
+step:719/1490 train_time:27892ms step_avg:38.79ms
+step:720/1490 train_time:27950ms step_avg:38.82ms
+step:721/1490 train_time:28003ms step_avg:38.84ms
+step:722/1490 train_time:28061ms step_avg:38.87ms
+step:723/1490 train_time:28114ms step_avg:38.89ms
+step:724/1490 train_time:28173ms step_avg:38.91ms
+step:725/1490 train_time:28226ms step_avg:38.93ms
+step:726/1490 train_time:28284ms step_avg:38.96ms
+step:727/1490 train_time:28338ms step_avg:38.98ms
+step:728/1490 train_time:28396ms step_avg:39.00ms
+step:729/1490 train_time:28449ms step_avg:39.02ms
+step:730/1490 train_time:28506ms step_avg:39.05ms
+step:731/1490 train_time:28559ms step_avg:39.07ms
+step:732/1490 train_time:28618ms step_avg:39.10ms
+step:733/1490 train_time:28670ms step_avg:39.11ms
+step:734/1490 train_time:28728ms step_avg:39.14ms
+step:735/1490 train_time:28781ms step_avg:39.16ms
+step:736/1490 train_time:28841ms step_avg:39.19ms
+step:737/1490 train_time:28894ms step_avg:39.21ms
+step:738/1490 train_time:28952ms step_avg:39.23ms
+step:739/1490 train_time:29004ms step_avg:39.25ms
+step:740/1490 train_time:29064ms step_avg:39.28ms
+step:741/1490 train_time:29118ms step_avg:39.30ms
+step:742/1490 train_time:29177ms step_avg:39.32ms
+step:743/1490 train_time:29230ms step_avg:39.34ms
+step:744/1490 train_time:29288ms step_avg:39.37ms
+step:745/1490 train_time:29341ms step_avg:39.38ms
+step:746/1490 train_time:29400ms step_avg:39.41ms
+step:747/1490 train_time:29453ms step_avg:39.43ms
+step:748/1490 train_time:29511ms step_avg:39.45ms
+step:749/1490 train_time:29564ms step_avg:39.47ms
+step:750/1490 train_time:29622ms step_avg:39.50ms
+step:750/1490 val_loss:3.8079 train_time:29689ms step_avg:39.59ms
+step:751/1490 train_time:29709ms step_avg:39.56ms
+step:752/1490 train_time:29737ms step_avg:39.54ms
+step:753/1490 train_time:29795ms step_avg:39.57ms
+step:754/1490 train_time:29856ms step_avg:39.60ms
+step:755/1490 train_time:29910ms step_avg:39.62ms
+step:756/1490 train_time:29969ms step_avg:39.64ms
+step:757/1490 train_time:30021ms step_avg:39.66ms
+step:758/1490 train_time:30079ms step_avg:39.68ms
+step:759/1490 train_time:30132ms step_avg:39.70ms
+step:760/1490 train_time:30190ms step_avg:39.72ms
+step:761/1490 train_time:30243ms step_avg:39.74ms
+step:762/1490 train_time:30300ms step_avg:39.76ms
+step:763/1490 train_time:30353ms step_avg:39.78ms
+step:764/1490 train_time:30410ms step_avg:39.80ms
+step:765/1490 train_time:30462ms step_avg:39.82ms
+step:766/1490 train_time:30520ms step_avg:39.84ms
+step:767/1490 train_time:30572ms step_avg:39.86ms
+step:768/1490 train_time:30630ms step_avg:39.88ms
+step:769/1490 train_time:30683ms step_avg:39.90ms
+step:770/1490 train_time:30744ms step_avg:39.93ms
+step:771/1490 train_time:30797ms step_avg:39.94ms
+step:772/1490 train_time:30858ms step_avg:39.97ms
+step:773/1490 train_time:30912ms step_avg:39.99ms
+step:774/1490 train_time:30972ms step_avg:40.01ms
+step:775/1490 train_time:31025ms step_avg:40.03ms
+step:776/1490 train_time:31084ms step_avg:40.06ms
+step:777/1490 train_time:31137ms step_avg:40.07ms
+step:778/1490 train_time:31195ms step_avg:40.10ms
+step:779/1490 train_time:31248ms step_avg:40.11ms
+step:780/1490 train_time:31305ms step_avg:40.13ms
+step:781/1490 train_time:31359ms step_avg:40.15ms
+step:782/1490 train_time:31416ms step_avg:40.17ms
+step:783/1490 train_time:31469ms step_avg:40.19ms
+step:784/1490 train_time:31527ms step_avg:40.21ms
+step:785/1490 train_time:31580ms step_avg:40.23ms
+step:786/1490 train_time:31638ms step_avg:40.25ms
+step:787/1490 train_time:31692ms step_avg:40.27ms
+step:788/1490 train_time:31750ms step_avg:40.29ms
+step:789/1490 train_time:31804ms step_avg:40.31ms
+step:790/1490 train_time:31863ms step_avg:40.33ms
+step:791/1490 train_time:31916ms step_avg:40.35ms
+step:792/1490 train_time:31976ms step_avg:40.37ms
+step:793/1490 train_time:32030ms step_avg:40.39ms
+step:794/1490 train_time:32088ms step_avg:40.41ms
+step:795/1490 train_time:32141ms step_avg:40.43ms
+step:796/1490 train_time:32199ms step_avg:40.45ms
+step:797/1490 train_time:32251ms step_avg:40.47ms
+step:798/1490 train_time:32309ms step_avg:40.49ms
+step:799/1490 train_time:32361ms step_avg:40.50ms
+step:800/1490 train_time:32419ms step_avg:40.52ms
+step:801/1490 train_time:32473ms step_avg:40.54ms
+step:802/1490 train_time:32531ms step_avg:40.56ms
+step:803/1490 train_time:32583ms step_avg:40.58ms
+step:804/1490 train_time:32642ms step_avg:40.60ms
+step:805/1490 train_time:32696ms step_avg:40.62ms
+step:806/1490 train_time:32754ms step_avg:40.64ms
+step:807/1490 train_time:32808ms step_avg:40.65ms
+step:808/1490 train_time:32865ms step_avg:40.67ms
+step:809/1490 train_time:32918ms step_avg:40.69ms
+step:810/1490 train_time:32977ms step_avg:40.71ms
+step:811/1490 train_time:33031ms step_avg:40.73ms
+step:812/1490 train_time:33089ms step_avg:40.75ms
+step:813/1490 train_time:33143ms step_avg:40.77ms
+step:814/1490 train_time:33201ms step_avg:40.79ms
+step:815/1490 train_time:33253ms step_avg:40.80ms
+step:816/1490 train_time:33311ms step_avg:40.82ms
+step:817/1490 train_time:33363ms step_avg:40.84ms
+step:818/1490 train_time:33422ms step_avg:40.86ms
+step:819/1490 train_time:33475ms step_avg:40.87ms
+step:820/1490 train_time:33533ms step_avg:40.89ms
+step:821/1490 train_time:33586ms step_avg:40.91ms
+step:822/1490 train_time:33644ms step_avg:40.93ms
+step:823/1490 train_time:33697ms step_avg:40.94ms
+step:824/1490 train_time:33756ms step_avg:40.97ms
+step:825/1490 train_time:33809ms step_avg:40.98ms
+step:826/1490 train_time:33867ms step_avg:41.00ms
+step:827/1490 train_time:33921ms step_avg:41.02ms
+step:828/1490 train_time:33979ms step_avg:41.04ms
+step:829/1490 train_time:34032ms step_avg:41.05ms
+step:830/1490 train_time:34091ms step_avg:41.07ms
+step:831/1490 train_time:34144ms step_avg:41.09ms
+step:832/1490 train_time:34202ms step_avg:41.11ms
+step:833/1490 train_time:34255ms step_avg:41.12ms
+step:834/1490 train_time:34314ms step_avg:41.14ms
+step:835/1490 train_time:34366ms step_avg:41.16ms
+step:836/1490 train_time:34424ms step_avg:41.18ms
+step:837/1490 train_time:34478ms step_avg:41.19ms
+step:838/1490 train_time:34536ms step_avg:41.21ms
+step:839/1490 train_time:34589ms step_avg:41.23ms
+step:840/1490 train_time:34647ms step_avg:41.25ms
+step:841/1490 train_time:34700ms step_avg:41.26ms
+step:842/1490 train_time:34758ms step_avg:41.28ms
+step:843/1490 train_time:34812ms step_avg:41.30ms
+step:844/1490 train_time:34871ms step_avg:41.32ms
+step:845/1490 train_time:34924ms step_avg:41.33ms
+step:846/1490 train_time:34982ms step_avg:41.35ms
+step:847/1490 train_time:35036ms step_avg:41.36ms
+step:848/1490 train_time:35095ms step_avg:41.39ms
+step:849/1490 train_time:35148ms step_avg:41.40ms
+step:850/1490 train_time:35206ms step_avg:41.42ms
+step:851/1490 train_time:35260ms step_avg:41.43ms
+step:852/1490 train_time:35318ms step_avg:41.45ms
+step:853/1490 train_time:35372ms step_avg:41.47ms
+step:854/1490 train_time:35430ms step_avg:41.49ms
+step:855/1490 train_time:35483ms step_avg:41.50ms
+step:856/1490 train_time:35541ms step_avg:41.52ms
+step:857/1490 train_time:35593ms step_avg:41.53ms
+step:858/1490 train_time:35652ms step_avg:41.55ms
+step:859/1490 train_time:35705ms step_avg:41.57ms
+step:860/1490 train_time:35763ms step_avg:41.58ms
+step:861/1490 train_time:35816ms step_avg:41.60ms
+step:862/1490 train_time:35874ms step_avg:41.62ms
+step:863/1490 train_time:35927ms step_avg:41.63ms
+step:864/1490 train_time:35985ms step_avg:41.65ms
+step:865/1490 train_time:36041ms step_avg:41.67ms
+step:866/1490 train_time:36098ms step_avg:41.68ms
+step:867/1490 train_time:36151ms step_avg:41.70ms
+step:868/1490 train_time:36208ms step_avg:41.71ms
+step:869/1490 train_time:36263ms step_avg:41.73ms
+step:870/1490 train_time:36320ms step_avg:41.75ms
+step:871/1490 train_time:36373ms step_avg:41.76ms
+step:872/1490 train_time:36432ms step_avg:41.78ms
+step:873/1490 train_time:36485ms step_avg:41.79ms
+step:874/1490 train_time:36544ms step_avg:41.81ms
+step:875/1490 train_time:36597ms step_avg:41.82ms
+step:876/1490 train_time:36654ms step_avg:41.84ms
+step:877/1490 train_time:36708ms step_avg:41.86ms
+step:878/1490 train_time:36766ms step_avg:41.87ms
+step:879/1490 train_time:36820ms step_avg:41.89ms
+step:880/1490 train_time:36878ms step_avg:41.91ms
+step:881/1490 train_time:36932ms step_avg:41.92ms
+step:882/1490 train_time:36990ms step_avg:41.94ms
+step:883/1490 train_time:37043ms step_avg:41.95ms
+step:884/1490 train_time:37101ms step_avg:41.97ms
+step:885/1490 train_time:37155ms step_avg:41.98ms
+step:886/1490 train_time:37213ms step_avg:42.00ms
+step:887/1490 train_time:37266ms step_avg:42.01ms
+step:888/1490 train_time:37324ms step_avg:42.03ms
+step:889/1490 train_time:37378ms step_avg:42.04ms
+step:890/1490 train_time:37436ms step_avg:42.06ms
+step:891/1490 train_time:37490ms step_avg:42.08ms
+step:892/1490 train_time:37548ms step_avg:42.09ms
+step:893/1490 train_time:37601ms step_avg:42.11ms
+step:894/1490 train_time:37659ms step_avg:42.12ms
+step:895/1490 train_time:37713ms step_avg:42.14ms
+step:896/1490 train_time:37771ms step_avg:42.16ms
+step:897/1490 train_time:37824ms step_avg:42.17ms
+step:898/1490 train_time:37882ms step_avg:42.19ms
+step:899/1490 train_time:37936ms step_avg:42.20ms
+step:900/1490 train_time:37995ms step_avg:42.22ms
+step:901/1490 train_time:38047ms step_avg:42.23ms
+step:902/1490 train_time:38105ms step_avg:42.24ms
+step:903/1490 train_time:38157ms step_avg:42.26ms
+step:904/1490 train_time:38216ms step_avg:42.27ms
+step:905/1490 train_time:38270ms step_avg:42.29ms
+step:906/1490 train_time:38328ms step_avg:42.30ms
+step:907/1490 train_time:38381ms step_avg:42.32ms
+step:908/1490 train_time:38440ms step_avg:42.33ms
+step:909/1490 train_time:38493ms step_avg:42.35ms
+step:910/1490 train_time:38551ms step_avg:42.36ms
+step:911/1490 train_time:38603ms step_avg:42.37ms
+step:912/1490 train_time:38661ms step_avg:42.39ms
+step:913/1490 train_time:38715ms step_avg:42.40ms
+step:914/1490 train_time:38773ms step_avg:42.42ms
+step:915/1490 train_time:38826ms step_avg:42.43ms
+step:916/1490 train_time:38885ms step_avg:42.45ms
+step:917/1490 train_time:38939ms step_avg:42.46ms
+step:918/1490 train_time:38998ms step_avg:42.48ms
+step:919/1490 train_time:39051ms step_avg:42.49ms
+step:920/1490 train_time:39109ms step_avg:42.51ms
+step:921/1490 train_time:39162ms step_avg:42.52ms
+step:922/1490 train_time:39220ms step_avg:42.54ms
+step:923/1490 train_time:39273ms step_avg:42.55ms
+step:924/1490 train_time:39331ms step_avg:42.57ms
+step:925/1490 train_time:39384ms step_avg:42.58ms
+step:926/1490 train_time:39443ms step_avg:42.60ms
+step:927/1490 train_time:39496ms step_avg:42.61ms
+step:928/1490 train_time:39555ms step_avg:42.62ms
+step:929/1490 train_time:39609ms step_avg:42.64ms
+step:930/1490 train_time:39666ms step_avg:42.65ms
+step:931/1490 train_time:39719ms step_avg:42.66ms
+step:932/1490 train_time:39778ms step_avg:42.68ms
+step:933/1490 train_time:39831ms step_avg:42.69ms
+step:934/1490 train_time:39889ms step_avg:42.71ms
+step:935/1490 train_time:39942ms step_avg:42.72ms
+step:936/1490 train_time:40001ms step_avg:42.74ms
+step:937/1490 train_time:40054ms step_avg:42.75ms
+step:938/1490 train_time:40112ms step_avg:42.76ms
+step:939/1490 train_time:40166ms step_avg:42.78ms
+step:940/1490 train_time:40224ms step_avg:42.79ms
+step:941/1490 train_time:40277ms step_avg:42.80ms
+step:942/1490 train_time:40336ms step_avg:42.82ms
+step:943/1490 train_time:40389ms step_avg:42.83ms
+step:944/1490 train_time:40447ms step_avg:42.85ms
+step:945/1490 train_time:40501ms step_avg:42.86ms
+step:946/1490 train_time:40559ms step_avg:42.87ms
+step:947/1490 train_time:40612ms step_avg:42.88ms
+step:948/1490 train_time:40670ms step_avg:42.90ms
+step:949/1490 train_time:40723ms step_avg:42.91ms
+step:950/1490 train_time:40781ms step_avg:42.93ms
+step:951/1490 train_time:40835ms step_avg:42.94ms
+step:952/1490 train_time:40894ms step_avg:42.96ms
+step:953/1490 train_time:40947ms step_avg:42.97ms
+step:954/1490 train_time:41004ms step_avg:42.98ms
+step:955/1490 train_time:41058ms step_avg:42.99ms
+step:956/1490 train_time:41116ms step_avg:43.01ms
+step:957/1490 train_time:41169ms step_avg:43.02ms
+step:958/1490 train_time:41227ms step_avg:43.03ms
+step:959/1490 train_time:41280ms step_avg:43.05ms
+step:960/1490 train_time:41339ms step_avg:43.06ms
+step:961/1490 train_time:41392ms step_avg:43.07ms
+step:962/1490 train_time:41450ms step_avg:43.09ms
+step:963/1490 train_time:41503ms step_avg:43.10ms
+step:964/1490 train_time:41561ms step_avg:43.11ms
+step:965/1490 train_time:41614ms step_avg:43.12ms
+step:966/1490 train_time:41673ms step_avg:43.14ms
+step:967/1490 train_time:41725ms step_avg:43.15ms
+step:968/1490 train_time:41787ms step_avg:43.17ms
+step:969/1490 train_time:41867ms step_avg:43.21ms
+step:970/1490 train_time:41950ms step_avg:43.25ms
+step:971/1490 train_time:42028ms step_avg:43.28ms
+step:972/1490 train_time:42114ms step_avg:43.33ms
+step:973/1490 train_time:42192ms step_avg:43.36ms
+step:974/1490 train_time:42276ms step_avg:43.40ms
+step:975/1490 train_time:42355ms step_avg:43.44ms
+step:976/1490 train_time:42439ms step_avg:43.48ms
+step:977/1490 train_time:42518ms step_avg:43.52ms
+step:978/1490 train_time:42602ms step_avg:43.56ms
+step:979/1490 train_time:42681ms step_avg:43.60ms
+step:980/1490 train_time:42765ms step_avg:43.64ms
+step:981/1490 train_time:42843ms step_avg:43.67ms
+step:982/1490 train_time:42925ms step_avg:43.71ms
+step:983/1490 train_time:43004ms step_avg:43.75ms
+step:984/1490 train_time:43088ms step_avg:43.79ms
+step:985/1490 train_time:43166ms step_avg:43.82ms
+step:986/1490 train_time:43251ms step_avg:43.86ms
+step:987/1490 train_time:43329ms step_avg:43.90ms
+step:988/1490 train_time:43413ms step_avg:43.94ms
+step:989/1490 train_time:43493ms step_avg:43.98ms
+step:990/1490 train_time:43576ms step_avg:44.02ms
+step:991/1490 train_time:43656ms step_avg:44.05ms
+step:992/1490 train_time:43741ms step_avg:44.09ms
+step:993/1490 train_time:43821ms step_avg:44.13ms
+step:994/1490 train_time:43904ms step_avg:44.17ms
+step:995/1490 train_time:43984ms step_avg:44.20ms
+step:996/1490 train_time:44068ms step_avg:44.25ms
+step:997/1490 train_time:44145ms step_avg:44.28ms
+step:998/1490 train_time:44229ms step_avg:44.32ms
+step:999/1490 train_time:44307ms step_avg:44.35ms
+step:1000/1490 train_time:44391ms step_avg:44.39ms
+step:1000/1490 val_loss:3.5184 train_time:44486ms step_avg:44.49ms
+step:1001/1490 train_time:44509ms step_avg:44.46ms
+step:1002/1490 train_time:44559ms step_avg:44.47ms
+step:1003/1490 train_time:44642ms step_avg:44.51ms
+step:1004/1490 train_time:44730ms step_avg:44.55ms
+step:1005/1490 train_time:44809ms step_avg:44.59ms
+step:1006/1490 train_time:44892ms step_avg:44.62ms
+step:1007/1490 train_time:44969ms step_avg:44.66ms
+step:1008/1490 train_time:45052ms step_avg:44.69ms
+step:1009/1490 train_time:45130ms step_avg:44.73ms
+step:1010/1490 train_time:45214ms step_avg:44.77ms
+step:1011/1490 train_time:45293ms step_avg:44.80ms
+step:1012/1490 train_time:45375ms step_avg:44.84ms
+step:1013/1490 train_time:45454ms step_avg:44.87ms
+step:1014/1490 train_time:45538ms step_avg:44.91ms
+step:1015/1490 train_time:45619ms step_avg:44.94ms
+step:1016/1490 train_time:45704ms step_avg:44.98ms
+step:1017/1490 train_time:45785ms step_avg:45.02ms
+step:1018/1490 train_time:45870ms step_avg:45.06ms
+step:1019/1490 train_time:45948ms step_avg:45.09ms
+step:1020/1490 train_time:46031ms step_avg:45.13ms
+step:1021/1490 train_time:46109ms step_avg:45.16ms
+step:1022/1490 train_time:46194ms step_avg:45.20ms
+step:1023/1490 train_time:46271ms step_avg:45.23ms
+step:1024/1490 train_time:46355ms step_avg:45.27ms
+step:1025/1490 train_time:46434ms step_avg:45.30ms
+step:1026/1490 train_time:46517ms step_avg:45.34ms
+step:1027/1490 train_time:46597ms step_avg:45.37ms
+step:1028/1490 train_time:46682ms step_avg:45.41ms
+step:1029/1490 train_time:46761ms step_avg:45.44ms
+step:1030/1490 train_time:46846ms step_avg:45.48ms
+step:1031/1490 train_time:46925ms step_avg:45.51ms
+step:1032/1490 train_time:47009ms step_avg:45.55ms
+step:1033/1490 train_time:47087ms step_avg:45.58ms
+step:1034/1490 train_time:47171ms step_avg:45.62ms
+step:1035/1490 train_time:47249ms step_avg:45.65ms
+step:1036/1490 train_time:47332ms step_avg:45.69ms
+step:1037/1490 train_time:47413ms step_avg:45.72ms
+step:1038/1490 train_time:47496ms step_avg:45.76ms
+step:1039/1490 train_time:47576ms step_avg:45.79ms
+step:1040/1490 train_time:47660ms step_avg:45.83ms
+step:1041/1490 train_time:47738ms step_avg:45.86ms
+step:1042/1490 train_time:47823ms step_avg:45.90ms
+step:1043/1490 train_time:47902ms step_avg:45.93ms
+step:1044/1490 train_time:47986ms step_avg:45.96ms
+step:1045/1490 train_time:48065ms step_avg:46.00ms
+step:1046/1490 train_time:48150ms step_avg:46.03ms
+step:1047/1490 train_time:48228ms step_avg:46.06ms
+step:1048/1490 train_time:48312ms step_avg:46.10ms
+step:1049/1490 train_time:48391ms step_avg:46.13ms
+step:1050/1490 train_time:48476ms step_avg:46.17ms
+step:1051/1490 train_time:48556ms step_avg:46.20ms
+step:1052/1490 train_time:48639ms step_avg:46.23ms
+step:1053/1490 train_time:48718ms step_avg:46.27ms
+step:1054/1490 train_time:48803ms step_avg:46.30ms
+step:1055/1490 train_time:48882ms step_avg:46.33ms
+step:1056/1490 train_time:48964ms step_avg:46.37ms
+step:1057/1490 train_time:49043ms step_avg:46.40ms
+step:1058/1490 train_time:49127ms step_avg:46.43ms
+step:1059/1490 train_time:49207ms step_avg:46.47ms
+step:1060/1490 train_time:49290ms step_avg:46.50ms
+step:1061/1490 train_time:49370ms step_avg:46.53ms
+step:1062/1490 train_time:49456ms step_avg:46.57ms
+step:1063/1490 train_time:49535ms step_avg:46.60ms
+step:1064/1490 train_time:49620ms step_avg:46.64ms
+step:1065/1490 train_time:49698ms step_avg:46.66ms
+step:1066/1490 train_time:49781ms step_avg:46.70ms
+step:1067/1490 train_time:49858ms step_avg:46.73ms
+step:1068/1490 train_time:49943ms step_avg:46.76ms
+step:1069/1490 train_time:50023ms step_avg:46.79ms
+step:1070/1490 train_time:50105ms step_avg:46.83ms
+step:1071/1490 train_time:50185ms step_avg:46.86ms
+step:1072/1490 train_time:50270ms step_avg:46.89ms
+step:1073/1490 train_time:50349ms step_avg:46.92ms
+step:1074/1490 train_time:50433ms step_avg:46.96ms
+step:1075/1490 train_time:50513ms step_avg:46.99ms
+step:1076/1490 train_time:50598ms step_avg:47.02ms
+step:1077/1490 train_time:50676ms step_avg:47.05ms
+step:1078/1490 train_time:50759ms step_avg:47.09ms
+step:1079/1490 train_time:50837ms step_avg:47.11ms
+step:1080/1490 train_time:50921ms step_avg:47.15ms
+step:1081/1490 train_time:51000ms step_avg:47.18ms
+step:1082/1490 train_time:51085ms step_avg:47.21ms
+step:1083/1490 train_time:51163ms step_avg:47.24ms
+step:1084/1490 train_time:51248ms step_avg:47.28ms
+step:1085/1490 train_time:51328ms step_avg:47.31ms
+step:1086/1490 train_time:51413ms step_avg:47.34ms
+step:1087/1490 train_time:51492ms step_avg:47.37ms
+step:1088/1490 train_time:51577ms step_avg:47.41ms
+step:1089/1490 train_time:51655ms step_avg:47.43ms
+step:1090/1490 train_time:51738ms step_avg:47.47ms
+step:1091/1490 train_time:51817ms step_avg:47.50ms
+step:1092/1490 train_time:51903ms step_avg:47.53ms
+step:1093/1490 train_time:51981ms step_avg:47.56ms
+step:1094/1490 train_time:52065ms step_avg:47.59ms
+step:1095/1490 train_time:52146ms step_avg:47.62ms
+step:1096/1490 train_time:52229ms step_avg:47.65ms
+step:1097/1490 train_time:52309ms step_avg:47.68ms
+step:1098/1490 train_time:52394ms step_avg:47.72ms
+step:1099/1490 train_time:52475ms step_avg:47.75ms
+step:1100/1490 train_time:52560ms step_avg:47.78ms
+step:1101/1490 train_time:52637ms step_avg:47.81ms
+step:1102/1490 train_time:52722ms step_avg:47.84ms
+step:1103/1490 train_time:52801ms step_avg:47.87ms
+step:1104/1490 train_time:52885ms step_avg:47.90ms
+step:1105/1490 train_time:52965ms step_avg:47.93ms
+step:1106/1490 train_time:53047ms step_avg:47.96ms
+step:1107/1490 train_time:53127ms step_avg:47.99ms
+step:1108/1490 train_time:53211ms step_avg:48.02ms
+step:1109/1490 train_time:53291ms step_avg:48.05ms
+step:1110/1490 train_time:53375ms step_avg:48.09ms
+step:1111/1490 train_time:53455ms step_avg:48.11ms
+step:1112/1490 train_time:53538ms step_avg:48.15ms
+step:1113/1490 train_time:53617ms step_avg:48.17ms
+step:1114/1490 train_time:53701ms step_avg:48.21ms
+step:1115/1490 train_time:53780ms step_avg:48.23ms
+step:1116/1490 train_time:53863ms step_avg:48.26ms
+step:1117/1490 train_time:53942ms step_avg:48.29ms
+step:1118/1490 train_time:54027ms step_avg:48.32ms
+step:1119/1490 train_time:54106ms step_avg:48.35ms
+step:1120/1490 train_time:54190ms step_avg:48.38ms
+step:1121/1490 train_time:54269ms step_avg:48.41ms
+step:1122/1490 train_time:54354ms step_avg:48.44ms
+step:1123/1490 train_time:54433ms step_avg:48.47ms
+step:1124/1490 train_time:54518ms step_avg:48.50ms
+step:1125/1490 train_time:54596ms step_avg:48.53ms
+step:1126/1490 train_time:54680ms step_avg:48.56ms
+step:1127/1490 train_time:54757ms step_avg:48.59ms
+step:1128/1490 train_time:54840ms step_avg:48.62ms
+step:1129/1490 train_time:54918ms step_avg:48.64ms
+step:1130/1490 train_time:55003ms step_avg:48.68ms
+step:1131/1490 train_time:55083ms step_avg:48.70ms
+step:1132/1490 train_time:55168ms step_avg:48.74ms
+step:1133/1490 train_time:55246ms step_avg:48.76ms
+step:1134/1490 train_time:55333ms step_avg:48.79ms
+step:1135/1490 train_time:55412ms step_avg:48.82ms
+step:1136/1490 train_time:55496ms step_avg:48.85ms
+step:1137/1490 train_time:55576ms step_avg:48.88ms
+step:1138/1490 train_time:55660ms step_avg:48.91ms
+step:1139/1490 train_time:55738ms step_avg:48.94ms
+step:1140/1490 train_time:55822ms step_avg:48.97ms
+step:1141/1490 train_time:55900ms step_avg:48.99ms
+step:1142/1490 train_time:55984ms step_avg:49.02ms
+step:1143/1490 train_time:56063ms step_avg:49.05ms
+step:1144/1490 train_time:56147ms step_avg:49.08ms
+step:1145/1490 train_time:56227ms step_avg:49.11ms
+step:1146/1490 train_time:56310ms step_avg:49.14ms
+step:1147/1490 train_time:56390ms step_avg:49.16ms
+step:1148/1490 train_time:56474ms step_avg:49.19ms
+step:1149/1490 train_time:56553ms step_avg:49.22ms
+step:1150/1490 train_time:56636ms step_avg:49.25ms
+step:1151/1490 train_time:56714ms step_avg:49.27ms
+step:1152/1490 train_time:56798ms step_avg:49.30ms
+step:1153/1490 train_time:56876ms step_avg:49.33ms
+step:1154/1490 train_time:56959ms step_avg:49.36ms
+step:1155/1490 train_time:57038ms step_avg:49.38ms
+step:1156/1490 train_time:57122ms step_avg:49.41ms
+step:1157/1490 train_time:57202ms step_avg:49.44ms
+step:1158/1490 train_time:57288ms step_avg:49.47ms
+step:1159/1490 train_time:57367ms step_avg:49.50ms
+step:1160/1490 train_time:57450ms step_avg:49.53ms
+step:1161/1490 train_time:57529ms step_avg:49.55ms
+step:1162/1490 train_time:57614ms step_avg:49.58ms
+step:1163/1490 train_time:57693ms step_avg:49.61ms
+step:1164/1490 train_time:57776ms step_avg:49.64ms
+step:1165/1490 train_time:57854ms step_avg:49.66ms
+step:1166/1490 train_time:57937ms step_avg:49.69ms
+step:1167/1490 train_time:58016ms step_avg:49.71ms
+step:1168/1490 train_time:58100ms step_avg:49.74ms
+step:1169/1490 train_time:58178ms step_avg:49.77ms
+step:1170/1490 train_time:58263ms step_avg:49.80ms
+step:1171/1490 train_time:58342ms step_avg:49.82ms
+step:1172/1490 train_time:58428ms step_avg:49.85ms
+step:1173/1490 train_time:58508ms step_avg:49.88ms
+step:1174/1490 train_time:58593ms step_avg:49.91ms
+step:1175/1490 train_time:58673ms step_avg:49.93ms
+step:1176/1490 train_time:58757ms step_avg:49.96ms
+step:1177/1490 train_time:58835ms step_avg:49.99ms
+step:1178/1490 train_time:58918ms step_avg:50.02ms
+step:1179/1490 train_time:58996ms step_avg:50.04ms
+step:1180/1490 train_time:59082ms step_avg:50.07ms
+step:1181/1490 train_time:59159ms step_avg:50.09ms
+step:1182/1490 train_time:59242ms step_avg:50.12ms
+step:1183/1490 train_time:59322ms step_avg:50.15ms
+step:1184/1490 train_time:59407ms step_avg:50.18ms
+step:1185/1490 train_time:59488ms step_avg:50.20ms
+step:1186/1490 train_time:59574ms step_avg:50.23ms
+step:1187/1490 train_time:59653ms step_avg:50.25ms
+step:1188/1490 train_time:59736ms step_avg:50.28ms
+step:1189/1490 train_time:59816ms step_avg:50.31ms
+step:1190/1490 train_time:59899ms step_avg:50.34ms
+step:1191/1490 train_time:59977ms step_avg:50.36ms
+step:1192/1490 train_time:60062ms step_avg:50.39ms
+step:1193/1490 train_time:60139ms step_avg:50.41ms
+step:1194/1490 train_time:60223ms step_avg:50.44ms
+step:1195/1490 train_time:60302ms step_avg:50.46ms
+step:1196/1490 train_time:60386ms step_avg:50.49ms
+step:1197/1490 train_time:60466ms step_avg:50.51ms
+step:1198/1490 train_time:60553ms step_avg:50.54ms
+step:1199/1490 train_time:60632ms step_avg:50.57ms
+step:1200/1490 train_time:60715ms step_avg:50.60ms
+step:1201/1490 train_time:60794ms step_avg:50.62ms
+step:1202/1490 train_time:60879ms step_avg:50.65ms
+step:1203/1490 train_time:60957ms step_avg:50.67ms
+step:1204/1490 train_time:61040ms step_avg:50.70ms
+step:1205/1490 train_time:61118ms step_avg:50.72ms
+step:1206/1490 train_time:61202ms step_avg:50.75ms
+step:1207/1490 train_time:61281ms step_avg:50.77ms
+step:1208/1490 train_time:61366ms step_avg:50.80ms
+step:1209/1490 train_time:61445ms step_avg:50.82ms
+step:1210/1490 train_time:61531ms step_avg:50.85ms
+step:1211/1490 train_time:61612ms step_avg:50.88ms
+step:1212/1490 train_time:61696ms step_avg:50.90ms
+step:1213/1490 train_time:61775ms step_avg:50.93ms
+step:1214/1490 train_time:61859ms step_avg:50.95ms
+step:1215/1490 train_time:61936ms step_avg:50.98ms
+step:1216/1490 train_time:62021ms step_avg:51.00ms
+step:1217/1490 train_time:62099ms step_avg:51.03ms
+step:1218/1490 train_time:62182ms step_avg:51.05ms
+step:1219/1490 train_time:62261ms step_avg:51.08ms
+step:1220/1490 train_time:62345ms step_avg:51.10ms
+step:1221/1490 train_time:62424ms step_avg:51.13ms
+step:1222/1490 train_time:62510ms step_avg:51.15ms
+step:1223/1490 train_time:62590ms step_avg:51.18ms
+step:1224/1490 train_time:62677ms step_avg:51.21ms
+step:1225/1490 train_time:62755ms step_avg:51.23ms
+step:1226/1490 train_time:62839ms step_avg:51.26ms
+step:1227/1490 train_time:62917ms step_avg:51.28ms
+step:1228/1490 train_time:63000ms step_avg:51.30ms
+step:1229/1490 train_time:63078ms step_avg:51.32ms
+step:1230/1490 train_time:63161ms step_avg:51.35ms
+step:1231/1490 train_time:63240ms step_avg:51.37ms
+step:1232/1490 train_time:63325ms step_avg:51.40ms
+step:1233/1490 train_time:63403ms step_avg:51.42ms
+step:1234/1490 train_time:63487ms step_avg:51.45ms
+step:1235/1490 train_time:63567ms step_avg:51.47ms
+step:1236/1490 train_time:63652ms step_avg:51.50ms
+step:1237/1490 train_time:63731ms step_avg:51.52ms
+step:1238/1490 train_time:63816ms step_avg:51.55ms
+step:1239/1490 train_time:63894ms step_avg:51.57ms
+step:1240/1490 train_time:63979ms step_avg:51.60ms
+step:1241/1490 train_time:64056ms step_avg:51.62ms
+step:1242/1490 train_time:64139ms step_avg:51.64ms
+step:1243/1490 train_time:64217ms step_avg:51.66ms
+step:1244/1490 train_time:64301ms step_avg:51.69ms
+step:1245/1490 train_time:64380ms step_avg:51.71ms
+step:1246/1490 train_time:64464ms step_avg:51.74ms
+step:1247/1490 train_time:64544ms step_avg:51.76ms
+step:1248/1490 train_time:64629ms step_avg:51.79ms
+step:1249/1490 train_time:64709ms step_avg:51.81ms
+step:1250/1490 train_time:64793ms step_avg:51.83ms
+step:1250/1490 val_loss:3.3738 train_time:64889ms step_avg:51.91ms
+step:1251/1490 train_time:64909ms step_avg:51.89ms
+step:1252/1490 train_time:64962ms step_avg:51.89ms
+step:1253/1490 train_time:65044ms step_avg:51.91ms
+step:1254/1490 train_time:65129ms step_avg:51.94ms
+step:1255/1490 train_time:65207ms step_avg:51.96ms
+step:1256/1490 train_time:65291ms step_avg:51.98ms
+step:1257/1490 train_time:65368ms step_avg:52.00ms
+step:1258/1490 train_time:65451ms step_avg:52.03ms
+step:1259/1490 train_time:65529ms step_avg:52.05ms
+step:1260/1490 train_time:65613ms step_avg:52.07ms
+step:1261/1490 train_time:65691ms step_avg:52.09ms
+step:1262/1490 train_time:65774ms step_avg:52.12ms
+step:1263/1490 train_time:65853ms step_avg:52.14ms
+step:1264/1490 train_time:65937ms step_avg:52.17ms
+step:1265/1490 train_time:66019ms step_avg:52.19ms
+step:1266/1490 train_time:66105ms step_avg:52.22ms
+step:1267/1490 train_time:66185ms step_avg:52.24ms
+step:1268/1490 train_time:66269ms step_avg:52.26ms
+step:1269/1490 train_time:66347ms step_avg:52.28ms
+step:1270/1490 train_time:66430ms step_avg:52.31ms
+step:1271/1490 train_time:66508ms step_avg:52.33ms
+step:1272/1490 train_time:66592ms step_avg:52.35ms
+step:1273/1490 train_time:66669ms step_avg:52.37ms
+step:1274/1490 train_time:66753ms step_avg:52.40ms
+step:1275/1490 train_time:66831ms step_avg:52.42ms
+step:1276/1490 train_time:66916ms step_avg:52.44ms
+step:1277/1490 train_time:66997ms step_avg:52.46ms
+step:1278/1490 train_time:67083ms step_avg:52.49ms
+step:1279/1490 train_time:67163ms step_avg:52.51ms
+step:1280/1490 train_time:67247ms step_avg:52.54ms
+step:1281/1490 train_time:67326ms step_avg:52.56ms
+step:1282/1490 train_time:67410ms step_avg:52.58ms
+step:1283/1490 train_time:67488ms step_avg:52.60ms
+step:1284/1490 train_time:67572ms step_avg:52.63ms
+step:1285/1490 train_time:67648ms step_avg:52.64ms
+step:1286/1490 train_time:67733ms step_avg:52.67ms
+step:1287/1490 train_time:67811ms step_avg:52.69ms
+step:1288/1490 train_time:67896ms step_avg:52.71ms
+step:1289/1490 train_time:67976ms step_avg:52.74ms
+step:1290/1490 train_time:68062ms step_avg:52.76ms
+step:1291/1490 train_time:68141ms step_avg:52.78ms
+step:1292/1490 train_time:68226ms step_avg:52.81ms
+step:1293/1490 train_time:68306ms step_avg:52.83ms
+step:1294/1490 train_time:68389ms step_avg:52.85ms
+step:1295/1490 train_time:68467ms step_avg:52.87ms
+step:1296/1490 train_time:68549ms step_avg:52.89ms
+step:1297/1490 train_time:68629ms step_avg:52.91ms
+step:1298/1490 train_time:68713ms step_avg:52.94ms
+step:1299/1490 train_time:68791ms step_avg:52.96ms
+step:1300/1490 train_time:68875ms step_avg:52.98ms
+step:1301/1490 train_time:68955ms step_avg:53.00ms
+step:1302/1490 train_time:69041ms step_avg:53.03ms
+step:1303/1490 train_time:69120ms step_avg:53.05ms
+step:1304/1490 train_time:69206ms step_avg:53.07ms
+step:1305/1490 train_time:69285ms step_avg:53.09ms
+step:1306/1490 train_time:69369ms step_avg:53.12ms
+step:1307/1490 train_time:69447ms step_avg:53.13ms
+step:1308/1490 train_time:69531ms step_avg:53.16ms
+step:1309/1490 train_time:69609ms step_avg:53.18ms
+step:1310/1490 train_time:69693ms step_avg:53.20ms
+step:1311/1490 train_time:69771ms step_avg:53.22ms
+step:1312/1490 train_time:69854ms step_avg:53.24ms
+step:1313/1490 train_time:69934ms step_avg:53.26ms
+step:1314/1490 train_time:70019ms step_avg:53.29ms
+step:1315/1490 train_time:70098ms step_avg:53.31ms
+step:1316/1490 train_time:70185ms step_avg:53.33ms
+step:1317/1490 train_time:70264ms step_avg:53.35ms
+step:1318/1490 train_time:70347ms step_avg:53.37ms
+step:1319/1490 train_time:70426ms step_avg:53.39ms
+step:1320/1490 train_time:70511ms step_avg:53.42ms
+step:1321/1490 train_time:70590ms step_avg:53.44ms
+step:1322/1490 train_time:70673ms step_avg:53.46ms
+step:1323/1490 train_time:70750ms step_avg:53.48ms
+step:1324/1490 train_time:70834ms step_avg:53.50ms
+step:1325/1490 train_time:70913ms step_avg:53.52ms
+step:1326/1490 train_time:70999ms step_avg:53.54ms
+step:1327/1490 train_time:71080ms step_avg:53.56ms
+step:1328/1490 train_time:71165ms step_avg:53.59ms
+step:1329/1490 train_time:71244ms step_avg:53.61ms
+step:1330/1490 train_time:71328ms step_avg:53.63ms
+step:1331/1490 train_time:71407ms step_avg:53.65ms
+step:1332/1490 train_time:71491ms step_avg:53.67ms
+step:1333/1490 train_time:71569ms step_avg:53.69ms
+step:1334/1490 train_time:71652ms step_avg:53.71ms
+step:1335/1490 train_time:71731ms step_avg:53.73ms
+step:1336/1490 train_time:71815ms step_avg:53.75ms
+step:1337/1490 train_time:71893ms step_avg:53.77ms
+step:1338/1490 train_time:71977ms step_avg:53.79ms
+step:1339/1490 train_time:72056ms step_avg:53.81ms
+step:1340/1490 train_time:72141ms step_avg:53.84ms
+step:1341/1490 train_time:72221ms step_avg:53.86ms
+step:1342/1490 train_time:72305ms step_avg:53.88ms
+step:1343/1490 train_time:72386ms step_avg:53.90ms
+step:1344/1490 train_time:72469ms step_avg:53.92ms
+step:1345/1490 train_time:72547ms step_avg:53.94ms
+step:1346/1490 train_time:72631ms step_avg:53.96ms
+step:1347/1490 train_time:72709ms step_avg:53.98ms
+step:1348/1490 train_time:72793ms step_avg:54.00ms
+step:1349/1490 train_time:72872ms step_avg:54.02ms
+step:1350/1490 train_time:72956ms step_avg:54.04ms
+step:1351/1490 train_time:73036ms step_avg:54.06ms
+step:1352/1490 train_time:73121ms step_avg:54.08ms
+step:1353/1490 train_time:73202ms step_avg:54.10ms
+step:1354/1490 train_time:73288ms step_avg:54.13ms
+step:1355/1490 train_time:73367ms step_avg:54.15ms
+step:1356/1490 train_time:73450ms step_avg:54.17ms
+step:1357/1490 train_time:73529ms step_avg:54.18ms
+step:1358/1490 train_time:73613ms step_avg:54.21ms
+step:1359/1490 train_time:73691ms step_avg:54.22ms
+step:1360/1490 train_time:73774ms step_avg:54.25ms
+step:1361/1490 train_time:73852ms step_avg:54.26ms
+step:1362/1490 train_time:73935ms step_avg:54.28ms
+step:1363/1490 train_time:74015ms step_avg:54.30ms
+step:1364/1490 train_time:74100ms step_avg:54.33ms
+step:1365/1490 train_time:74181ms step_avg:54.35ms
+step:1366/1490 train_time:74267ms step_avg:54.37ms
+step:1367/1490 train_time:74347ms step_avg:54.39ms
+step:1368/1490 train_time:74430ms step_avg:54.41ms
+step:1369/1490 train_time:74509ms step_avg:54.43ms
+step:1370/1490 train_time:74594ms step_avg:54.45ms
+step:1371/1490 train_time:74673ms step_avg:54.47ms
+step:1372/1490 train_time:74757ms step_avg:54.49ms
+step:1373/1490 train_time:74835ms step_avg:54.50ms
+step:1374/1490 train_time:74918ms step_avg:54.53ms
+step:1375/1490 train_time:74997ms step_avg:54.54ms
+step:1376/1490 train_time:75081ms step_avg:54.56ms
+step:1377/1490 train_time:75160ms step_avg:54.58ms
+step:1378/1490 train_time:75246ms step_avg:54.60ms
+step:1379/1490 train_time:75325ms step_avg:54.62ms
+step:1380/1490 train_time:75410ms step_avg:54.64ms
+step:1381/1490 train_time:75487ms step_avg:54.66ms
+step:1382/1490 train_time:75571ms step_avg:54.68ms
+step:1383/1490 train_time:75649ms step_avg:54.70ms
+step:1384/1490 train_time:75734ms step_avg:54.72ms
+step:1385/1490 train_time:75812ms step_avg:54.74ms
+step:1386/1490 train_time:75896ms step_avg:54.76ms
+step:1387/1490 train_time:75975ms step_avg:54.78ms
+step:1388/1490 train_time:76060ms step_avg:54.80ms
+step:1389/1490 train_time:76138ms step_avg:54.82ms
+step:1390/1490 train_time:76224ms step_avg:54.84ms
+step:1391/1490 train_time:76302ms step_avg:54.85ms
+step:1392/1490 train_time:76388ms step_avg:54.88ms
+step:1393/1490 train_time:76467ms step_avg:54.89ms
+step:1394/1490 train_time:76550ms step_avg:54.91ms
+step:1395/1490 train_time:76629ms step_avg:54.93ms
+step:1396/1490 train_time:76712ms step_avg:54.95ms
+step:1397/1490 train_time:76789ms step_avg:54.97ms
+step:1398/1490 train_time:76874ms step_avg:54.99ms
+step:1399/1490 train_time:76953ms step_avg:55.01ms
+step:1400/1490 train_time:77038ms step_avg:55.03ms
+step:1401/1490 train_time:77117ms step_avg:55.04ms
+step:1402/1490 train_time:77202ms step_avg:55.07ms
+step:1403/1490 train_time:77281ms step_avg:55.08ms
+step:1404/1490 train_time:77367ms step_avg:55.10ms
+step:1405/1490 train_time:77446ms step_avg:55.12ms
+step:1406/1490 train_time:77528ms step_avg:55.14ms
+step:1407/1490 train_time:77607ms step_avg:55.16ms
+step:1408/1490 train_time:77691ms step_avg:55.18ms
+step:1409/1490 train_time:77768ms step_avg:55.19ms
+step:1410/1490 train_time:77852ms step_avg:55.21ms
+step:1411/1490 train_time:77933ms step_avg:55.23ms
+step:1412/1490 train_time:78017ms step_avg:55.25ms
+step:1413/1490 train_time:78097ms step_avg:55.27ms
+step:1414/1490 train_time:78182ms step_avg:55.29ms
+step:1415/1490 train_time:78262ms step_avg:55.31ms
+step:1416/1490 train_time:78347ms step_avg:55.33ms
+step:1417/1490 train_time:78426ms step_avg:55.35ms
+step:1418/1490 train_time:78509ms step_avg:55.37ms
+step:1419/1490 train_time:78588ms step_avg:55.38ms
+step:1420/1490 train_time:78671ms step_avg:55.40ms
+step:1421/1490 train_time:78748ms step_avg:55.42ms
+step:1422/1490 train_time:78834ms step_avg:55.44ms
+step:1423/1490 train_time:78913ms step_avg:55.46ms
+step:1424/1490 train_time:78998ms step_avg:55.48ms
+step:1425/1490 train_time:79076ms step_avg:55.49ms
+step:1426/1490 train_time:79161ms step_avg:55.51ms
+step:1427/1490 train_time:79241ms step_avg:55.53ms
+step:1428/1490 train_time:79325ms step_avg:55.55ms
+step:1429/1490 train_time:79404ms step_avg:55.57ms
+step:1430/1490 train_time:79488ms step_avg:55.59ms
+step:1431/1490 train_time:79567ms step_avg:55.60ms
+step:1432/1490 train_time:79650ms step_avg:55.62ms
+step:1433/1490 train_time:79729ms step_avg:55.64ms
+step:1434/1490 train_time:79814ms step_avg:55.66ms
+step:1435/1490 train_time:79892ms step_avg:55.67ms
+step:1436/1490 train_time:79975ms step_avg:55.69ms
+step:1437/1490 train_time:80055ms step_avg:55.71ms
+step:1438/1490 train_time:80141ms step_avg:55.73ms
+step:1439/1490 train_time:80220ms step_avg:55.75ms
+step:1440/1490 train_time:80305ms step_avg:55.77ms
+step:1441/1490 train_time:80385ms step_avg:55.78ms
+step:1442/1490 train_time:80468ms step_avg:55.80ms
+step:1443/1490 train_time:80546ms step_avg:55.82ms
+step:1444/1490 train_time:80629ms step_avg:55.84ms
+step:1445/1490 train_time:80707ms step_avg:55.85ms
+step:1446/1490 train_time:80793ms step_avg:55.87ms
+step:1447/1490 train_time:80872ms step_avg:55.89ms
+step:1448/1490 train_time:80956ms step_avg:55.91ms
+step:1449/1490 train_time:81036ms step_avg:55.93ms
+step:1450/1490 train_time:81120ms step_avg:55.94ms
+step:1451/1490 train_time:81202ms step_avg:55.96ms
+step:1452/1490 train_time:81290ms step_avg:55.99ms
+step:1453/1490 train_time:81368ms step_avg:56.00ms
+step:1454/1490 train_time:81452ms step_avg:56.02ms
+step:1455/1490 train_time:81530ms step_avg:56.03ms
+step:1456/1490 train_time:81616ms step_avg:56.05ms
+step:1457/1490 train_time:81696ms step_avg:56.07ms
+step:1458/1490 train_time:81780ms step_avg:56.09ms
+step:1459/1490 train_time:81858ms step_avg:56.11ms
+step:1460/1490 train_time:81942ms step_avg:56.12ms
+step:1461/1490 train_time:82021ms step_avg:56.14ms
+step:1462/1490 train_time:82105ms step_avg:56.16ms
+step:1463/1490 train_time:82185ms step_avg:56.18ms
+step:1464/1490 train_time:82269ms step_avg:56.19ms
+step:1465/1490 train_time:82348ms step_avg:56.21ms
+step:1466/1490 train_time:82432ms step_avg:56.23ms
+step:1467/1490 train_time:82512ms step_avg:56.25ms
+step:1468/1490 train_time:82597ms step_avg:56.27ms
+step:1469/1490 train_time:82678ms step_avg:56.28ms
+step:1470/1490 train_time:82761ms step_avg:56.30ms
+step:1471/1490 train_time:82840ms step_avg:56.32ms
+step:1472/1490 train_time:82923ms step_avg:56.33ms
+step:1473/1490 train_time:83002ms step_avg:56.35ms
+step:1474/1490 train_time:83087ms step_avg:56.37ms
+step:1475/1490 train_time:83165ms step_avg:56.38ms
+step:1476/1490 train_time:83250ms step_avg:56.40ms
+step:1477/1490 train_time:83328ms step_avg:56.42ms
+step:1478/1490 train_time:83413ms step_avg:56.44ms
+step:1479/1490 train_time:83492ms step_avg:56.45ms
+step:1480/1490 train_time:83577ms step_avg:56.47ms
+step:1481/1490 train_time:83657ms step_avg:56.49ms
+step:1482/1490 train_time:83741ms step_avg:56.51ms
+step:1483/1490 train_time:83821ms step_avg:56.52ms
+step:1484/1490 train_time:83906ms step_avg:56.54ms
+step:1485/1490 train_time:83985ms step_avg:56.56ms
+step:1486/1490 train_time:84068ms step_avg:56.57ms
+step:1487/1490 train_time:84148ms step_avg:56.59ms
+step:1488/1490 train_time:84233ms step_avg:56.61ms
+step:1489/1490 train_time:84312ms step_avg:56.62ms
+step:1490/1490 train_time:84395ms step_avg:56.64ms
+step:1490/1490 val_loss:3.2804 train_time:84491ms step_avg:56.71ms
+peak memory allocated: 31253 MiB reserved: 45226 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/814a7cf6-6b74-4cbe-ac34-f82d6f795f4f.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/814a7cf6-6b74-4cbe-ac34-f82d6f795f4f.txt
@@ -1,0 +1,4804 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 21:43:13 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8284 train_time:0ms step_avg:0.04ms
+step:1/1490 train_time:82ms step_avg:81.89ms
+step:2/1490 train_time:103ms step_avg:51.74ms
+step:3/1490 train_time:121ms step_avg:40.30ms
+step:4/1490 train_time:149ms step_avg:37.33ms
+step:5/1490 train_time:176ms step_avg:35.10ms
+step:6/1490 train_time:210ms step_avg:34.92ms
+step:7/1490 train_time:236ms step_avg:33.74ms
+step:8/1490 train_time:270ms step_avg:33.77ms
+step:9/1490 train_time:297ms step_avg:32.97ms
+step:10/1490 train_time:330ms step_avg:33.05ms
+step:11/1490 train_time:357ms step_avg:32.50ms
+step:12/1490 train_time:391ms step_avg:32.58ms
+step:13/1490 train_time:418ms step_avg:32.18ms
+step:14/1490 train_time:452ms step_avg:32.29ms
+step:15/1490 train_time:479ms step_avg:31.95ms
+step:16/1490 train_time:513ms step_avg:32.06ms
+step:17/1490 train_time:540ms step_avg:31.76ms
+step:18/1490 train_time:574ms step_avg:31.86ms
+step:19/1490 train_time:601ms step_avg:31.61ms
+step:20/1490 train_time:635ms step_avg:31.74ms
+step:21/1490 train_time:662ms step_avg:31.50ms
+step:22/1490 train_time:696ms step_avg:31.63ms
+step:23/1490 train_time:722ms step_avg:31.41ms
+step:24/1490 train_time:756ms step_avg:31.50ms
+step:25/1490 train_time:783ms step_avg:31.31ms
+step:26/1490 train_time:817ms step_avg:31.41ms
+step:27/1490 train_time:843ms step_avg:31.24ms
+step:28/1490 train_time:877ms step_avg:31.32ms
+step:29/1490 train_time:904ms step_avg:31.17ms
+step:30/1490 train_time:938ms step_avg:31.27ms
+step:31/1490 train_time:965ms step_avg:31.14ms
+step:32/1490 train_time:1000ms step_avg:31.26ms
+step:33/1490 train_time:1028ms step_avg:31.14ms
+step:34/1490 train_time:1062ms step_avg:31.25ms
+step:35/1490 train_time:1090ms step_avg:31.14ms
+step:36/1490 train_time:1124ms step_avg:31.22ms
+step:37/1490 train_time:1151ms step_avg:31.11ms
+step:38/1490 train_time:1186ms step_avg:31.20ms
+step:39/1490 train_time:1212ms step_avg:31.09ms
+step:40/1490 train_time:1246ms step_avg:31.16ms
+step:41/1490 train_time:1274ms step_avg:31.06ms
+step:42/1490 train_time:1308ms step_avg:31.13ms
+step:43/1490 train_time:1334ms step_avg:31.03ms
+step:44/1490 train_time:1368ms step_avg:31.08ms
+step:45/1490 train_time:1395ms step_avg:30.99ms
+step:46/1490 train_time:1428ms step_avg:31.04ms
+step:47/1490 train_time:1455ms step_avg:30.96ms
+step:48/1490 train_time:1489ms step_avg:31.02ms
+step:49/1490 train_time:1516ms step_avg:30.94ms
+step:50/1490 train_time:1549ms step_avg:30.99ms
+step:51/1490 train_time:1577ms step_avg:30.91ms
+step:52/1490 train_time:1610ms step_avg:30.96ms
+step:53/1490 train_time:1637ms step_avg:30.89ms
+step:54/1490 train_time:1671ms step_avg:30.95ms
+step:55/1490 train_time:1698ms step_avg:30.87ms
+step:56/1490 train_time:1731ms step_avg:30.92ms
+step:57/1490 train_time:1759ms step_avg:30.85ms
+step:58/1490 train_time:1792ms step_avg:30.90ms
+step:59/1490 train_time:1820ms step_avg:30.84ms
+step:60/1490 train_time:1853ms step_avg:30.89ms
+step:61/1490 train_time:1880ms step_avg:30.82ms
+step:62/1490 train_time:1914ms step_avg:30.87ms
+step:63/1490 train_time:1941ms step_avg:30.81ms
+step:64/1490 train_time:1975ms step_avg:30.86ms
+step:65/1490 train_time:2002ms step_avg:30.81ms
+step:66/1490 train_time:2036ms step_avg:30.85ms
+step:67/1490 train_time:2064ms step_avg:30.80ms
+step:68/1490 train_time:2098ms step_avg:30.85ms
+step:69/1490 train_time:2125ms step_avg:30.80ms
+step:70/1490 train_time:2159ms step_avg:30.85ms
+step:71/1490 train_time:2186ms step_avg:30.79ms
+step:72/1490 train_time:2220ms step_avg:30.83ms
+step:73/1490 train_time:2247ms step_avg:30.78ms
+step:74/1490 train_time:2281ms step_avg:30.82ms
+step:75/1490 train_time:2308ms step_avg:30.77ms
+step:76/1490 train_time:2342ms step_avg:30.82ms
+step:77/1490 train_time:2369ms step_avg:30.77ms
+step:78/1490 train_time:2404ms step_avg:30.81ms
+step:79/1490 train_time:2431ms step_avg:30.77ms
+step:80/1490 train_time:2465ms step_avg:30.81ms
+step:81/1490 train_time:2492ms step_avg:30.76ms
+step:82/1490 train_time:2525ms step_avg:30.80ms
+step:83/1490 train_time:2552ms step_avg:30.75ms
+step:84/1490 train_time:2586ms step_avg:30.78ms
+step:85/1490 train_time:2613ms step_avg:30.74ms
+step:86/1490 train_time:2647ms step_avg:30.77ms
+step:87/1490 train_time:2673ms step_avg:30.72ms
+step:88/1490 train_time:2707ms step_avg:30.76ms
+step:89/1490 train_time:2734ms step_avg:30.71ms
+step:90/1490 train_time:2767ms step_avg:30.75ms
+step:91/1490 train_time:2794ms step_avg:30.71ms
+step:92/1490 train_time:2828ms step_avg:30.74ms
+step:93/1490 train_time:2855ms step_avg:30.70ms
+step:94/1490 train_time:2888ms step_avg:30.73ms
+step:95/1490 train_time:2916ms step_avg:30.69ms
+step:96/1490 train_time:2949ms step_avg:30.72ms
+step:97/1490 train_time:2976ms step_avg:30.68ms
+step:98/1490 train_time:3010ms step_avg:30.72ms
+step:99/1490 train_time:3037ms step_avg:30.68ms
+step:100/1490 train_time:3071ms step_avg:30.71ms
+step:101/1490 train_time:3098ms step_avg:30.68ms
+step:102/1490 train_time:3132ms step_avg:30.71ms
+step:103/1490 train_time:3159ms step_avg:30.67ms
+step:104/1490 train_time:3193ms step_avg:30.70ms
+step:105/1490 train_time:3220ms step_avg:30.67ms
+step:106/1490 train_time:3254ms step_avg:30.70ms
+step:107/1490 train_time:3281ms step_avg:30.66ms
+step:108/1490 train_time:3315ms step_avg:30.69ms
+step:109/1490 train_time:3342ms step_avg:30.66ms
+step:110/1490 train_time:3377ms step_avg:30.70ms
+step:111/1490 train_time:3403ms step_avg:30.66ms
+step:112/1490 train_time:3437ms step_avg:30.69ms
+step:113/1490 train_time:3464ms step_avg:30.66ms
+step:114/1490 train_time:3499ms step_avg:30.69ms
+step:115/1490 train_time:3525ms step_avg:30.66ms
+step:116/1490 train_time:3560ms step_avg:30.69ms
+step:117/1490 train_time:3586ms step_avg:30.65ms
+step:118/1490 train_time:3620ms step_avg:30.68ms
+step:119/1490 train_time:3647ms step_avg:30.65ms
+step:120/1490 train_time:3681ms step_avg:30.67ms
+step:121/1490 train_time:3708ms step_avg:30.64ms
+step:122/1490 train_time:3741ms step_avg:30.67ms
+step:123/1490 train_time:3768ms step_avg:30.64ms
+step:124/1490 train_time:3802ms step_avg:30.66ms
+step:125/1490 train_time:3829ms step_avg:30.63ms
+step:126/1490 train_time:3863ms step_avg:30.66ms
+step:127/1490 train_time:3890ms step_avg:30.63ms
+step:128/1490 train_time:3923ms step_avg:30.65ms
+step:129/1490 train_time:3951ms step_avg:30.62ms
+step:130/1490 train_time:3984ms step_avg:30.65ms
+step:131/1490 train_time:4011ms step_avg:30.62ms
+step:132/1490 train_time:4045ms step_avg:30.64ms
+step:133/1490 train_time:4072ms step_avg:30.62ms
+step:134/1490 train_time:4106ms step_avg:30.64ms
+step:135/1490 train_time:4133ms step_avg:30.62ms
+step:136/1490 train_time:4167ms step_avg:30.64ms
+step:137/1490 train_time:4194ms step_avg:30.61ms
+step:138/1490 train_time:4228ms step_avg:30.64ms
+step:139/1490 train_time:4255ms step_avg:30.61ms
+step:140/1490 train_time:4289ms step_avg:30.63ms
+step:141/1490 train_time:4316ms step_avg:30.61ms
+step:142/1490 train_time:4350ms step_avg:30.63ms
+step:143/1490 train_time:4376ms step_avg:30.60ms
+step:144/1490 train_time:4411ms step_avg:30.63ms
+step:145/1490 train_time:4437ms step_avg:30.60ms
+step:146/1490 train_time:4471ms step_avg:30.62ms
+step:147/1490 train_time:4498ms step_avg:30.60ms
+step:148/1490 train_time:4532ms step_avg:30.62ms
+step:149/1490 train_time:4559ms step_avg:30.60ms
+step:150/1490 train_time:4593ms step_avg:30.62ms
+step:151/1490 train_time:4620ms step_avg:30.60ms
+step:152/1490 train_time:4654ms step_avg:30.62ms
+step:153/1490 train_time:4681ms step_avg:30.60ms
+step:154/1490 train_time:4715ms step_avg:30.62ms
+step:155/1490 train_time:4742ms step_avg:30.59ms
+step:156/1490 train_time:4776ms step_avg:30.62ms
+step:157/1490 train_time:4803ms step_avg:30.59ms
+step:158/1490 train_time:4837ms step_avg:30.61ms
+step:159/1490 train_time:4864ms step_avg:30.59ms
+step:160/1490 train_time:4898ms step_avg:30.61ms
+step:161/1490 train_time:4925ms step_avg:30.59ms
+step:162/1490 train_time:4959ms step_avg:30.61ms
+step:163/1490 train_time:4986ms step_avg:30.59ms
+step:164/1490 train_time:5020ms step_avg:30.61ms
+step:165/1490 train_time:5047ms step_avg:30.59ms
+step:166/1490 train_time:5081ms step_avg:30.61ms
+step:167/1490 train_time:5108ms step_avg:30.58ms
+step:168/1490 train_time:5142ms step_avg:30.61ms
+step:169/1490 train_time:5169ms step_avg:30.59ms
+step:170/1490 train_time:5203ms step_avg:30.61ms
+step:171/1490 train_time:5230ms step_avg:30.59ms
+step:172/1490 train_time:5264ms step_avg:30.61ms
+step:173/1490 train_time:5291ms step_avg:30.58ms
+step:174/1490 train_time:5324ms step_avg:30.60ms
+step:175/1490 train_time:5351ms step_avg:30.58ms
+step:176/1490 train_time:5385ms step_avg:30.60ms
+step:177/1490 train_time:5412ms step_avg:30.58ms
+step:178/1490 train_time:5446ms step_avg:30.59ms
+step:179/1490 train_time:5473ms step_avg:30.57ms
+step:180/1490 train_time:5506ms step_avg:30.59ms
+step:181/1490 train_time:5533ms step_avg:30.57ms
+step:182/1490 train_time:5567ms step_avg:30.59ms
+step:183/1490 train_time:5594ms step_avg:30.57ms
+step:184/1490 train_time:5632ms step_avg:30.61ms
+step:185/1490 train_time:5655ms step_avg:30.57ms
+step:186/1490 train_time:5689ms step_avg:30.59ms
+step:187/1490 train_time:5716ms step_avg:30.57ms
+step:188/1490 train_time:5750ms step_avg:30.58ms
+step:189/1490 train_time:5777ms step_avg:30.57ms
+step:190/1490 train_time:5811ms step_avg:30.58ms
+step:191/1490 train_time:5838ms step_avg:30.56ms
+step:192/1490 train_time:5872ms step_avg:30.58ms
+step:193/1490 train_time:5899ms step_avg:30.56ms
+step:194/1490 train_time:5933ms step_avg:30.58ms
+step:195/1490 train_time:5960ms step_avg:30.56ms
+step:196/1490 train_time:5994ms step_avg:30.58ms
+step:197/1490 train_time:6021ms step_avg:30.56ms
+step:198/1490 train_time:6054ms step_avg:30.58ms
+step:199/1490 train_time:6081ms step_avg:30.56ms
+step:200/1490 train_time:6115ms step_avg:30.57ms
+step:201/1490 train_time:6142ms step_avg:30.56ms
+step:202/1490 train_time:6177ms step_avg:30.58ms
+step:203/1490 train_time:6204ms step_avg:30.56ms
+step:204/1490 train_time:6237ms step_avg:30.58ms
+step:205/1490 train_time:6264ms step_avg:30.56ms
+step:206/1490 train_time:6298ms step_avg:30.57ms
+step:207/1490 train_time:6326ms step_avg:30.56ms
+step:208/1490 train_time:6360ms step_avg:30.58ms
+step:209/1490 train_time:6387ms step_avg:30.56ms
+step:210/1490 train_time:6421ms step_avg:30.58ms
+step:211/1490 train_time:6448ms step_avg:30.56ms
+step:212/1490 train_time:6482ms step_avg:30.58ms
+step:213/1490 train_time:6509ms step_avg:30.56ms
+step:214/1490 train_time:6542ms step_avg:30.57ms
+step:215/1490 train_time:6570ms step_avg:30.56ms
+step:216/1490 train_time:6604ms step_avg:30.57ms
+step:217/1490 train_time:6631ms step_avg:30.56ms
+step:218/1490 train_time:6665ms step_avg:30.57ms
+step:219/1490 train_time:6692ms step_avg:30.56ms
+step:220/1490 train_time:6725ms step_avg:30.57ms
+step:221/1490 train_time:6752ms step_avg:30.55ms
+step:222/1490 train_time:6786ms step_avg:30.57ms
+step:223/1490 train_time:6813ms step_avg:30.55ms
+step:224/1490 train_time:6846ms step_avg:30.56ms
+step:225/1490 train_time:6874ms step_avg:30.55ms
+step:226/1490 train_time:6907ms step_avg:30.56ms
+step:227/1490 train_time:6935ms step_avg:30.55ms
+step:228/1490 train_time:6968ms step_avg:30.56ms
+step:229/1490 train_time:6995ms step_avg:30.55ms
+step:230/1490 train_time:7029ms step_avg:30.56ms
+step:231/1490 train_time:7056ms step_avg:30.55ms
+step:232/1490 train_time:7090ms step_avg:30.56ms
+step:233/1490 train_time:7117ms step_avg:30.54ms
+step:234/1490 train_time:7151ms step_avg:30.56ms
+step:235/1490 train_time:7178ms step_avg:30.54ms
+step:236/1490 train_time:7211ms step_avg:30.56ms
+step:237/1490 train_time:7239ms step_avg:30.54ms
+step:238/1490 train_time:7272ms step_avg:30.56ms
+step:239/1490 train_time:7300ms step_avg:30.54ms
+step:240/1490 train_time:7333ms step_avg:30.56ms
+step:241/1490 train_time:7360ms step_avg:30.54ms
+step:242/1490 train_time:7394ms step_avg:30.55ms
+step:243/1490 train_time:7421ms step_avg:30.54ms
+step:244/1490 train_time:7455ms step_avg:30.55ms
+step:245/1490 train_time:7482ms step_avg:30.54ms
+step:246/1490 train_time:7516ms step_avg:30.55ms
+step:247/1490 train_time:7543ms step_avg:30.54ms
+step:248/1490 train_time:7578ms step_avg:30.56ms
+step:249/1490 train_time:7605ms step_avg:30.54ms
+step:250/1490 train_time:7638ms step_avg:30.55ms
+step:250/1490 val_loss:4.5195 train_time:7677ms step_avg:30.71ms
+step:251/1490 train_time:7694ms step_avg:30.65ms
+step:252/1490 train_time:7712ms step_avg:30.60ms
+step:253/1490 train_time:7728ms step_avg:30.55ms
+step:254/1490 train_time:7763ms step_avg:30.56ms
+step:255/1490 train_time:7792ms step_avg:30.56ms
+step:256/1490 train_time:7827ms step_avg:30.57ms
+step:257/1490 train_time:7854ms step_avg:30.56ms
+step:258/1490 train_time:7888ms step_avg:30.57ms
+step:259/1490 train_time:7915ms step_avg:30.56ms
+step:260/1490 train_time:7949ms step_avg:30.57ms
+step:261/1490 train_time:7977ms step_avg:30.56ms
+step:262/1490 train_time:8011ms step_avg:30.58ms
+step:263/1490 train_time:8038ms step_avg:30.56ms
+step:264/1490 train_time:8072ms step_avg:30.57ms
+step:265/1490 train_time:8098ms step_avg:30.56ms
+step:266/1490 train_time:8132ms step_avg:30.57ms
+step:267/1490 train_time:8159ms step_avg:30.56ms
+step:268/1490 train_time:8192ms step_avg:30.57ms
+step:269/1490 train_time:8219ms step_avg:30.55ms
+step:270/1490 train_time:8253ms step_avg:30.57ms
+step:271/1490 train_time:8280ms step_avg:30.55ms
+step:272/1490 train_time:8314ms step_avg:30.57ms
+step:273/1490 train_time:8342ms step_avg:30.56ms
+step:274/1490 train_time:8375ms step_avg:30.56ms
+step:275/1490 train_time:8401ms step_avg:30.55ms
+step:276/1490 train_time:8435ms step_avg:30.56ms
+step:277/1490 train_time:8462ms step_avg:30.55ms
+step:278/1490 train_time:8495ms step_avg:30.56ms
+step:279/1490 train_time:8522ms step_avg:30.55ms
+step:280/1490 train_time:8556ms step_avg:30.56ms
+step:281/1490 train_time:8583ms step_avg:30.54ms
+step:282/1490 train_time:8617ms step_avg:30.56ms
+step:283/1490 train_time:8644ms step_avg:30.54ms
+step:284/1490 train_time:8678ms step_avg:30.55ms
+step:285/1490 train_time:8705ms step_avg:30.54ms
+step:286/1490 train_time:8739ms step_avg:30.56ms
+step:287/1490 train_time:8766ms step_avg:30.54ms
+step:288/1490 train_time:8800ms step_avg:30.56ms
+step:289/1490 train_time:8827ms step_avg:30.54ms
+step:290/1490 train_time:8861ms step_avg:30.55ms
+step:291/1490 train_time:8888ms step_avg:30.54ms
+step:292/1490 train_time:8922ms step_avg:30.56ms
+step:293/1490 train_time:8949ms step_avg:30.54ms
+step:294/1490 train_time:8983ms step_avg:30.55ms
+step:295/1490 train_time:9009ms step_avg:30.54ms
+step:296/1490 train_time:9043ms step_avg:30.55ms
+step:297/1490 train_time:9070ms step_avg:30.54ms
+step:298/1490 train_time:9104ms step_avg:30.55ms
+step:299/1490 train_time:9131ms step_avg:30.54ms
+step:300/1490 train_time:9165ms step_avg:30.55ms
+step:301/1490 train_time:9192ms step_avg:30.54ms
+step:302/1490 train_time:9226ms step_avg:30.55ms
+step:303/1490 train_time:9253ms step_avg:30.54ms
+step:304/1490 train_time:9287ms step_avg:30.55ms
+step:305/1490 train_time:9314ms step_avg:30.54ms
+step:306/1490 train_time:9348ms step_avg:30.55ms
+step:307/1490 train_time:9375ms step_avg:30.54ms
+step:308/1490 train_time:9409ms step_avg:30.55ms
+step:309/1490 train_time:9436ms step_avg:30.54ms
+step:310/1490 train_time:9470ms step_avg:30.55ms
+step:311/1490 train_time:9497ms step_avg:30.54ms
+step:312/1490 train_time:9531ms step_avg:30.55ms
+step:313/1490 train_time:9558ms step_avg:30.54ms
+step:314/1490 train_time:9592ms step_avg:30.55ms
+step:315/1490 train_time:9619ms step_avg:30.54ms
+step:316/1490 train_time:9653ms step_avg:30.55ms
+step:317/1490 train_time:9680ms step_avg:30.54ms
+step:318/1490 train_time:9714ms step_avg:30.55ms
+step:319/1490 train_time:9741ms step_avg:30.54ms
+step:320/1490 train_time:9775ms step_avg:30.55ms
+step:321/1490 train_time:9802ms step_avg:30.54ms
+step:322/1490 train_time:9836ms step_avg:30.55ms
+step:323/1490 train_time:9863ms step_avg:30.53ms
+step:324/1490 train_time:9897ms step_avg:30.55ms
+step:325/1490 train_time:9924ms step_avg:30.54ms
+step:326/1490 train_time:9958ms step_avg:30.54ms
+step:327/1490 train_time:9985ms step_avg:30.53ms
+step:328/1490 train_time:10018ms step_avg:30.54ms
+step:329/1490 train_time:10045ms step_avg:30.53ms
+step:330/1490 train_time:10079ms step_avg:30.54ms
+step:331/1490 train_time:10106ms step_avg:30.53ms
+step:332/1490 train_time:10140ms step_avg:30.54ms
+step:333/1490 train_time:10167ms step_avg:30.53ms
+step:334/1490 train_time:10201ms step_avg:30.54ms
+step:335/1490 train_time:10228ms step_avg:30.53ms
+step:336/1490 train_time:10262ms step_avg:30.54ms
+step:337/1490 train_time:10289ms step_avg:30.53ms
+step:338/1490 train_time:10323ms step_avg:30.54ms
+step:339/1490 train_time:10350ms step_avg:30.53ms
+step:340/1490 train_time:10383ms step_avg:30.54ms
+step:341/1490 train_time:10411ms step_avg:30.53ms
+step:342/1490 train_time:10445ms step_avg:30.54ms
+step:343/1490 train_time:10471ms step_avg:30.53ms
+step:344/1490 train_time:10505ms step_avg:30.54ms
+step:345/1490 train_time:10532ms step_avg:30.53ms
+step:346/1490 train_time:10566ms step_avg:30.54ms
+step:347/1490 train_time:10593ms step_avg:30.53ms
+step:348/1490 train_time:10627ms step_avg:30.54ms
+step:349/1490 train_time:10655ms step_avg:30.53ms
+step:350/1490 train_time:10689ms step_avg:30.54ms
+step:351/1490 train_time:10716ms step_avg:30.53ms
+step:352/1490 train_time:10750ms step_avg:30.54ms
+step:353/1490 train_time:10777ms step_avg:30.53ms
+step:354/1490 train_time:10811ms step_avg:30.54ms
+step:355/1490 train_time:10838ms step_avg:30.53ms
+step:356/1490 train_time:10872ms step_avg:30.54ms
+step:357/1490 train_time:10899ms step_avg:30.53ms
+step:358/1490 train_time:10933ms step_avg:30.54ms
+step:359/1490 train_time:10960ms step_avg:30.53ms
+step:360/1490 train_time:10995ms step_avg:30.54ms
+step:361/1490 train_time:11021ms step_avg:30.53ms
+step:362/1490 train_time:11055ms step_avg:30.54ms
+step:363/1490 train_time:11082ms step_avg:30.53ms
+step:364/1490 train_time:11117ms step_avg:30.54ms
+step:365/1490 train_time:11143ms step_avg:30.53ms
+step:366/1490 train_time:11177ms step_avg:30.54ms
+step:367/1490 train_time:11204ms step_avg:30.53ms
+step:368/1490 train_time:11238ms step_avg:30.54ms
+step:369/1490 train_time:11265ms step_avg:30.53ms
+step:370/1490 train_time:11299ms step_avg:30.54ms
+step:371/1490 train_time:11326ms step_avg:30.53ms
+step:372/1490 train_time:11360ms step_avg:30.54ms
+step:373/1490 train_time:11387ms step_avg:30.53ms
+step:374/1490 train_time:11421ms step_avg:30.54ms
+step:375/1490 train_time:11448ms step_avg:30.53ms
+step:376/1490 train_time:11482ms step_avg:30.54ms
+step:377/1490 train_time:11509ms step_avg:30.53ms
+step:378/1490 train_time:11543ms step_avg:30.54ms
+step:379/1490 train_time:11570ms step_avg:30.53ms
+step:380/1490 train_time:11603ms step_avg:30.53ms
+step:381/1490 train_time:11631ms step_avg:30.53ms
+step:382/1490 train_time:11664ms step_avg:30.53ms
+step:383/1490 train_time:11691ms step_avg:30.53ms
+step:384/1490 train_time:11725ms step_avg:30.53ms
+step:385/1490 train_time:11752ms step_avg:30.52ms
+step:386/1490 train_time:11785ms step_avg:30.53ms
+step:387/1490 train_time:11813ms step_avg:30.52ms
+step:388/1490 train_time:11846ms step_avg:30.53ms
+step:389/1490 train_time:11874ms step_avg:30.52ms
+step:390/1490 train_time:11907ms step_avg:30.53ms
+step:391/1490 train_time:11935ms step_avg:30.52ms
+step:392/1490 train_time:11968ms step_avg:30.53ms
+step:393/1490 train_time:11996ms step_avg:30.52ms
+step:394/1490 train_time:12029ms step_avg:30.53ms
+step:395/1490 train_time:12057ms step_avg:30.52ms
+step:396/1490 train_time:12091ms step_avg:30.53ms
+step:397/1490 train_time:12118ms step_avg:30.52ms
+step:398/1490 train_time:12152ms step_avg:30.53ms
+step:399/1490 train_time:12179ms step_avg:30.52ms
+step:400/1490 train_time:12213ms step_avg:30.53ms
+step:401/1490 train_time:12240ms step_avg:30.52ms
+step:402/1490 train_time:12274ms step_avg:30.53ms
+step:403/1490 train_time:12301ms step_avg:30.52ms
+step:404/1490 train_time:12335ms step_avg:30.53ms
+step:405/1490 train_time:12362ms step_avg:30.52ms
+step:406/1490 train_time:12396ms step_avg:30.53ms
+step:407/1490 train_time:12423ms step_avg:30.52ms
+step:408/1490 train_time:12457ms step_avg:30.53ms
+step:409/1490 train_time:12485ms step_avg:30.53ms
+step:410/1490 train_time:12520ms step_avg:30.54ms
+step:411/1490 train_time:12546ms step_avg:30.53ms
+step:412/1490 train_time:12580ms step_avg:30.53ms
+step:413/1490 train_time:12607ms step_avg:30.52ms
+step:414/1490 train_time:12641ms step_avg:30.53ms
+step:415/1490 train_time:12668ms step_avg:30.53ms
+step:416/1490 train_time:12701ms step_avg:30.53ms
+step:417/1490 train_time:12729ms step_avg:30.52ms
+step:418/1490 train_time:12762ms step_avg:30.53ms
+step:419/1490 train_time:12789ms step_avg:30.52ms
+step:420/1490 train_time:12823ms step_avg:30.53ms
+step:421/1490 train_time:12850ms step_avg:30.52ms
+step:422/1490 train_time:12884ms step_avg:30.53ms
+step:423/1490 train_time:12911ms step_avg:30.52ms
+step:424/1490 train_time:12944ms step_avg:30.53ms
+step:425/1490 train_time:12971ms step_avg:30.52ms
+step:426/1490 train_time:13005ms step_avg:30.53ms
+step:427/1490 train_time:13033ms step_avg:30.52ms
+step:428/1490 train_time:13067ms step_avg:30.53ms
+step:429/1490 train_time:13094ms step_avg:30.52ms
+step:430/1490 train_time:13128ms step_avg:30.53ms
+step:431/1490 train_time:13155ms step_avg:30.52ms
+step:432/1490 train_time:13189ms step_avg:30.53ms
+step:433/1490 train_time:13216ms step_avg:30.52ms
+step:434/1490 train_time:13250ms step_avg:30.53ms
+step:435/1490 train_time:13277ms step_avg:30.52ms
+step:436/1490 train_time:13311ms step_avg:30.53ms
+step:437/1490 train_time:13338ms step_avg:30.52ms
+step:438/1490 train_time:13372ms step_avg:30.53ms
+step:439/1490 train_time:13400ms step_avg:30.52ms
+step:440/1490 train_time:13434ms step_avg:30.53ms
+step:441/1490 train_time:13461ms step_avg:30.52ms
+step:442/1490 train_time:13495ms step_avg:30.53ms
+step:443/1490 train_time:13522ms step_avg:30.52ms
+step:444/1490 train_time:13556ms step_avg:30.53ms
+step:445/1490 train_time:13583ms step_avg:30.52ms
+step:446/1490 train_time:13617ms step_avg:30.53ms
+step:447/1490 train_time:13644ms step_avg:30.52ms
+step:448/1490 train_time:13678ms step_avg:30.53ms
+step:449/1490 train_time:13705ms step_avg:30.52ms
+step:450/1490 train_time:13739ms step_avg:30.53ms
+step:451/1490 train_time:13766ms step_avg:30.52ms
+step:452/1490 train_time:13800ms step_avg:30.53ms
+step:453/1490 train_time:13827ms step_avg:30.52ms
+step:454/1490 train_time:13861ms step_avg:30.53ms
+step:455/1490 train_time:13888ms step_avg:30.52ms
+step:456/1490 train_time:13921ms step_avg:30.53ms
+step:457/1490 train_time:13948ms step_avg:30.52ms
+step:458/1490 train_time:13982ms step_avg:30.53ms
+step:459/1490 train_time:14010ms step_avg:30.52ms
+step:460/1490 train_time:14044ms step_avg:30.53ms
+step:461/1490 train_time:14070ms step_avg:30.52ms
+step:462/1490 train_time:14104ms step_avg:30.53ms
+step:463/1490 train_time:14131ms step_avg:30.52ms
+step:464/1490 train_time:14165ms step_avg:30.53ms
+step:465/1490 train_time:14192ms step_avg:30.52ms
+step:466/1490 train_time:14226ms step_avg:30.53ms
+step:467/1490 train_time:14253ms step_avg:30.52ms
+step:468/1490 train_time:14287ms step_avg:30.53ms
+step:469/1490 train_time:14314ms step_avg:30.52ms
+step:470/1490 train_time:14348ms step_avg:30.53ms
+step:471/1490 train_time:14375ms step_avg:30.52ms
+step:472/1490 train_time:14408ms step_avg:30.53ms
+step:473/1490 train_time:14436ms step_avg:30.52ms
+step:474/1490 train_time:14470ms step_avg:30.53ms
+step:475/1490 train_time:14497ms step_avg:30.52ms
+step:476/1490 train_time:14531ms step_avg:30.53ms
+step:477/1490 train_time:14558ms step_avg:30.52ms
+step:478/1490 train_time:14592ms step_avg:30.53ms
+step:479/1490 train_time:14619ms step_avg:30.52ms
+step:480/1490 train_time:14653ms step_avg:30.53ms
+step:481/1490 train_time:14680ms step_avg:30.52ms
+step:482/1490 train_time:14714ms step_avg:30.53ms
+step:483/1490 train_time:14741ms step_avg:30.52ms
+step:484/1490 train_time:14778ms step_avg:30.53ms
+step:485/1490 train_time:14830ms step_avg:30.58ms
+step:486/1490 train_time:14887ms step_avg:30.63ms
+step:487/1490 train_time:14940ms step_avg:30.68ms
+step:488/1490 train_time:14999ms step_avg:30.74ms
+step:489/1490 train_time:15052ms step_avg:30.78ms
+step:490/1490 train_time:15110ms step_avg:30.84ms
+step:491/1490 train_time:15163ms step_avg:30.88ms
+step:492/1490 train_time:15220ms step_avg:30.94ms
+step:493/1490 train_time:15273ms step_avg:30.98ms
+step:494/1490 train_time:15331ms step_avg:31.03ms
+step:495/1490 train_time:15384ms step_avg:31.08ms
+step:496/1490 train_time:15443ms step_avg:31.13ms
+step:497/1490 train_time:15496ms step_avg:31.18ms
+step:498/1490 train_time:15555ms step_avg:31.23ms
+step:499/1490 train_time:15608ms step_avg:31.28ms
+step:500/1490 train_time:15667ms step_avg:31.33ms
+step:500/1490 val_loss:4.3008 train_time:15735ms step_avg:31.47ms
+step:501/1490 train_time:15753ms step_avg:31.44ms
+step:502/1490 train_time:15782ms step_avg:31.44ms
+step:503/1490 train_time:15838ms step_avg:31.49ms
+step:504/1490 train_time:15899ms step_avg:31.55ms
+step:505/1490 train_time:15954ms step_avg:31.59ms
+step:506/1490 train_time:16012ms step_avg:31.64ms
+step:507/1490 train_time:16064ms step_avg:31.69ms
+step:508/1490 train_time:16123ms step_avg:31.74ms
+step:509/1490 train_time:16176ms step_avg:31.78ms
+step:510/1490 train_time:16234ms step_avg:31.83ms
+step:511/1490 train_time:16286ms step_avg:31.87ms
+step:512/1490 train_time:16344ms step_avg:31.92ms
+step:513/1490 train_time:16396ms step_avg:31.96ms
+step:514/1490 train_time:16454ms step_avg:32.01ms
+step:515/1490 train_time:16506ms step_avg:32.05ms
+step:516/1490 train_time:16564ms step_avg:32.10ms
+step:517/1490 train_time:16616ms step_avg:32.14ms
+step:518/1490 train_time:16674ms step_avg:32.19ms
+step:519/1490 train_time:16728ms step_avg:32.23ms
+step:520/1490 train_time:16788ms step_avg:32.29ms
+step:521/1490 train_time:16843ms step_avg:32.33ms
+step:522/1490 train_time:16903ms step_avg:32.38ms
+step:523/1490 train_time:16957ms step_avg:32.42ms
+step:524/1490 train_time:17015ms step_avg:32.47ms
+step:525/1490 train_time:17068ms step_avg:32.51ms
+step:526/1490 train_time:17127ms step_avg:32.56ms
+step:527/1490 train_time:17179ms step_avg:32.60ms
+step:528/1490 train_time:17238ms step_avg:32.65ms
+step:529/1490 train_time:17291ms step_avg:32.69ms
+step:530/1490 train_time:17348ms step_avg:32.73ms
+step:531/1490 train_time:17401ms step_avg:32.77ms
+step:532/1490 train_time:17459ms step_avg:32.82ms
+step:533/1490 train_time:17512ms step_avg:32.86ms
+step:534/1490 train_time:17570ms step_avg:32.90ms
+step:535/1490 train_time:17623ms step_avg:32.94ms
+step:536/1490 train_time:17682ms step_avg:32.99ms
+step:537/1490 train_time:17736ms step_avg:33.03ms
+step:538/1490 train_time:17795ms step_avg:33.08ms
+step:539/1490 train_time:17848ms step_avg:33.11ms
+step:540/1490 train_time:17907ms step_avg:33.16ms
+step:541/1490 train_time:17961ms step_avg:33.20ms
+step:542/1490 train_time:18020ms step_avg:33.25ms
+step:543/1490 train_time:18074ms step_avg:33.29ms
+step:544/1490 train_time:18132ms step_avg:33.33ms
+step:545/1490 train_time:18185ms step_avg:33.37ms
+step:546/1490 train_time:18243ms step_avg:33.41ms
+step:547/1490 train_time:18296ms step_avg:33.45ms
+step:548/1490 train_time:18354ms step_avg:33.49ms
+step:549/1490 train_time:18407ms step_avg:33.53ms
+step:550/1490 train_time:18465ms step_avg:33.57ms
+step:551/1490 train_time:18518ms step_avg:33.61ms
+step:552/1490 train_time:18577ms step_avg:33.65ms
+step:553/1490 train_time:18630ms step_avg:33.69ms
+step:554/1490 train_time:18688ms step_avg:33.73ms
+step:555/1490 train_time:18742ms step_avg:33.77ms
+step:556/1490 train_time:18801ms step_avg:33.82ms
+step:557/1490 train_time:18855ms step_avg:33.85ms
+step:558/1490 train_time:18913ms step_avg:33.89ms
+step:559/1490 train_time:18966ms step_avg:33.93ms
+step:560/1490 train_time:19025ms step_avg:33.97ms
+step:561/1490 train_time:19079ms step_avg:34.01ms
+step:562/1490 train_time:19137ms step_avg:34.05ms
+step:563/1490 train_time:19189ms step_avg:34.08ms
+step:564/1490 train_time:19247ms step_avg:34.13ms
+step:565/1490 train_time:19301ms step_avg:34.16ms
+step:566/1490 train_time:19359ms step_avg:34.20ms
+step:567/1490 train_time:19412ms step_avg:34.24ms
+step:568/1490 train_time:19469ms step_avg:34.28ms
+step:569/1490 train_time:19523ms step_avg:34.31ms
+step:570/1490 train_time:19581ms step_avg:34.35ms
+step:571/1490 train_time:19634ms step_avg:34.39ms
+step:572/1490 train_time:19693ms step_avg:34.43ms
+step:573/1490 train_time:19745ms step_avg:34.46ms
+step:574/1490 train_time:19804ms step_avg:34.50ms
+step:575/1490 train_time:19857ms step_avg:34.53ms
+step:576/1490 train_time:19916ms step_avg:34.58ms
+step:577/1490 train_time:19968ms step_avg:34.61ms
+step:578/1490 train_time:20027ms step_avg:34.65ms
+step:579/1490 train_time:20082ms step_avg:34.68ms
+step:580/1490 train_time:20140ms step_avg:34.72ms
+step:581/1490 train_time:20193ms step_avg:34.75ms
+step:582/1490 train_time:20251ms step_avg:34.80ms
+step:583/1490 train_time:20305ms step_avg:34.83ms
+step:584/1490 train_time:20363ms step_avg:34.87ms
+step:585/1490 train_time:20416ms step_avg:34.90ms
+step:586/1490 train_time:20473ms step_avg:34.94ms
+step:587/1490 train_time:20527ms step_avg:34.97ms
+step:588/1490 train_time:20586ms step_avg:35.01ms
+step:589/1490 train_time:20639ms step_avg:35.04ms
+step:590/1490 train_time:20697ms step_avg:35.08ms
+step:591/1490 train_time:20751ms step_avg:35.11ms
+step:592/1490 train_time:20809ms step_avg:35.15ms
+step:593/1490 train_time:20862ms step_avg:35.18ms
+step:594/1490 train_time:20920ms step_avg:35.22ms
+step:595/1490 train_time:20974ms step_avg:35.25ms
+step:596/1490 train_time:21032ms step_avg:35.29ms
+step:597/1490 train_time:21086ms step_avg:35.32ms
+step:598/1490 train_time:21144ms step_avg:35.36ms
+step:599/1490 train_time:21198ms step_avg:35.39ms
+step:600/1490 train_time:21255ms step_avg:35.42ms
+step:601/1490 train_time:21308ms step_avg:35.45ms
+step:602/1490 train_time:21366ms step_avg:35.49ms
+step:603/1490 train_time:21419ms step_avg:35.52ms
+step:604/1490 train_time:21478ms step_avg:35.56ms
+step:605/1490 train_time:21531ms step_avg:35.59ms
+step:606/1490 train_time:21589ms step_avg:35.63ms
+step:607/1490 train_time:21642ms step_avg:35.65ms
+step:608/1490 train_time:21701ms step_avg:35.69ms
+step:609/1490 train_time:21755ms step_avg:35.72ms
+step:610/1490 train_time:21812ms step_avg:35.76ms
+step:611/1490 train_time:21866ms step_avg:35.79ms
+step:612/1490 train_time:21925ms step_avg:35.83ms
+step:613/1490 train_time:21978ms step_avg:35.85ms
+step:614/1490 train_time:22036ms step_avg:35.89ms
+step:615/1490 train_time:22090ms step_avg:35.92ms
+step:616/1490 train_time:22148ms step_avg:35.95ms
+step:617/1490 train_time:22202ms step_avg:35.98ms
+step:618/1490 train_time:22261ms step_avg:36.02ms
+step:619/1490 train_time:22313ms step_avg:36.05ms
+step:620/1490 train_time:22370ms step_avg:36.08ms
+step:621/1490 train_time:22424ms step_avg:36.11ms
+step:622/1490 train_time:22483ms step_avg:36.15ms
+step:623/1490 train_time:22536ms step_avg:36.17ms
+step:624/1490 train_time:22594ms step_avg:36.21ms
+step:625/1490 train_time:22647ms step_avg:36.24ms
+step:626/1490 train_time:22706ms step_avg:36.27ms
+step:627/1490 train_time:22759ms step_avg:36.30ms
+step:628/1490 train_time:22817ms step_avg:36.33ms
+step:629/1490 train_time:22870ms step_avg:36.36ms
+step:630/1490 train_time:22928ms step_avg:36.39ms
+step:631/1490 train_time:22983ms step_avg:36.42ms
+step:632/1490 train_time:23041ms step_avg:36.46ms
+step:633/1490 train_time:23095ms step_avg:36.48ms
+step:634/1490 train_time:23152ms step_avg:36.52ms
+step:635/1490 train_time:23206ms step_avg:36.55ms
+step:636/1490 train_time:23265ms step_avg:36.58ms
+step:637/1490 train_time:23318ms step_avg:36.61ms
+step:638/1490 train_time:23377ms step_avg:36.64ms
+step:639/1490 train_time:23430ms step_avg:36.67ms
+step:640/1490 train_time:23488ms step_avg:36.70ms
+step:641/1490 train_time:23540ms step_avg:36.72ms
+step:642/1490 train_time:23599ms step_avg:36.76ms
+step:643/1490 train_time:23653ms step_avg:36.79ms
+step:644/1490 train_time:23711ms step_avg:36.82ms
+step:645/1490 train_time:23764ms step_avg:36.84ms
+step:646/1490 train_time:23822ms step_avg:36.88ms
+step:647/1490 train_time:23875ms step_avg:36.90ms
+step:648/1490 train_time:23933ms step_avg:36.93ms
+step:649/1490 train_time:23988ms step_avg:36.96ms
+step:650/1490 train_time:24046ms step_avg:36.99ms
+step:651/1490 train_time:24099ms step_avg:37.02ms
+step:652/1490 train_time:24157ms step_avg:37.05ms
+step:653/1490 train_time:24210ms step_avg:37.08ms
+step:654/1490 train_time:24268ms step_avg:37.11ms
+step:655/1490 train_time:24322ms step_avg:37.13ms
+step:656/1490 train_time:24381ms step_avg:37.17ms
+step:657/1490 train_time:24434ms step_avg:37.19ms
+step:658/1490 train_time:24492ms step_avg:37.22ms
+step:659/1490 train_time:24545ms step_avg:37.25ms
+step:660/1490 train_time:24603ms step_avg:37.28ms
+step:661/1490 train_time:24656ms step_avg:37.30ms
+step:662/1490 train_time:24715ms step_avg:37.33ms
+step:663/1490 train_time:24768ms step_avg:37.36ms
+step:664/1490 train_time:24825ms step_avg:37.39ms
+step:665/1490 train_time:24879ms step_avg:37.41ms
+step:666/1490 train_time:24938ms step_avg:37.44ms
+step:667/1490 train_time:24991ms step_avg:37.47ms
+step:668/1490 train_time:25049ms step_avg:37.50ms
+step:669/1490 train_time:25103ms step_avg:37.52ms
+step:670/1490 train_time:25161ms step_avg:37.55ms
+step:671/1490 train_time:25214ms step_avg:37.58ms
+step:672/1490 train_time:25271ms step_avg:37.61ms
+step:673/1490 train_time:25325ms step_avg:37.63ms
+step:674/1490 train_time:25384ms step_avg:37.66ms
+step:675/1490 train_time:25437ms step_avg:37.68ms
+step:676/1490 train_time:25495ms step_avg:37.71ms
+step:677/1490 train_time:25548ms step_avg:37.74ms
+step:678/1490 train_time:25607ms step_avg:37.77ms
+step:679/1490 train_time:25660ms step_avg:37.79ms
+step:680/1490 train_time:25720ms step_avg:37.82ms
+step:681/1490 train_time:25773ms step_avg:37.85ms
+step:682/1490 train_time:25831ms step_avg:37.87ms
+step:683/1490 train_time:25884ms step_avg:37.90ms
+step:684/1490 train_time:25943ms step_avg:37.93ms
+step:685/1490 train_time:25996ms step_avg:37.95ms
+step:686/1490 train_time:26053ms step_avg:37.98ms
+step:687/1490 train_time:26106ms step_avg:38.00ms
+step:688/1490 train_time:26164ms step_avg:38.03ms
+step:689/1490 train_time:26217ms step_avg:38.05ms
+step:690/1490 train_time:26276ms step_avg:38.08ms
+step:691/1490 train_time:26330ms step_avg:38.10ms
+step:692/1490 train_time:26388ms step_avg:38.13ms
+step:693/1490 train_time:26441ms step_avg:38.15ms
+step:694/1490 train_time:26500ms step_avg:38.18ms
+step:695/1490 train_time:26553ms step_avg:38.21ms
+step:696/1490 train_time:26611ms step_avg:38.23ms
+step:697/1490 train_time:26664ms step_avg:38.25ms
+step:698/1490 train_time:26723ms step_avg:38.28ms
+step:699/1490 train_time:26776ms step_avg:38.31ms
+step:700/1490 train_time:26834ms step_avg:38.33ms
+step:701/1490 train_time:26887ms step_avg:38.36ms
+step:702/1490 train_time:26946ms step_avg:38.38ms
+step:703/1490 train_time:26999ms step_avg:38.41ms
+step:704/1490 train_time:27057ms step_avg:38.43ms
+step:705/1490 train_time:27110ms step_avg:38.45ms
+step:706/1490 train_time:27179ms step_avg:38.50ms
+step:707/1490 train_time:27232ms step_avg:38.52ms
+step:708/1490 train_time:27289ms step_avg:38.54ms
+step:709/1490 train_time:27342ms step_avg:38.56ms
+step:710/1490 train_time:27400ms step_avg:38.59ms
+step:711/1490 train_time:27453ms step_avg:38.61ms
+step:712/1490 train_time:27511ms step_avg:38.64ms
+step:713/1490 train_time:27564ms step_avg:38.66ms
+step:714/1490 train_time:27623ms step_avg:38.69ms
+step:715/1490 train_time:27675ms step_avg:38.71ms
+step:716/1490 train_time:27733ms step_avg:38.73ms
+step:717/1490 train_time:27787ms step_avg:38.75ms
+step:718/1490 train_time:27845ms step_avg:38.78ms
+step:719/1490 train_time:27898ms step_avg:38.80ms
+step:720/1490 train_time:27957ms step_avg:38.83ms
+step:721/1490 train_time:28010ms step_avg:38.85ms
+step:722/1490 train_time:28068ms step_avg:38.88ms
+step:723/1490 train_time:28123ms step_avg:38.90ms
+step:724/1490 train_time:28182ms step_avg:38.93ms
+step:725/1490 train_time:28235ms step_avg:38.95ms
+step:726/1490 train_time:28294ms step_avg:38.97ms
+step:727/1490 train_time:28346ms step_avg:38.99ms
+step:728/1490 train_time:28405ms step_avg:39.02ms
+step:729/1490 train_time:28457ms step_avg:39.04ms
+step:730/1490 train_time:28515ms step_avg:39.06ms
+step:731/1490 train_time:28568ms step_avg:39.08ms
+step:732/1490 train_time:28627ms step_avg:39.11ms
+step:733/1490 train_time:28680ms step_avg:39.13ms
+step:734/1490 train_time:28739ms step_avg:39.15ms
+step:735/1490 train_time:28792ms step_avg:39.17ms
+step:736/1490 train_time:28850ms step_avg:39.20ms
+step:737/1490 train_time:28904ms step_avg:39.22ms
+step:738/1490 train_time:28962ms step_avg:39.24ms
+step:739/1490 train_time:29015ms step_avg:39.26ms
+step:740/1490 train_time:29073ms step_avg:39.29ms
+step:741/1490 train_time:29127ms step_avg:39.31ms
+step:742/1490 train_time:29185ms step_avg:39.33ms
+step:743/1490 train_time:29239ms step_avg:39.35ms
+step:744/1490 train_time:29298ms step_avg:39.38ms
+step:745/1490 train_time:29351ms step_avg:39.40ms
+step:746/1490 train_time:29408ms step_avg:39.42ms
+step:747/1490 train_time:29461ms step_avg:39.44ms
+step:748/1490 train_time:29520ms step_avg:39.47ms
+step:749/1490 train_time:29574ms step_avg:39.48ms
+step:750/1490 train_time:29632ms step_avg:39.51ms
+step:750/1490 val_loss:3.7967 train_time:29698ms step_avg:39.60ms
+step:751/1490 train_time:29715ms step_avg:39.57ms
+step:752/1490 train_time:29744ms step_avg:39.55ms
+step:753/1490 train_time:29800ms step_avg:39.57ms
+step:754/1490 train_time:29863ms step_avg:39.61ms
+step:755/1490 train_time:29918ms step_avg:39.63ms
+step:756/1490 train_time:29977ms step_avg:39.65ms
+step:757/1490 train_time:30029ms step_avg:39.67ms
+step:758/1490 train_time:30088ms step_avg:39.69ms
+step:759/1490 train_time:30140ms step_avg:39.71ms
+step:760/1490 train_time:30198ms step_avg:39.73ms
+step:761/1490 train_time:30251ms step_avg:39.75ms
+step:762/1490 train_time:30310ms step_avg:39.78ms
+step:763/1490 train_time:30362ms step_avg:39.79ms
+step:764/1490 train_time:30419ms step_avg:39.82ms
+step:765/1490 train_time:30472ms step_avg:39.83ms
+step:766/1490 train_time:30529ms step_avg:39.86ms
+step:767/1490 train_time:30582ms step_avg:39.87ms
+step:768/1490 train_time:30640ms step_avg:39.90ms
+step:769/1490 train_time:30695ms step_avg:39.92ms
+step:770/1490 train_time:30756ms step_avg:39.94ms
+step:771/1490 train_time:30810ms step_avg:39.96ms
+step:772/1490 train_time:30870ms step_avg:39.99ms
+step:773/1490 train_time:30923ms step_avg:40.00ms
+step:774/1490 train_time:30982ms step_avg:40.03ms
+step:775/1490 train_time:31035ms step_avg:40.04ms
+step:776/1490 train_time:31092ms step_avg:40.07ms
+step:777/1490 train_time:31145ms step_avg:40.08ms
+step:778/1490 train_time:31204ms step_avg:40.11ms
+step:779/1490 train_time:31257ms step_avg:40.12ms
+step:780/1490 train_time:31314ms step_avg:40.15ms
+step:781/1490 train_time:31367ms step_avg:40.16ms
+step:782/1490 train_time:31425ms step_avg:40.19ms
+step:783/1490 train_time:31477ms step_avg:40.20ms
+step:784/1490 train_time:31534ms step_avg:40.22ms
+step:785/1490 train_time:31587ms step_avg:40.24ms
+step:786/1490 train_time:31646ms step_avg:40.26ms
+step:787/1490 train_time:31700ms step_avg:40.28ms
+step:788/1490 train_time:31759ms step_avg:40.30ms
+step:789/1490 train_time:31813ms step_avg:40.32ms
+step:790/1490 train_time:31872ms step_avg:40.34ms
+step:791/1490 train_time:31925ms step_avg:40.36ms
+step:792/1490 train_time:31983ms step_avg:40.38ms
+step:793/1490 train_time:32037ms step_avg:40.40ms
+step:794/1490 train_time:32095ms step_avg:40.42ms
+step:795/1490 train_time:32148ms step_avg:40.44ms
+step:796/1490 train_time:32207ms step_avg:40.46ms
+step:797/1490 train_time:32260ms step_avg:40.48ms
+step:798/1490 train_time:32317ms step_avg:40.50ms
+step:799/1490 train_time:32370ms step_avg:40.51ms
+step:800/1490 train_time:32428ms step_avg:40.54ms
+step:801/1490 train_time:32481ms step_avg:40.55ms
+step:802/1490 train_time:32539ms step_avg:40.57ms
+step:803/1490 train_time:32592ms step_avg:40.59ms
+step:804/1490 train_time:32650ms step_avg:40.61ms
+step:805/1490 train_time:32704ms step_avg:40.63ms
+step:806/1490 train_time:32762ms step_avg:40.65ms
+step:807/1490 train_time:32815ms step_avg:40.66ms
+step:808/1490 train_time:32873ms step_avg:40.68ms
+step:809/1490 train_time:32927ms step_avg:40.70ms
+step:810/1490 train_time:32986ms step_avg:40.72ms
+step:811/1490 train_time:33039ms step_avg:40.74ms
+step:812/1490 train_time:33097ms step_avg:40.76ms
+step:813/1490 train_time:33150ms step_avg:40.77ms
+step:814/1490 train_time:33209ms step_avg:40.80ms
+step:815/1490 train_time:33261ms step_avg:40.81ms
+step:816/1490 train_time:33320ms step_avg:40.83ms
+step:817/1490 train_time:33373ms step_avg:40.85ms
+step:818/1490 train_time:33431ms step_avg:40.87ms
+step:819/1490 train_time:33483ms step_avg:40.88ms
+step:820/1490 train_time:33542ms step_avg:40.90ms
+step:821/1490 train_time:33594ms step_avg:40.92ms
+step:822/1490 train_time:33652ms step_avg:40.94ms
+step:823/1490 train_time:33707ms step_avg:40.96ms
+step:824/1490 train_time:33765ms step_avg:40.98ms
+step:825/1490 train_time:33819ms step_avg:40.99ms
+step:826/1490 train_time:33877ms step_avg:41.01ms
+step:827/1490 train_time:33930ms step_avg:41.03ms
+step:828/1490 train_time:33988ms step_avg:41.05ms
+step:829/1490 train_time:34042ms step_avg:41.06ms
+step:830/1490 train_time:34100ms step_avg:41.08ms
+step:831/1490 train_time:34153ms step_avg:41.10ms
+step:832/1490 train_time:34212ms step_avg:41.12ms
+step:833/1490 train_time:34265ms step_avg:41.13ms
+step:834/1490 train_time:34322ms step_avg:41.15ms
+step:835/1490 train_time:34375ms step_avg:41.17ms
+step:836/1490 train_time:34434ms step_avg:41.19ms
+step:837/1490 train_time:34487ms step_avg:41.20ms
+step:838/1490 train_time:34545ms step_avg:41.22ms
+step:839/1490 train_time:34599ms step_avg:41.24ms
+step:840/1490 train_time:34657ms step_avg:41.26ms
+step:841/1490 train_time:34710ms step_avg:41.27ms
+step:842/1490 train_time:34768ms step_avg:41.29ms
+step:843/1490 train_time:34821ms step_avg:41.31ms
+step:844/1490 train_time:34878ms step_avg:41.33ms
+step:845/1490 train_time:34932ms step_avg:41.34ms
+step:846/1490 train_time:34990ms step_avg:41.36ms
+step:847/1490 train_time:35044ms step_avg:41.37ms
+step:848/1490 train_time:35103ms step_avg:41.40ms
+step:849/1490 train_time:35157ms step_avg:41.41ms
+step:850/1490 train_time:35215ms step_avg:41.43ms
+step:851/1490 train_time:35268ms step_avg:41.44ms
+step:852/1490 train_time:35326ms step_avg:41.46ms
+step:853/1490 train_time:35379ms step_avg:41.48ms
+step:854/1490 train_time:35436ms step_avg:41.49ms
+step:855/1490 train_time:35489ms step_avg:41.51ms
+step:856/1490 train_time:35549ms step_avg:41.53ms
+step:857/1490 train_time:35602ms step_avg:41.54ms
+step:858/1490 train_time:35660ms step_avg:41.56ms
+step:859/1490 train_time:35713ms step_avg:41.58ms
+step:860/1490 train_time:35771ms step_avg:41.59ms
+step:861/1490 train_time:35824ms step_avg:41.61ms
+step:862/1490 train_time:35882ms step_avg:41.63ms
+step:863/1490 train_time:35934ms step_avg:41.64ms
+step:864/1490 train_time:35993ms step_avg:41.66ms
+step:865/1490 train_time:36047ms step_avg:41.67ms
+step:866/1490 train_time:36106ms step_avg:41.69ms
+step:867/1490 train_time:36159ms step_avg:41.71ms
+step:868/1490 train_time:36216ms step_avg:41.72ms
+step:869/1490 train_time:36270ms step_avg:41.74ms
+step:870/1490 train_time:36328ms step_avg:41.76ms
+step:871/1490 train_time:36380ms step_avg:41.77ms
+step:872/1490 train_time:36438ms step_avg:41.79ms
+step:873/1490 train_time:36490ms step_avg:41.80ms
+step:874/1490 train_time:36550ms step_avg:41.82ms
+step:875/1490 train_time:36603ms step_avg:41.83ms
+step:876/1490 train_time:36662ms step_avg:41.85ms
+step:877/1490 train_time:36715ms step_avg:41.86ms
+step:878/1490 train_time:36773ms step_avg:41.88ms
+step:879/1490 train_time:36826ms step_avg:41.90ms
+step:880/1490 train_time:36884ms step_avg:41.91ms
+step:881/1490 train_time:36938ms step_avg:41.93ms
+step:882/1490 train_time:36996ms step_avg:41.95ms
+step:883/1490 train_time:37050ms step_avg:41.96ms
+step:884/1490 train_time:37109ms step_avg:41.98ms
+step:885/1490 train_time:37162ms step_avg:41.99ms
+step:886/1490 train_time:37220ms step_avg:42.01ms
+step:887/1490 train_time:37273ms step_avg:42.02ms
+step:888/1490 train_time:37331ms step_avg:42.04ms
+step:889/1490 train_time:37383ms step_avg:42.05ms
+step:890/1490 train_time:37442ms step_avg:42.07ms
+step:891/1490 train_time:37495ms step_avg:42.08ms
+step:892/1490 train_time:37553ms step_avg:42.10ms
+step:893/1490 train_time:37607ms step_avg:42.11ms
+step:894/1490 train_time:37665ms step_avg:42.13ms
+step:895/1490 train_time:37719ms step_avg:42.14ms
+step:896/1490 train_time:37776ms step_avg:42.16ms
+step:897/1490 train_time:37830ms step_avg:42.17ms
+step:898/1490 train_time:37888ms step_avg:42.19ms
+step:899/1490 train_time:37941ms step_avg:42.20ms
+step:900/1490 train_time:38000ms step_avg:42.22ms
+step:901/1490 train_time:38053ms step_avg:42.23ms
+step:902/1490 train_time:38112ms step_avg:42.25ms
+step:903/1490 train_time:38165ms step_avg:42.26ms
+step:904/1490 train_time:38223ms step_avg:42.28ms
+step:905/1490 train_time:38276ms step_avg:42.29ms
+step:906/1490 train_time:38334ms step_avg:42.31ms
+step:907/1490 train_time:38387ms step_avg:42.32ms
+step:908/1490 train_time:38445ms step_avg:42.34ms
+step:909/1490 train_time:38498ms step_avg:42.35ms
+step:910/1490 train_time:38557ms step_avg:42.37ms
+step:911/1490 train_time:38610ms step_avg:42.38ms
+step:912/1490 train_time:38668ms step_avg:42.40ms
+step:913/1490 train_time:38722ms step_avg:42.41ms
+step:914/1490 train_time:38779ms step_avg:42.43ms
+step:915/1490 train_time:38832ms step_avg:42.44ms
+step:916/1490 train_time:38890ms step_avg:42.46ms
+step:917/1490 train_time:38944ms step_avg:42.47ms
+step:918/1490 train_time:39002ms step_avg:42.49ms
+step:919/1490 train_time:39056ms step_avg:42.50ms
+step:920/1490 train_time:39114ms step_avg:42.52ms
+step:921/1490 train_time:39168ms step_avg:42.53ms
+step:922/1490 train_time:39226ms step_avg:42.54ms
+step:923/1490 train_time:39278ms step_avg:42.55ms
+step:924/1490 train_time:39336ms step_avg:42.57ms
+step:925/1490 train_time:39389ms step_avg:42.58ms
+step:926/1490 train_time:39448ms step_avg:42.60ms
+step:927/1490 train_time:39501ms step_avg:42.61ms
+step:928/1490 train_time:39559ms step_avg:42.63ms
+step:929/1490 train_time:39612ms step_avg:42.64ms
+step:930/1490 train_time:39670ms step_avg:42.66ms
+step:931/1490 train_time:39723ms step_avg:42.67ms
+step:932/1490 train_time:39781ms step_avg:42.68ms
+step:933/1490 train_time:39834ms step_avg:42.69ms
+step:934/1490 train_time:39892ms step_avg:42.71ms
+step:935/1490 train_time:39945ms step_avg:42.72ms
+step:936/1490 train_time:40003ms step_avg:42.74ms
+step:937/1490 train_time:40057ms step_avg:42.75ms
+step:938/1490 train_time:40115ms step_avg:42.77ms
+step:939/1490 train_time:40169ms step_avg:42.78ms
+step:940/1490 train_time:40226ms step_avg:42.79ms
+step:941/1490 train_time:40279ms step_avg:42.80ms
+step:942/1490 train_time:40336ms step_avg:42.82ms
+step:943/1490 train_time:40389ms step_avg:42.83ms
+step:944/1490 train_time:40449ms step_avg:42.85ms
+step:945/1490 train_time:40502ms step_avg:42.86ms
+step:946/1490 train_time:40561ms step_avg:42.88ms
+step:947/1490 train_time:40613ms step_avg:42.89ms
+step:948/1490 train_time:40671ms step_avg:42.90ms
+step:949/1490 train_time:40724ms step_avg:42.91ms
+step:950/1490 train_time:40782ms step_avg:42.93ms
+step:951/1490 train_time:40835ms step_avg:42.94ms
+step:952/1490 train_time:40893ms step_avg:42.95ms
+step:953/1490 train_time:40946ms step_avg:42.97ms
+step:954/1490 train_time:41004ms step_avg:42.98ms
+step:955/1490 train_time:41058ms step_avg:42.99ms
+step:956/1490 train_time:41116ms step_avg:43.01ms
+step:957/1490 train_time:41169ms step_avg:43.02ms
+step:958/1490 train_time:41228ms step_avg:43.04ms
+step:959/1490 train_time:41281ms step_avg:43.05ms
+step:960/1490 train_time:41339ms step_avg:43.06ms
+step:961/1490 train_time:41391ms step_avg:43.07ms
+step:962/1490 train_time:41450ms step_avg:43.09ms
+step:963/1490 train_time:41504ms step_avg:43.10ms
+step:964/1490 train_time:41562ms step_avg:43.11ms
+step:965/1490 train_time:41614ms step_avg:43.12ms
+step:966/1490 train_time:41672ms step_avg:43.14ms
+step:967/1490 train_time:41726ms step_avg:43.15ms
+step:968/1490 train_time:41787ms step_avg:43.17ms
+step:969/1490 train_time:41868ms step_avg:43.21ms
+step:970/1490 train_time:41951ms step_avg:43.25ms
+step:971/1490 train_time:42030ms step_avg:43.28ms
+step:972/1490 train_time:42113ms step_avg:43.33ms
+step:973/1490 train_time:42190ms step_avg:43.36ms
+step:974/1490 train_time:42274ms step_avg:43.40ms
+step:975/1490 train_time:42352ms step_avg:43.44ms
+step:976/1490 train_time:42437ms step_avg:43.48ms
+step:977/1490 train_time:42515ms step_avg:43.52ms
+step:978/1490 train_time:42600ms step_avg:43.56ms
+step:979/1490 train_time:42679ms step_avg:43.59ms
+step:980/1490 train_time:42762ms step_avg:43.63ms
+step:981/1490 train_time:42842ms step_avg:43.67ms
+step:982/1490 train_time:42927ms step_avg:43.71ms
+step:983/1490 train_time:43006ms step_avg:43.75ms
+step:984/1490 train_time:43089ms step_avg:43.79ms
+step:985/1490 train_time:43167ms step_avg:43.82ms
+step:986/1490 train_time:43251ms step_avg:43.86ms
+step:987/1490 train_time:43330ms step_avg:43.90ms
+step:988/1490 train_time:43413ms step_avg:43.94ms
+step:989/1490 train_time:43491ms step_avg:43.97ms
+step:990/1490 train_time:43575ms step_avg:44.01ms
+step:991/1490 train_time:43652ms step_avg:44.05ms
+step:992/1490 train_time:43738ms step_avg:44.09ms
+step:993/1490 train_time:43816ms step_avg:44.12ms
+step:994/1490 train_time:43900ms step_avg:44.16ms
+step:995/1490 train_time:43980ms step_avg:44.20ms
+step:996/1490 train_time:44064ms step_avg:44.24ms
+step:997/1490 train_time:44142ms step_avg:44.28ms
+step:998/1490 train_time:44226ms step_avg:44.31ms
+step:999/1490 train_time:44305ms step_avg:44.35ms
+step:1000/1490 train_time:44389ms step_avg:44.39ms
+step:1000/1490 val_loss:3.5156 train_time:44483ms step_avg:44.48ms
+step:1001/1490 train_time:44500ms step_avg:44.46ms
+step:1002/1490 train_time:44552ms step_avg:44.46ms
+step:1003/1490 train_time:44631ms step_avg:44.50ms
+step:1004/1490 train_time:44722ms step_avg:44.54ms
+step:1005/1490 train_time:44802ms step_avg:44.58ms
+step:1006/1490 train_time:44886ms step_avg:44.62ms
+step:1007/1490 train_time:44965ms step_avg:44.65ms
+step:1008/1490 train_time:45048ms step_avg:44.69ms
+step:1009/1490 train_time:45125ms step_avg:44.72ms
+step:1010/1490 train_time:45208ms step_avg:44.76ms
+step:1011/1490 train_time:45285ms step_avg:44.79ms
+step:1012/1490 train_time:45367ms step_avg:44.83ms
+step:1013/1490 train_time:45446ms step_avg:44.86ms
+step:1014/1490 train_time:45532ms step_avg:44.90ms
+step:1015/1490 train_time:45616ms step_avg:44.94ms
+step:1016/1490 train_time:45702ms step_avg:44.98ms
+step:1017/1490 train_time:45781ms step_avg:45.02ms
+step:1018/1490 train_time:45865ms step_avg:45.05ms
+step:1019/1490 train_time:45943ms step_avg:45.09ms
+step:1020/1490 train_time:46027ms step_avg:45.12ms
+step:1021/1490 train_time:46104ms step_avg:45.16ms
+step:1022/1490 train_time:46187ms step_avg:45.19ms
+step:1023/1490 train_time:46266ms step_avg:45.23ms
+step:1024/1490 train_time:46348ms step_avg:45.26ms
+step:1025/1490 train_time:46426ms step_avg:45.29ms
+step:1026/1490 train_time:46511ms step_avg:45.33ms
+step:1027/1490 train_time:46593ms step_avg:45.37ms
+step:1028/1490 train_time:46680ms step_avg:45.41ms
+step:1029/1490 train_time:46758ms step_avg:45.44ms
+step:1030/1490 train_time:46841ms step_avg:45.48ms
+step:1031/1490 train_time:46920ms step_avg:45.51ms
+step:1032/1490 train_time:47004ms step_avg:45.55ms
+step:1033/1490 train_time:47081ms step_avg:45.58ms
+step:1034/1490 train_time:47164ms step_avg:45.61ms
+step:1035/1490 train_time:47241ms step_avg:45.64ms
+step:1036/1490 train_time:47326ms step_avg:45.68ms
+step:1037/1490 train_time:47405ms step_avg:45.71ms
+step:1038/1490 train_time:47490ms step_avg:45.75ms
+step:1039/1490 train_time:47570ms step_avg:45.78ms
+step:1040/1490 train_time:47656ms step_avg:45.82ms
+step:1041/1490 train_time:47735ms step_avg:45.85ms
+step:1042/1490 train_time:47821ms step_avg:45.89ms
+step:1043/1490 train_time:47899ms step_avg:45.92ms
+step:1044/1490 train_time:47982ms step_avg:45.96ms
+step:1045/1490 train_time:48060ms step_avg:45.99ms
+step:1046/1490 train_time:48143ms step_avg:46.03ms
+step:1047/1490 train_time:48221ms step_avg:46.06ms
+step:1048/1490 train_time:48305ms step_avg:46.09ms
+step:1049/1490 train_time:48383ms step_avg:46.12ms
+step:1050/1490 train_time:48468ms step_avg:46.16ms
+step:1051/1490 train_time:48549ms step_avg:46.19ms
+step:1052/1490 train_time:48633ms step_avg:46.23ms
+step:1053/1490 train_time:48713ms step_avg:46.26ms
+step:1054/1490 train_time:48797ms step_avg:46.30ms
+step:1055/1490 train_time:48877ms step_avg:46.33ms
+step:1056/1490 train_time:48960ms step_avg:46.36ms
+step:1057/1490 train_time:49038ms step_avg:46.39ms
+step:1058/1490 train_time:49121ms step_avg:46.43ms
+step:1059/1490 train_time:49199ms step_avg:46.46ms
+step:1060/1490 train_time:49283ms step_avg:46.49ms
+step:1061/1490 train_time:49361ms step_avg:46.52ms
+step:1062/1490 train_time:49445ms step_avg:46.56ms
+step:1063/1490 train_time:49525ms step_avg:46.59ms
+step:1064/1490 train_time:49610ms step_avg:46.63ms
+step:1065/1490 train_time:49690ms step_avg:46.66ms
+step:1066/1490 train_time:49775ms step_avg:46.69ms
+step:1067/1490 train_time:49854ms step_avg:46.72ms
+step:1068/1490 train_time:49939ms step_avg:46.76ms
+step:1069/1490 train_time:50017ms step_avg:46.79ms
+step:1070/1490 train_time:50101ms step_avg:46.82ms
+step:1071/1490 train_time:50180ms step_avg:46.85ms
+step:1072/1490 train_time:50262ms step_avg:46.89ms
+step:1073/1490 train_time:50339ms step_avg:46.91ms
+step:1074/1490 train_time:50424ms step_avg:46.95ms
+step:1075/1490 train_time:50504ms step_avg:46.98ms
+step:1076/1490 train_time:50589ms step_avg:47.02ms
+step:1077/1490 train_time:50669ms step_avg:47.05ms
+step:1078/1490 train_time:50754ms step_avg:47.08ms
+step:1079/1490 train_time:50831ms step_avg:47.11ms
+step:1080/1490 train_time:50915ms step_avg:47.14ms
+step:1081/1490 train_time:50994ms step_avg:47.17ms
+step:1082/1490 train_time:51079ms step_avg:47.21ms
+step:1083/1490 train_time:51157ms step_avg:47.24ms
+step:1084/1490 train_time:51242ms step_avg:47.27ms
+step:1085/1490 train_time:51321ms step_avg:47.30ms
+step:1086/1490 train_time:51404ms step_avg:47.33ms
+step:1087/1490 train_time:51482ms step_avg:47.36ms
+step:1088/1490 train_time:51567ms step_avg:47.40ms
+step:1089/1490 train_time:51647ms step_avg:47.43ms
+step:1090/1490 train_time:51732ms step_avg:47.46ms
+step:1091/1490 train_time:51811ms step_avg:47.49ms
+step:1092/1490 train_time:51895ms step_avg:47.52ms
+step:1093/1490 train_time:51976ms step_avg:47.55ms
+step:1094/1490 train_time:52059ms step_avg:47.59ms
+step:1095/1490 train_time:52138ms step_avg:47.61ms
+step:1096/1490 train_time:52222ms step_avg:47.65ms
+step:1097/1490 train_time:52300ms step_avg:47.68ms
+step:1098/1490 train_time:52383ms step_avg:47.71ms
+step:1099/1490 train_time:52461ms step_avg:47.73ms
+step:1100/1490 train_time:52545ms step_avg:47.77ms
+step:1101/1490 train_time:52626ms step_avg:47.80ms
+step:1102/1490 train_time:52710ms step_avg:47.83ms
+step:1103/1490 train_time:52789ms step_avg:47.86ms
+step:1104/1490 train_time:52875ms step_avg:47.89ms
+step:1105/1490 train_time:52954ms step_avg:47.92ms
+step:1106/1490 train_time:53037ms step_avg:47.95ms
+step:1107/1490 train_time:53116ms step_avg:47.98ms
+step:1108/1490 train_time:53199ms step_avg:48.01ms
+step:1109/1490 train_time:53278ms step_avg:48.04ms
+step:1110/1490 train_time:53360ms step_avg:48.07ms
+step:1111/1490 train_time:53437ms step_avg:48.10ms
+step:1112/1490 train_time:53522ms step_avg:48.13ms
+step:1113/1490 train_time:53602ms step_avg:48.16ms
+step:1114/1490 train_time:53687ms step_avg:48.19ms
+step:1115/1490 train_time:53766ms step_avg:48.22ms
+step:1116/1490 train_time:53850ms step_avg:48.25ms
+step:1117/1490 train_time:53930ms step_avg:48.28ms
+step:1118/1490 train_time:54014ms step_avg:48.31ms
+step:1119/1490 train_time:54094ms step_avg:48.34ms
+step:1120/1490 train_time:54178ms step_avg:48.37ms
+step:1121/1490 train_time:54256ms step_avg:48.40ms
+step:1122/1490 train_time:54339ms step_avg:48.43ms
+step:1123/1490 train_time:54420ms step_avg:48.46ms
+step:1124/1490 train_time:54503ms step_avg:48.49ms
+step:1125/1490 train_time:54580ms step_avg:48.52ms
+step:1126/1490 train_time:54665ms step_avg:48.55ms
+step:1127/1490 train_time:54743ms step_avg:48.57ms
+step:1128/1490 train_time:54829ms step_avg:48.61ms
+step:1129/1490 train_time:54909ms step_avg:48.63ms
+step:1130/1490 train_time:54995ms step_avg:48.67ms
+step:1131/1490 train_time:55075ms step_avg:48.70ms
+step:1132/1490 train_time:55159ms step_avg:48.73ms
+step:1133/1490 train_time:55238ms step_avg:48.75ms
+step:1134/1490 train_time:55322ms step_avg:48.78ms
+step:1135/1490 train_time:55399ms step_avg:48.81ms
+step:1136/1490 train_time:55484ms step_avg:48.84ms
+step:1137/1490 train_time:55563ms step_avg:48.87ms
+step:1138/1490 train_time:55646ms step_avg:48.90ms
+step:1139/1490 train_time:55726ms step_avg:48.93ms
+step:1140/1490 train_time:55810ms step_avg:48.96ms
+step:1141/1490 train_time:55890ms step_avg:48.98ms
+step:1142/1490 train_time:55976ms step_avg:49.02ms
+step:1143/1490 train_time:56055ms step_avg:49.04ms
+step:1144/1490 train_time:56139ms step_avg:49.07ms
+step:1145/1490 train_time:56218ms step_avg:49.10ms
+step:1146/1490 train_time:56303ms step_avg:49.13ms
+step:1147/1490 train_time:56381ms step_avg:49.16ms
+step:1148/1490 train_time:56464ms step_avg:49.18ms
+step:1149/1490 train_time:56543ms step_avg:49.21ms
+step:1150/1490 train_time:56626ms step_avg:49.24ms
+step:1151/1490 train_time:56705ms step_avg:49.27ms
+step:1152/1490 train_time:56789ms step_avg:49.30ms
+step:1153/1490 train_time:56870ms step_avg:49.32ms
+step:1154/1490 train_time:56955ms step_avg:49.35ms
+step:1155/1490 train_time:57034ms step_avg:49.38ms
+step:1156/1490 train_time:57117ms step_avg:49.41ms
+step:1157/1490 train_time:57196ms step_avg:49.43ms
+step:1158/1490 train_time:57280ms step_avg:49.46ms
+step:1159/1490 train_time:57358ms step_avg:49.49ms
+step:1160/1490 train_time:57440ms step_avg:49.52ms
+step:1161/1490 train_time:57519ms step_avg:49.54ms
+step:1162/1490 train_time:57603ms step_avg:49.57ms
+step:1163/1490 train_time:57682ms step_avg:49.60ms
+step:1164/1490 train_time:57767ms step_avg:49.63ms
+step:1165/1490 train_time:57847ms step_avg:49.65ms
+step:1166/1490 train_time:57933ms step_avg:49.69ms
+step:1167/1490 train_time:58013ms step_avg:49.71ms
+step:1168/1490 train_time:58097ms step_avg:49.74ms
+step:1169/1490 train_time:58176ms step_avg:49.77ms
+step:1170/1490 train_time:58260ms step_avg:49.79ms
+step:1171/1490 train_time:58338ms step_avg:49.82ms
+step:1172/1490 train_time:58422ms step_avg:49.85ms
+step:1173/1490 train_time:58500ms step_avg:49.87ms
+step:1174/1490 train_time:58585ms step_avg:49.90ms
+step:1175/1490 train_time:58661ms step_avg:49.92ms
+step:1176/1490 train_time:58745ms step_avg:49.95ms
+step:1177/1490 train_time:58826ms step_avg:49.98ms
+step:1178/1490 train_time:58910ms step_avg:50.01ms
+step:1179/1490 train_time:58990ms step_avg:50.03ms
+step:1180/1490 train_time:59076ms step_avg:50.06ms
+step:1181/1490 train_time:59155ms step_avg:50.09ms
+step:1182/1490 train_time:59238ms step_avg:50.12ms
+step:1183/1490 train_time:59317ms step_avg:50.14ms
+step:1184/1490 train_time:59401ms step_avg:50.17ms
+step:1185/1490 train_time:59479ms step_avg:50.19ms
+step:1186/1490 train_time:59563ms step_avg:50.22ms
+step:1187/1490 train_time:59640ms step_avg:50.24ms
+step:1188/1490 train_time:59723ms step_avg:50.27ms
+step:1189/1490 train_time:59803ms step_avg:50.30ms
+step:1190/1490 train_time:59888ms step_avg:50.33ms
+step:1191/1490 train_time:59969ms step_avg:50.35ms
+step:1192/1490 train_time:60054ms step_avg:50.38ms
+step:1193/1490 train_time:60133ms step_avg:50.41ms
+step:1194/1490 train_time:60218ms step_avg:50.43ms
+step:1195/1490 train_time:60297ms step_avg:50.46ms
+step:1196/1490 train_time:60382ms step_avg:50.49ms
+step:1197/1490 train_time:60460ms step_avg:50.51ms
+step:1198/1490 train_time:60543ms step_avg:50.54ms
+step:1199/1490 train_time:60622ms step_avg:50.56ms
+step:1200/1490 train_time:60706ms step_avg:50.59ms
+step:1201/1490 train_time:60785ms step_avg:50.61ms
+step:1202/1490 train_time:60869ms step_avg:50.64ms
+step:1203/1490 train_time:60950ms step_avg:50.67ms
+step:1204/1490 train_time:61035ms step_avg:50.69ms
+step:1205/1490 train_time:61115ms step_avg:50.72ms
+step:1206/1490 train_time:61200ms step_avg:50.75ms
+step:1207/1490 train_time:61279ms step_avg:50.77ms
+step:1208/1490 train_time:61362ms step_avg:50.80ms
+step:1209/1490 train_time:61439ms step_avg:50.82ms
+step:1210/1490 train_time:61523ms step_avg:50.85ms
+step:1211/1490 train_time:61603ms step_avg:50.87ms
+step:1212/1490 train_time:61687ms step_avg:50.90ms
+step:1213/1490 train_time:61766ms step_avg:50.92ms
+step:1214/1490 train_time:61851ms step_avg:50.95ms
+step:1215/1490 train_time:61931ms step_avg:50.97ms
+step:1216/1490 train_time:62014ms step_avg:51.00ms
+step:1217/1490 train_time:62094ms step_avg:51.02ms
+step:1218/1490 train_time:62180ms step_avg:51.05ms
+step:1219/1490 train_time:62259ms step_avg:51.07ms
+step:1220/1490 train_time:62342ms step_avg:51.10ms
+step:1221/1490 train_time:62420ms step_avg:51.12ms
+step:1222/1490 train_time:62504ms step_avg:51.15ms
+step:1223/1490 train_time:62581ms step_avg:51.17ms
+step:1224/1490 train_time:62665ms step_avg:51.20ms
+step:1225/1490 train_time:62743ms step_avg:51.22ms
+step:1226/1490 train_time:62827ms step_avg:51.25ms
+step:1227/1490 train_time:62908ms step_avg:51.27ms
+step:1228/1490 train_time:62992ms step_avg:51.30ms
+step:1229/1490 train_time:63072ms step_avg:51.32ms
+step:1230/1490 train_time:63156ms step_avg:51.35ms
+step:1231/1490 train_time:63236ms step_avg:51.37ms
+step:1232/1490 train_time:63319ms step_avg:51.40ms
+step:1233/1490 train_time:63398ms step_avg:51.42ms
+step:1234/1490 train_time:63481ms step_avg:51.44ms
+step:1235/1490 train_time:63558ms step_avg:51.46ms
+step:1236/1490 train_time:63642ms step_avg:51.49ms
+step:1237/1490 train_time:63721ms step_avg:51.51ms
+step:1238/1490 train_time:63805ms step_avg:51.54ms
+step:1239/1490 train_time:63884ms step_avg:51.56ms
+step:1240/1490 train_time:63969ms step_avg:51.59ms
+step:1241/1490 train_time:64049ms step_avg:51.61ms
+step:1242/1490 train_time:64134ms step_avg:51.64ms
+step:1243/1490 train_time:64213ms step_avg:51.66ms
+step:1244/1490 train_time:64298ms step_avg:51.69ms
+step:1245/1490 train_time:64377ms step_avg:51.71ms
+step:1246/1490 train_time:64459ms step_avg:51.73ms
+step:1247/1490 train_time:64537ms step_avg:51.75ms
+step:1248/1490 train_time:64621ms step_avg:51.78ms
+step:1249/1490 train_time:64699ms step_avg:51.80ms
+step:1250/1490 train_time:64783ms step_avg:51.83ms
+step:1250/1490 val_loss:3.3715 train_time:64880ms step_avg:51.90ms
+step:1251/1490 train_time:64898ms step_avg:51.88ms
+step:1252/1490 train_time:64948ms step_avg:51.88ms
+step:1253/1490 train_time:65028ms step_avg:51.90ms
+step:1254/1490 train_time:65113ms step_avg:51.92ms
+step:1255/1490 train_time:65198ms step_avg:51.95ms
+step:1256/1490 train_time:65286ms step_avg:51.98ms
+step:1257/1490 train_time:65366ms step_avg:52.00ms
+step:1258/1490 train_time:65449ms step_avg:52.03ms
+step:1259/1490 train_time:65526ms step_avg:52.05ms
+step:1260/1490 train_time:65608ms step_avg:52.07ms
+step:1261/1490 train_time:65685ms step_avg:52.09ms
+step:1262/1490 train_time:65771ms step_avg:52.12ms
+step:1263/1490 train_time:65854ms step_avg:52.14ms
+step:1264/1490 train_time:65940ms step_avg:52.17ms
+step:1265/1490 train_time:66019ms step_avg:52.19ms
+step:1266/1490 train_time:66104ms step_avg:52.21ms
+step:1267/1490 train_time:66185ms step_avg:52.24ms
+step:1268/1490 train_time:66269ms step_avg:52.26ms
+step:1269/1490 train_time:66349ms step_avg:52.28ms
+step:1270/1490 train_time:66432ms step_avg:52.31ms
+step:1271/1490 train_time:66511ms step_avg:52.33ms
+step:1272/1490 train_time:66595ms step_avg:52.35ms
+step:1273/1490 train_time:66673ms step_avg:52.37ms
+step:1274/1490 train_time:66759ms step_avg:52.40ms
+step:1275/1490 train_time:66839ms step_avg:52.42ms
+step:1276/1490 train_time:66924ms step_avg:52.45ms
+step:1277/1490 train_time:67003ms step_avg:52.47ms
+step:1278/1490 train_time:67086ms step_avg:52.49ms
+step:1279/1490 train_time:67165ms step_avg:52.51ms
+step:1280/1490 train_time:67249ms step_avg:52.54ms
+step:1281/1490 train_time:67327ms step_avg:52.56ms
+step:1282/1490 train_time:67411ms step_avg:52.58ms
+step:1283/1490 train_time:67488ms step_avg:52.60ms
+step:1284/1490 train_time:67572ms step_avg:52.63ms
+step:1285/1490 train_time:67651ms step_avg:52.65ms
+step:1286/1490 train_time:67735ms step_avg:52.67ms
+step:1287/1490 train_time:67815ms step_avg:52.69ms
+step:1288/1490 train_time:67900ms step_avg:52.72ms
+step:1289/1490 train_time:67979ms step_avg:52.74ms
+step:1290/1490 train_time:68063ms step_avg:52.76ms
+step:1291/1490 train_time:68142ms step_avg:52.78ms
+step:1292/1490 train_time:68226ms step_avg:52.81ms
+step:1293/1490 train_time:68305ms step_avg:52.83ms
+step:1294/1490 train_time:68389ms step_avg:52.85ms
+step:1295/1490 train_time:68467ms step_avg:52.87ms
+step:1296/1490 train_time:68550ms step_avg:52.89ms
+step:1297/1490 train_time:68627ms step_avg:52.91ms
+step:1298/1490 train_time:68712ms step_avg:52.94ms
+step:1299/1490 train_time:68791ms step_avg:52.96ms
+step:1300/1490 train_time:68876ms step_avg:52.98ms
+step:1301/1490 train_time:68957ms step_avg:53.00ms
+step:1302/1490 train_time:69040ms step_avg:53.03ms
+step:1303/1490 train_time:69119ms step_avg:53.05ms
+step:1304/1490 train_time:69203ms step_avg:53.07ms
+step:1305/1490 train_time:69281ms step_avg:53.09ms
+step:1306/1490 train_time:69367ms step_avg:53.11ms
+step:1307/1490 train_time:69446ms step_avg:53.13ms
+step:1308/1490 train_time:69528ms step_avg:53.16ms
+step:1309/1490 train_time:69605ms step_avg:53.17ms
+step:1310/1490 train_time:69689ms step_avg:53.20ms
+step:1311/1490 train_time:69767ms step_avg:53.22ms
+step:1312/1490 train_time:69851ms step_avg:53.24ms
+step:1313/1490 train_time:69931ms step_avg:53.26ms
+step:1314/1490 train_time:70016ms step_avg:53.28ms
+step:1315/1490 train_time:70096ms step_avg:53.30ms
+step:1316/1490 train_time:70179ms step_avg:53.33ms
+step:1317/1490 train_time:70259ms step_avg:53.35ms
+step:1318/1490 train_time:70345ms step_avg:53.37ms
+step:1319/1490 train_time:70424ms step_avg:53.39ms
+step:1320/1490 train_time:70506ms step_avg:53.41ms
+step:1321/1490 train_time:70585ms step_avg:53.43ms
+step:1322/1490 train_time:70670ms step_avg:53.46ms
+step:1323/1490 train_time:70748ms step_avg:53.48ms
+step:1324/1490 train_time:70832ms step_avg:53.50ms
+step:1325/1490 train_time:70909ms step_avg:53.52ms
+step:1326/1490 train_time:70995ms step_avg:53.54ms
+step:1327/1490 train_time:71075ms step_avg:53.56ms
+step:1328/1490 train_time:71160ms step_avg:53.58ms
+step:1329/1490 train_time:71239ms step_avg:53.60ms
+step:1330/1490 train_time:71323ms step_avg:53.63ms
+step:1331/1490 train_time:71402ms step_avg:53.65ms
+step:1332/1490 train_time:71486ms step_avg:53.67ms
+step:1333/1490 train_time:71566ms step_avg:53.69ms
+step:1334/1490 train_time:71649ms step_avg:53.71ms
+step:1335/1490 train_time:71726ms step_avg:53.73ms
+step:1336/1490 train_time:71810ms step_avg:53.75ms
+step:1337/1490 train_time:71887ms step_avg:53.77ms
+step:1338/1490 train_time:71973ms step_avg:53.79ms
+step:1339/1490 train_time:72051ms step_avg:53.81ms
+step:1340/1490 train_time:72136ms step_avg:53.83ms
+step:1341/1490 train_time:72216ms step_avg:53.85ms
+step:1342/1490 train_time:72300ms step_avg:53.88ms
+step:1343/1490 train_time:72380ms step_avg:53.89ms
+step:1344/1490 train_time:72464ms step_avg:53.92ms
+step:1345/1490 train_time:72543ms step_avg:53.94ms
+step:1346/1490 train_time:72627ms step_avg:53.96ms
+step:1347/1490 train_time:72706ms step_avg:53.98ms
+step:1348/1490 train_time:72788ms step_avg:54.00ms
+step:1349/1490 train_time:72866ms step_avg:54.01ms
+step:1350/1490 train_time:72950ms step_avg:54.04ms
+step:1351/1490 train_time:73028ms step_avg:54.05ms
+step:1352/1490 train_time:73112ms step_avg:54.08ms
+step:1353/1490 train_time:73192ms step_avg:54.10ms
+step:1354/1490 train_time:73278ms step_avg:54.12ms
+step:1355/1490 train_time:73358ms step_avg:54.14ms
+step:1356/1490 train_time:73444ms step_avg:54.16ms
+step:1357/1490 train_time:73522ms step_avg:54.18ms
+step:1358/1490 train_time:73607ms step_avg:54.20ms
+step:1359/1490 train_time:73685ms step_avg:54.22ms
+step:1360/1490 train_time:73767ms step_avg:54.24ms
+step:1361/1490 train_time:73845ms step_avg:54.26ms
+step:1362/1490 train_time:73929ms step_avg:54.28ms
+step:1363/1490 train_time:74008ms step_avg:54.30ms
+step:1364/1490 train_time:74091ms step_avg:54.32ms
+step:1365/1490 train_time:74170ms step_avg:54.34ms
+step:1366/1490 train_time:74254ms step_avg:54.36ms
+step:1367/1490 train_time:74335ms step_avg:54.38ms
+step:1368/1490 train_time:74419ms step_avg:54.40ms
+step:1369/1490 train_time:74499ms step_avg:54.42ms
+step:1370/1490 train_time:74584ms step_avg:54.44ms
+step:1371/1490 train_time:74662ms step_avg:54.46ms
+step:1372/1490 train_time:74747ms step_avg:54.48ms
+step:1373/1490 train_time:74825ms step_avg:54.50ms
+step:1374/1490 train_time:74908ms step_avg:54.52ms
+step:1375/1490 train_time:74986ms step_avg:54.54ms
+step:1376/1490 train_time:75070ms step_avg:54.56ms
+step:1377/1490 train_time:75148ms step_avg:54.57ms
+step:1378/1490 train_time:75233ms step_avg:54.60ms
+step:1379/1490 train_time:75312ms step_avg:54.61ms
+step:1380/1490 train_time:75397ms step_avg:54.64ms
+step:1381/1490 train_time:75477ms step_avg:54.65ms
+step:1382/1490 train_time:75562ms step_avg:54.68ms
+step:1383/1490 train_time:75642ms step_avg:54.69ms
+step:1384/1490 train_time:75726ms step_avg:54.72ms
+step:1385/1490 train_time:75804ms step_avg:54.73ms
+step:1386/1490 train_time:75887ms step_avg:54.75ms
+step:1387/1490 train_time:75965ms step_avg:54.77ms
+step:1388/1490 train_time:76051ms step_avg:54.79ms
+step:1389/1490 train_time:76128ms step_avg:54.81ms
+step:1390/1490 train_time:76214ms step_avg:54.83ms
+step:1391/1490 train_time:76293ms step_avg:54.85ms
+step:1392/1490 train_time:76378ms step_avg:54.87ms
+step:1393/1490 train_time:76458ms step_avg:54.89ms
+step:1394/1490 train_time:76544ms step_avg:54.91ms
+step:1395/1490 train_time:76623ms step_avg:54.93ms
+step:1396/1490 train_time:76706ms step_avg:54.95ms
+step:1397/1490 train_time:76785ms step_avg:54.96ms
+step:1398/1490 train_time:76869ms step_avg:54.98ms
+step:1399/1490 train_time:76948ms step_avg:55.00ms
+step:1400/1490 train_time:77030ms step_avg:55.02ms
+step:1401/1490 train_time:77109ms step_avg:55.04ms
+step:1402/1490 train_time:77194ms step_avg:55.06ms
+step:1403/1490 train_time:77272ms step_avg:55.08ms
+step:1404/1490 train_time:77357ms step_avg:55.10ms
+step:1405/1490 train_time:77437ms step_avg:55.12ms
+step:1406/1490 train_time:77521ms step_avg:55.14ms
+step:1407/1490 train_time:77600ms step_avg:55.15ms
+step:1408/1490 train_time:77686ms step_avg:55.17ms
+step:1409/1490 train_time:77765ms step_avg:55.19ms
+step:1410/1490 train_time:77849ms step_avg:55.21ms
+step:1411/1490 train_time:77927ms step_avg:55.23ms
+step:1412/1490 train_time:78010ms step_avg:55.25ms
+step:1413/1490 train_time:78090ms step_avg:55.27ms
+step:1414/1490 train_time:78173ms step_avg:55.28ms
+step:1415/1490 train_time:78250ms step_avg:55.30ms
+step:1416/1490 train_time:78335ms step_avg:55.32ms
+step:1417/1490 train_time:78414ms step_avg:55.34ms
+step:1418/1490 train_time:78499ms step_avg:55.36ms
+step:1419/1490 train_time:78580ms step_avg:55.38ms
+step:1420/1490 train_time:78664ms step_avg:55.40ms
+step:1421/1490 train_time:78743ms step_avg:55.41ms
+step:1422/1490 train_time:78827ms step_avg:55.43ms
+step:1423/1490 train_time:78906ms step_avg:55.45ms
+step:1424/1490 train_time:78991ms step_avg:55.47ms
+step:1425/1490 train_time:79068ms step_avg:55.49ms
+step:1426/1490 train_time:79152ms step_avg:55.51ms
+step:1427/1490 train_time:79230ms step_avg:55.52ms
+step:1428/1490 train_time:79314ms step_avg:55.54ms
+step:1429/1490 train_time:79394ms step_avg:55.56ms
+step:1430/1490 train_time:79480ms step_avg:55.58ms
+step:1431/1490 train_time:79560ms step_avg:55.60ms
+step:1432/1490 train_time:79645ms step_avg:55.62ms
+step:1433/1490 train_time:79724ms step_avg:55.63ms
+step:1434/1490 train_time:79809ms step_avg:55.65ms
+step:1435/1490 train_time:79887ms step_avg:55.67ms
+step:1436/1490 train_time:79972ms step_avg:55.69ms
+step:1437/1490 train_time:80050ms step_avg:55.71ms
+step:1438/1490 train_time:80133ms step_avg:55.73ms
+step:1439/1490 train_time:80212ms step_avg:55.74ms
+step:1440/1490 train_time:80295ms step_avg:55.76ms
+step:1441/1490 train_time:80375ms step_avg:55.78ms
+step:1442/1490 train_time:80460ms step_avg:55.80ms
+step:1443/1490 train_time:80540ms step_avg:55.81ms
+step:1444/1490 train_time:80624ms step_avg:55.83ms
+step:1445/1490 train_time:80703ms step_avg:55.85ms
+step:1446/1490 train_time:80787ms step_avg:55.87ms
+step:1447/1490 train_time:80866ms step_avg:55.89ms
+step:1448/1490 train_time:80950ms step_avg:55.90ms
+step:1449/1490 train_time:81027ms step_avg:55.92ms
+step:1450/1490 train_time:81111ms step_avg:55.94ms
+step:1451/1490 train_time:81192ms step_avg:55.96ms
+step:1452/1490 train_time:81278ms step_avg:55.98ms
+step:1453/1490 train_time:81358ms step_avg:55.99ms
+step:1454/1490 train_time:81443ms step_avg:56.01ms
+step:1455/1490 train_time:81522ms step_avg:56.03ms
+step:1456/1490 train_time:81607ms step_avg:56.05ms
+step:1457/1490 train_time:81686ms step_avg:56.06ms
+step:1458/1490 train_time:81770ms step_avg:56.08ms
+step:1459/1490 train_time:81849ms step_avg:56.10ms
+step:1460/1490 train_time:81934ms step_avg:56.12ms
+step:1461/1490 train_time:82012ms step_avg:56.13ms
+step:1462/1490 train_time:82095ms step_avg:56.15ms
+step:1463/1490 train_time:82175ms step_avg:56.17ms
+step:1464/1490 train_time:82259ms step_avg:56.19ms
+step:1465/1490 train_time:82339ms step_avg:56.20ms
+step:1466/1490 train_time:82424ms step_avg:56.22ms
+step:1467/1490 train_time:82503ms step_avg:56.24ms
+step:1468/1490 train_time:82588ms step_avg:56.26ms
+step:1469/1490 train_time:82666ms step_avg:56.27ms
+step:1470/1490 train_time:82750ms step_avg:56.29ms
+step:1471/1490 train_time:82829ms step_avg:56.31ms
+step:1472/1490 train_time:82911ms step_avg:56.33ms
+step:1473/1490 train_time:82991ms step_avg:56.34ms
+step:1474/1490 train_time:83074ms step_avg:56.36ms
+step:1475/1490 train_time:83153ms step_avg:56.37ms
+step:1476/1490 train_time:83238ms step_avg:56.39ms
+step:1477/1490 train_time:83317ms step_avg:56.41ms
+step:1478/1490 train_time:83401ms step_avg:56.43ms
+step:1479/1490 train_time:83481ms step_avg:56.44ms
+step:1480/1490 train_time:83565ms step_avg:56.46ms
+step:1481/1490 train_time:83645ms step_avg:56.48ms
+step:1482/1490 train_time:83728ms step_avg:56.50ms
+step:1483/1490 train_time:83807ms step_avg:56.51ms
+step:1484/1490 train_time:83891ms step_avg:56.53ms
+step:1485/1490 train_time:83969ms step_avg:56.54ms
+step:1486/1490 train_time:84054ms step_avg:56.56ms
+step:1487/1490 train_time:84133ms step_avg:56.58ms
+step:1488/1490 train_time:84217ms step_avg:56.60ms
+step:1489/1490 train_time:84298ms step_avg:56.61ms
+step:1490/1490 train_time:84382ms step_avg:56.63ms
+step:1490/1490 val_loss:3.2792 train_time:84477ms step_avg:56.70ms
+peak memory allocated: 30949 MiB reserved: 45386 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/8c15ee82-523b-40a1-ae99-6daf9765c57b.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/8c15ee82-523b-40a1-ae99-6daf9765c57b.txt
@@ -1,0 +1,4804 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 21:47:45 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8304 train_time:0ms step_avg:0.05ms
+step:1/1490 train_time:84ms step_avg:83.90ms
+step:2/1490 train_time:107ms step_avg:53.67ms
+step:3/1490 train_time:128ms step_avg:42.61ms
+step:4/1490 train_time:148ms step_avg:37.09ms
+step:5/1490 train_time:171ms step_avg:34.15ms
+step:6/1490 train_time:205ms step_avg:34.18ms
+step:7/1490 train_time:232ms step_avg:33.11ms
+step:8/1490 train_time:266ms step_avg:33.22ms
+step:9/1490 train_time:293ms step_avg:32.51ms
+step:10/1490 train_time:327ms step_avg:32.70ms
+step:11/1490 train_time:353ms step_avg:32.12ms
+step:12/1490 train_time:387ms step_avg:32.26ms
+step:13/1490 train_time:414ms step_avg:31.87ms
+step:14/1490 train_time:448ms step_avg:32.02ms
+step:15/1490 train_time:475ms step_avg:31.69ms
+step:16/1490 train_time:510ms step_avg:31.85ms
+step:17/1490 train_time:537ms step_avg:31.57ms
+step:18/1490 train_time:571ms step_avg:31.73ms
+step:19/1490 train_time:598ms step_avg:31.47ms
+step:20/1490 train_time:633ms step_avg:31.65ms
+step:21/1490 train_time:659ms step_avg:31.39ms
+step:22/1490 train_time:694ms step_avg:31.52ms
+step:23/1490 train_time:720ms step_avg:31.32ms
+step:24/1490 train_time:755ms step_avg:31.44ms
+step:25/1490 train_time:781ms step_avg:31.25ms
+step:26/1490 train_time:816ms step_avg:31.37ms
+step:27/1490 train_time:842ms step_avg:31.20ms
+step:28/1490 train_time:876ms step_avg:31.30ms
+step:29/1490 train_time:903ms step_avg:31.15ms
+step:30/1490 train_time:938ms step_avg:31.27ms
+step:31/1490 train_time:964ms step_avg:31.11ms
+step:32/1490 train_time:999ms step_avg:31.21ms
+step:33/1490 train_time:1026ms step_avg:31.09ms
+step:34/1490 train_time:1061ms step_avg:31.20ms
+step:35/1490 train_time:1088ms step_avg:31.08ms
+step:36/1490 train_time:1123ms step_avg:31.20ms
+step:37/1490 train_time:1149ms step_avg:31.06ms
+step:38/1490 train_time:1183ms step_avg:31.14ms
+step:39/1490 train_time:1210ms step_avg:31.03ms
+step:40/1490 train_time:1244ms step_avg:31.10ms
+step:41/1490 train_time:1271ms step_avg:31.01ms
+step:42/1490 train_time:1305ms step_avg:31.08ms
+step:43/1490 train_time:1332ms step_avg:30.98ms
+step:44/1490 train_time:1366ms step_avg:31.04ms
+step:45/1490 train_time:1393ms step_avg:30.95ms
+step:46/1490 train_time:1426ms step_avg:31.01ms
+step:47/1490 train_time:1453ms step_avg:30.92ms
+step:48/1490 train_time:1487ms step_avg:30.98ms
+step:49/1490 train_time:1514ms step_avg:30.91ms
+step:50/1490 train_time:1548ms step_avg:30.97ms
+step:51/1490 train_time:1576ms step_avg:30.91ms
+step:52/1490 train_time:1610ms step_avg:30.95ms
+step:53/1490 train_time:1636ms step_avg:30.88ms
+step:54/1490 train_time:1671ms step_avg:30.94ms
+step:55/1490 train_time:1698ms step_avg:30.86ms
+step:56/1490 train_time:1732ms step_avg:30.92ms
+step:57/1490 train_time:1758ms step_avg:30.85ms
+step:58/1490 train_time:1793ms step_avg:30.91ms
+step:59/1490 train_time:1820ms step_avg:30.84ms
+step:60/1490 train_time:1854ms step_avg:30.89ms
+step:61/1490 train_time:1880ms step_avg:30.83ms
+step:62/1490 train_time:1914ms step_avg:30.88ms
+step:63/1490 train_time:1941ms step_avg:30.81ms
+step:64/1490 train_time:1976ms step_avg:30.87ms
+step:65/1490 train_time:2007ms step_avg:30.87ms
+step:66/1490 train_time:2037ms step_avg:30.86ms
+step:67/1490 train_time:2064ms step_avg:30.80ms
+step:68/1490 train_time:2098ms step_avg:30.85ms
+step:69/1490 train_time:2125ms step_avg:30.79ms
+step:70/1490 train_time:2159ms step_avg:30.84ms
+step:71/1490 train_time:2185ms step_avg:30.78ms
+step:72/1490 train_time:2220ms step_avg:30.83ms
+step:73/1490 train_time:2247ms step_avg:30.77ms
+step:74/1490 train_time:2280ms step_avg:30.82ms
+step:75/1490 train_time:2307ms step_avg:30.76ms
+step:76/1490 train_time:2341ms step_avg:30.81ms
+step:77/1490 train_time:2368ms step_avg:30.75ms
+step:78/1490 train_time:2402ms step_avg:30.79ms
+step:79/1490 train_time:2429ms step_avg:30.74ms
+step:80/1490 train_time:2463ms step_avg:30.78ms
+step:81/1490 train_time:2489ms step_avg:30.73ms
+step:82/1490 train_time:2523ms step_avg:30.77ms
+step:83/1490 train_time:2550ms step_avg:30.72ms
+step:84/1490 train_time:2584ms step_avg:30.76ms
+step:85/1490 train_time:2611ms step_avg:30.71ms
+step:86/1490 train_time:2644ms step_avg:30.75ms
+step:87/1490 train_time:2672ms step_avg:30.71ms
+step:88/1490 train_time:2706ms step_avg:30.75ms
+step:89/1490 train_time:2733ms step_avg:30.70ms
+step:90/1490 train_time:2767ms step_avg:30.74ms
+step:91/1490 train_time:2794ms step_avg:30.70ms
+step:92/1490 train_time:2827ms step_avg:30.73ms
+step:93/1490 train_time:2854ms step_avg:30.69ms
+step:94/1490 train_time:2889ms step_avg:30.73ms
+step:95/1490 train_time:2914ms step_avg:30.68ms
+step:96/1490 train_time:2949ms step_avg:30.72ms
+step:97/1490 train_time:2975ms step_avg:30.67ms
+step:98/1490 train_time:3009ms step_avg:30.71ms
+step:99/1490 train_time:3036ms step_avg:30.67ms
+step:100/1490 train_time:3070ms step_avg:30.70ms
+step:101/1490 train_time:3097ms step_avg:30.67ms
+step:102/1490 train_time:3131ms step_avg:30.70ms
+step:103/1490 train_time:3158ms step_avg:30.66ms
+step:104/1490 train_time:3192ms step_avg:30.70ms
+step:105/1490 train_time:3219ms step_avg:30.66ms
+step:106/1490 train_time:3254ms step_avg:30.70ms
+step:107/1490 train_time:3281ms step_avg:30.66ms
+step:108/1490 train_time:3315ms step_avg:30.69ms
+step:109/1490 train_time:3342ms step_avg:30.66ms
+step:110/1490 train_time:3376ms step_avg:30.69ms
+step:111/1490 train_time:3403ms step_avg:30.66ms
+step:112/1490 train_time:3436ms step_avg:30.68ms
+step:113/1490 train_time:3463ms step_avg:30.65ms
+step:114/1490 train_time:3497ms step_avg:30.68ms
+step:115/1490 train_time:3524ms step_avg:30.65ms
+step:116/1490 train_time:3558ms step_avg:30.68ms
+step:117/1490 train_time:3585ms step_avg:30.64ms
+step:118/1490 train_time:3619ms step_avg:30.67ms
+step:119/1490 train_time:3646ms step_avg:30.64ms
+step:120/1490 train_time:3680ms step_avg:30.67ms
+step:121/1490 train_time:3707ms step_avg:30.64ms
+step:122/1490 train_time:3741ms step_avg:30.67ms
+step:123/1490 train_time:3768ms step_avg:30.63ms
+step:124/1490 train_time:3802ms step_avg:30.66ms
+step:125/1490 train_time:3828ms step_avg:30.63ms
+step:126/1490 train_time:3862ms step_avg:30.65ms
+step:127/1490 train_time:3889ms step_avg:30.62ms
+step:128/1490 train_time:3923ms step_avg:30.65ms
+step:129/1490 train_time:3949ms step_avg:30.62ms
+step:130/1490 train_time:3983ms step_avg:30.64ms
+step:131/1490 train_time:4010ms step_avg:30.61ms
+step:132/1490 train_time:4044ms step_avg:30.63ms
+step:133/1490 train_time:4071ms step_avg:30.61ms
+step:134/1490 train_time:4105ms step_avg:30.63ms
+step:135/1490 train_time:4132ms step_avg:30.60ms
+step:136/1490 train_time:4166ms step_avg:30.63ms
+step:137/1490 train_time:4192ms step_avg:30.60ms
+step:138/1490 train_time:4226ms step_avg:30.62ms
+step:139/1490 train_time:4253ms step_avg:30.60ms
+step:140/1490 train_time:4286ms step_avg:30.62ms
+step:141/1490 train_time:4314ms step_avg:30.59ms
+step:142/1490 train_time:4347ms step_avg:30.62ms
+step:143/1490 train_time:4375ms step_avg:30.59ms
+step:144/1490 train_time:4408ms step_avg:30.61ms
+step:145/1490 train_time:4436ms step_avg:30.59ms
+step:146/1490 train_time:4469ms step_avg:30.61ms
+step:147/1490 train_time:4496ms step_avg:30.59ms
+step:148/1490 train_time:4530ms step_avg:30.61ms
+step:149/1490 train_time:4557ms step_avg:30.58ms
+step:150/1490 train_time:4591ms step_avg:30.61ms
+step:151/1490 train_time:4619ms step_avg:30.59ms
+step:152/1490 train_time:4653ms step_avg:30.61ms
+step:153/1490 train_time:4680ms step_avg:30.59ms
+step:154/1490 train_time:4714ms step_avg:30.61ms
+step:155/1490 train_time:4741ms step_avg:30.58ms
+step:156/1490 train_time:4775ms step_avg:30.61ms
+step:157/1490 train_time:4801ms step_avg:30.58ms
+step:158/1490 train_time:4836ms step_avg:30.60ms
+step:159/1490 train_time:4863ms step_avg:30.58ms
+step:160/1490 train_time:4897ms step_avg:30.60ms
+step:161/1490 train_time:4923ms step_avg:30.58ms
+step:162/1490 train_time:4957ms step_avg:30.60ms
+step:163/1490 train_time:4984ms step_avg:30.58ms
+step:164/1490 train_time:5018ms step_avg:30.60ms
+step:165/1490 train_time:5045ms step_avg:30.57ms
+step:166/1490 train_time:5079ms step_avg:30.60ms
+step:167/1490 train_time:5106ms step_avg:30.57ms
+step:168/1490 train_time:5140ms step_avg:30.59ms
+step:169/1490 train_time:5167ms step_avg:30.57ms
+step:170/1490 train_time:5201ms step_avg:30.59ms
+step:171/1490 train_time:5228ms step_avg:30.57ms
+step:172/1490 train_time:5261ms step_avg:30.59ms
+step:173/1490 train_time:5288ms step_avg:30.57ms
+step:174/1490 train_time:5322ms step_avg:30.59ms
+step:175/1490 train_time:5349ms step_avg:30.56ms
+step:176/1490 train_time:5383ms step_avg:30.58ms
+step:177/1490 train_time:5410ms step_avg:30.56ms
+step:178/1490 train_time:5443ms step_avg:30.58ms
+step:179/1490 train_time:5470ms step_avg:30.56ms
+step:180/1490 train_time:5503ms step_avg:30.57ms
+step:181/1490 train_time:5531ms step_avg:30.56ms
+step:182/1490 train_time:5565ms step_avg:30.58ms
+step:183/1490 train_time:5592ms step_avg:30.56ms
+step:184/1490 train_time:5626ms step_avg:30.57ms
+step:185/1490 train_time:5653ms step_avg:30.55ms
+step:186/1490 train_time:5686ms step_avg:30.57ms
+step:187/1490 train_time:5713ms step_avg:30.55ms
+step:188/1490 train_time:5747ms step_avg:30.57ms
+step:189/1490 train_time:5774ms step_avg:30.55ms
+step:190/1490 train_time:5808ms step_avg:30.57ms
+step:191/1490 train_time:5835ms step_avg:30.55ms
+step:192/1490 train_time:5869ms step_avg:30.57ms
+step:193/1490 train_time:5896ms step_avg:30.55ms
+step:194/1490 train_time:5930ms step_avg:30.57ms
+step:195/1490 train_time:5957ms step_avg:30.55ms
+step:196/1490 train_time:5993ms step_avg:30.58ms
+step:197/1490 train_time:6018ms step_avg:30.55ms
+step:198/1490 train_time:6052ms step_avg:30.57ms
+step:199/1490 train_time:6079ms step_avg:30.55ms
+step:200/1490 train_time:6114ms step_avg:30.57ms
+step:201/1490 train_time:6140ms step_avg:30.55ms
+step:202/1490 train_time:6174ms step_avg:30.57ms
+step:203/1490 train_time:6201ms step_avg:30.55ms
+step:204/1490 train_time:6236ms step_avg:30.57ms
+step:205/1490 train_time:6262ms step_avg:30.55ms
+step:206/1490 train_time:6296ms step_avg:30.57ms
+step:207/1490 train_time:6323ms step_avg:30.55ms
+step:208/1490 train_time:6358ms step_avg:30.57ms
+step:209/1490 train_time:6385ms step_avg:30.55ms
+step:210/1490 train_time:6419ms step_avg:30.57ms
+step:211/1490 train_time:6446ms step_avg:30.55ms
+step:212/1490 train_time:6480ms step_avg:30.57ms
+step:213/1490 train_time:6507ms step_avg:30.55ms
+step:214/1490 train_time:6540ms step_avg:30.56ms
+step:215/1490 train_time:6567ms step_avg:30.54ms
+step:216/1490 train_time:6601ms step_avg:30.56ms
+step:217/1490 train_time:6628ms step_avg:30.54ms
+step:218/1490 train_time:6662ms step_avg:30.56ms
+step:219/1490 train_time:6689ms step_avg:30.54ms
+step:220/1490 train_time:6723ms step_avg:30.56ms
+step:221/1490 train_time:6750ms step_avg:30.54ms
+step:222/1490 train_time:6784ms step_avg:30.56ms
+step:223/1490 train_time:6811ms step_avg:30.54ms
+step:224/1490 train_time:6844ms step_avg:30.56ms
+step:225/1490 train_time:6872ms step_avg:30.54ms
+step:226/1490 train_time:6905ms step_avg:30.55ms
+step:227/1490 train_time:6932ms step_avg:30.54ms
+step:228/1490 train_time:7011ms step_avg:30.75ms
+step:229/1490 train_time:7026ms step_avg:30.68ms
+step:230/1490 train_time:7049ms step_avg:30.65ms
+step:231/1490 train_time:7075ms step_avg:30.63ms
+step:232/1490 train_time:7109ms step_avg:30.64ms
+step:233/1490 train_time:7136ms step_avg:30.63ms
+step:234/1490 train_time:7169ms step_avg:30.64ms
+step:235/1490 train_time:7196ms step_avg:30.62ms
+step:236/1490 train_time:7230ms step_avg:30.63ms
+step:237/1490 train_time:7258ms step_avg:30.62ms
+step:238/1490 train_time:7291ms step_avg:30.64ms
+step:239/1490 train_time:7318ms step_avg:30.62ms
+step:240/1490 train_time:7351ms step_avg:30.63ms
+step:241/1490 train_time:7378ms step_avg:30.62ms
+step:242/1490 train_time:7412ms step_avg:30.63ms
+step:243/1490 train_time:7439ms step_avg:30.61ms
+step:244/1490 train_time:7473ms step_avg:30.63ms
+step:245/1490 train_time:7500ms step_avg:30.61ms
+step:246/1490 train_time:7534ms step_avg:30.63ms
+step:247/1490 train_time:7560ms step_avg:30.61ms
+step:248/1490 train_time:7594ms step_avg:30.62ms
+step:249/1490 train_time:7621ms step_avg:30.61ms
+step:250/1490 train_time:7655ms step_avg:30.62ms
+step:250/1490 val_loss:4.5158 train_time:7693ms step_avg:30.77ms
+step:251/1490 train_time:7711ms step_avg:30.72ms
+step:252/1490 train_time:7730ms step_avg:30.68ms
+step:253/1490 train_time:7746ms step_avg:30.62ms
+step:254/1490 train_time:7779ms step_avg:30.63ms
+step:255/1490 train_time:7808ms step_avg:30.62ms
+step:256/1490 train_time:7844ms step_avg:30.64ms
+step:257/1490 train_time:7871ms step_avg:30.63ms
+step:258/1490 train_time:7906ms step_avg:30.64ms
+step:259/1490 train_time:7933ms step_avg:30.63ms
+step:260/1490 train_time:7967ms step_avg:30.64ms
+step:261/1490 train_time:7995ms step_avg:30.63ms
+step:262/1490 train_time:8029ms step_avg:30.64ms
+step:263/1490 train_time:8055ms step_avg:30.63ms
+step:264/1490 train_time:8090ms step_avg:30.64ms
+step:265/1490 train_time:8116ms step_avg:30.63ms
+step:266/1490 train_time:8151ms step_avg:30.64ms
+step:267/1490 train_time:8177ms step_avg:30.62ms
+step:268/1490 train_time:8211ms step_avg:30.64ms
+step:269/1490 train_time:8237ms step_avg:30.62ms
+step:270/1490 train_time:8271ms step_avg:30.64ms
+step:271/1490 train_time:8298ms step_avg:30.62ms
+step:272/1490 train_time:8332ms step_avg:30.63ms
+step:273/1490 train_time:8359ms step_avg:30.62ms
+step:274/1490 train_time:8393ms step_avg:30.63ms
+step:275/1490 train_time:8420ms step_avg:30.62ms
+step:276/1490 train_time:8454ms step_avg:30.63ms
+step:277/1490 train_time:8481ms step_avg:30.62ms
+step:278/1490 train_time:8514ms step_avg:30.63ms
+step:279/1490 train_time:8541ms step_avg:30.61ms
+step:280/1490 train_time:8575ms step_avg:30.62ms
+step:281/1490 train_time:8602ms step_avg:30.61ms
+step:282/1490 train_time:8636ms step_avg:30.62ms
+step:283/1490 train_time:8662ms step_avg:30.61ms
+step:284/1490 train_time:8696ms step_avg:30.62ms
+step:285/1490 train_time:8723ms step_avg:30.61ms
+step:286/1490 train_time:8757ms step_avg:30.62ms
+step:287/1490 train_time:8784ms step_avg:30.61ms
+step:288/1490 train_time:8818ms step_avg:30.62ms
+step:289/1490 train_time:8845ms step_avg:30.61ms
+step:290/1490 train_time:8880ms step_avg:30.62ms
+step:291/1490 train_time:8907ms step_avg:30.61ms
+step:292/1490 train_time:8941ms step_avg:30.62ms
+step:293/1490 train_time:8968ms step_avg:30.61ms
+step:294/1490 train_time:9002ms step_avg:30.62ms
+step:295/1490 train_time:9029ms step_avg:30.61ms
+step:296/1490 train_time:9063ms step_avg:30.62ms
+step:297/1490 train_time:9090ms step_avg:30.61ms
+step:298/1490 train_time:9124ms step_avg:30.62ms
+step:299/1490 train_time:9152ms step_avg:30.61ms
+step:300/1490 train_time:9186ms step_avg:30.62ms
+step:301/1490 train_time:9213ms step_avg:30.61ms
+step:302/1490 train_time:9247ms step_avg:30.62ms
+step:303/1490 train_time:9274ms step_avg:30.61ms
+step:304/1490 train_time:9308ms step_avg:30.62ms
+step:305/1490 train_time:9335ms step_avg:30.61ms
+step:306/1490 train_time:9370ms step_avg:30.62ms
+step:307/1490 train_time:9396ms step_avg:30.61ms
+step:308/1490 train_time:9430ms step_avg:30.62ms
+step:309/1490 train_time:9457ms step_avg:30.60ms
+step:310/1490 train_time:9491ms step_avg:30.62ms
+step:311/1490 train_time:9518ms step_avg:30.60ms
+step:312/1490 train_time:9552ms step_avg:30.62ms
+step:313/1490 train_time:9579ms step_avg:30.60ms
+step:314/1490 train_time:9613ms step_avg:30.62ms
+step:315/1490 train_time:9640ms step_avg:30.60ms
+step:316/1490 train_time:9674ms step_avg:30.61ms
+step:317/1490 train_time:9701ms step_avg:30.60ms
+step:318/1490 train_time:9735ms step_avg:30.61ms
+step:319/1490 train_time:9762ms step_avg:30.60ms
+step:320/1490 train_time:9796ms step_avg:30.61ms
+step:321/1490 train_time:9823ms step_avg:30.60ms
+step:322/1490 train_time:9857ms step_avg:30.61ms
+step:323/1490 train_time:9884ms step_avg:30.60ms
+step:324/1490 train_time:9918ms step_avg:30.61ms
+step:325/1490 train_time:9945ms step_avg:30.60ms
+step:326/1490 train_time:9979ms step_avg:30.61ms
+step:327/1490 train_time:10006ms step_avg:30.60ms
+step:328/1490 train_time:10040ms step_avg:30.61ms
+step:329/1490 train_time:10068ms step_avg:30.60ms
+step:330/1490 train_time:10101ms step_avg:30.61ms
+step:331/1490 train_time:10129ms step_avg:30.60ms
+step:332/1490 train_time:10162ms step_avg:30.61ms
+step:333/1490 train_time:10189ms step_avg:30.60ms
+step:334/1490 train_time:10223ms step_avg:30.61ms
+step:335/1490 train_time:10250ms step_avg:30.60ms
+step:336/1490 train_time:10285ms step_avg:30.61ms
+step:337/1490 train_time:10311ms step_avg:30.60ms
+step:338/1490 train_time:10345ms step_avg:30.61ms
+step:339/1490 train_time:10372ms step_avg:30.60ms
+step:340/1490 train_time:10407ms step_avg:30.61ms
+step:341/1490 train_time:10434ms step_avg:30.60ms
+step:342/1490 train_time:10468ms step_avg:30.61ms
+step:343/1490 train_time:10495ms step_avg:30.60ms
+step:344/1490 train_time:10529ms step_avg:30.61ms
+step:345/1490 train_time:10556ms step_avg:30.60ms
+step:346/1490 train_time:10590ms step_avg:30.61ms
+step:347/1490 train_time:10618ms step_avg:30.60ms
+step:348/1490 train_time:10651ms step_avg:30.61ms
+step:349/1490 train_time:10678ms step_avg:30.60ms
+step:350/1490 train_time:10713ms step_avg:30.61ms
+step:351/1490 train_time:10740ms step_avg:30.60ms
+step:352/1490 train_time:10775ms step_avg:30.61ms
+step:353/1490 train_time:10801ms step_avg:30.60ms
+step:354/1490 train_time:10836ms step_avg:30.61ms
+step:355/1490 train_time:10862ms step_avg:30.60ms
+step:356/1490 train_time:10897ms step_avg:30.61ms
+step:357/1490 train_time:10924ms step_avg:30.60ms
+step:358/1490 train_time:10957ms step_avg:30.61ms
+step:359/1490 train_time:10984ms step_avg:30.60ms
+step:360/1490 train_time:11018ms step_avg:30.61ms
+step:361/1490 train_time:11045ms step_avg:30.60ms
+step:362/1490 train_time:11078ms step_avg:30.60ms
+step:363/1490 train_time:11105ms step_avg:30.59ms
+step:364/1490 train_time:11139ms step_avg:30.60ms
+step:365/1490 train_time:11166ms step_avg:30.59ms
+step:366/1490 train_time:11200ms step_avg:30.60ms
+step:367/1490 train_time:11227ms step_avg:30.59ms
+step:368/1490 train_time:11260ms step_avg:30.60ms
+step:369/1490 train_time:11288ms step_avg:30.59ms
+step:370/1490 train_time:11321ms step_avg:30.60ms
+step:371/1490 train_time:11348ms step_avg:30.59ms
+step:372/1490 train_time:11382ms step_avg:30.60ms
+step:373/1490 train_time:11409ms step_avg:30.59ms
+step:374/1490 train_time:11443ms step_avg:30.60ms
+step:375/1490 train_time:11470ms step_avg:30.59ms
+step:376/1490 train_time:11504ms step_avg:30.60ms
+step:377/1490 train_time:11531ms step_avg:30.59ms
+step:378/1490 train_time:11565ms step_avg:30.60ms
+step:379/1490 train_time:11592ms step_avg:30.59ms
+step:380/1490 train_time:11628ms step_avg:30.60ms
+step:381/1490 train_time:11654ms step_avg:30.59ms
+step:382/1490 train_time:11688ms step_avg:30.60ms
+step:383/1490 train_time:11715ms step_avg:30.59ms
+step:384/1490 train_time:11749ms step_avg:30.60ms
+step:385/1490 train_time:11776ms step_avg:30.59ms
+step:386/1490 train_time:11810ms step_avg:30.60ms
+step:387/1490 train_time:11838ms step_avg:30.59ms
+step:388/1490 train_time:11872ms step_avg:30.60ms
+step:389/1490 train_time:11899ms step_avg:30.59ms
+step:390/1490 train_time:11933ms step_avg:30.60ms
+step:391/1490 train_time:11960ms step_avg:30.59ms
+step:392/1490 train_time:11995ms step_avg:30.60ms
+step:393/1490 train_time:12022ms step_avg:30.59ms
+step:394/1490 train_time:12056ms step_avg:30.60ms
+step:395/1490 train_time:12083ms step_avg:30.59ms
+step:396/1490 train_time:12116ms step_avg:30.60ms
+step:397/1490 train_time:12143ms step_avg:30.59ms
+step:398/1490 train_time:12177ms step_avg:30.60ms
+step:399/1490 train_time:12204ms step_avg:30.59ms
+step:400/1490 train_time:12238ms step_avg:30.59ms
+step:401/1490 train_time:12265ms step_avg:30.59ms
+step:402/1490 train_time:12299ms step_avg:30.59ms
+step:403/1490 train_time:12326ms step_avg:30.59ms
+step:404/1490 train_time:12360ms step_avg:30.59ms
+step:405/1490 train_time:12387ms step_avg:30.58ms
+step:406/1490 train_time:12420ms step_avg:30.59ms
+step:407/1490 train_time:12448ms step_avg:30.58ms
+step:408/1490 train_time:12482ms step_avg:30.59ms
+step:409/1490 train_time:12509ms step_avg:30.58ms
+step:410/1490 train_time:12543ms step_avg:30.59ms
+step:411/1490 train_time:12570ms step_avg:30.58ms
+step:412/1490 train_time:12604ms step_avg:30.59ms
+step:413/1490 train_time:12631ms step_avg:30.58ms
+step:414/1490 train_time:12664ms step_avg:30.59ms
+step:415/1490 train_time:12691ms step_avg:30.58ms
+step:416/1490 train_time:12726ms step_avg:30.59ms
+step:417/1490 train_time:12752ms step_avg:30.58ms
+step:418/1490 train_time:12787ms step_avg:30.59ms
+step:419/1490 train_time:12814ms step_avg:30.58ms
+step:420/1490 train_time:12848ms step_avg:30.59ms
+step:421/1490 train_time:12875ms step_avg:30.58ms
+step:422/1490 train_time:12910ms step_avg:30.59ms
+step:423/1490 train_time:12937ms step_avg:30.58ms
+step:424/1490 train_time:12971ms step_avg:30.59ms
+step:425/1490 train_time:12998ms step_avg:30.58ms
+step:426/1490 train_time:13033ms step_avg:30.59ms
+step:427/1490 train_time:13060ms step_avg:30.59ms
+step:428/1490 train_time:13094ms step_avg:30.59ms
+step:429/1490 train_time:13121ms step_avg:30.59ms
+step:430/1490 train_time:13155ms step_avg:30.59ms
+step:431/1490 train_time:13182ms step_avg:30.58ms
+step:432/1490 train_time:13216ms step_avg:30.59ms
+step:433/1490 train_time:13244ms step_avg:30.59ms
+step:434/1490 train_time:13279ms step_avg:30.60ms
+step:435/1490 train_time:13305ms step_avg:30.59ms
+step:436/1490 train_time:13338ms step_avg:30.59ms
+step:437/1490 train_time:13365ms step_avg:30.58ms
+step:438/1490 train_time:13399ms step_avg:30.59ms
+step:439/1490 train_time:13426ms step_avg:30.58ms
+step:440/1490 train_time:13460ms step_avg:30.59ms
+step:441/1490 train_time:13487ms step_avg:30.58ms
+step:442/1490 train_time:13521ms step_avg:30.59ms
+step:443/1490 train_time:13548ms step_avg:30.58ms
+step:444/1490 train_time:13582ms step_avg:30.59ms
+step:445/1490 train_time:13609ms step_avg:30.58ms
+step:446/1490 train_time:13643ms step_avg:30.59ms
+step:447/1490 train_time:13669ms step_avg:30.58ms
+step:448/1490 train_time:13703ms step_avg:30.59ms
+step:449/1490 train_time:13730ms step_avg:30.58ms
+step:450/1490 train_time:13767ms step_avg:30.59ms
+step:451/1490 train_time:13792ms step_avg:30.58ms
+step:452/1490 train_time:13826ms step_avg:30.59ms
+step:453/1490 train_time:13853ms step_avg:30.58ms
+step:454/1490 train_time:13888ms step_avg:30.59ms
+step:455/1490 train_time:13915ms step_avg:30.58ms
+step:456/1490 train_time:13950ms step_avg:30.59ms
+step:457/1490 train_time:13977ms step_avg:30.58ms
+step:458/1490 train_time:14011ms step_avg:30.59ms
+step:459/1490 train_time:14038ms step_avg:30.58ms
+step:460/1490 train_time:14073ms step_avg:30.59ms
+step:461/1490 train_time:14099ms step_avg:30.58ms
+step:462/1490 train_time:14134ms step_avg:30.59ms
+step:463/1490 train_time:14161ms step_avg:30.59ms
+step:464/1490 train_time:14195ms step_avg:30.59ms
+step:465/1490 train_time:14222ms step_avg:30.59ms
+step:466/1490 train_time:14256ms step_avg:30.59ms
+step:467/1490 train_time:14284ms step_avg:30.59ms
+step:468/1490 train_time:14318ms step_avg:30.59ms
+step:469/1490 train_time:14345ms step_avg:30.59ms
+step:470/1490 train_time:14379ms step_avg:30.59ms
+step:471/1490 train_time:14406ms step_avg:30.59ms
+step:472/1490 train_time:14439ms step_avg:30.59ms
+step:473/1490 train_time:14467ms step_avg:30.58ms
+step:474/1490 train_time:14500ms step_avg:30.59ms
+step:475/1490 train_time:14527ms step_avg:30.58ms
+step:476/1490 train_time:14561ms step_avg:30.59ms
+step:477/1490 train_time:14588ms step_avg:30.58ms
+step:478/1490 train_time:14622ms step_avg:30.59ms
+step:479/1490 train_time:14649ms step_avg:30.58ms
+step:480/1490 train_time:14683ms step_avg:30.59ms
+step:481/1490 train_time:14710ms step_avg:30.58ms
+step:482/1490 train_time:14745ms step_avg:30.59ms
+step:483/1490 train_time:14771ms step_avg:30.58ms
+step:484/1490 train_time:14807ms step_avg:30.59ms
+step:485/1490 train_time:14859ms step_avg:30.64ms
+step:486/1490 train_time:14917ms step_avg:30.69ms
+step:487/1490 train_time:14970ms step_avg:30.74ms
+step:488/1490 train_time:15029ms step_avg:30.80ms
+step:489/1490 train_time:15082ms step_avg:30.84ms
+step:490/1490 train_time:15141ms step_avg:30.90ms
+step:491/1490 train_time:15193ms step_avg:30.94ms
+step:492/1490 train_time:15252ms step_avg:31.00ms
+step:493/1490 train_time:15306ms step_avg:31.05ms
+step:494/1490 train_time:15364ms step_avg:31.10ms
+step:495/1490 train_time:15417ms step_avg:31.15ms
+step:496/1490 train_time:15476ms step_avg:31.20ms
+step:497/1490 train_time:15530ms step_avg:31.25ms
+step:498/1490 train_time:15588ms step_avg:31.30ms
+step:499/1490 train_time:15641ms step_avg:31.34ms
+step:500/1490 train_time:15698ms step_avg:31.40ms
+step:500/1490 val_loss:4.2318 train_time:15765ms step_avg:31.53ms
+step:501/1490 train_time:15785ms step_avg:31.51ms
+step:502/1490 train_time:15812ms step_avg:31.50ms
+step:503/1490 train_time:15869ms step_avg:31.55ms
+step:504/1490 train_time:15928ms step_avg:31.60ms
+step:505/1490 train_time:15982ms step_avg:31.65ms
+step:506/1490 train_time:16041ms step_avg:31.70ms
+step:507/1490 train_time:16094ms step_avg:31.74ms
+step:508/1490 train_time:16340ms step_avg:32.16ms
+step:509/1490 train_time:16392ms step_avg:32.20ms
+step:510/1490 train_time:16449ms step_avg:32.25ms
+step:511/1490 train_time:16502ms step_avg:32.29ms
+step:512/1490 train_time:16559ms step_avg:32.34ms
+step:513/1490 train_time:16612ms step_avg:32.38ms
+step:514/1490 train_time:16669ms step_avg:32.43ms
+step:515/1490 train_time:16721ms step_avg:32.47ms
+step:516/1490 train_time:16779ms step_avg:32.52ms
+step:517/1490 train_time:16831ms step_avg:32.56ms
+step:518/1490 train_time:16889ms step_avg:32.60ms
+step:519/1490 train_time:16942ms step_avg:32.64ms
+step:520/1490 train_time:16999ms step_avg:32.69ms
+step:521/1490 train_time:17052ms step_avg:32.73ms
+step:522/1490 train_time:17110ms step_avg:32.78ms
+step:523/1490 train_time:17161ms step_avg:32.81ms
+step:524/1490 train_time:17220ms step_avg:32.86ms
+step:525/1490 train_time:17279ms step_avg:32.91ms
+step:526/1490 train_time:17340ms step_avg:32.97ms
+step:527/1490 train_time:17394ms step_avg:33.01ms
+step:528/1490 train_time:17453ms step_avg:33.06ms
+step:529/1490 train_time:17507ms step_avg:33.09ms
+step:530/1490 train_time:17565ms step_avg:33.14ms
+step:531/1490 train_time:17617ms step_avg:33.18ms
+step:532/1490 train_time:17676ms step_avg:33.23ms
+step:533/1490 train_time:17729ms step_avg:33.26ms
+step:534/1490 train_time:17786ms step_avg:33.31ms
+step:535/1490 train_time:17839ms step_avg:33.34ms
+step:536/1490 train_time:17896ms step_avg:33.39ms
+step:537/1490 train_time:17949ms step_avg:33.42ms
+step:538/1490 train_time:18006ms step_avg:33.47ms
+step:539/1490 train_time:18058ms step_avg:33.50ms
+step:540/1490 train_time:18120ms step_avg:33.56ms
+step:541/1490 train_time:18170ms step_avg:33.59ms
+step:542/1490 train_time:18230ms step_avg:33.63ms
+step:543/1490 train_time:18285ms step_avg:33.67ms
+step:544/1490 train_time:18344ms step_avg:33.72ms
+step:545/1490 train_time:18398ms step_avg:33.76ms
+step:546/1490 train_time:18457ms step_avg:33.80ms
+step:547/1490 train_time:18510ms step_avg:33.84ms
+step:548/1490 train_time:18568ms step_avg:33.88ms
+step:549/1490 train_time:18620ms step_avg:33.92ms
+step:550/1490 train_time:18679ms step_avg:33.96ms
+step:551/1490 train_time:18732ms step_avg:34.00ms
+step:552/1490 train_time:18790ms step_avg:34.04ms
+step:553/1490 train_time:18843ms step_avg:34.07ms
+step:554/1490 train_time:18900ms step_avg:34.12ms
+step:555/1490 train_time:18953ms step_avg:34.15ms
+step:556/1490 train_time:19011ms step_avg:34.19ms
+step:557/1490 train_time:19065ms step_avg:34.23ms
+step:558/1490 train_time:19121ms step_avg:34.27ms
+step:559/1490 train_time:19175ms step_avg:34.30ms
+step:560/1490 train_time:19236ms step_avg:34.35ms
+step:561/1490 train_time:19290ms step_avg:34.38ms
+step:562/1490 train_time:19349ms step_avg:34.43ms
+step:563/1490 train_time:19402ms step_avg:34.46ms
+step:564/1490 train_time:19460ms step_avg:34.50ms
+step:565/1490 train_time:19513ms step_avg:34.54ms
+step:566/1490 train_time:19573ms step_avg:34.58ms
+step:567/1490 train_time:19626ms step_avg:34.61ms
+step:568/1490 train_time:19683ms step_avg:34.65ms
+step:569/1490 train_time:19737ms step_avg:34.69ms
+step:570/1490 train_time:19795ms step_avg:34.73ms
+step:571/1490 train_time:19848ms step_avg:34.76ms
+step:572/1490 train_time:19905ms step_avg:34.80ms
+step:573/1490 train_time:19958ms step_avg:34.83ms
+step:574/1490 train_time:20016ms step_avg:34.87ms
+step:575/1490 train_time:20068ms step_avg:34.90ms
+step:576/1490 train_time:20127ms step_avg:34.94ms
+step:577/1490 train_time:20180ms step_avg:34.97ms
+step:578/1490 train_time:20240ms step_avg:35.02ms
+step:579/1490 train_time:20293ms step_avg:35.05ms
+step:580/1490 train_time:20351ms step_avg:35.09ms
+step:581/1490 train_time:20405ms step_avg:35.12ms
+step:582/1490 train_time:20463ms step_avg:35.16ms
+step:583/1490 train_time:20517ms step_avg:35.19ms
+step:584/1490 train_time:20575ms step_avg:35.23ms
+step:585/1490 train_time:20629ms step_avg:35.26ms
+step:586/1490 train_time:20687ms step_avg:35.30ms
+step:587/1490 train_time:20740ms step_avg:35.33ms
+step:588/1490 train_time:20798ms step_avg:35.37ms
+step:589/1490 train_time:20851ms step_avg:35.40ms
+step:590/1490 train_time:20909ms step_avg:35.44ms
+step:591/1490 train_time:20961ms step_avg:35.47ms
+step:592/1490 train_time:21020ms step_avg:35.51ms
+step:593/1490 train_time:21073ms step_avg:35.54ms
+step:594/1490 train_time:21131ms step_avg:35.57ms
+step:595/1490 train_time:21184ms step_avg:35.60ms
+step:596/1490 train_time:21243ms step_avg:35.64ms
+step:597/1490 train_time:21296ms step_avg:35.67ms
+step:598/1490 train_time:21355ms step_avg:35.71ms
+step:599/1490 train_time:21408ms step_avg:35.74ms
+step:600/1490 train_time:21466ms step_avg:35.78ms
+step:601/1490 train_time:21519ms step_avg:35.80ms
+step:602/1490 train_time:21578ms step_avg:35.84ms
+step:603/1490 train_time:21631ms step_avg:35.87ms
+step:604/1490 train_time:21690ms step_avg:35.91ms
+step:605/1490 train_time:21743ms step_avg:35.94ms
+step:606/1490 train_time:21800ms step_avg:35.97ms
+step:607/1490 train_time:21854ms step_avg:36.00ms
+step:608/1490 train_time:21912ms step_avg:36.04ms
+step:609/1490 train_time:21965ms step_avg:36.07ms
+step:610/1490 train_time:22023ms step_avg:36.10ms
+step:611/1490 train_time:22076ms step_avg:36.13ms
+step:612/1490 train_time:22135ms step_avg:36.17ms
+step:613/1490 train_time:22188ms step_avg:36.20ms
+step:614/1490 train_time:22247ms step_avg:36.23ms
+step:615/1490 train_time:22300ms step_avg:36.26ms
+step:616/1490 train_time:22358ms step_avg:36.30ms
+step:617/1490 train_time:22412ms step_avg:36.32ms
+step:618/1490 train_time:22471ms step_avg:36.36ms
+step:619/1490 train_time:22523ms step_avg:36.39ms
+step:620/1490 train_time:22582ms step_avg:36.42ms
+step:621/1490 train_time:22635ms step_avg:36.45ms
+step:622/1490 train_time:22694ms step_avg:36.49ms
+step:623/1490 train_time:22747ms step_avg:36.51ms
+step:624/1490 train_time:22804ms step_avg:36.55ms
+step:625/1490 train_time:22858ms step_avg:36.57ms
+step:626/1490 train_time:22916ms step_avg:36.61ms
+step:627/1490 train_time:22970ms step_avg:36.63ms
+step:628/1490 train_time:23028ms step_avg:36.67ms
+step:629/1490 train_time:23081ms step_avg:36.69ms
+step:630/1490 train_time:23139ms step_avg:36.73ms
+step:631/1490 train_time:23192ms step_avg:36.75ms
+step:632/1490 train_time:23251ms step_avg:36.79ms
+step:633/1490 train_time:23304ms step_avg:36.82ms
+step:634/1490 train_time:23362ms step_avg:36.85ms
+step:635/1490 train_time:23415ms step_avg:36.87ms
+step:636/1490 train_time:23474ms step_avg:36.91ms
+step:637/1490 train_time:23527ms step_avg:36.93ms
+step:638/1490 train_time:23586ms step_avg:36.97ms
+step:639/1490 train_time:23639ms step_avg:36.99ms
+step:640/1490 train_time:23697ms step_avg:37.03ms
+step:641/1490 train_time:23751ms step_avg:37.05ms
+step:642/1490 train_time:23809ms step_avg:37.09ms
+step:643/1490 train_time:23862ms step_avg:37.11ms
+step:644/1490 train_time:23921ms step_avg:37.14ms
+step:645/1490 train_time:23974ms step_avg:37.17ms
+step:646/1490 train_time:24032ms step_avg:37.20ms
+step:647/1490 train_time:24086ms step_avg:37.23ms
+step:648/1490 train_time:24144ms step_avg:37.26ms
+step:649/1490 train_time:24198ms step_avg:37.29ms
+step:650/1490 train_time:24256ms step_avg:37.32ms
+step:651/1490 train_time:24309ms step_avg:37.34ms
+step:652/1490 train_time:24367ms step_avg:37.37ms
+step:653/1490 train_time:24420ms step_avg:37.40ms
+step:654/1490 train_time:24478ms step_avg:37.43ms
+step:655/1490 train_time:24532ms step_avg:37.45ms
+step:656/1490 train_time:24590ms step_avg:37.49ms
+step:657/1490 train_time:24644ms step_avg:37.51ms
+step:658/1490 train_time:24701ms step_avg:37.54ms
+step:659/1490 train_time:24754ms step_avg:37.56ms
+step:660/1490 train_time:24813ms step_avg:37.60ms
+step:661/1490 train_time:24867ms step_avg:37.62ms
+step:662/1490 train_time:24925ms step_avg:37.65ms
+step:663/1490 train_time:24978ms step_avg:37.67ms
+step:664/1490 train_time:25037ms step_avg:37.71ms
+step:665/1490 train_time:25089ms step_avg:37.73ms
+step:666/1490 train_time:25148ms step_avg:37.76ms
+step:667/1490 train_time:25201ms step_avg:37.78ms
+step:668/1490 train_time:25259ms step_avg:37.81ms
+step:669/1490 train_time:25312ms step_avg:37.84ms
+step:670/1490 train_time:25371ms step_avg:37.87ms
+step:671/1490 train_time:25424ms step_avg:37.89ms
+step:672/1490 train_time:25483ms step_avg:37.92ms
+step:673/1490 train_time:25537ms step_avg:37.94ms
+step:674/1490 train_time:25595ms step_avg:37.97ms
+step:675/1490 train_time:25649ms step_avg:38.00ms
+step:676/1490 train_time:25707ms step_avg:38.03ms
+step:677/1490 train_time:25759ms step_avg:38.05ms
+step:678/1490 train_time:25817ms step_avg:38.08ms
+step:679/1490 train_time:25871ms step_avg:38.10ms
+step:680/1490 train_time:25930ms step_avg:38.13ms
+step:681/1490 train_time:25983ms step_avg:38.15ms
+step:682/1490 train_time:26042ms step_avg:38.18ms
+step:683/1490 train_time:26095ms step_avg:38.21ms
+step:684/1490 train_time:26153ms step_avg:38.24ms
+step:685/1490 train_time:26206ms step_avg:38.26ms
+step:686/1490 train_time:26265ms step_avg:38.29ms
+step:687/1490 train_time:26318ms step_avg:38.31ms
+step:688/1490 train_time:26376ms step_avg:38.34ms
+step:689/1490 train_time:26430ms step_avg:38.36ms
+step:690/1490 train_time:26488ms step_avg:38.39ms
+step:691/1490 train_time:26541ms step_avg:38.41ms
+step:692/1490 train_time:26598ms step_avg:38.44ms
+step:693/1490 train_time:26653ms step_avg:38.46ms
+step:694/1490 train_time:26711ms step_avg:38.49ms
+step:695/1490 train_time:26765ms step_avg:38.51ms
+step:696/1490 train_time:26822ms step_avg:38.54ms
+step:697/1490 train_time:26876ms step_avg:38.56ms
+step:698/1490 train_time:26935ms step_avg:38.59ms
+step:699/1490 train_time:26988ms step_avg:38.61ms
+step:700/1490 train_time:27046ms step_avg:38.64ms
+step:701/1490 train_time:27099ms step_avg:38.66ms
+step:702/1490 train_time:27158ms step_avg:38.69ms
+step:703/1490 train_time:27210ms step_avg:38.71ms
+step:704/1490 train_time:27269ms step_avg:38.73ms
+step:705/1490 train_time:27321ms step_avg:38.75ms
+step:706/1490 train_time:27379ms step_avg:38.78ms
+step:707/1490 train_time:27433ms step_avg:38.80ms
+step:708/1490 train_time:27494ms step_avg:38.83ms
+step:709/1490 train_time:27545ms step_avg:38.85ms
+step:710/1490 train_time:27602ms step_avg:38.88ms
+step:711/1490 train_time:27656ms step_avg:38.90ms
+step:712/1490 train_time:27715ms step_avg:38.93ms
+step:713/1490 train_time:27768ms step_avg:38.95ms
+step:714/1490 train_time:27827ms step_avg:38.97ms
+step:715/1490 train_time:27881ms step_avg:38.99ms
+step:716/1490 train_time:27940ms step_avg:39.02ms
+step:717/1490 train_time:27993ms step_avg:39.04ms
+step:718/1490 train_time:28051ms step_avg:39.07ms
+step:719/1490 train_time:28104ms step_avg:39.09ms
+step:720/1490 train_time:28162ms step_avg:39.11ms
+step:721/1490 train_time:28215ms step_avg:39.13ms
+step:722/1490 train_time:28274ms step_avg:39.16ms
+step:723/1490 train_time:28327ms step_avg:39.18ms
+step:724/1490 train_time:28386ms step_avg:39.21ms
+step:725/1490 train_time:28438ms step_avg:39.22ms
+step:726/1490 train_time:28496ms step_avg:39.25ms
+step:727/1490 train_time:28550ms step_avg:39.27ms
+step:728/1490 train_time:28608ms step_avg:39.30ms
+step:729/1490 train_time:28661ms step_avg:39.32ms
+step:730/1490 train_time:28719ms step_avg:39.34ms
+step:731/1490 train_time:28773ms step_avg:39.36ms
+step:732/1490 train_time:28833ms step_avg:39.39ms
+step:733/1490 train_time:28886ms step_avg:39.41ms
+step:734/1490 train_time:28944ms step_avg:39.43ms
+step:735/1490 train_time:28998ms step_avg:39.45ms
+step:736/1490 train_time:29056ms step_avg:39.48ms
+step:737/1490 train_time:29109ms step_avg:39.50ms
+step:738/1490 train_time:29167ms step_avg:39.52ms
+step:739/1490 train_time:29219ms step_avg:39.54ms
+step:740/1490 train_time:29277ms step_avg:39.56ms
+step:741/1490 train_time:29331ms step_avg:39.58ms
+step:742/1490 train_time:29390ms step_avg:39.61ms
+step:743/1490 train_time:29443ms step_avg:39.63ms
+step:744/1490 train_time:29501ms step_avg:39.65ms
+step:745/1490 train_time:29556ms step_avg:39.67ms
+step:746/1490 train_time:29615ms step_avg:39.70ms
+step:747/1490 train_time:29667ms step_avg:39.72ms
+step:748/1490 train_time:29726ms step_avg:39.74ms
+step:749/1490 train_time:29779ms step_avg:39.76ms
+step:750/1490 train_time:29838ms step_avg:39.78ms
+step:750/1490 val_loss:3.8047 train_time:29904ms step_avg:39.87ms
+step:751/1490 train_time:29924ms step_avg:39.85ms
+step:752/1490 train_time:29952ms step_avg:39.83ms
+step:753/1490 train_time:30009ms step_avg:39.85ms
+step:754/1490 train_time:30072ms step_avg:39.88ms
+step:755/1490 train_time:30127ms step_avg:39.90ms
+step:756/1490 train_time:30184ms step_avg:39.93ms
+step:757/1490 train_time:30236ms step_avg:39.94ms
+step:758/1490 train_time:30295ms step_avg:39.97ms
+step:759/1490 train_time:30348ms step_avg:39.98ms
+step:760/1490 train_time:30405ms step_avg:40.01ms
+step:761/1490 train_time:30458ms step_avg:40.02ms
+step:762/1490 train_time:30516ms step_avg:40.05ms
+step:763/1490 train_time:30568ms step_avg:40.06ms
+step:764/1490 train_time:30625ms step_avg:40.09ms
+step:765/1490 train_time:30678ms step_avg:40.10ms
+step:766/1490 train_time:30736ms step_avg:40.13ms
+step:767/1490 train_time:30789ms step_avg:40.14ms
+step:768/1490 train_time:30847ms step_avg:40.17ms
+step:769/1490 train_time:30902ms step_avg:40.19ms
+step:770/1490 train_time:30963ms step_avg:40.21ms
+step:771/1490 train_time:31016ms step_avg:40.23ms
+step:772/1490 train_time:31076ms step_avg:40.25ms
+step:773/1490 train_time:31130ms step_avg:40.27ms
+step:774/1490 train_time:31188ms step_avg:40.30ms
+step:775/1490 train_time:31242ms step_avg:40.31ms
+step:776/1490 train_time:31300ms step_avg:40.34ms
+step:777/1490 train_time:31354ms step_avg:40.35ms
+step:778/1490 train_time:31412ms step_avg:40.38ms
+step:779/1490 train_time:31465ms step_avg:40.39ms
+step:780/1490 train_time:31522ms step_avg:40.41ms
+step:781/1490 train_time:31575ms step_avg:40.43ms
+step:782/1490 train_time:31632ms step_avg:40.45ms
+step:783/1490 train_time:31686ms step_avg:40.47ms
+step:784/1490 train_time:31743ms step_avg:40.49ms
+step:785/1490 train_time:31796ms step_avg:40.51ms
+step:786/1490 train_time:31854ms step_avg:40.53ms
+step:787/1490 train_time:31908ms step_avg:40.54ms
+step:788/1490 train_time:31967ms step_avg:40.57ms
+step:789/1490 train_time:32021ms step_avg:40.58ms
+step:790/1490 train_time:32080ms step_avg:40.61ms
+step:791/1490 train_time:32134ms step_avg:40.62ms
+step:792/1490 train_time:32193ms step_avg:40.65ms
+step:793/1490 train_time:32246ms step_avg:40.66ms
+step:794/1490 train_time:32304ms step_avg:40.68ms
+step:795/1490 train_time:32358ms step_avg:40.70ms
+step:796/1490 train_time:32415ms step_avg:40.72ms
+step:797/1490 train_time:32468ms step_avg:40.74ms
+step:798/1490 train_time:32525ms step_avg:40.76ms
+step:799/1490 train_time:32579ms step_avg:40.77ms
+step:800/1490 train_time:32637ms step_avg:40.80ms
+step:801/1490 train_time:32690ms step_avg:40.81ms
+step:802/1490 train_time:32747ms step_avg:40.83ms
+step:803/1490 train_time:32800ms step_avg:40.85ms
+step:804/1490 train_time:32859ms step_avg:40.87ms
+step:805/1490 train_time:32912ms step_avg:40.88ms
+step:806/1490 train_time:32971ms step_avg:40.91ms
+step:807/1490 train_time:33025ms step_avg:40.92ms
+step:808/1490 train_time:33083ms step_avg:40.94ms
+step:809/1490 train_time:33137ms step_avg:40.96ms
+step:810/1490 train_time:33195ms step_avg:40.98ms
+step:811/1490 train_time:33250ms step_avg:41.00ms
+step:812/1490 train_time:33307ms step_avg:41.02ms
+step:813/1490 train_time:33361ms step_avg:41.03ms
+step:814/1490 train_time:33419ms step_avg:41.06ms
+step:815/1490 train_time:33472ms step_avg:41.07ms
+step:816/1490 train_time:33530ms step_avg:41.09ms
+step:817/1490 train_time:33583ms step_avg:41.11ms
+step:818/1490 train_time:33641ms step_avg:41.13ms
+step:819/1490 train_time:33693ms step_avg:41.14ms
+step:820/1490 train_time:33751ms step_avg:41.16ms
+step:821/1490 train_time:33805ms step_avg:41.18ms
+step:822/1490 train_time:33863ms step_avg:41.20ms
+step:823/1490 train_time:33916ms step_avg:41.21ms
+step:824/1490 train_time:33975ms step_avg:41.23ms
+step:825/1490 train_time:34028ms step_avg:41.25ms
+step:826/1490 train_time:34086ms step_avg:41.27ms
+step:827/1490 train_time:34141ms step_avg:41.28ms
+step:828/1490 train_time:34198ms step_avg:41.30ms
+step:829/1490 train_time:34252ms step_avg:41.32ms
+step:830/1490 train_time:34311ms step_avg:41.34ms
+step:831/1490 train_time:34363ms step_avg:41.35ms
+step:832/1490 train_time:34421ms step_avg:41.37ms
+step:833/1490 train_time:34474ms step_avg:41.39ms
+step:834/1490 train_time:34533ms step_avg:41.41ms
+step:835/1490 train_time:34586ms step_avg:41.42ms
+step:836/1490 train_time:34643ms step_avg:41.44ms
+step:837/1490 train_time:34698ms step_avg:41.46ms
+step:838/1490 train_time:34756ms step_avg:41.47ms
+step:839/1490 train_time:34808ms step_avg:41.49ms
+step:840/1490 train_time:34866ms step_avg:41.51ms
+step:841/1490 train_time:34920ms step_avg:41.52ms
+step:842/1490 train_time:34978ms step_avg:41.54ms
+step:843/1490 train_time:35031ms step_avg:41.56ms
+step:844/1490 train_time:35090ms step_avg:41.58ms
+step:845/1490 train_time:35142ms step_avg:41.59ms
+step:846/1490 train_time:35202ms step_avg:41.61ms
+step:847/1490 train_time:35256ms step_avg:41.62ms
+step:848/1490 train_time:35315ms step_avg:41.64ms
+step:849/1490 train_time:35368ms step_avg:41.66ms
+step:850/1490 train_time:35425ms step_avg:41.68ms
+step:851/1490 train_time:35479ms step_avg:41.69ms
+step:852/1490 train_time:35536ms step_avg:41.71ms
+step:853/1490 train_time:35589ms step_avg:41.72ms
+step:854/1490 train_time:35648ms step_avg:41.74ms
+step:855/1490 train_time:35701ms step_avg:41.76ms
+step:856/1490 train_time:35759ms step_avg:41.78ms
+step:857/1490 train_time:35812ms step_avg:41.79ms
+step:858/1490 train_time:35871ms step_avg:41.81ms
+step:859/1490 train_time:35924ms step_avg:41.82ms
+step:860/1490 train_time:35982ms step_avg:41.84ms
+step:861/1490 train_time:36036ms step_avg:41.85ms
+step:862/1490 train_time:36094ms step_avg:41.87ms
+step:863/1490 train_time:36148ms step_avg:41.89ms
+step:864/1490 train_time:36206ms step_avg:41.90ms
+step:865/1490 train_time:36260ms step_avg:41.92ms
+step:866/1490 train_time:36318ms step_avg:41.94ms
+step:867/1490 train_time:36371ms step_avg:41.95ms
+step:868/1490 train_time:36429ms step_avg:41.97ms
+step:869/1490 train_time:36482ms step_avg:41.98ms
+step:870/1490 train_time:36540ms step_avg:42.00ms
+step:871/1490 train_time:36593ms step_avg:42.01ms
+step:872/1490 train_time:36652ms step_avg:42.03ms
+step:873/1490 train_time:36706ms step_avg:42.05ms
+step:874/1490 train_time:36764ms step_avg:42.06ms
+step:875/1490 train_time:36816ms step_avg:42.08ms
+step:876/1490 train_time:36875ms step_avg:42.09ms
+step:877/1490 train_time:36928ms step_avg:42.11ms
+step:878/1490 train_time:36987ms step_avg:42.13ms
+step:879/1490 train_time:37039ms step_avg:42.14ms
+step:880/1490 train_time:37098ms step_avg:42.16ms
+step:881/1490 train_time:37151ms step_avg:42.17ms
+step:882/1490 train_time:37210ms step_avg:42.19ms
+step:883/1490 train_time:37263ms step_avg:42.20ms
+step:884/1490 train_time:37320ms step_avg:42.22ms
+step:885/1490 train_time:37373ms step_avg:42.23ms
+step:886/1490 train_time:37432ms step_avg:42.25ms
+step:887/1490 train_time:37485ms step_avg:42.26ms
+step:888/1490 train_time:37543ms step_avg:42.28ms
+step:889/1490 train_time:37596ms step_avg:42.29ms
+step:890/1490 train_time:37655ms step_avg:42.31ms
+step:891/1490 train_time:37708ms step_avg:42.32ms
+step:892/1490 train_time:37767ms step_avg:42.34ms
+step:893/1490 train_time:37819ms step_avg:42.35ms
+step:894/1490 train_time:37877ms step_avg:42.37ms
+step:895/1490 train_time:37929ms step_avg:42.38ms
+step:896/1490 train_time:37988ms step_avg:42.40ms
+step:897/1490 train_time:38041ms step_avg:42.41ms
+step:898/1490 train_time:38100ms step_avg:42.43ms
+step:899/1490 train_time:38153ms step_avg:42.44ms
+step:900/1490 train_time:38212ms step_avg:42.46ms
+step:901/1490 train_time:38265ms step_avg:42.47ms
+step:902/1490 train_time:38323ms step_avg:42.49ms
+step:903/1490 train_time:38377ms step_avg:42.50ms
+step:904/1490 train_time:38435ms step_avg:42.52ms
+step:905/1490 train_time:38488ms step_avg:42.53ms
+step:906/1490 train_time:38546ms step_avg:42.54ms
+step:907/1490 train_time:38600ms step_avg:42.56ms
+step:908/1490 train_time:38658ms step_avg:42.58ms
+step:909/1490 train_time:38711ms step_avg:42.59ms
+step:910/1490 train_time:38770ms step_avg:42.60ms
+step:911/1490 train_time:38822ms step_avg:42.62ms
+step:912/1490 train_time:38880ms step_avg:42.63ms
+step:913/1490 train_time:38933ms step_avg:42.64ms
+step:914/1490 train_time:38992ms step_avg:42.66ms
+step:915/1490 train_time:39045ms step_avg:42.67ms
+step:916/1490 train_time:39103ms step_avg:42.69ms
+step:917/1490 train_time:39157ms step_avg:42.70ms
+step:918/1490 train_time:39215ms step_avg:42.72ms
+step:919/1490 train_time:39268ms step_avg:42.73ms
+step:920/1490 train_time:39325ms step_avg:42.74ms
+step:921/1490 train_time:39379ms step_avg:42.76ms
+step:922/1490 train_time:39437ms step_avg:42.77ms
+step:923/1490 train_time:39490ms step_avg:42.78ms
+step:924/1490 train_time:39549ms step_avg:42.80ms
+step:925/1490 train_time:39602ms step_avg:42.81ms
+step:926/1490 train_time:39661ms step_avg:42.83ms
+step:927/1490 train_time:39713ms step_avg:42.84ms
+step:928/1490 train_time:39772ms step_avg:42.86ms
+step:929/1490 train_time:39825ms step_avg:42.87ms
+step:930/1490 train_time:39883ms step_avg:42.89ms
+step:931/1490 train_time:39937ms step_avg:42.90ms
+step:932/1490 train_time:39995ms step_avg:42.91ms
+step:933/1490 train_time:40049ms step_avg:42.92ms
+step:934/1490 train_time:40107ms step_avg:42.94ms
+step:935/1490 train_time:40161ms step_avg:42.95ms
+step:936/1490 train_time:40219ms step_avg:42.97ms
+step:937/1490 train_time:40272ms step_avg:42.98ms
+step:938/1490 train_time:40330ms step_avg:43.00ms
+step:939/1490 train_time:40382ms step_avg:43.01ms
+step:940/1490 train_time:40440ms step_avg:43.02ms
+step:941/1490 train_time:40494ms step_avg:43.03ms
+step:942/1490 train_time:40553ms step_avg:43.05ms
+step:943/1490 train_time:40606ms step_avg:43.06ms
+step:944/1490 train_time:40664ms step_avg:43.08ms
+step:945/1490 train_time:40717ms step_avg:43.09ms
+step:946/1490 train_time:40776ms step_avg:43.10ms
+step:947/1490 train_time:40829ms step_avg:43.11ms
+step:948/1490 train_time:40886ms step_avg:43.13ms
+step:949/1490 train_time:40939ms step_avg:43.14ms
+step:950/1490 train_time:40999ms step_avg:43.16ms
+step:951/1490 train_time:41053ms step_avg:43.17ms
+step:952/1490 train_time:41111ms step_avg:43.18ms
+step:953/1490 train_time:41164ms step_avg:43.19ms
+step:954/1490 train_time:41222ms step_avg:43.21ms
+step:955/1490 train_time:41275ms step_avg:43.22ms
+step:956/1490 train_time:41334ms step_avg:43.24ms
+step:957/1490 train_time:41387ms step_avg:43.25ms
+step:958/1490 train_time:41445ms step_avg:43.26ms
+step:959/1490 train_time:41499ms step_avg:43.27ms
+step:960/1490 train_time:41558ms step_avg:43.29ms
+step:961/1490 train_time:41611ms step_avg:43.30ms
+step:962/1490 train_time:41669ms step_avg:43.31ms
+step:963/1490 train_time:41722ms step_avg:43.32ms
+step:964/1490 train_time:41780ms step_avg:43.34ms
+step:965/1490 train_time:41834ms step_avg:43.35ms
+step:966/1490 train_time:41892ms step_avg:43.37ms
+step:967/1490 train_time:41945ms step_avg:43.38ms
+step:968/1490 train_time:42006ms step_avg:43.39ms
+step:969/1490 train_time:42086ms step_avg:43.43ms
+step:970/1490 train_time:42169ms step_avg:43.47ms
+step:971/1490 train_time:42249ms step_avg:43.51ms
+step:972/1490 train_time:42332ms step_avg:43.55ms
+step:973/1490 train_time:42412ms step_avg:43.59ms
+step:974/1490 train_time:42496ms step_avg:43.63ms
+step:975/1490 train_time:42575ms step_avg:43.67ms
+step:976/1490 train_time:42658ms step_avg:43.71ms
+step:977/1490 train_time:42737ms step_avg:43.74ms
+step:978/1490 train_time:42821ms step_avg:43.78ms
+step:979/1490 train_time:42900ms step_avg:43.82ms
+step:980/1490 train_time:42984ms step_avg:43.86ms
+step:981/1490 train_time:43062ms step_avg:43.90ms
+step:982/1490 train_time:43144ms step_avg:43.94ms
+step:983/1490 train_time:43223ms step_avg:43.97ms
+step:984/1490 train_time:43308ms step_avg:44.01ms
+step:985/1490 train_time:43387ms step_avg:44.05ms
+step:986/1490 train_time:43472ms step_avg:44.09ms
+step:987/1490 train_time:43552ms step_avg:44.13ms
+step:988/1490 train_time:43635ms step_avg:44.17ms
+step:989/1490 train_time:43714ms step_avg:44.20ms
+step:990/1490 train_time:43799ms step_avg:44.24ms
+step:991/1490 train_time:43879ms step_avg:44.28ms
+step:992/1490 train_time:43962ms step_avg:44.32ms
+step:993/1490 train_time:44041ms step_avg:44.35ms
+step:994/1490 train_time:44125ms step_avg:44.39ms
+step:995/1490 train_time:44203ms step_avg:44.43ms
+step:996/1490 train_time:44286ms step_avg:44.46ms
+step:997/1490 train_time:44363ms step_avg:44.50ms
+step:998/1490 train_time:44448ms step_avg:44.54ms
+step:999/1490 train_time:44528ms step_avg:44.57ms
+step:1000/1490 train_time:44614ms step_avg:44.61ms
+step:1000/1490 val_loss:3.5175 train_time:44710ms step_avg:44.71ms
+step:1001/1490 train_time:44730ms step_avg:44.69ms
+step:1002/1490 train_time:44783ms step_avg:44.69ms
+step:1003/1490 train_time:44865ms step_avg:44.73ms
+step:1004/1490 train_time:44954ms step_avg:44.78ms
+step:1005/1490 train_time:45033ms step_avg:44.81ms
+step:1006/1490 train_time:45117ms step_avg:44.85ms
+step:1007/1490 train_time:45196ms step_avg:44.88ms
+step:1008/1490 train_time:45278ms step_avg:44.92ms
+step:1009/1490 train_time:45355ms step_avg:44.95ms
+step:1010/1490 train_time:45438ms step_avg:44.99ms
+step:1011/1490 train_time:45516ms step_avg:45.02ms
+step:1012/1490 train_time:45600ms step_avg:45.06ms
+step:1013/1490 train_time:45679ms step_avg:45.09ms
+step:1014/1490 train_time:45764ms step_avg:45.13ms
+step:1015/1490 train_time:45846ms step_avg:45.17ms
+step:1016/1490 train_time:45934ms step_avg:45.21ms
+step:1017/1490 train_time:46014ms step_avg:45.25ms
+step:1018/1490 train_time:46099ms step_avg:45.28ms
+step:1019/1490 train_time:46177ms step_avg:45.32ms
+step:1020/1490 train_time:46259ms step_avg:45.35ms
+step:1021/1490 train_time:46337ms step_avg:45.38ms
+step:1022/1490 train_time:46421ms step_avg:45.42ms
+step:1023/1490 train_time:46500ms step_avg:45.45ms
+step:1024/1490 train_time:46583ms step_avg:45.49ms
+step:1025/1490 train_time:46661ms step_avg:45.52ms
+step:1026/1490 train_time:46745ms step_avg:45.56ms
+step:1027/1490 train_time:46826ms step_avg:45.60ms
+step:1028/1490 train_time:46912ms step_avg:45.63ms
+step:1029/1490 train_time:46992ms step_avg:45.67ms
+step:1030/1490 train_time:47076ms step_avg:45.70ms
+step:1031/1490 train_time:47155ms step_avg:45.74ms
+step:1032/1490 train_time:47239ms step_avg:45.77ms
+step:1033/1490 train_time:47317ms step_avg:45.81ms
+step:1034/1490 train_time:47400ms step_avg:45.84ms
+step:1035/1490 train_time:47478ms step_avg:45.87ms
+step:1036/1490 train_time:47561ms step_avg:45.91ms
+step:1037/1490 train_time:47640ms step_avg:45.94ms
+step:1038/1490 train_time:47724ms step_avg:45.98ms
+step:1039/1490 train_time:47805ms step_avg:46.01ms
+step:1040/1490 train_time:47890ms step_avg:46.05ms
+step:1041/1490 train_time:47970ms step_avg:46.08ms
+step:1042/1490 train_time:48055ms step_avg:46.12ms
+step:1043/1490 train_time:48133ms step_avg:46.15ms
+step:1044/1490 train_time:48217ms step_avg:46.18ms
+step:1045/1490 train_time:48295ms step_avg:46.22ms
+step:1046/1490 train_time:48379ms step_avg:46.25ms
+step:1047/1490 train_time:48456ms step_avg:46.28ms
+step:1048/1490 train_time:48540ms step_avg:46.32ms
+step:1049/1490 train_time:48616ms step_avg:46.34ms
+step:1050/1490 train_time:48700ms step_avg:46.38ms
+step:1051/1490 train_time:48780ms step_avg:46.41ms
+step:1052/1490 train_time:48865ms step_avg:46.45ms
+step:1053/1490 train_time:48947ms step_avg:46.48ms
+step:1054/1490 train_time:49032ms step_avg:46.52ms
+step:1055/1490 train_time:49111ms step_avg:46.55ms
+step:1056/1490 train_time:49197ms step_avg:46.59ms
+step:1057/1490 train_time:49275ms step_avg:46.62ms
+step:1058/1490 train_time:49358ms step_avg:46.65ms
+step:1059/1490 train_time:49438ms step_avg:46.68ms
+step:1060/1490 train_time:49521ms step_avg:46.72ms
+step:1061/1490 train_time:49599ms step_avg:46.75ms
+step:1062/1490 train_time:49682ms step_avg:46.78ms
+step:1063/1490 train_time:49762ms step_avg:46.81ms
+step:1064/1490 train_time:49846ms step_avg:46.85ms
+step:1065/1490 train_time:49926ms step_avg:46.88ms
+step:1066/1490 train_time:50010ms step_avg:46.91ms
+step:1067/1490 train_time:50090ms step_avg:46.95ms
+step:1068/1490 train_time:50175ms step_avg:46.98ms
+step:1069/1490 train_time:50254ms step_avg:47.01ms
+step:1070/1490 train_time:50337ms step_avg:47.04ms
+step:1071/1490 train_time:50416ms step_avg:47.07ms
+step:1072/1490 train_time:50500ms step_avg:47.11ms
+step:1073/1490 train_time:50577ms step_avg:47.14ms
+step:1074/1490 train_time:50660ms step_avg:47.17ms
+step:1075/1490 train_time:50739ms step_avg:47.20ms
+step:1076/1490 train_time:50824ms step_avg:47.23ms
+step:1077/1490 train_time:50903ms step_avg:47.26ms
+step:1078/1490 train_time:50988ms step_avg:47.30ms
+step:1079/1490 train_time:51067ms step_avg:47.33ms
+step:1080/1490 train_time:51152ms step_avg:47.36ms
+step:1081/1490 train_time:51231ms step_avg:47.39ms
+step:1082/1490 train_time:51315ms step_avg:47.43ms
+step:1083/1490 train_time:51394ms step_avg:47.45ms
+step:1084/1490 train_time:51476ms step_avg:47.49ms
+step:1085/1490 train_time:51555ms step_avg:47.52ms
+step:1086/1490 train_time:51639ms step_avg:47.55ms
+step:1087/1490 train_time:51717ms step_avg:47.58ms
+step:1088/1490 train_time:51802ms step_avg:47.61ms
+step:1089/1490 train_time:51881ms step_avg:47.64ms
+step:1090/1490 train_time:51967ms step_avg:47.68ms
+step:1091/1490 train_time:52047ms step_avg:47.71ms
+step:1092/1490 train_time:52131ms step_avg:47.74ms
+step:1093/1490 train_time:52210ms step_avg:47.77ms
+step:1094/1490 train_time:52295ms step_avg:47.80ms
+step:1095/1490 train_time:52373ms step_avg:47.83ms
+step:1096/1490 train_time:52455ms step_avg:47.86ms
+step:1097/1490 train_time:52535ms step_avg:47.89ms
+step:1098/1490 train_time:52618ms step_avg:47.92ms
+step:1099/1490 train_time:52697ms step_avg:47.95ms
+step:1100/1490 train_time:52781ms step_avg:47.98ms
+step:1101/1490 train_time:52861ms step_avg:48.01ms
+step:1102/1490 train_time:52945ms step_avg:48.04ms
+step:1103/1490 train_time:53025ms step_avg:48.07ms
+step:1104/1490 train_time:53111ms step_avg:48.11ms
+step:1105/1490 train_time:53190ms step_avg:48.14ms
+step:1106/1490 train_time:53273ms step_avg:48.17ms
+step:1107/1490 train_time:53352ms step_avg:48.19ms
+step:1108/1490 train_time:53437ms step_avg:48.23ms
+step:1109/1490 train_time:53515ms step_avg:48.26ms
+step:1110/1490 train_time:53598ms step_avg:48.29ms
+step:1111/1490 train_time:53675ms step_avg:48.31ms
+step:1112/1490 train_time:53759ms step_avg:48.34ms
+step:1113/1490 train_time:53838ms step_avg:48.37ms
+step:1114/1490 train_time:53923ms step_avg:48.40ms
+step:1115/1490 train_time:54002ms step_avg:48.43ms
+step:1116/1490 train_time:54088ms step_avg:48.47ms
+step:1117/1490 train_time:54166ms step_avg:48.49ms
+step:1118/1490 train_time:54250ms step_avg:48.52ms
+step:1119/1490 train_time:54329ms step_avg:48.55ms
+step:1120/1490 train_time:54413ms step_avg:48.58ms
+step:1121/1490 train_time:54493ms step_avg:48.61ms
+step:1122/1490 train_time:54575ms step_avg:48.64ms
+step:1123/1490 train_time:54653ms step_avg:48.67ms
+step:1124/1490 train_time:54738ms step_avg:48.70ms
+step:1125/1490 train_time:54817ms step_avg:48.73ms
+step:1126/1490 train_time:54902ms step_avg:48.76ms
+step:1127/1490 train_time:54980ms step_avg:48.78ms
+step:1128/1490 train_time:55066ms step_avg:48.82ms
+step:1129/1490 train_time:55145ms step_avg:48.84ms
+step:1130/1490 train_time:55230ms step_avg:48.88ms
+step:1131/1490 train_time:55309ms step_avg:48.90ms
+step:1132/1490 train_time:55394ms step_avg:48.93ms
+step:1133/1490 train_time:55473ms step_avg:48.96ms
+step:1134/1490 train_time:55556ms step_avg:48.99ms
+step:1135/1490 train_time:55635ms step_avg:49.02ms
+step:1136/1490 train_time:55719ms step_avg:49.05ms
+step:1137/1490 train_time:55798ms step_avg:49.07ms
+step:1138/1490 train_time:55882ms step_avg:49.11ms
+step:1139/1490 train_time:55961ms step_avg:49.13ms
+step:1140/1490 train_time:56046ms step_avg:49.16ms
+step:1141/1490 train_time:56125ms step_avg:49.19ms
+step:1142/1490 train_time:56210ms step_avg:49.22ms
+step:1143/1490 train_time:56290ms step_avg:49.25ms
+step:1144/1490 train_time:56375ms step_avg:49.28ms
+step:1145/1490 train_time:56454ms step_avg:49.30ms
+step:1146/1490 train_time:56538ms step_avg:49.34ms
+step:1147/1490 train_time:56617ms step_avg:49.36ms
+step:1148/1490 train_time:56701ms step_avg:49.39ms
+step:1149/1490 train_time:56780ms step_avg:49.42ms
+step:1150/1490 train_time:56863ms step_avg:49.45ms
+step:1151/1490 train_time:56941ms step_avg:49.47ms
+step:1152/1490 train_time:57026ms step_avg:49.50ms
+step:1153/1490 train_time:57104ms step_avg:49.53ms
+step:1154/1490 train_time:57189ms step_avg:49.56ms
+step:1155/1490 train_time:57269ms step_avg:49.58ms
+step:1156/1490 train_time:57353ms step_avg:49.61ms
+step:1157/1490 train_time:57432ms step_avg:49.64ms
+step:1158/1490 train_time:57516ms step_avg:49.67ms
+step:1159/1490 train_time:57595ms step_avg:49.69ms
+step:1160/1490 train_time:57678ms step_avg:49.72ms
+step:1161/1490 train_time:57756ms step_avg:49.75ms
+step:1162/1490 train_time:57840ms step_avg:49.78ms
+step:1163/1490 train_time:57920ms step_avg:49.80ms
+step:1164/1490 train_time:58003ms step_avg:49.83ms
+step:1165/1490 train_time:58083ms step_avg:49.86ms
+step:1166/1490 train_time:58168ms step_avg:49.89ms
+step:1167/1490 train_time:58247ms step_avg:49.91ms
+step:1168/1490 train_time:58332ms step_avg:49.94ms
+step:1169/1490 train_time:58410ms step_avg:49.97ms
+step:1170/1490 train_time:58494ms step_avg:50.00ms
+step:1171/1490 train_time:58574ms step_avg:50.02ms
+step:1172/1490 train_time:58657ms step_avg:50.05ms
+step:1173/1490 train_time:58735ms step_avg:50.07ms
+step:1174/1490 train_time:58819ms step_avg:50.10ms
+step:1175/1490 train_time:58897ms step_avg:50.13ms
+step:1176/1490 train_time:58982ms step_avg:50.15ms
+step:1177/1490 train_time:59062ms step_avg:50.18ms
+step:1178/1490 train_time:59145ms step_avg:50.21ms
+step:1179/1490 train_time:59225ms step_avg:50.23ms
+step:1180/1490 train_time:59310ms step_avg:50.26ms
+step:1181/1490 train_time:59389ms step_avg:50.29ms
+step:1182/1490 train_time:59474ms step_avg:50.32ms
+step:1183/1490 train_time:59552ms step_avg:50.34ms
+step:1184/1490 train_time:59636ms step_avg:50.37ms
+step:1185/1490 train_time:59714ms step_avg:50.39ms
+step:1186/1490 train_time:59799ms step_avg:50.42ms
+step:1187/1490 train_time:59876ms step_avg:50.44ms
+step:1188/1490 train_time:59959ms step_avg:50.47ms
+step:1189/1490 train_time:60038ms step_avg:50.49ms
+step:1190/1490 train_time:60123ms step_avg:50.52ms
+step:1191/1490 train_time:60204ms step_avg:50.55ms
+step:1192/1490 train_time:60290ms step_avg:50.58ms
+step:1193/1490 train_time:60368ms step_avg:50.60ms
+step:1194/1490 train_time:60452ms step_avg:50.63ms
+step:1195/1490 train_time:60533ms step_avg:50.66ms
+step:1196/1490 train_time:60616ms step_avg:50.68ms
+step:1197/1490 train_time:60695ms step_avg:50.71ms
+step:1198/1490 train_time:60778ms step_avg:50.73ms
+step:1199/1490 train_time:60856ms step_avg:50.76ms
+step:1200/1490 train_time:60941ms step_avg:50.78ms
+step:1201/1490 train_time:61020ms step_avg:50.81ms
+step:1202/1490 train_time:61103ms step_avg:50.83ms
+step:1203/1490 train_time:61182ms step_avg:50.86ms
+step:1204/1490 train_time:61267ms step_avg:50.89ms
+step:1205/1490 train_time:61347ms step_avg:50.91ms
+step:1206/1490 train_time:61432ms step_avg:50.94ms
+step:1207/1490 train_time:61511ms step_avg:50.96ms
+step:1208/1490 train_time:61596ms step_avg:50.99ms
+step:1209/1490 train_time:61674ms step_avg:51.01ms
+step:1210/1490 train_time:61757ms step_avg:51.04ms
+step:1211/1490 train_time:61835ms step_avg:51.06ms
+step:1212/1490 train_time:61920ms step_avg:51.09ms
+step:1213/1490 train_time:61998ms step_avg:51.11ms
+step:1214/1490 train_time:62082ms step_avg:51.14ms
+step:1215/1490 train_time:62161ms step_avg:51.16ms
+step:1216/1490 train_time:62245ms step_avg:51.19ms
+step:1217/1490 train_time:62324ms step_avg:51.21ms
+step:1218/1490 train_time:62409ms step_avg:51.24ms
+step:1219/1490 train_time:62490ms step_avg:51.26ms
+step:1220/1490 train_time:62575ms step_avg:51.29ms
+step:1221/1490 train_time:62653ms step_avg:51.31ms
+step:1222/1490 train_time:62736ms step_avg:51.34ms
+step:1223/1490 train_time:62814ms step_avg:51.36ms
+step:1224/1490 train_time:62899ms step_avg:51.39ms
+step:1225/1490 train_time:62975ms step_avg:51.41ms
+step:1226/1490 train_time:63060ms step_avg:51.44ms
+step:1227/1490 train_time:63141ms step_avg:51.46ms
+step:1228/1490 train_time:63225ms step_avg:51.49ms
+step:1229/1490 train_time:63305ms step_avg:51.51ms
+step:1230/1490 train_time:63390ms step_avg:51.54ms
+step:1231/1490 train_time:63470ms step_avg:51.56ms
+step:1232/1490 train_time:63554ms step_avg:51.59ms
+step:1233/1490 train_time:63634ms step_avg:51.61ms
+step:1234/1490 train_time:63717ms step_avg:51.63ms
+step:1235/1490 train_time:63796ms step_avg:51.66ms
+step:1236/1490 train_time:63879ms step_avg:51.68ms
+step:1237/1490 train_time:63956ms step_avg:51.70ms
+step:1238/1490 train_time:64041ms step_avg:51.73ms
+step:1239/1490 train_time:64120ms step_avg:51.75ms
+step:1240/1490 train_time:64204ms step_avg:51.78ms
+step:1241/1490 train_time:64283ms step_avg:51.80ms
+step:1242/1490 train_time:64368ms step_avg:51.83ms
+step:1243/1490 train_time:64448ms step_avg:51.85ms
+step:1244/1490 train_time:64533ms step_avg:51.88ms
+step:1245/1490 train_time:64612ms step_avg:51.90ms
+step:1246/1490 train_time:64696ms step_avg:51.92ms
+step:1247/1490 train_time:64775ms step_avg:51.94ms
+step:1248/1490 train_time:64858ms step_avg:51.97ms
+step:1249/1490 train_time:64936ms step_avg:51.99ms
+step:1250/1490 train_time:65020ms step_avg:52.02ms
+step:1250/1490 val_loss:3.3725 train_time:65115ms step_avg:52.09ms
+step:1251/1490 train_time:65133ms step_avg:52.06ms
+step:1252/1490 train_time:65184ms step_avg:52.06ms
+step:1253/1490 train_time:65260ms step_avg:52.08ms
+step:1254/1490 train_time:65349ms step_avg:52.11ms
+step:1255/1490 train_time:65431ms step_avg:52.14ms
+step:1256/1490 train_time:65514ms step_avg:52.16ms
+step:1257/1490 train_time:65594ms step_avg:52.18ms
+step:1258/1490 train_time:65679ms step_avg:52.21ms
+step:1259/1490 train_time:65757ms step_avg:52.23ms
+step:1260/1490 train_time:65840ms step_avg:52.25ms
+step:1261/1490 train_time:65917ms step_avg:52.27ms
+step:1262/1490 train_time:65999ms step_avg:52.30ms
+step:1263/1490 train_time:66077ms step_avg:52.32ms
+step:1264/1490 train_time:66164ms step_avg:52.34ms
+step:1265/1490 train_time:66245ms step_avg:52.37ms
+step:1266/1490 train_time:66332ms step_avg:52.39ms
+step:1267/1490 train_time:66411ms step_avg:52.42ms
+step:1268/1490 train_time:66496ms step_avg:52.44ms
+step:1269/1490 train_time:66574ms step_avg:52.46ms
+step:1270/1490 train_time:66657ms step_avg:52.49ms
+step:1271/1490 train_time:66735ms step_avg:52.51ms
+step:1272/1490 train_time:66818ms step_avg:52.53ms
+step:1273/1490 train_time:66895ms step_avg:52.55ms
+step:1274/1490 train_time:66979ms step_avg:52.57ms
+step:1275/1490 train_time:67056ms step_avg:52.59ms
+step:1276/1490 train_time:67140ms step_avg:52.62ms
+step:1277/1490 train_time:67221ms step_avg:52.64ms
+step:1278/1490 train_time:67306ms step_avg:52.66ms
+step:1279/1490 train_time:67385ms step_avg:52.69ms
+step:1280/1490 train_time:67470ms step_avg:52.71ms
+step:1281/1490 train_time:67548ms step_avg:52.73ms
+step:1282/1490 train_time:67634ms step_avg:52.76ms
+step:1283/1490 train_time:67712ms step_avg:52.78ms
+step:1284/1490 train_time:67795ms step_avg:52.80ms
+step:1285/1490 train_time:67874ms step_avg:52.82ms
+step:1286/1490 train_time:67958ms step_avg:52.84ms
+step:1287/1490 train_time:68037ms step_avg:52.86ms
+step:1288/1490 train_time:68120ms step_avg:52.89ms
+step:1289/1490 train_time:68200ms step_avg:52.91ms
+step:1290/1490 train_time:68285ms step_avg:52.93ms
+step:1291/1490 train_time:68364ms step_avg:52.95ms
+step:1292/1490 train_time:68448ms step_avg:52.98ms
+step:1293/1490 train_time:68528ms step_avg:53.00ms
+step:1294/1490 train_time:68612ms step_avg:53.02ms
+step:1295/1490 train_time:68691ms step_avg:53.04ms
+step:1296/1490 train_time:68775ms step_avg:53.07ms
+step:1297/1490 train_time:68853ms step_avg:53.09ms
+step:1298/1490 train_time:68938ms step_avg:53.11ms
+step:1299/1490 train_time:69016ms step_avg:53.13ms
+step:1300/1490 train_time:69099ms step_avg:53.15ms
+step:1301/1490 train_time:69179ms step_avg:53.17ms
+step:1302/1490 train_time:69262ms step_avg:53.20ms
+step:1303/1490 train_time:69340ms step_avg:53.22ms
+step:1304/1490 train_time:69424ms step_avg:53.24ms
+step:1305/1490 train_time:69503ms step_avg:53.26ms
+step:1306/1490 train_time:69589ms step_avg:53.28ms
+step:1307/1490 train_time:69668ms step_avg:53.30ms
+step:1308/1490 train_time:69752ms step_avg:53.33ms
+step:1309/1490 train_time:69831ms step_avg:53.35ms
+step:1310/1490 train_time:69915ms step_avg:53.37ms
+step:1311/1490 train_time:69994ms step_avg:53.39ms
+step:1312/1490 train_time:70080ms step_avg:53.41ms
+step:1313/1490 train_time:70159ms step_avg:53.43ms
+step:1314/1490 train_time:70242ms step_avg:53.46ms
+step:1315/1490 train_time:70321ms step_avg:53.48ms
+step:1316/1490 train_time:70405ms step_avg:53.50ms
+step:1317/1490 train_time:70484ms step_avg:53.52ms
+step:1318/1490 train_time:70568ms step_avg:53.54ms
+step:1319/1490 train_time:70647ms step_avg:53.56ms
+step:1320/1490 train_time:70732ms step_avg:53.58ms
+step:1321/1490 train_time:70811ms step_avg:53.60ms
+step:1322/1490 train_time:70895ms step_avg:53.63ms
+step:1323/1490 train_time:70974ms step_avg:53.65ms
+step:1324/1490 train_time:71058ms step_avg:53.67ms
+step:1325/1490 train_time:71137ms step_avg:53.69ms
+step:1326/1490 train_time:71222ms step_avg:53.71ms
+step:1327/1490 train_time:71301ms step_avg:53.73ms
+step:1328/1490 train_time:71385ms step_avg:53.75ms
+step:1329/1490 train_time:71463ms step_avg:53.77ms
+step:1330/1490 train_time:71547ms step_avg:53.79ms
+step:1331/1490 train_time:71625ms step_avg:53.81ms
+step:1332/1490 train_time:71710ms step_avg:53.84ms
+step:1333/1490 train_time:71790ms step_avg:53.86ms
+step:1334/1490 train_time:71876ms step_avg:53.88ms
+step:1335/1490 train_time:71955ms step_avg:53.90ms
+step:1336/1490 train_time:72040ms step_avg:53.92ms
+step:1337/1490 train_time:72119ms step_avg:53.94ms
+step:1338/1490 train_time:72202ms step_avg:53.96ms
+step:1339/1490 train_time:72282ms step_avg:53.98ms
+step:1340/1490 train_time:72365ms step_avg:54.00ms
+step:1341/1490 train_time:72443ms step_avg:54.02ms
+step:1342/1490 train_time:72527ms step_avg:54.04ms
+step:1343/1490 train_time:72604ms step_avg:54.06ms
+step:1344/1490 train_time:72689ms step_avg:54.08ms
+step:1345/1490 train_time:72769ms step_avg:54.10ms
+step:1346/1490 train_time:72853ms step_avg:54.13ms
+step:1347/1490 train_time:72932ms step_avg:54.14ms
+step:1348/1490 train_time:73016ms step_avg:54.17ms
+step:1349/1490 train_time:73096ms step_avg:54.19ms
+step:1350/1490 train_time:73181ms step_avg:54.21ms
+step:1351/1490 train_time:73260ms step_avg:54.23ms
+step:1352/1490 train_time:73342ms step_avg:54.25ms
+step:1353/1490 train_time:73421ms step_avg:54.27ms
+step:1354/1490 train_time:73504ms step_avg:54.29ms
+step:1355/1490 train_time:73582ms step_avg:54.30ms
+step:1356/1490 train_time:73665ms step_avg:54.33ms
+step:1357/1490 train_time:73744ms step_avg:54.34ms
+step:1358/1490 train_time:73830ms step_avg:54.37ms
+step:1359/1490 train_time:73911ms step_avg:54.39ms
+step:1360/1490 train_time:73997ms step_avg:54.41ms
+step:1361/1490 train_time:74075ms step_avg:54.43ms
+step:1362/1490 train_time:74159ms step_avg:54.45ms
+step:1363/1490 train_time:74240ms step_avg:54.47ms
+step:1364/1490 train_time:74323ms step_avg:54.49ms
+step:1365/1490 train_time:74401ms step_avg:54.51ms
+step:1366/1490 train_time:74485ms step_avg:54.53ms
+step:1367/1490 train_time:74564ms step_avg:54.55ms
+step:1368/1490 train_time:74647ms step_avg:54.57ms
+step:1369/1490 train_time:74726ms step_avg:54.58ms
+step:1370/1490 train_time:74809ms step_avg:54.61ms
+step:1371/1490 train_time:74889ms step_avg:54.62ms
+step:1372/1490 train_time:74974ms step_avg:54.65ms
+step:1373/1490 train_time:75053ms step_avg:54.66ms
+step:1374/1490 train_time:75138ms step_avg:54.69ms
+step:1375/1490 train_time:75217ms step_avg:54.70ms
+step:1376/1490 train_time:75301ms step_avg:54.72ms
+step:1377/1490 train_time:75381ms step_avg:54.74ms
+step:1378/1490 train_time:75464ms step_avg:54.76ms
+step:1379/1490 train_time:75541ms step_avg:54.78ms
+step:1380/1490 train_time:75626ms step_avg:54.80ms
+step:1381/1490 train_time:75704ms step_avg:54.82ms
+step:1382/1490 train_time:75788ms step_avg:54.84ms
+step:1383/1490 train_time:75868ms step_avg:54.86ms
+step:1384/1490 train_time:75953ms step_avg:54.88ms
+step:1385/1490 train_time:76033ms step_avg:54.90ms
+step:1386/1490 train_time:76117ms step_avg:54.92ms
+step:1387/1490 train_time:76196ms step_avg:54.94ms
+step:1388/1490 train_time:76283ms step_avg:54.96ms
+step:1389/1490 train_time:76360ms step_avg:54.98ms
+step:1390/1490 train_time:76444ms step_avg:55.00ms
+step:1391/1490 train_time:76522ms step_avg:55.01ms
+step:1392/1490 train_time:76607ms step_avg:55.03ms
+step:1393/1490 train_time:76685ms step_avg:55.05ms
+step:1394/1490 train_time:76769ms step_avg:55.07ms
+step:1395/1490 train_time:76848ms step_avg:55.09ms
+step:1396/1490 train_time:76932ms step_avg:55.11ms
+step:1397/1490 train_time:77011ms step_avg:55.13ms
+step:1398/1490 train_time:77095ms step_avg:55.15ms
+step:1399/1490 train_time:77175ms step_avg:55.16ms
+step:1400/1490 train_time:77260ms step_avg:55.19ms
+step:1401/1490 train_time:77339ms step_avg:55.20ms
+step:1402/1490 train_time:77422ms step_avg:55.22ms
+step:1403/1490 train_time:77500ms step_avg:55.24ms
+step:1404/1490 train_time:77584ms step_avg:55.26ms
+step:1405/1490 train_time:77662ms step_avg:55.28ms
+step:1406/1490 train_time:77745ms step_avg:55.30ms
+step:1407/1490 train_time:77824ms step_avg:55.31ms
+step:1408/1490 train_time:77909ms step_avg:55.33ms
+step:1409/1490 train_time:77989ms step_avg:55.35ms
+step:1410/1490 train_time:78076ms step_avg:55.37ms
+step:1411/1490 train_time:78155ms step_avg:55.39ms
+step:1412/1490 train_time:78239ms step_avg:55.41ms
+step:1413/1490 train_time:78319ms step_avg:55.43ms
+step:1414/1490 train_time:78403ms step_avg:55.45ms
+step:1415/1490 train_time:78481ms step_avg:55.46ms
+step:1416/1490 train_time:78564ms step_avg:55.48ms
+step:1417/1490 train_time:78642ms step_avg:55.50ms
+step:1418/1490 train_time:78726ms step_avg:55.52ms
+step:1419/1490 train_time:78804ms step_avg:55.53ms
+step:1420/1490 train_time:78888ms step_avg:55.56ms
+step:1421/1490 train_time:78968ms step_avg:55.57ms
+step:1422/1490 train_time:79053ms step_avg:55.59ms
+step:1423/1490 train_time:79134ms step_avg:55.61ms
+step:1424/1490 train_time:79218ms step_avg:55.63ms
+step:1425/1490 train_time:79298ms step_avg:55.65ms
+step:1426/1490 train_time:79382ms step_avg:55.67ms
+step:1427/1490 train_time:79460ms step_avg:55.68ms
+step:1428/1490 train_time:79543ms step_avg:55.70ms
+step:1429/1490 train_time:79621ms step_avg:55.72ms
+step:1430/1490 train_time:79706ms step_avg:55.74ms
+step:1431/1490 train_time:79784ms step_avg:55.75ms
+step:1432/1490 train_time:79868ms step_avg:55.77ms
+step:1433/1490 train_time:79947ms step_avg:55.79ms
+step:1434/1490 train_time:80034ms step_avg:55.81ms
+step:1435/1490 train_time:80114ms step_avg:55.83ms
+step:1436/1490 train_time:80200ms step_avg:55.85ms
+step:1437/1490 train_time:80279ms step_avg:55.87ms
+step:1438/1490 train_time:80363ms step_avg:55.89ms
+step:1439/1490 train_time:80440ms step_avg:55.90ms
+step:1440/1490 train_time:80524ms step_avg:55.92ms
+step:1441/1490 train_time:80601ms step_avg:55.93ms
+step:1442/1490 train_time:80686ms step_avg:55.95ms
+step:1443/1490 train_time:80764ms step_avg:55.97ms
+step:1444/1490 train_time:80848ms step_avg:55.99ms
+step:1445/1490 train_time:80927ms step_avg:56.00ms
+step:1446/1490 train_time:81013ms step_avg:56.03ms
+step:1447/1490 train_time:81093ms step_avg:56.04ms
+step:1448/1490 train_time:81180ms step_avg:56.06ms
+step:1449/1490 train_time:81258ms step_avg:56.08ms
+step:1450/1490 train_time:81341ms step_avg:56.10ms
+step:1451/1490 train_time:81424ms step_avg:56.12ms
+step:1452/1490 train_time:81509ms step_avg:56.14ms
+step:1453/1490 train_time:81588ms step_avg:56.15ms
+step:1454/1490 train_time:81672ms step_avg:56.17ms
+step:1455/1490 train_time:81751ms step_avg:56.19ms
+step:1456/1490 train_time:81834ms step_avg:56.20ms
+step:1457/1490 train_time:81913ms step_avg:56.22ms
+step:1458/1490 train_time:81998ms step_avg:56.24ms
+step:1459/1490 train_time:82077ms step_avg:56.26ms
+step:1460/1490 train_time:82163ms step_avg:56.28ms
+step:1461/1490 train_time:82242ms step_avg:56.29ms
+step:1462/1490 train_time:82325ms step_avg:56.31ms
+step:1463/1490 train_time:82404ms step_avg:56.33ms
+step:1464/1490 train_time:82489ms step_avg:56.34ms
+step:1465/1490 train_time:82568ms step_avg:56.36ms
+step:1466/1490 train_time:82651ms step_avg:56.38ms
+step:1467/1490 train_time:82730ms step_avg:56.39ms
+step:1468/1490 train_time:82815ms step_avg:56.41ms
+step:1469/1490 train_time:82893ms step_avg:56.43ms
+step:1470/1490 train_time:82977ms step_avg:56.45ms
+step:1471/1490 train_time:83057ms step_avg:56.46ms
+step:1472/1490 train_time:83141ms step_avg:56.48ms
+step:1473/1490 train_time:83221ms step_avg:56.50ms
+step:1474/1490 train_time:83306ms step_avg:56.52ms
+step:1475/1490 train_time:83385ms step_avg:56.53ms
+step:1476/1490 train_time:83470ms step_avg:56.55ms
+step:1477/1490 train_time:83549ms step_avg:56.57ms
+step:1478/1490 train_time:83633ms step_avg:56.59ms
+step:1479/1490 train_time:83712ms step_avg:56.60ms
+step:1480/1490 train_time:83797ms step_avg:56.62ms
+step:1481/1490 train_time:83875ms step_avg:56.63ms
+step:1482/1490 train_time:83959ms step_avg:56.65ms
+step:1483/1490 train_time:84039ms step_avg:56.67ms
+step:1484/1490 train_time:84123ms step_avg:56.69ms
+step:1485/1490 train_time:84201ms step_avg:56.70ms
+step:1486/1490 train_time:84285ms step_avg:56.72ms
+step:1487/1490 train_time:84363ms step_avg:56.73ms
+step:1488/1490 train_time:84447ms step_avg:56.75ms
+step:1489/1490 train_time:84528ms step_avg:56.77ms
+step:1490/1490 train_time:84613ms step_avg:56.79ms
+step:1490/1490 val_loss:3.2804 train_time:84709ms step_avg:56.85ms
+peak memory allocated: 31204 MiB reserved: 45306 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/92ed97f0-3326-45da-b6c9-0961b7e5ae9c.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/92ed97f0-3326-45da-b6c9-0961b7e5ae9c.txt
@@ -1,0 +1,4804 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 21:52:09 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8306 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:85ms step_avg:84.57ms
+step:2/1490 train_time:107ms step_avg:53.75ms
+step:3/1490 train_time:125ms step_avg:41.57ms
+step:4/1490 train_time:154ms step_avg:38.62ms
+step:5/1490 train_time:181ms step_avg:36.12ms
+step:6/1490 train_time:215ms step_avg:35.80ms
+step:7/1490 train_time:242ms step_avg:34.51ms
+step:8/1490 train_time:276ms step_avg:34.50ms
+step:9/1490 train_time:302ms step_avg:33.61ms
+step:10/1490 train_time:337ms step_avg:33.68ms
+step:11/1490 train_time:363ms step_avg:33.04ms
+step:12/1490 train_time:398ms step_avg:33.18ms
+step:13/1490 train_time:425ms step_avg:32.68ms
+step:14/1490 train_time:459ms step_avg:32.79ms
+step:15/1490 train_time:486ms step_avg:32.42ms
+step:16/1490 train_time:520ms step_avg:32.52ms
+step:17/1490 train_time:547ms step_avg:32.21ms
+step:18/1490 train_time:582ms step_avg:32.32ms
+step:19/1490 train_time:608ms step_avg:32.01ms
+step:20/1490 train_time:642ms step_avg:32.12ms
+step:21/1490 train_time:669ms step_avg:31.88ms
+step:22/1490 train_time:704ms step_avg:32.00ms
+step:23/1490 train_time:730ms step_avg:31.74ms
+step:24/1490 train_time:764ms step_avg:31.84ms
+step:25/1490 train_time:791ms step_avg:31.65ms
+step:26/1490 train_time:825ms step_avg:31.73ms
+step:27/1490 train_time:852ms step_avg:31.56ms
+step:28/1490 train_time:886ms step_avg:31.65ms
+step:29/1490 train_time:913ms step_avg:31.49ms
+step:30/1490 train_time:947ms step_avg:31.56ms
+step:31/1490 train_time:974ms step_avg:31.42ms
+step:32/1490 train_time:1008ms step_avg:31.49ms
+step:33/1490 train_time:1035ms step_avg:31.36ms
+step:34/1490 train_time:1069ms step_avg:31.44ms
+step:35/1490 train_time:1096ms step_avg:31.32ms
+step:36/1490 train_time:1131ms step_avg:31.41ms
+step:37/1490 train_time:1158ms step_avg:31.29ms
+step:38/1490 train_time:1192ms step_avg:31.37ms
+step:39/1490 train_time:1219ms step_avg:31.27ms
+step:40/1490 train_time:1254ms step_avg:31.35ms
+step:41/1490 train_time:1281ms step_avg:31.25ms
+step:42/1490 train_time:1315ms step_avg:31.32ms
+step:43/1490 train_time:1342ms step_avg:31.22ms
+step:44/1490 train_time:1377ms step_avg:31.29ms
+step:45/1490 train_time:1404ms step_avg:31.19ms
+step:46/1490 train_time:1438ms step_avg:31.26ms
+step:47/1490 train_time:1464ms step_avg:31.16ms
+step:48/1490 train_time:1499ms step_avg:31.23ms
+step:49/1490 train_time:1526ms step_avg:31.14ms
+step:50/1490 train_time:1560ms step_avg:31.20ms
+step:51/1490 train_time:1587ms step_avg:31.12ms
+step:52/1490 train_time:1621ms step_avg:31.18ms
+step:53/1490 train_time:1648ms step_avg:31.09ms
+step:54/1490 train_time:1682ms step_avg:31.15ms
+step:55/1490 train_time:1709ms step_avg:31.07ms
+step:56/1490 train_time:1743ms step_avg:31.12ms
+step:57/1490 train_time:1770ms step_avg:31.04ms
+step:58/1490 train_time:1804ms step_avg:31.10ms
+step:59/1490 train_time:1830ms step_avg:31.02ms
+step:60/1490 train_time:1864ms step_avg:31.07ms
+step:61/1490 train_time:1891ms step_avg:31.00ms
+step:62/1490 train_time:1925ms step_avg:31.04ms
+step:63/1490 train_time:1952ms step_avg:30.98ms
+step:64/1490 train_time:1986ms step_avg:31.03ms
+step:65/1490 train_time:2013ms step_avg:30.96ms
+step:66/1490 train_time:2046ms step_avg:31.00ms
+step:67/1490 train_time:2073ms step_avg:30.95ms
+step:68/1490 train_time:2107ms step_avg:30.99ms
+step:69/1490 train_time:2134ms step_avg:30.93ms
+step:70/1490 train_time:2168ms step_avg:30.97ms
+step:71/1490 train_time:2195ms step_avg:30.92ms
+step:72/1490 train_time:2229ms step_avg:30.96ms
+step:73/1490 train_time:2256ms step_avg:30.90ms
+step:74/1490 train_time:2290ms step_avg:30.94ms
+step:75/1490 train_time:2317ms step_avg:30.89ms
+step:76/1490 train_time:2352ms step_avg:30.94ms
+step:77/1490 train_time:2379ms step_avg:30.90ms
+step:78/1490 train_time:2414ms step_avg:30.95ms
+step:79/1490 train_time:2441ms step_avg:30.89ms
+step:80/1490 train_time:2474ms step_avg:30.93ms
+step:81/1490 train_time:2501ms step_avg:30.88ms
+step:82/1490 train_time:2535ms step_avg:30.92ms
+step:83/1490 train_time:2562ms step_avg:30.87ms
+step:84/1490 train_time:2597ms step_avg:30.91ms
+step:85/1490 train_time:2624ms step_avg:30.87ms
+step:86/1490 train_time:2658ms step_avg:30.91ms
+step:87/1490 train_time:2685ms step_avg:30.86ms
+step:88/1490 train_time:2719ms step_avg:30.90ms
+step:89/1490 train_time:2746ms step_avg:30.86ms
+step:90/1490 train_time:2780ms step_avg:30.89ms
+step:91/1490 train_time:2807ms step_avg:30.85ms
+step:92/1490 train_time:2841ms step_avg:30.88ms
+step:93/1490 train_time:2868ms step_avg:30.84ms
+step:94/1490 train_time:2902ms step_avg:30.87ms
+step:95/1490 train_time:2928ms step_avg:30.83ms
+step:96/1490 train_time:2962ms step_avg:30.86ms
+step:97/1490 train_time:2989ms step_avg:30.82ms
+step:98/1490 train_time:3023ms step_avg:30.85ms
+step:99/1490 train_time:3050ms step_avg:30.81ms
+step:100/1490 train_time:3084ms step_avg:30.84ms
+step:101/1490 train_time:3110ms step_avg:30.80ms
+step:102/1490 train_time:3144ms step_avg:30.83ms
+step:103/1490 train_time:3171ms step_avg:30.79ms
+step:104/1490 train_time:3205ms step_avg:30.81ms
+step:105/1490 train_time:3232ms step_avg:30.78ms
+step:106/1490 train_time:3265ms step_avg:30.80ms
+step:107/1490 train_time:3292ms step_avg:30.77ms
+step:108/1490 train_time:3326ms step_avg:30.80ms
+step:109/1490 train_time:3353ms step_avg:30.77ms
+step:110/1490 train_time:3387ms step_avg:30.79ms
+step:111/1490 train_time:3414ms step_avg:30.76ms
+step:112/1490 train_time:3448ms step_avg:30.79ms
+step:113/1490 train_time:3475ms step_avg:30.75ms
+step:114/1490 train_time:3509ms step_avg:30.78ms
+step:115/1490 train_time:3537ms step_avg:30.75ms
+step:116/1490 train_time:3571ms step_avg:30.78ms
+step:117/1490 train_time:3598ms step_avg:30.75ms
+step:118/1490 train_time:3632ms step_avg:30.78ms
+step:119/1490 train_time:3659ms step_avg:30.75ms
+step:120/1490 train_time:3694ms step_avg:30.78ms
+step:121/1490 train_time:3721ms step_avg:30.75ms
+step:122/1490 train_time:3755ms step_avg:30.78ms
+step:123/1490 train_time:3782ms step_avg:30.74ms
+step:124/1490 train_time:3816ms step_avg:30.77ms
+step:125/1490 train_time:3842ms step_avg:30.74ms
+step:126/1490 train_time:3877ms step_avg:30.77ms
+step:127/1490 train_time:3904ms step_avg:30.74ms
+step:128/1490 train_time:3938ms step_avg:30.76ms
+step:129/1490 train_time:3965ms step_avg:30.73ms
+step:130/1490 train_time:3999ms step_avg:30.76ms
+step:131/1490 train_time:4026ms step_avg:30.73ms
+step:132/1490 train_time:4060ms step_avg:30.76ms
+step:133/1490 train_time:4087ms step_avg:30.73ms
+step:134/1490 train_time:4121ms step_avg:30.76ms
+step:135/1490 train_time:4148ms step_avg:30.73ms
+step:136/1490 train_time:4183ms step_avg:30.75ms
+step:137/1490 train_time:4209ms step_avg:30.72ms
+step:138/1490 train_time:4243ms step_avg:30.75ms
+step:139/1490 train_time:4270ms step_avg:30.72ms
+step:140/1490 train_time:4304ms step_avg:30.74ms
+step:141/1490 train_time:4331ms step_avg:30.72ms
+step:142/1490 train_time:4365ms step_avg:30.74ms
+step:143/1490 train_time:4392ms step_avg:30.71ms
+step:144/1490 train_time:4426ms step_avg:30.73ms
+step:145/1490 train_time:4453ms step_avg:30.71ms
+step:146/1490 train_time:4486ms step_avg:30.73ms
+step:147/1490 train_time:4513ms step_avg:30.70ms
+step:148/1490 train_time:4547ms step_avg:30.72ms
+step:149/1490 train_time:4574ms step_avg:30.70ms
+step:150/1490 train_time:4608ms step_avg:30.72ms
+step:151/1490 train_time:4636ms step_avg:30.70ms
+step:152/1490 train_time:4669ms step_avg:30.72ms
+step:153/1490 train_time:4696ms step_avg:30.69ms
+step:154/1490 train_time:4730ms step_avg:30.72ms
+step:155/1490 train_time:4757ms step_avg:30.69ms
+step:156/1490 train_time:4791ms step_avg:30.71ms
+step:157/1490 train_time:4818ms step_avg:30.69ms
+step:158/1490 train_time:4852ms step_avg:30.71ms
+step:159/1490 train_time:4879ms step_avg:30.69ms
+step:160/1490 train_time:4914ms step_avg:30.71ms
+step:161/1490 train_time:4940ms step_avg:30.68ms
+step:162/1490 train_time:4974ms step_avg:30.71ms
+step:163/1490 train_time:5001ms step_avg:30.68ms
+step:164/1490 train_time:5035ms step_avg:30.70ms
+step:165/1490 train_time:5062ms step_avg:30.68ms
+step:166/1490 train_time:5097ms step_avg:30.70ms
+step:167/1490 train_time:5123ms step_avg:30.68ms
+step:168/1490 train_time:5158ms step_avg:30.70ms
+step:169/1490 train_time:5185ms step_avg:30.68ms
+step:170/1490 train_time:5219ms step_avg:30.70ms
+step:171/1490 train_time:5246ms step_avg:30.68ms
+step:172/1490 train_time:5280ms step_avg:30.70ms
+step:173/1490 train_time:5307ms step_avg:30.68ms
+step:174/1490 train_time:5341ms step_avg:30.70ms
+step:175/1490 train_time:5368ms step_avg:30.68ms
+step:176/1490 train_time:5402ms step_avg:30.69ms
+step:177/1490 train_time:5430ms step_avg:30.68ms
+step:178/1490 train_time:5464ms step_avg:30.69ms
+step:179/1490 train_time:5490ms step_avg:30.67ms
+step:180/1490 train_time:5524ms step_avg:30.69ms
+step:181/1490 train_time:5551ms step_avg:30.67ms
+step:182/1490 train_time:5585ms step_avg:30.69ms
+step:183/1490 train_time:5612ms step_avg:30.67ms
+step:184/1490 train_time:5646ms step_avg:30.68ms
+step:185/1490 train_time:5673ms step_avg:30.66ms
+step:186/1490 train_time:5706ms step_avg:30.68ms
+step:187/1490 train_time:5733ms step_avg:30.66ms
+step:188/1490 train_time:5767ms step_avg:30.67ms
+step:189/1490 train_time:5794ms step_avg:30.66ms
+step:190/1490 train_time:5828ms step_avg:30.67ms
+step:191/1490 train_time:5855ms step_avg:30.65ms
+step:192/1490 train_time:5888ms step_avg:30.67ms
+step:193/1490 train_time:5915ms step_avg:30.65ms
+step:194/1490 train_time:5949ms step_avg:30.67ms
+step:195/1490 train_time:5977ms step_avg:30.65ms
+step:196/1490 train_time:6011ms step_avg:30.67ms
+step:197/1490 train_time:6038ms step_avg:30.65ms
+step:198/1490 train_time:6072ms step_avg:30.66ms
+step:199/1490 train_time:6099ms step_avg:30.65ms
+step:200/1490 train_time:6133ms step_avg:30.67ms
+step:201/1490 train_time:6160ms step_avg:30.65ms
+step:202/1490 train_time:6194ms step_avg:30.67ms
+step:203/1490 train_time:6221ms step_avg:30.65ms
+step:204/1490 train_time:6257ms step_avg:30.67ms
+step:205/1490 train_time:6283ms step_avg:30.65ms
+step:206/1490 train_time:6317ms step_avg:30.67ms
+step:207/1490 train_time:6344ms step_avg:30.65ms
+step:208/1490 train_time:6378ms step_avg:30.66ms
+step:209/1490 train_time:6405ms step_avg:30.65ms
+step:210/1490 train_time:6439ms step_avg:30.66ms
+step:211/1490 train_time:6466ms step_avg:30.65ms
+step:212/1490 train_time:6501ms step_avg:30.66ms
+step:213/1490 train_time:6528ms step_avg:30.65ms
+step:214/1490 train_time:6562ms step_avg:30.66ms
+step:215/1490 train_time:6589ms step_avg:30.65ms
+step:216/1490 train_time:6623ms step_avg:30.66ms
+step:217/1490 train_time:6649ms step_avg:30.64ms
+step:218/1490 train_time:6683ms step_avg:30.66ms
+step:219/1490 train_time:6710ms step_avg:30.64ms
+step:220/1490 train_time:6744ms step_avg:30.65ms
+step:221/1490 train_time:6771ms step_avg:30.64ms
+step:222/1490 train_time:6804ms step_avg:30.65ms
+step:223/1490 train_time:6832ms step_avg:30.64ms
+step:224/1490 train_time:6865ms step_avg:30.65ms
+step:225/1490 train_time:6892ms step_avg:30.63ms
+step:226/1490 train_time:6926ms step_avg:30.65ms
+step:227/1490 train_time:6953ms step_avg:30.63ms
+step:228/1490 train_time:6987ms step_avg:30.64ms
+step:229/1490 train_time:7013ms step_avg:30.63ms
+step:230/1490 train_time:7047ms step_avg:30.64ms
+step:231/1490 train_time:7074ms step_avg:30.62ms
+step:232/1490 train_time:7108ms step_avg:30.64ms
+step:233/1490 train_time:7135ms step_avg:30.62ms
+step:234/1490 train_time:7168ms step_avg:30.63ms
+step:235/1490 train_time:7196ms step_avg:30.62ms
+step:236/1490 train_time:7229ms step_avg:30.63ms
+step:237/1490 train_time:7257ms step_avg:30.62ms
+step:238/1490 train_time:7291ms step_avg:30.63ms
+step:239/1490 train_time:7318ms step_avg:30.62ms
+step:240/1490 train_time:7352ms step_avg:30.63ms
+step:241/1490 train_time:7379ms step_avg:30.62ms
+step:242/1490 train_time:7413ms step_avg:30.63ms
+step:243/1490 train_time:7441ms step_avg:30.62ms
+step:244/1490 train_time:7475ms step_avg:30.63ms
+step:245/1490 train_time:7502ms step_avg:30.62ms
+step:246/1490 train_time:7536ms step_avg:30.64ms
+step:247/1490 train_time:7563ms step_avg:30.62ms
+step:248/1490 train_time:7598ms step_avg:30.64ms
+step:249/1490 train_time:7625ms step_avg:30.62ms
+step:250/1490 train_time:7659ms step_avg:30.63ms
+step:250/1490 val_loss:4.5024 train_time:7697ms step_avg:30.79ms
+step:251/1490 train_time:7716ms step_avg:30.74ms
+step:252/1490 train_time:7735ms step_avg:30.69ms
+step:253/1490 train_time:7750ms step_avg:30.63ms
+step:254/1490 train_time:7784ms step_avg:30.65ms
+step:255/1490 train_time:7813ms step_avg:30.64ms
+step:256/1490 train_time:7848ms step_avg:30.66ms
+step:257/1490 train_time:7876ms step_avg:30.64ms
+step:258/1490 train_time:7910ms step_avg:30.66ms
+step:259/1490 train_time:7937ms step_avg:30.64ms
+step:260/1490 train_time:7971ms step_avg:30.66ms
+step:261/1490 train_time:7998ms step_avg:30.64ms
+step:262/1490 train_time:8032ms step_avg:30.66ms
+step:263/1490 train_time:8059ms step_avg:30.64ms
+step:264/1490 train_time:8093ms step_avg:30.66ms
+step:265/1490 train_time:8120ms step_avg:30.64ms
+step:266/1490 train_time:8154ms step_avg:30.65ms
+step:267/1490 train_time:8181ms step_avg:30.64ms
+step:268/1490 train_time:8215ms step_avg:30.65ms
+step:269/1490 train_time:8241ms step_avg:30.64ms
+step:270/1490 train_time:8275ms step_avg:30.65ms
+step:271/1490 train_time:8302ms step_avg:30.63ms
+step:272/1490 train_time:8336ms step_avg:30.65ms
+step:273/1490 train_time:8362ms step_avg:30.63ms
+step:274/1490 train_time:8396ms step_avg:30.64ms
+step:275/1490 train_time:8423ms step_avg:30.63ms
+step:276/1490 train_time:8457ms step_avg:30.64ms
+step:277/1490 train_time:8484ms step_avg:30.63ms
+step:278/1490 train_time:8518ms step_avg:30.64ms
+step:279/1490 train_time:8545ms step_avg:30.63ms
+step:280/1490 train_time:8578ms step_avg:30.64ms
+step:281/1490 train_time:8605ms step_avg:30.62ms
+step:282/1490 train_time:8640ms step_avg:30.64ms
+step:283/1490 train_time:8666ms step_avg:30.62ms
+step:284/1490 train_time:8700ms step_avg:30.63ms
+step:285/1490 train_time:8727ms step_avg:30.62ms
+step:286/1490 train_time:8761ms step_avg:30.63ms
+step:287/1490 train_time:8788ms step_avg:30.62ms
+step:288/1490 train_time:8822ms step_avg:30.63ms
+step:289/1490 train_time:8849ms step_avg:30.62ms
+step:290/1490 train_time:8883ms step_avg:30.63ms
+step:291/1490 train_time:8911ms step_avg:30.62ms
+step:292/1490 train_time:8945ms step_avg:30.63ms
+step:293/1490 train_time:8972ms step_avg:30.62ms
+step:294/1490 train_time:9007ms step_avg:30.64ms
+step:295/1490 train_time:9034ms step_avg:30.62ms
+step:296/1490 train_time:9068ms step_avg:30.64ms
+step:297/1490 train_time:9095ms step_avg:30.62ms
+step:298/1490 train_time:9130ms step_avg:30.64ms
+step:299/1490 train_time:9157ms step_avg:30.62ms
+step:300/1490 train_time:9191ms step_avg:30.64ms
+step:301/1490 train_time:9218ms step_avg:30.62ms
+step:302/1490 train_time:9252ms step_avg:30.64ms
+step:303/1490 train_time:9278ms step_avg:30.62ms
+step:304/1490 train_time:9313ms step_avg:30.63ms
+step:305/1490 train_time:9340ms step_avg:30.62ms
+step:306/1490 train_time:9374ms step_avg:30.63ms
+step:307/1490 train_time:9400ms step_avg:30.62ms
+step:308/1490 train_time:9435ms step_avg:30.63ms
+step:309/1490 train_time:9462ms step_avg:30.62ms
+step:310/1490 train_time:9496ms step_avg:30.63ms
+step:311/1490 train_time:9522ms step_avg:30.62ms
+step:312/1490 train_time:9557ms step_avg:30.63ms
+step:313/1490 train_time:9584ms step_avg:30.62ms
+step:314/1490 train_time:9618ms step_avg:30.63ms
+step:315/1490 train_time:9644ms step_avg:30.62ms
+step:316/1490 train_time:9678ms step_avg:30.63ms
+step:317/1490 train_time:9705ms step_avg:30.61ms
+step:318/1490 train_time:9739ms step_avg:30.63ms
+step:319/1490 train_time:9766ms step_avg:30.61ms
+step:320/1490 train_time:9800ms step_avg:30.62ms
+step:321/1490 train_time:9827ms step_avg:30.61ms
+step:322/1490 train_time:9861ms step_avg:30.62ms
+step:323/1490 train_time:9888ms step_avg:30.61ms
+step:324/1490 train_time:9922ms step_avg:30.62ms
+step:325/1490 train_time:9949ms step_avg:30.61ms
+step:326/1490 train_time:9983ms step_avg:30.62ms
+step:327/1490 train_time:10010ms step_avg:30.61ms
+step:328/1490 train_time:10044ms step_avg:30.62ms
+step:329/1490 train_time:10071ms step_avg:30.61ms
+step:330/1490 train_time:10105ms step_avg:30.62ms
+step:331/1490 train_time:10133ms step_avg:30.61ms
+step:332/1490 train_time:10167ms step_avg:30.62ms
+step:333/1490 train_time:10194ms step_avg:30.61ms
+step:334/1490 train_time:10228ms step_avg:30.62ms
+step:335/1490 train_time:10255ms step_avg:30.61ms
+step:336/1490 train_time:10289ms step_avg:30.62ms
+step:337/1490 train_time:10316ms step_avg:30.61ms
+step:338/1490 train_time:10351ms step_avg:30.62ms
+step:339/1490 train_time:10377ms step_avg:30.61ms
+step:340/1490 train_time:10411ms step_avg:30.62ms
+step:341/1490 train_time:10439ms step_avg:30.61ms
+step:342/1490 train_time:10473ms step_avg:30.62ms
+step:343/1490 train_time:10500ms step_avg:30.61ms
+step:344/1490 train_time:10534ms step_avg:30.62ms
+step:345/1490 train_time:10561ms step_avg:30.61ms
+step:346/1490 train_time:10595ms step_avg:30.62ms
+step:347/1490 train_time:10622ms step_avg:30.61ms
+step:348/1490 train_time:10656ms step_avg:30.62ms
+step:349/1490 train_time:10683ms step_avg:30.61ms
+step:350/1490 train_time:10717ms step_avg:30.62ms
+step:351/1490 train_time:10744ms step_avg:30.61ms
+step:352/1490 train_time:10779ms step_avg:30.62ms
+step:353/1490 train_time:10806ms step_avg:30.61ms
+step:354/1490 train_time:10839ms step_avg:30.62ms
+step:355/1490 train_time:10867ms step_avg:30.61ms
+step:356/1490 train_time:10900ms step_avg:30.62ms
+step:357/1490 train_time:10928ms step_avg:30.61ms
+step:358/1490 train_time:10961ms step_avg:30.62ms
+step:359/1490 train_time:10989ms step_avg:30.61ms
+step:360/1490 train_time:11022ms step_avg:30.62ms
+step:361/1490 train_time:11049ms step_avg:30.61ms
+step:362/1490 train_time:11083ms step_avg:30.62ms
+step:363/1490 train_time:11111ms step_avg:30.61ms
+step:364/1490 train_time:11145ms step_avg:30.62ms
+step:365/1490 train_time:11171ms step_avg:30.61ms
+step:366/1490 train_time:11206ms step_avg:30.62ms
+step:367/1490 train_time:11233ms step_avg:30.61ms
+step:368/1490 train_time:11267ms step_avg:30.62ms
+step:369/1490 train_time:11294ms step_avg:30.61ms
+step:370/1490 train_time:11328ms step_avg:30.62ms
+step:371/1490 train_time:11355ms step_avg:30.61ms
+step:372/1490 train_time:11390ms step_avg:30.62ms
+step:373/1490 train_time:11417ms step_avg:30.61ms
+step:374/1490 train_time:11451ms step_avg:30.62ms
+step:375/1490 train_time:11478ms step_avg:30.61ms
+step:376/1490 train_time:11513ms step_avg:30.62ms
+step:377/1490 train_time:11539ms step_avg:30.61ms
+step:378/1490 train_time:11574ms step_avg:30.62ms
+step:379/1490 train_time:11600ms step_avg:30.61ms
+step:380/1490 train_time:11635ms step_avg:30.62ms
+step:381/1490 train_time:11662ms step_avg:30.61ms
+step:382/1490 train_time:11696ms step_avg:30.62ms
+step:383/1490 train_time:11723ms step_avg:30.61ms
+step:384/1490 train_time:11757ms step_avg:30.62ms
+step:385/1490 train_time:11784ms step_avg:30.61ms
+step:386/1490 train_time:11818ms step_avg:30.62ms
+step:387/1490 train_time:11845ms step_avg:30.61ms
+step:388/1490 train_time:11879ms step_avg:30.62ms
+step:389/1490 train_time:11906ms step_avg:30.61ms
+step:390/1490 train_time:11940ms step_avg:30.61ms
+step:391/1490 train_time:11967ms step_avg:30.61ms
+step:392/1490 train_time:12000ms step_avg:30.61ms
+step:393/1490 train_time:12027ms step_avg:30.60ms
+step:394/1490 train_time:12061ms step_avg:30.61ms
+step:395/1490 train_time:12088ms step_avg:30.60ms
+step:396/1490 train_time:12122ms step_avg:30.61ms
+step:397/1490 train_time:12149ms step_avg:30.60ms
+step:398/1490 train_time:12182ms step_avg:30.61ms
+step:399/1490 train_time:12210ms step_avg:30.60ms
+step:400/1490 train_time:12244ms step_avg:30.61ms
+step:401/1490 train_time:12271ms step_avg:30.60ms
+step:402/1490 train_time:12305ms step_avg:30.61ms
+step:403/1490 train_time:12332ms step_avg:30.60ms
+step:404/1490 train_time:12367ms step_avg:30.61ms
+step:405/1490 train_time:12394ms step_avg:30.60ms
+step:406/1490 train_time:12428ms step_avg:30.61ms
+step:407/1490 train_time:12455ms step_avg:30.60ms
+step:408/1490 train_time:12490ms step_avg:30.61ms
+step:409/1490 train_time:12517ms step_avg:30.60ms
+step:410/1490 train_time:12551ms step_avg:30.61ms
+step:411/1490 train_time:12578ms step_avg:30.60ms
+step:412/1490 train_time:12612ms step_avg:30.61ms
+step:413/1490 train_time:12639ms step_avg:30.60ms
+step:414/1490 train_time:12673ms step_avg:30.61ms
+step:415/1490 train_time:12700ms step_avg:30.60ms
+step:416/1490 train_time:12735ms step_avg:30.61ms
+step:417/1490 train_time:12762ms step_avg:30.60ms
+step:418/1490 train_time:12796ms step_avg:30.61ms
+step:419/1490 train_time:12823ms step_avg:30.60ms
+step:420/1490 train_time:12857ms step_avg:30.61ms
+step:421/1490 train_time:12884ms step_avg:30.60ms
+step:422/1490 train_time:12918ms step_avg:30.61ms
+step:423/1490 train_time:12945ms step_avg:30.60ms
+step:424/1490 train_time:12979ms step_avg:30.61ms
+step:425/1490 train_time:13007ms step_avg:30.60ms
+step:426/1490 train_time:13040ms step_avg:30.61ms
+step:427/1490 train_time:13067ms step_avg:30.60ms
+step:428/1490 train_time:13101ms step_avg:30.61ms
+step:429/1490 train_time:13128ms step_avg:30.60ms
+step:430/1490 train_time:13162ms step_avg:30.61ms
+step:431/1490 train_time:13189ms step_avg:30.60ms
+step:432/1490 train_time:13223ms step_avg:30.61ms
+step:433/1490 train_time:13250ms step_avg:30.60ms
+step:434/1490 train_time:13283ms step_avg:30.61ms
+step:435/1490 train_time:13310ms step_avg:30.60ms
+step:436/1490 train_time:13344ms step_avg:30.61ms
+step:437/1490 train_time:13372ms step_avg:30.60ms
+step:438/1490 train_time:13406ms step_avg:30.61ms
+step:439/1490 train_time:13433ms step_avg:30.60ms
+step:440/1490 train_time:13468ms step_avg:30.61ms
+step:441/1490 train_time:13495ms step_avg:30.60ms
+step:442/1490 train_time:13529ms step_avg:30.61ms
+step:443/1490 train_time:13556ms step_avg:30.60ms
+step:444/1490 train_time:13590ms step_avg:30.61ms
+step:445/1490 train_time:13617ms step_avg:30.60ms
+step:446/1490 train_time:13651ms step_avg:30.61ms
+step:447/1490 train_time:13678ms step_avg:30.60ms
+step:448/1490 train_time:13713ms step_avg:30.61ms
+step:449/1490 train_time:13740ms step_avg:30.60ms
+step:450/1490 train_time:13774ms step_avg:30.61ms
+step:451/1490 train_time:13801ms step_avg:30.60ms
+step:452/1490 train_time:13836ms step_avg:30.61ms
+step:453/1490 train_time:13863ms step_avg:30.60ms
+step:454/1490 train_time:13897ms step_avg:30.61ms
+step:455/1490 train_time:13924ms step_avg:30.60ms
+step:456/1490 train_time:13958ms step_avg:30.61ms
+step:457/1490 train_time:13986ms step_avg:30.60ms
+step:458/1490 train_time:14020ms step_avg:30.61ms
+step:459/1490 train_time:14047ms step_avg:30.60ms
+step:460/1490 train_time:14080ms step_avg:30.61ms
+step:461/1490 train_time:14107ms step_avg:30.60ms
+step:462/1490 train_time:14141ms step_avg:30.61ms
+step:463/1490 train_time:14168ms step_avg:30.60ms
+step:464/1490 train_time:14202ms step_avg:30.61ms
+step:465/1490 train_time:14229ms step_avg:30.60ms
+step:466/1490 train_time:14262ms step_avg:30.61ms
+step:467/1490 train_time:14290ms step_avg:30.60ms
+step:468/1490 train_time:14324ms step_avg:30.61ms
+step:469/1490 train_time:14351ms step_avg:30.60ms
+step:470/1490 train_time:14384ms step_avg:30.61ms
+step:471/1490 train_time:14412ms step_avg:30.60ms
+step:472/1490 train_time:14446ms step_avg:30.61ms
+step:473/1490 train_time:14473ms step_avg:30.60ms
+step:474/1490 train_time:14507ms step_avg:30.61ms
+step:475/1490 train_time:14534ms step_avg:30.60ms
+step:476/1490 train_time:14569ms step_avg:30.61ms
+step:477/1490 train_time:14596ms step_avg:30.60ms
+step:478/1490 train_time:14630ms step_avg:30.61ms
+step:479/1490 train_time:14658ms step_avg:30.60ms
+step:480/1490 train_time:14691ms step_avg:30.61ms
+step:481/1490 train_time:14718ms step_avg:30.60ms
+step:482/1490 train_time:14752ms step_avg:30.61ms
+step:483/1490 train_time:14779ms step_avg:30.60ms
+step:484/1490 train_time:14816ms step_avg:30.61ms
+step:485/1490 train_time:14868ms step_avg:30.65ms
+step:486/1490 train_time:14926ms step_avg:30.71ms
+step:487/1490 train_time:14980ms step_avg:30.76ms
+step:488/1490 train_time:15039ms step_avg:30.82ms
+step:489/1490 train_time:15092ms step_avg:30.86ms
+step:490/1490 train_time:15149ms step_avg:30.92ms
+step:491/1490 train_time:15203ms step_avg:30.96ms
+step:492/1490 train_time:15261ms step_avg:31.02ms
+step:493/1490 train_time:15313ms step_avg:31.06ms
+step:494/1490 train_time:15372ms step_avg:31.12ms
+step:495/1490 train_time:15425ms step_avg:31.16ms
+step:496/1490 train_time:15482ms step_avg:31.21ms
+step:497/1490 train_time:15536ms step_avg:31.26ms
+step:498/1490 train_time:15595ms step_avg:31.32ms
+step:499/1490 train_time:15649ms step_avg:31.36ms
+step:500/1490 train_time:15707ms step_avg:31.41ms
+step:500/1490 val_loss:4.2807 train_time:15775ms step_avg:31.55ms
+step:501/1490 train_time:15797ms step_avg:31.53ms
+step:502/1490 train_time:15826ms step_avg:31.53ms
+step:503/1490 train_time:15883ms step_avg:31.58ms
+step:504/1490 train_time:15943ms step_avg:31.63ms
+step:505/1490 train_time:15997ms step_avg:31.68ms
+step:506/1490 train_time:16055ms step_avg:31.73ms
+step:507/1490 train_time:16110ms step_avg:31.77ms
+step:508/1490 train_time:16167ms step_avg:31.82ms
+step:509/1490 train_time:16220ms step_avg:31.87ms
+step:510/1490 train_time:16278ms step_avg:31.92ms
+step:511/1490 train_time:16330ms step_avg:31.96ms
+step:512/1490 train_time:16388ms step_avg:32.01ms
+step:513/1490 train_time:16441ms step_avg:32.05ms
+step:514/1490 train_time:16498ms step_avg:32.10ms
+step:515/1490 train_time:16551ms step_avg:32.14ms
+step:516/1490 train_time:16608ms step_avg:32.19ms
+step:517/1490 train_time:16661ms step_avg:32.23ms
+step:518/1490 train_time:16719ms step_avg:32.28ms
+step:519/1490 train_time:16773ms step_avg:32.32ms
+step:520/1490 train_time:16832ms step_avg:32.37ms
+step:521/1490 train_time:16888ms step_avg:32.41ms
+step:522/1490 train_time:16947ms step_avg:32.47ms
+step:523/1490 train_time:17002ms step_avg:32.51ms
+step:524/1490 train_time:17060ms step_avg:32.56ms
+step:525/1490 train_time:17113ms step_avg:32.60ms
+step:526/1490 train_time:17171ms step_avg:32.64ms
+step:527/1490 train_time:17225ms step_avg:32.68ms
+step:528/1490 train_time:17283ms step_avg:32.73ms
+step:529/1490 train_time:17335ms step_avg:32.77ms
+step:530/1490 train_time:17393ms step_avg:32.82ms
+step:531/1490 train_time:17446ms step_avg:32.85ms
+step:532/1490 train_time:17503ms step_avg:32.90ms
+step:533/1490 train_time:17556ms step_avg:32.94ms
+step:534/1490 train_time:17614ms step_avg:32.98ms
+step:535/1490 train_time:17666ms step_avg:33.02ms
+step:536/1490 train_time:17725ms step_avg:33.07ms
+step:537/1490 train_time:17779ms step_avg:33.11ms
+step:538/1490 train_time:17838ms step_avg:33.16ms
+step:539/1490 train_time:17891ms step_avg:33.19ms
+step:540/1490 train_time:17949ms step_avg:33.24ms
+step:541/1490 train_time:18004ms step_avg:33.28ms
+step:542/1490 train_time:18062ms step_avg:33.32ms
+step:543/1490 train_time:18116ms step_avg:33.36ms
+step:544/1490 train_time:18175ms step_avg:33.41ms
+step:545/1490 train_time:18229ms step_avg:33.45ms
+step:546/1490 train_time:18287ms step_avg:33.49ms
+step:547/1490 train_time:18339ms step_avg:33.53ms
+step:548/1490 train_time:18397ms step_avg:33.57ms
+step:549/1490 train_time:18450ms step_avg:33.61ms
+step:550/1490 train_time:18507ms step_avg:33.65ms
+step:551/1490 train_time:18560ms step_avg:33.68ms
+step:552/1490 train_time:18618ms step_avg:33.73ms
+step:553/1490 train_time:18671ms step_avg:33.76ms
+step:554/1490 train_time:18729ms step_avg:33.81ms
+step:555/1490 train_time:18783ms step_avg:33.84ms
+step:556/1490 train_time:18842ms step_avg:33.89ms
+step:557/1490 train_time:18895ms step_avg:33.92ms
+step:558/1490 train_time:18953ms step_avg:33.97ms
+step:559/1490 train_time:19006ms step_avg:34.00ms
+step:560/1490 train_time:19064ms step_avg:34.04ms
+step:561/1490 train_time:19118ms step_avg:34.08ms
+step:562/1490 train_time:19177ms step_avg:34.12ms
+step:563/1490 train_time:19231ms step_avg:34.16ms
+step:564/1490 train_time:19289ms step_avg:34.20ms
+step:565/1490 train_time:19342ms step_avg:34.23ms
+step:566/1490 train_time:19400ms step_avg:34.28ms
+step:567/1490 train_time:19453ms step_avg:34.31ms
+step:568/1490 train_time:19511ms step_avg:34.35ms
+step:569/1490 train_time:19563ms step_avg:34.38ms
+step:570/1490 train_time:19621ms step_avg:34.42ms
+step:571/1490 train_time:19675ms step_avg:34.46ms
+step:572/1490 train_time:19733ms step_avg:34.50ms
+step:573/1490 train_time:19786ms step_avg:34.53ms
+step:574/1490 train_time:19844ms step_avg:34.57ms
+step:575/1490 train_time:19898ms step_avg:34.60ms
+step:576/1490 train_time:19956ms step_avg:34.65ms
+step:577/1490 train_time:20009ms step_avg:34.68ms
+step:578/1490 train_time:20068ms step_avg:34.72ms
+step:579/1490 train_time:20122ms step_avg:34.75ms
+step:580/1490 train_time:20180ms step_avg:34.79ms
+step:581/1490 train_time:20233ms step_avg:34.83ms
+step:582/1490 train_time:20292ms step_avg:34.87ms
+step:583/1490 train_time:20344ms step_avg:34.90ms
+step:584/1490 train_time:20403ms step_avg:34.94ms
+step:585/1490 train_time:20455ms step_avg:34.97ms
+step:586/1490 train_time:20513ms step_avg:35.00ms
+step:587/1490 train_time:20565ms step_avg:35.03ms
+step:588/1490 train_time:20624ms step_avg:35.07ms
+step:589/1490 train_time:20676ms step_avg:35.10ms
+step:590/1490 train_time:20736ms step_avg:35.15ms
+step:591/1490 train_time:20790ms step_avg:35.18ms
+step:592/1490 train_time:20848ms step_avg:35.22ms
+step:593/1490 train_time:20902ms step_avg:35.25ms
+step:594/1490 train_time:20960ms step_avg:35.29ms
+step:595/1490 train_time:21013ms step_avg:35.32ms
+step:596/1490 train_time:21071ms step_avg:35.35ms
+step:597/1490 train_time:21125ms step_avg:35.38ms
+step:598/1490 train_time:21184ms step_avg:35.42ms
+step:599/1490 train_time:21237ms step_avg:35.45ms
+step:600/1490 train_time:21295ms step_avg:35.49ms
+step:601/1490 train_time:21348ms step_avg:35.52ms
+step:602/1490 train_time:21406ms step_avg:35.56ms
+step:603/1490 train_time:21458ms step_avg:35.59ms
+step:604/1490 train_time:21517ms step_avg:35.62ms
+step:605/1490 train_time:21570ms step_avg:35.65ms
+step:606/1490 train_time:21626ms step_avg:35.69ms
+step:607/1490 train_time:21681ms step_avg:35.72ms
+step:608/1490 train_time:21740ms step_avg:35.76ms
+step:609/1490 train_time:21793ms step_avg:35.78ms
+step:610/1490 train_time:21851ms step_avg:35.82ms
+step:611/1490 train_time:21904ms step_avg:35.85ms
+step:612/1490 train_time:21963ms step_avg:35.89ms
+step:613/1490 train_time:22016ms step_avg:35.91ms
+step:614/1490 train_time:22075ms step_avg:35.95ms
+step:615/1490 train_time:22128ms step_avg:35.98ms
+step:616/1490 train_time:22187ms step_avg:36.02ms
+step:617/1490 train_time:22240ms step_avg:36.05ms
+step:618/1490 train_time:22298ms step_avg:36.08ms
+step:619/1490 train_time:22351ms step_avg:36.11ms
+step:620/1490 train_time:22409ms step_avg:36.14ms
+step:621/1490 train_time:22462ms step_avg:36.17ms
+step:622/1490 train_time:22520ms step_avg:36.21ms
+step:623/1490 train_time:22573ms step_avg:36.23ms
+step:624/1490 train_time:22631ms step_avg:36.27ms
+step:625/1490 train_time:22685ms step_avg:36.30ms
+step:626/1490 train_time:22742ms step_avg:36.33ms
+step:627/1490 train_time:22797ms step_avg:36.36ms
+step:628/1490 train_time:22855ms step_avg:36.39ms
+step:629/1490 train_time:22909ms step_avg:36.42ms
+step:630/1490 train_time:22967ms step_avg:36.46ms
+step:631/1490 train_time:23020ms step_avg:36.48ms
+step:632/1490 train_time:23078ms step_avg:36.52ms
+step:633/1490 train_time:23132ms step_avg:36.54ms
+step:634/1490 train_time:23190ms step_avg:36.58ms
+step:635/1490 train_time:23243ms step_avg:36.60ms
+step:636/1490 train_time:23301ms step_avg:36.64ms
+step:637/1490 train_time:23354ms step_avg:36.66ms
+step:638/1490 train_time:23412ms step_avg:36.70ms
+step:639/1490 train_time:23465ms step_avg:36.72ms
+step:640/1490 train_time:23523ms step_avg:36.76ms
+step:641/1490 train_time:23577ms step_avg:36.78ms
+step:642/1490 train_time:23636ms step_avg:36.82ms
+step:643/1490 train_time:23689ms step_avg:36.84ms
+step:644/1490 train_time:23747ms step_avg:36.87ms
+step:645/1490 train_time:23801ms step_avg:36.90ms
+step:646/1490 train_time:23859ms step_avg:36.93ms
+step:647/1490 train_time:23913ms step_avg:36.96ms
+step:648/1490 train_time:23971ms step_avg:36.99ms
+step:649/1490 train_time:24025ms step_avg:37.02ms
+step:650/1490 train_time:24084ms step_avg:37.05ms
+step:651/1490 train_time:24136ms step_avg:37.08ms
+step:652/1490 train_time:24195ms step_avg:37.11ms
+step:653/1490 train_time:24249ms step_avg:37.13ms
+step:654/1490 train_time:24307ms step_avg:37.17ms
+step:655/1490 train_time:24360ms step_avg:37.19ms
+step:656/1490 train_time:24418ms step_avg:37.22ms
+step:657/1490 train_time:24471ms step_avg:37.25ms
+step:658/1490 train_time:24528ms step_avg:37.28ms
+step:659/1490 train_time:24583ms step_avg:37.30ms
+step:660/1490 train_time:24641ms step_avg:37.33ms
+step:661/1490 train_time:24694ms step_avg:37.36ms
+step:662/1490 train_time:24751ms step_avg:37.39ms
+step:663/1490 train_time:24804ms step_avg:37.41ms
+step:664/1490 train_time:24862ms step_avg:37.44ms
+step:665/1490 train_time:24916ms step_avg:37.47ms
+step:666/1490 train_time:24975ms step_avg:37.50ms
+step:667/1490 train_time:25028ms step_avg:37.52ms
+step:668/1490 train_time:25087ms step_avg:37.56ms
+step:669/1490 train_time:25141ms step_avg:37.58ms
+step:670/1490 train_time:25199ms step_avg:37.61ms
+step:671/1490 train_time:25252ms step_avg:37.63ms
+step:672/1490 train_time:25309ms step_avg:37.66ms
+step:673/1490 train_time:25363ms step_avg:37.69ms
+step:674/1490 train_time:25422ms step_avg:37.72ms
+step:675/1490 train_time:25475ms step_avg:37.74ms
+step:676/1490 train_time:25534ms step_avg:37.77ms
+step:677/1490 train_time:25587ms step_avg:37.79ms
+step:678/1490 train_time:25645ms step_avg:37.82ms
+step:679/1490 train_time:25699ms step_avg:37.85ms
+step:680/1490 train_time:25757ms step_avg:37.88ms
+step:681/1490 train_time:25810ms step_avg:37.90ms
+step:682/1490 train_time:25867ms step_avg:37.93ms
+step:683/1490 train_time:25921ms step_avg:37.95ms
+step:684/1490 train_time:25980ms step_avg:37.98ms
+step:685/1490 train_time:26033ms step_avg:38.00ms
+step:686/1490 train_time:26091ms step_avg:38.03ms
+step:687/1490 train_time:26144ms step_avg:38.06ms
+step:688/1490 train_time:26203ms step_avg:38.09ms
+step:689/1490 train_time:26255ms step_avg:38.11ms
+step:690/1490 train_time:26314ms step_avg:38.14ms
+step:691/1490 train_time:26367ms step_avg:38.16ms
+step:692/1490 train_time:26425ms step_avg:38.19ms
+step:693/1490 train_time:26479ms step_avg:38.21ms
+step:694/1490 train_time:26537ms step_avg:38.24ms
+step:695/1490 train_time:26590ms step_avg:38.26ms
+step:696/1490 train_time:26648ms step_avg:38.29ms
+step:697/1490 train_time:26701ms step_avg:38.31ms
+step:698/1490 train_time:26759ms step_avg:38.34ms
+step:699/1490 train_time:26812ms step_avg:38.36ms
+step:700/1490 train_time:26871ms step_avg:38.39ms
+step:701/1490 train_time:26924ms step_avg:38.41ms
+step:702/1490 train_time:26983ms step_avg:38.44ms
+step:703/1490 train_time:27035ms step_avg:38.46ms
+step:704/1490 train_time:27093ms step_avg:38.48ms
+step:705/1490 train_time:27147ms step_avg:38.51ms
+step:706/1490 train_time:27205ms step_avg:38.53ms
+step:707/1490 train_time:27257ms step_avg:38.55ms
+step:708/1490 train_time:27316ms step_avg:38.58ms
+step:709/1490 train_time:27370ms step_avg:38.60ms
+step:710/1490 train_time:27429ms step_avg:38.63ms
+step:711/1490 train_time:27483ms step_avg:38.65ms
+step:712/1490 train_time:27540ms step_avg:38.68ms
+step:713/1490 train_time:27593ms step_avg:38.70ms
+step:714/1490 train_time:27651ms step_avg:38.73ms
+step:715/1490 train_time:27704ms step_avg:38.75ms
+step:716/1490 train_time:27762ms step_avg:38.77ms
+step:717/1490 train_time:27816ms step_avg:38.79ms
+step:718/1490 train_time:27875ms step_avg:38.82ms
+step:719/1490 train_time:27928ms step_avg:38.84ms
+step:720/1490 train_time:27987ms step_avg:38.87ms
+step:721/1490 train_time:28040ms step_avg:38.89ms
+step:722/1490 train_time:28098ms step_avg:38.92ms
+step:723/1490 train_time:28152ms step_avg:38.94ms
+step:724/1490 train_time:28210ms step_avg:38.96ms
+step:725/1490 train_time:28262ms step_avg:38.98ms
+step:726/1490 train_time:28321ms step_avg:39.01ms
+step:727/1490 train_time:28375ms step_avg:39.03ms
+step:728/1490 train_time:28433ms step_avg:39.06ms
+step:729/1490 train_time:28487ms step_avg:39.08ms
+step:730/1490 train_time:28545ms step_avg:39.10ms
+step:731/1490 train_time:28597ms step_avg:39.12ms
+step:732/1490 train_time:28657ms step_avg:39.15ms
+step:733/1490 train_time:28710ms step_avg:39.17ms
+step:734/1490 train_time:28767ms step_avg:39.19ms
+step:735/1490 train_time:28821ms step_avg:39.21ms
+step:736/1490 train_time:28880ms step_avg:39.24ms
+step:737/1490 train_time:28933ms step_avg:39.26ms
+step:738/1490 train_time:28991ms step_avg:39.28ms
+step:739/1490 train_time:29044ms step_avg:39.30ms
+step:740/1490 train_time:29103ms step_avg:39.33ms
+step:741/1490 train_time:29156ms step_avg:39.35ms
+step:742/1490 train_time:29214ms step_avg:39.37ms
+step:743/1490 train_time:29267ms step_avg:39.39ms
+step:744/1490 train_time:29325ms step_avg:39.42ms
+step:745/1490 train_time:29379ms step_avg:39.44ms
+step:746/1490 train_time:29437ms step_avg:39.46ms
+step:747/1490 train_time:29491ms step_avg:39.48ms
+step:748/1490 train_time:29548ms step_avg:39.50ms
+step:749/1490 train_time:29602ms step_avg:39.52ms
+step:750/1490 train_time:29660ms step_avg:39.55ms
+step:750/1490 val_loss:3.8007 train_time:29726ms step_avg:39.64ms
+step:751/1490 train_time:29744ms step_avg:39.61ms
+step:752/1490 train_time:29773ms step_avg:39.59ms
+step:753/1490 train_time:29829ms step_avg:39.61ms
+step:754/1490 train_time:29890ms step_avg:39.64ms
+step:755/1490 train_time:29947ms step_avg:39.66ms
+step:756/1490 train_time:30007ms step_avg:39.69ms
+step:757/1490 train_time:30060ms step_avg:39.71ms
+step:758/1490 train_time:30119ms step_avg:39.73ms
+step:759/1490 train_time:30172ms step_avg:39.75ms
+step:760/1490 train_time:30229ms step_avg:39.78ms
+step:761/1490 train_time:30282ms step_avg:39.79ms
+step:762/1490 train_time:30341ms step_avg:39.82ms
+step:763/1490 train_time:30394ms step_avg:39.83ms
+step:764/1490 train_time:30450ms step_avg:39.86ms
+step:765/1490 train_time:30504ms step_avg:39.87ms
+step:766/1490 train_time:30561ms step_avg:39.90ms
+step:767/1490 train_time:30613ms step_avg:39.91ms
+step:768/1490 train_time:30671ms step_avg:39.94ms
+step:769/1490 train_time:30725ms step_avg:39.95ms
+step:770/1490 train_time:30784ms step_avg:39.98ms
+step:771/1490 train_time:30839ms step_avg:40.00ms
+step:772/1490 train_time:30900ms step_avg:40.03ms
+step:773/1490 train_time:30954ms step_avg:40.04ms
+step:774/1490 train_time:31013ms step_avg:40.07ms
+step:775/1490 train_time:31066ms step_avg:40.09ms
+step:776/1490 train_time:31124ms step_avg:40.11ms
+step:777/1490 train_time:31176ms step_avg:40.12ms
+step:778/1490 train_time:31234ms step_avg:40.15ms
+step:779/1490 train_time:31287ms step_avg:40.16ms
+step:780/1490 train_time:31347ms step_avg:40.19ms
+step:781/1490 train_time:31398ms step_avg:40.20ms
+step:782/1490 train_time:31456ms step_avg:40.23ms
+step:783/1490 train_time:31509ms step_avg:40.24ms
+step:784/1490 train_time:31566ms step_avg:40.26ms
+step:785/1490 train_time:31619ms step_avg:40.28ms
+step:786/1490 train_time:31677ms step_avg:40.30ms
+step:787/1490 train_time:31731ms step_avg:40.32ms
+step:788/1490 train_time:31790ms step_avg:40.34ms
+step:789/1490 train_time:31845ms step_avg:40.36ms
+step:790/1490 train_time:31904ms step_avg:40.39ms
+step:791/1490 train_time:31958ms step_avg:40.40ms
+step:792/1490 train_time:32018ms step_avg:40.43ms
+step:793/1490 train_time:32071ms step_avg:40.44ms
+step:794/1490 train_time:32128ms step_avg:40.46ms
+step:795/1490 train_time:32182ms step_avg:40.48ms
+step:796/1490 train_time:32239ms step_avg:40.50ms
+step:797/1490 train_time:32293ms step_avg:40.52ms
+step:798/1490 train_time:32350ms step_avg:40.54ms
+step:799/1490 train_time:32404ms step_avg:40.56ms
+step:800/1490 train_time:32462ms step_avg:40.58ms
+step:801/1490 train_time:32514ms step_avg:40.59ms
+step:802/1490 train_time:32571ms step_avg:40.61ms
+step:803/1490 train_time:32625ms step_avg:40.63ms
+step:804/1490 train_time:32682ms step_avg:40.65ms
+step:805/1490 train_time:32736ms step_avg:40.67ms
+step:806/1490 train_time:32795ms step_avg:40.69ms
+step:807/1490 train_time:32849ms step_avg:40.70ms
+step:808/1490 train_time:32908ms step_avg:40.73ms
+step:809/1490 train_time:32961ms step_avg:40.74ms
+step:810/1490 train_time:33020ms step_avg:40.77ms
+step:811/1490 train_time:33074ms step_avg:40.78ms
+step:812/1490 train_time:33132ms step_avg:40.80ms
+step:813/1490 train_time:33184ms step_avg:40.82ms
+step:814/1490 train_time:33243ms step_avg:40.84ms
+step:815/1490 train_time:33297ms step_avg:40.85ms
+step:816/1490 train_time:33355ms step_avg:40.88ms
+step:817/1490 train_time:33407ms step_avg:40.89ms
+step:818/1490 train_time:33465ms step_avg:40.91ms
+step:819/1490 train_time:33518ms step_avg:40.93ms
+step:820/1490 train_time:33576ms step_avg:40.95ms
+step:821/1490 train_time:33628ms step_avg:40.96ms
+step:822/1490 train_time:33686ms step_avg:40.98ms
+step:823/1490 train_time:33740ms step_avg:41.00ms
+step:824/1490 train_time:33799ms step_avg:41.02ms
+step:825/1490 train_time:33853ms step_avg:41.03ms
+step:826/1490 train_time:33911ms step_avg:41.05ms
+step:827/1490 train_time:33964ms step_avg:41.07ms
+step:828/1490 train_time:34023ms step_avg:41.09ms
+step:829/1490 train_time:34076ms step_avg:41.11ms
+step:830/1490 train_time:34135ms step_avg:41.13ms
+step:831/1490 train_time:34188ms step_avg:41.14ms
+step:832/1490 train_time:34246ms step_avg:41.16ms
+step:833/1490 train_time:34300ms step_avg:41.18ms
+step:834/1490 train_time:34358ms step_avg:41.20ms
+step:835/1490 train_time:34411ms step_avg:41.21ms
+step:836/1490 train_time:34468ms step_avg:41.23ms
+step:837/1490 train_time:34522ms step_avg:41.24ms
+step:838/1490 train_time:34580ms step_avg:41.26ms
+step:839/1490 train_time:34633ms step_avg:41.28ms
+step:840/1490 train_time:34691ms step_avg:41.30ms
+step:841/1490 train_time:34745ms step_avg:41.31ms
+step:842/1490 train_time:34804ms step_avg:41.33ms
+step:843/1490 train_time:34857ms step_avg:41.35ms
+step:844/1490 train_time:34916ms step_avg:41.37ms
+step:845/1490 train_time:34968ms step_avg:41.38ms
+step:846/1490 train_time:35027ms step_avg:41.40ms
+step:847/1490 train_time:35080ms step_avg:41.42ms
+step:848/1490 train_time:35139ms step_avg:41.44ms
+step:849/1490 train_time:35193ms step_avg:41.45ms
+step:850/1490 train_time:35250ms step_avg:41.47ms
+step:851/1490 train_time:35305ms step_avg:41.49ms
+step:852/1490 train_time:35362ms step_avg:41.50ms
+step:853/1490 train_time:35415ms step_avg:41.52ms
+step:854/1490 train_time:35473ms step_avg:41.54ms
+step:855/1490 train_time:35526ms step_avg:41.55ms
+step:856/1490 train_time:35584ms step_avg:41.57ms
+step:857/1490 train_time:35637ms step_avg:41.58ms
+step:858/1490 train_time:35696ms step_avg:41.60ms
+step:859/1490 train_time:35749ms step_avg:41.62ms
+step:860/1490 train_time:35808ms step_avg:41.64ms
+step:861/1490 train_time:35860ms step_avg:41.65ms
+step:862/1490 train_time:35919ms step_avg:41.67ms
+step:863/1490 train_time:35973ms step_avg:41.68ms
+step:864/1490 train_time:36031ms step_avg:41.70ms
+step:865/1490 train_time:36084ms step_avg:41.72ms
+step:866/1490 train_time:36143ms step_avg:41.74ms
+step:867/1490 train_time:36197ms step_avg:41.75ms
+step:868/1490 train_time:36255ms step_avg:41.77ms
+step:869/1490 train_time:36308ms step_avg:41.78ms
+step:870/1490 train_time:36366ms step_avg:41.80ms
+step:871/1490 train_time:36419ms step_avg:41.81ms
+step:872/1490 train_time:36477ms step_avg:41.83ms
+step:873/1490 train_time:36530ms step_avg:41.84ms
+step:874/1490 train_time:36588ms step_avg:41.86ms
+step:875/1490 train_time:36641ms step_avg:41.88ms
+step:876/1490 train_time:36700ms step_avg:41.89ms
+step:877/1490 train_time:36753ms step_avg:41.91ms
+step:878/1490 train_time:36811ms step_avg:41.93ms
+step:879/1490 train_time:36864ms step_avg:41.94ms
+step:880/1490 train_time:36923ms step_avg:41.96ms
+step:881/1490 train_time:36976ms step_avg:41.97ms
+step:882/1490 train_time:37034ms step_avg:41.99ms
+step:883/1490 train_time:37088ms step_avg:42.00ms
+step:884/1490 train_time:37146ms step_avg:42.02ms
+step:885/1490 train_time:37199ms step_avg:42.03ms
+step:886/1490 train_time:37258ms step_avg:42.05ms
+step:887/1490 train_time:37311ms step_avg:42.06ms
+step:888/1490 train_time:37368ms step_avg:42.08ms
+step:889/1490 train_time:37422ms step_avg:42.09ms
+step:890/1490 train_time:37480ms step_avg:42.11ms
+step:891/1490 train_time:37533ms step_avg:42.12ms
+step:892/1490 train_time:37591ms step_avg:42.14ms
+step:893/1490 train_time:37645ms step_avg:42.16ms
+step:894/1490 train_time:37704ms step_avg:42.17ms
+step:895/1490 train_time:37757ms step_avg:42.19ms
+step:896/1490 train_time:37816ms step_avg:42.21ms
+step:897/1490 train_time:37868ms step_avg:42.22ms
+step:898/1490 train_time:37927ms step_avg:42.24ms
+step:899/1490 train_time:37980ms step_avg:42.25ms
+step:900/1490 train_time:38039ms step_avg:42.27ms
+step:901/1490 train_time:38093ms step_avg:42.28ms
+step:902/1490 train_time:38151ms step_avg:42.30ms
+step:903/1490 train_time:38205ms step_avg:42.31ms
+step:904/1490 train_time:38263ms step_avg:42.33ms
+step:905/1490 train_time:38317ms step_avg:42.34ms
+step:906/1490 train_time:38374ms step_avg:42.36ms
+step:907/1490 train_time:38427ms step_avg:42.37ms
+step:908/1490 train_time:38485ms step_avg:42.38ms
+step:909/1490 train_time:38538ms step_avg:42.40ms
+step:910/1490 train_time:38596ms step_avg:42.41ms
+step:911/1490 train_time:38650ms step_avg:42.43ms
+step:912/1490 train_time:38709ms step_avg:42.44ms
+step:913/1490 train_time:38762ms step_avg:42.46ms
+step:914/1490 train_time:38821ms step_avg:42.47ms
+step:915/1490 train_time:38874ms step_avg:42.49ms
+step:916/1490 train_time:38932ms step_avg:42.50ms
+step:917/1490 train_time:38985ms step_avg:42.51ms
+step:918/1490 train_time:39043ms step_avg:42.53ms
+step:919/1490 train_time:39097ms step_avg:42.54ms
+step:920/1490 train_time:39155ms step_avg:42.56ms
+step:921/1490 train_time:39208ms step_avg:42.57ms
+step:922/1490 train_time:39266ms step_avg:42.59ms
+step:923/1490 train_time:39320ms step_avg:42.60ms
+step:924/1490 train_time:39378ms step_avg:42.62ms
+step:925/1490 train_time:39431ms step_avg:42.63ms
+step:926/1490 train_time:39489ms step_avg:42.64ms
+step:927/1490 train_time:39542ms step_avg:42.66ms
+step:928/1490 train_time:39601ms step_avg:42.67ms
+step:929/1490 train_time:39654ms step_avg:42.68ms
+step:930/1490 train_time:39712ms step_avg:42.70ms
+step:931/1490 train_time:39765ms step_avg:42.71ms
+step:932/1490 train_time:39824ms step_avg:42.73ms
+step:933/1490 train_time:39877ms step_avg:42.74ms
+step:934/1490 train_time:39936ms step_avg:42.76ms
+step:935/1490 train_time:39989ms step_avg:42.77ms
+step:936/1490 train_time:40047ms step_avg:42.78ms
+step:937/1490 train_time:40102ms step_avg:42.80ms
+step:938/1490 train_time:40160ms step_avg:42.81ms
+step:939/1490 train_time:40213ms step_avg:42.83ms
+step:940/1490 train_time:40270ms step_avg:42.84ms
+step:941/1490 train_time:40324ms step_avg:42.85ms
+step:942/1490 train_time:40381ms step_avg:42.87ms
+step:943/1490 train_time:40435ms step_avg:42.88ms
+step:944/1490 train_time:40493ms step_avg:42.90ms
+step:945/1490 train_time:40547ms step_avg:42.91ms
+step:946/1490 train_time:40605ms step_avg:42.92ms
+step:947/1490 train_time:40659ms step_avg:42.93ms
+step:948/1490 train_time:40717ms step_avg:42.95ms
+step:949/1490 train_time:40770ms step_avg:42.96ms
+step:950/1490 train_time:40828ms step_avg:42.98ms
+step:951/1490 train_time:40882ms step_avg:42.99ms
+step:952/1490 train_time:40940ms step_avg:43.00ms
+step:953/1490 train_time:40993ms step_avg:43.01ms
+step:954/1490 train_time:41051ms step_avg:43.03ms
+step:955/1490 train_time:41105ms step_avg:43.04ms
+step:956/1490 train_time:41163ms step_avg:43.06ms
+step:957/1490 train_time:41217ms step_avg:43.07ms
+step:958/1490 train_time:41275ms step_avg:43.08ms
+step:959/1490 train_time:41327ms step_avg:43.09ms
+step:960/1490 train_time:41386ms step_avg:43.11ms
+step:961/1490 train_time:41439ms step_avg:43.12ms
+step:962/1490 train_time:41497ms step_avg:43.14ms
+step:963/1490 train_time:41551ms step_avg:43.15ms
+step:964/1490 train_time:41609ms step_avg:43.16ms
+step:965/1490 train_time:41662ms step_avg:43.17ms
+step:966/1490 train_time:41720ms step_avg:43.19ms
+step:967/1490 train_time:41773ms step_avg:43.20ms
+step:968/1490 train_time:41833ms step_avg:43.22ms
+step:969/1490 train_time:41914ms step_avg:43.25ms
+step:970/1490 train_time:41998ms step_avg:43.30ms
+step:971/1490 train_time:42078ms step_avg:43.33ms
+step:972/1490 train_time:42162ms step_avg:43.38ms
+step:973/1490 train_time:42240ms step_avg:43.41ms
+step:974/1490 train_time:42324ms step_avg:43.45ms
+step:975/1490 train_time:42402ms step_avg:43.49ms
+step:976/1490 train_time:42486ms step_avg:43.53ms
+step:977/1490 train_time:42564ms step_avg:43.57ms
+step:978/1490 train_time:42649ms step_avg:43.61ms
+step:979/1490 train_time:42727ms step_avg:43.64ms
+step:980/1490 train_time:42810ms step_avg:43.68ms
+step:981/1490 train_time:42887ms step_avg:43.72ms
+step:982/1490 train_time:42973ms step_avg:43.76ms
+step:983/1490 train_time:43051ms step_avg:43.80ms
+step:984/1490 train_time:43136ms step_avg:43.84ms
+step:985/1490 train_time:43216ms step_avg:43.87ms
+step:986/1490 train_time:43301ms step_avg:43.92ms
+step:987/1490 train_time:43380ms step_avg:43.95ms
+step:988/1490 train_time:43463ms step_avg:43.99ms
+step:989/1490 train_time:43542ms step_avg:44.03ms
+step:990/1490 train_time:43627ms step_avg:44.07ms
+step:991/1490 train_time:43705ms step_avg:44.10ms
+step:992/1490 train_time:43788ms step_avg:44.14ms
+step:993/1490 train_time:43868ms step_avg:44.18ms
+step:994/1490 train_time:43951ms step_avg:44.22ms
+step:995/1490 train_time:44029ms step_avg:44.25ms
+step:996/1490 train_time:44113ms step_avg:44.29ms
+step:997/1490 train_time:44192ms step_avg:44.32ms
+step:998/1490 train_time:44276ms step_avg:44.36ms
+step:999/1490 train_time:44357ms step_avg:44.40ms
+step:1000/1490 train_time:44441ms step_avg:44.44ms
+step:1000/1490 val_loss:3.5149 train_time:44535ms step_avg:44.54ms
+step:1001/1490 train_time:44553ms step_avg:44.51ms
+step:1002/1490 train_time:44607ms step_avg:44.52ms
+step:1003/1490 train_time:44691ms step_avg:44.56ms
+step:1004/1490 train_time:44778ms step_avg:44.60ms
+step:1005/1490 train_time:44858ms step_avg:44.63ms
+step:1006/1490 train_time:44941ms step_avg:44.67ms
+step:1007/1490 train_time:45020ms step_avg:44.71ms
+step:1008/1490 train_time:45102ms step_avg:44.74ms
+step:1009/1490 train_time:45180ms step_avg:44.78ms
+step:1010/1490 train_time:45264ms step_avg:44.82ms
+step:1011/1490 train_time:45341ms step_avg:44.85ms
+step:1012/1490 train_time:45423ms step_avg:44.88ms
+step:1013/1490 train_time:45502ms step_avg:44.92ms
+step:1014/1490 train_time:45588ms step_avg:44.96ms
+step:1015/1490 train_time:45670ms step_avg:44.99ms
+step:1016/1490 train_time:45756ms step_avg:45.04ms
+step:1017/1490 train_time:45836ms step_avg:45.07ms
+step:1018/1490 train_time:45920ms step_avg:45.11ms
+step:1019/1490 train_time:45999ms step_avg:45.14ms
+step:1020/1490 train_time:46082ms step_avg:45.18ms
+step:1021/1490 train_time:46159ms step_avg:45.21ms
+step:1022/1490 train_time:46242ms step_avg:45.25ms
+step:1023/1490 train_time:46319ms step_avg:45.28ms
+step:1024/1490 train_time:46403ms step_avg:45.32ms
+step:1025/1490 train_time:46482ms step_avg:45.35ms
+step:1026/1490 train_time:46567ms step_avg:45.39ms
+step:1027/1490 train_time:46647ms step_avg:45.42ms
+step:1028/1490 train_time:46734ms step_avg:45.46ms
+step:1029/1490 train_time:46813ms step_avg:45.49ms
+step:1030/1490 train_time:46898ms step_avg:45.53ms
+step:1031/1490 train_time:46977ms step_avg:45.56ms
+step:1032/1490 train_time:47060ms step_avg:45.60ms
+step:1033/1490 train_time:47139ms step_avg:45.63ms
+step:1034/1490 train_time:47221ms step_avg:45.67ms
+step:1035/1490 train_time:47299ms step_avg:45.70ms
+step:1036/1490 train_time:47382ms step_avg:45.74ms
+step:1037/1490 train_time:47459ms step_avg:45.77ms
+step:1038/1490 train_time:47544ms step_avg:45.80ms
+step:1039/1490 train_time:47624ms step_avg:45.84ms
+step:1040/1490 train_time:47709ms step_avg:45.87ms
+step:1041/1490 train_time:47791ms step_avg:45.91ms
+step:1042/1490 train_time:47877ms step_avg:45.95ms
+step:1043/1490 train_time:47957ms step_avg:45.98ms
+step:1044/1490 train_time:48040ms step_avg:46.02ms
+step:1045/1490 train_time:48118ms step_avg:46.05ms
+step:1046/1490 train_time:48201ms step_avg:46.08ms
+step:1047/1490 train_time:48280ms step_avg:46.11ms
+step:1048/1490 train_time:48363ms step_avg:46.15ms
+step:1049/1490 train_time:48440ms step_avg:46.18ms
+step:1050/1490 train_time:48524ms step_avg:46.21ms
+step:1051/1490 train_time:48603ms step_avg:46.24ms
+step:1052/1490 train_time:48688ms step_avg:46.28ms
+step:1053/1490 train_time:48769ms step_avg:46.31ms
+step:1054/1490 train_time:48855ms step_avg:46.35ms
+step:1055/1490 train_time:48935ms step_avg:46.38ms
+step:1056/1490 train_time:49019ms step_avg:46.42ms
+step:1057/1490 train_time:49098ms step_avg:46.45ms
+step:1058/1490 train_time:49181ms step_avg:46.48ms
+step:1059/1490 train_time:49259ms step_avg:46.51ms
+step:1060/1490 train_time:49342ms step_avg:46.55ms
+step:1061/1490 train_time:49420ms step_avg:46.58ms
+step:1062/1490 train_time:49504ms step_avg:46.61ms
+step:1063/1490 train_time:49583ms step_avg:46.64ms
+step:1064/1490 train_time:49667ms step_avg:46.68ms
+step:1065/1490 train_time:49746ms step_avg:46.71ms
+step:1066/1490 train_time:49832ms step_avg:46.75ms
+step:1067/1490 train_time:49912ms step_avg:46.78ms
+step:1068/1490 train_time:49999ms step_avg:46.82ms
+step:1069/1490 train_time:50078ms step_avg:46.85ms
+step:1070/1490 train_time:50162ms step_avg:46.88ms
+step:1071/1490 train_time:50241ms step_avg:46.91ms
+step:1072/1490 train_time:50324ms step_avg:46.94ms
+step:1073/1490 train_time:50401ms step_avg:46.97ms
+step:1074/1490 train_time:50485ms step_avg:47.01ms
+step:1075/1490 train_time:50564ms step_avg:47.04ms
+step:1076/1490 train_time:50646ms step_avg:47.07ms
+step:1077/1490 train_time:50725ms step_avg:47.10ms
+step:1078/1490 train_time:50812ms step_avg:47.13ms
+step:1079/1490 train_time:50892ms step_avg:47.17ms
+step:1080/1490 train_time:50977ms step_avg:47.20ms
+step:1081/1490 train_time:51056ms step_avg:47.23ms
+step:1082/1490 train_time:51141ms step_avg:47.26ms
+step:1083/1490 train_time:51220ms step_avg:47.29ms
+step:1084/1490 train_time:51304ms step_avg:47.33ms
+step:1085/1490 train_time:51382ms step_avg:47.36ms
+step:1086/1490 train_time:51465ms step_avg:47.39ms
+step:1087/1490 train_time:51544ms step_avg:47.42ms
+step:1088/1490 train_time:51628ms step_avg:47.45ms
+step:1089/1490 train_time:51709ms step_avg:47.48ms
+step:1090/1490 train_time:51791ms step_avg:47.51ms
+step:1091/1490 train_time:51870ms step_avg:47.54ms
+step:1092/1490 train_time:51954ms step_avg:47.58ms
+step:1093/1490 train_time:52034ms step_avg:47.61ms
+step:1094/1490 train_time:52120ms step_avg:47.64ms
+step:1095/1490 train_time:52199ms step_avg:47.67ms
+step:1096/1490 train_time:52282ms step_avg:47.70ms
+step:1097/1490 train_time:52361ms step_avg:47.73ms
+step:1098/1490 train_time:52445ms step_avg:47.76ms
+step:1099/1490 train_time:52522ms step_avg:47.79ms
+step:1100/1490 train_time:52605ms step_avg:47.82ms
+step:1101/1490 train_time:52685ms step_avg:47.85ms
+step:1102/1490 train_time:52769ms step_avg:47.88ms
+step:1103/1490 train_time:52849ms step_avg:47.91ms
+step:1104/1490 train_time:52935ms step_avg:47.95ms
+step:1105/1490 train_time:53015ms step_avg:47.98ms
+step:1106/1490 train_time:53100ms step_avg:48.01ms
+step:1107/1490 train_time:53179ms step_avg:48.04ms
+step:1108/1490 train_time:53264ms step_avg:48.07ms
+step:1109/1490 train_time:53342ms step_avg:48.10ms
+step:1110/1490 train_time:53425ms step_avg:48.13ms
+step:1111/1490 train_time:53502ms step_avg:48.16ms
+step:1112/1490 train_time:53587ms step_avg:48.19ms
+step:1113/1490 train_time:53667ms step_avg:48.22ms
+step:1114/1490 train_time:53751ms step_avg:48.25ms
+step:1115/1490 train_time:53829ms step_avg:48.28ms
+step:1116/1490 train_time:53914ms step_avg:48.31ms
+step:1117/1490 train_time:53994ms step_avg:48.34ms
+step:1118/1490 train_time:54079ms step_avg:48.37ms
+step:1119/1490 train_time:54159ms step_avg:48.40ms
+step:1120/1490 train_time:54244ms step_avg:48.43ms
+step:1121/1490 train_time:54322ms step_avg:48.46ms
+step:1122/1490 train_time:54405ms step_avg:48.49ms
+step:1123/1490 train_time:54484ms step_avg:48.52ms
+step:1124/1490 train_time:54567ms step_avg:48.55ms
+step:1125/1490 train_time:54646ms step_avg:48.57ms
+step:1126/1490 train_time:54731ms step_avg:48.61ms
+step:1127/1490 train_time:54809ms step_avg:48.63ms
+step:1128/1490 train_time:54895ms step_avg:48.67ms
+step:1129/1490 train_time:54975ms step_avg:48.69ms
+step:1130/1490 train_time:55060ms step_avg:48.73ms
+step:1131/1490 train_time:55139ms step_avg:48.75ms
+step:1132/1490 train_time:55223ms step_avg:48.78ms
+step:1133/1490 train_time:55300ms step_avg:48.81ms
+step:1134/1490 train_time:55385ms step_avg:48.84ms
+step:1135/1490 train_time:55463ms step_avg:48.87ms
+step:1136/1490 train_time:55547ms step_avg:48.90ms
+step:1137/1490 train_time:55626ms step_avg:48.92ms
+step:1138/1490 train_time:55709ms step_avg:48.95ms
+step:1139/1490 train_time:55789ms step_avg:48.98ms
+step:1140/1490 train_time:55874ms step_avg:49.01ms
+step:1141/1490 train_time:55954ms step_avg:49.04ms
+step:1142/1490 train_time:56039ms step_avg:49.07ms
+step:1143/1490 train_time:56118ms step_avg:49.10ms
+step:1144/1490 train_time:56202ms step_avg:49.13ms
+step:1145/1490 train_time:56280ms step_avg:49.15ms
+step:1146/1490 train_time:56363ms step_avg:49.18ms
+step:1147/1490 train_time:56442ms step_avg:49.21ms
+step:1148/1490 train_time:56525ms step_avg:49.24ms
+step:1149/1490 train_time:56603ms step_avg:49.26ms
+step:1150/1490 train_time:56687ms step_avg:49.29ms
+step:1151/1490 train_time:56766ms step_avg:49.32ms
+step:1152/1490 train_time:56850ms step_avg:49.35ms
+step:1153/1490 train_time:56930ms step_avg:49.38ms
+step:1154/1490 train_time:57016ms step_avg:49.41ms
+step:1155/1490 train_time:57094ms step_avg:49.43ms
+step:1156/1490 train_time:57180ms step_avg:49.46ms
+step:1157/1490 train_time:57259ms step_avg:49.49ms
+step:1158/1490 train_time:57342ms step_avg:49.52ms
+step:1159/1490 train_time:57420ms step_avg:49.54ms
+step:1160/1490 train_time:57502ms step_avg:49.57ms
+step:1161/1490 train_time:57581ms step_avg:49.60ms
+step:1162/1490 train_time:57665ms step_avg:49.63ms
+step:1163/1490 train_time:57745ms step_avg:49.65ms
+step:1164/1490 train_time:57828ms step_avg:49.68ms
+step:1165/1490 train_time:57909ms step_avg:49.71ms
+step:1166/1490 train_time:57994ms step_avg:49.74ms
+step:1167/1490 train_time:58073ms step_avg:49.76ms
+step:1168/1490 train_time:58158ms step_avg:49.79ms
+step:1169/1490 train_time:58236ms step_avg:49.82ms
+step:1170/1490 train_time:58320ms step_avg:49.85ms
+step:1171/1490 train_time:58397ms step_avg:49.87ms
+step:1172/1490 train_time:58482ms step_avg:49.90ms
+step:1173/1490 train_time:58559ms step_avg:49.92ms
+step:1174/1490 train_time:58644ms step_avg:49.95ms
+step:1175/1490 train_time:58722ms step_avg:49.98ms
+step:1176/1490 train_time:58807ms step_avg:50.01ms
+step:1177/1490 train_time:58887ms step_avg:50.03ms
+step:1178/1490 train_time:58972ms step_avg:50.06ms
+step:1179/1490 train_time:59051ms step_avg:50.09ms
+step:1180/1490 train_time:59137ms step_avg:50.12ms
+step:1181/1490 train_time:59216ms step_avg:50.14ms
+step:1182/1490 train_time:59300ms step_avg:50.17ms
+step:1183/1490 train_time:59379ms step_avg:50.19ms
+step:1184/1490 train_time:59463ms step_avg:50.22ms
+step:1185/1490 train_time:59542ms step_avg:50.25ms
+step:1186/1490 train_time:59627ms step_avg:50.28ms
+step:1187/1490 train_time:59705ms step_avg:50.30ms
+step:1188/1490 train_time:59788ms step_avg:50.33ms
+step:1189/1490 train_time:59867ms step_avg:50.35ms
+step:1190/1490 train_time:59953ms step_avg:50.38ms
+step:1191/1490 train_time:60033ms step_avg:50.41ms
+step:1192/1490 train_time:60117ms step_avg:50.43ms
+step:1193/1490 train_time:60195ms step_avg:50.46ms
+step:1194/1490 train_time:60280ms step_avg:50.49ms
+step:1195/1490 train_time:60359ms step_avg:50.51ms
+step:1196/1490 train_time:60444ms step_avg:50.54ms
+step:1197/1490 train_time:60522ms step_avg:50.56ms
+step:1198/1490 train_time:60605ms step_avg:50.59ms
+step:1199/1490 train_time:60684ms step_avg:50.61ms
+step:1200/1490 train_time:60768ms step_avg:50.64ms
+step:1201/1490 train_time:60848ms step_avg:50.66ms
+step:1202/1490 train_time:60935ms step_avg:50.69ms
+step:1203/1490 train_time:61013ms step_avg:50.72ms
+step:1204/1490 train_time:61098ms step_avg:50.75ms
+step:1205/1490 train_time:61177ms step_avg:50.77ms
+step:1206/1490 train_time:61261ms step_avg:50.80ms
+step:1207/1490 train_time:61339ms step_avg:50.82ms
+step:1208/1490 train_time:61422ms step_avg:50.85ms
+step:1209/1490 train_time:61500ms step_avg:50.87ms
+step:1210/1490 train_time:61583ms step_avg:50.90ms
+step:1211/1490 train_time:61663ms step_avg:50.92ms
+step:1212/1490 train_time:61746ms step_avg:50.95ms
+step:1213/1490 train_time:61824ms step_avg:50.97ms
+step:1214/1490 train_time:61910ms step_avg:51.00ms
+step:1215/1490 train_time:61989ms step_avg:51.02ms
+step:1216/1490 train_time:62074ms step_avg:51.05ms
+step:1217/1490 train_time:62154ms step_avg:51.07ms
+step:1218/1490 train_time:62239ms step_avg:51.10ms
+step:1219/1490 train_time:62318ms step_avg:51.12ms
+step:1220/1490 train_time:62400ms step_avg:51.15ms
+step:1221/1490 train_time:62479ms step_avg:51.17ms
+step:1222/1490 train_time:62563ms step_avg:51.20ms
+step:1223/1490 train_time:62642ms step_avg:51.22ms
+step:1224/1490 train_time:62726ms step_avg:51.25ms
+step:1225/1490 train_time:62803ms step_avg:51.27ms
+step:1226/1490 train_time:62888ms step_avg:51.29ms
+step:1227/1490 train_time:62967ms step_avg:51.32ms
+step:1228/1490 train_time:63051ms step_avg:51.34ms
+step:1229/1490 train_time:63131ms step_avg:51.37ms
+step:1230/1490 train_time:63216ms step_avg:51.40ms
+step:1231/1490 train_time:63296ms step_avg:51.42ms
+step:1232/1490 train_time:63380ms step_avg:51.45ms
+step:1233/1490 train_time:63459ms step_avg:51.47ms
+step:1234/1490 train_time:63543ms step_avg:51.49ms
+step:1235/1490 train_time:63621ms step_avg:51.51ms
+step:1236/1490 train_time:63704ms step_avg:51.54ms
+step:1237/1490 train_time:63783ms step_avg:51.56ms
+step:1238/1490 train_time:63867ms step_avg:51.59ms
+step:1239/1490 train_time:63947ms step_avg:51.61ms
+step:1240/1490 train_time:64032ms step_avg:51.64ms
+step:1241/1490 train_time:64111ms step_avg:51.66ms
+step:1242/1490 train_time:64195ms step_avg:51.69ms
+step:1243/1490 train_time:64275ms step_avg:51.71ms
+step:1244/1490 train_time:64359ms step_avg:51.74ms
+step:1245/1490 train_time:64439ms step_avg:51.76ms
+step:1246/1490 train_time:64523ms step_avg:51.78ms
+step:1247/1490 train_time:64601ms step_avg:51.81ms
+step:1248/1490 train_time:64685ms step_avg:51.83ms
+step:1249/1490 train_time:64762ms step_avg:51.85ms
+step:1250/1490 train_time:64847ms step_avg:51.88ms
+step:1250/1490 val_loss:3.3700 train_time:64943ms step_avg:51.95ms
+step:1251/1490 train_time:64961ms step_avg:51.93ms
+step:1252/1490 train_time:65015ms step_avg:51.93ms
+step:1253/1490 train_time:65096ms step_avg:51.95ms
+step:1254/1490 train_time:65182ms step_avg:51.98ms
+step:1255/1490 train_time:65260ms step_avg:52.00ms
+step:1256/1490 train_time:65345ms step_avg:52.03ms
+step:1257/1490 train_time:65423ms step_avg:52.05ms
+step:1258/1490 train_time:65505ms step_avg:52.07ms
+step:1259/1490 train_time:65583ms step_avg:52.09ms
+step:1260/1490 train_time:65665ms step_avg:52.12ms
+step:1261/1490 train_time:65744ms step_avg:52.14ms
+step:1262/1490 train_time:65827ms step_avg:52.16ms
+step:1263/1490 train_time:65905ms step_avg:52.18ms
+step:1264/1490 train_time:65992ms step_avg:52.21ms
+step:1265/1490 train_time:66073ms step_avg:52.23ms
+step:1266/1490 train_time:66159ms step_avg:52.26ms
+step:1267/1490 train_time:66239ms step_avg:52.28ms
+step:1268/1490 train_time:66323ms step_avg:52.31ms
+step:1269/1490 train_time:66403ms step_avg:52.33ms
+step:1270/1490 train_time:66485ms step_avg:52.35ms
+step:1271/1490 train_time:66563ms step_avg:52.37ms
+step:1272/1490 train_time:66646ms step_avg:52.39ms
+step:1273/1490 train_time:66724ms step_avg:52.41ms
+step:1274/1490 train_time:66807ms step_avg:52.44ms
+step:1275/1490 train_time:66886ms step_avg:52.46ms
+step:1276/1490 train_time:66971ms step_avg:52.49ms
+step:1277/1490 train_time:67051ms step_avg:52.51ms
+step:1278/1490 train_time:67135ms step_avg:52.53ms
+step:1279/1490 train_time:67214ms step_avg:52.55ms
+step:1280/1490 train_time:67300ms step_avg:52.58ms
+step:1281/1490 train_time:67378ms step_avg:52.60ms
+step:1282/1490 train_time:67463ms step_avg:52.62ms
+step:1283/1490 train_time:67540ms step_avg:52.64ms
+step:1284/1490 train_time:67625ms step_avg:52.67ms
+step:1285/1490 train_time:67704ms step_avg:52.69ms
+step:1286/1490 train_time:67789ms step_avg:52.71ms
+step:1287/1490 train_time:67868ms step_avg:52.73ms
+step:1288/1490 train_time:67952ms step_avg:52.76ms
+step:1289/1490 train_time:68031ms step_avg:52.78ms
+step:1290/1490 train_time:68114ms step_avg:52.80ms
+step:1291/1490 train_time:68194ms step_avg:52.82ms
+step:1292/1490 train_time:68279ms step_avg:52.85ms
+step:1293/1490 train_time:68359ms step_avg:52.87ms
+step:1294/1490 train_time:68444ms step_avg:52.89ms
+step:1295/1490 train_time:68522ms step_avg:52.91ms
+step:1296/1490 train_time:68604ms step_avg:52.94ms
+step:1297/1490 train_time:68682ms step_avg:52.95ms
+step:1298/1490 train_time:68767ms step_avg:52.98ms
+step:1299/1490 train_time:68847ms step_avg:53.00ms
+step:1300/1490 train_time:68931ms step_avg:53.02ms
+step:1301/1490 train_time:69010ms step_avg:53.04ms
+step:1302/1490 train_time:69094ms step_avg:53.07ms
+step:1303/1490 train_time:69173ms step_avg:53.09ms
+step:1304/1490 train_time:69257ms step_avg:53.11ms
+step:1305/1490 train_time:69335ms step_avg:53.13ms
+step:1306/1490 train_time:69420ms step_avg:53.15ms
+step:1307/1490 train_time:69500ms step_avg:53.18ms
+step:1308/1490 train_time:69584ms step_avg:53.20ms
+step:1309/1490 train_time:69663ms step_avg:53.22ms
+step:1310/1490 train_time:69747ms step_avg:53.24ms
+step:1311/1490 train_time:69825ms step_avg:53.26ms
+step:1312/1490 train_time:69910ms step_avg:53.29ms
+step:1313/1490 train_time:69990ms step_avg:53.31ms
+step:1314/1490 train_time:70074ms step_avg:53.33ms
+step:1315/1490 train_time:70154ms step_avg:53.35ms
+step:1316/1490 train_time:70237ms step_avg:53.37ms
+step:1317/1490 train_time:70315ms step_avg:53.39ms
+step:1318/1490 train_time:70400ms step_avg:53.41ms
+step:1319/1490 train_time:70480ms step_avg:53.43ms
+step:1320/1490 train_time:70564ms step_avg:53.46ms
+step:1321/1490 train_time:70644ms step_avg:53.48ms
+step:1322/1490 train_time:70729ms step_avg:53.50ms
+step:1323/1490 train_time:70806ms step_avg:53.52ms
+step:1324/1490 train_time:70891ms step_avg:53.54ms
+step:1325/1490 train_time:70970ms step_avg:53.56ms
+step:1326/1490 train_time:71054ms step_avg:53.58ms
+step:1327/1490 train_time:71132ms step_avg:53.60ms
+step:1328/1490 train_time:71216ms step_avg:53.63ms
+step:1329/1490 train_time:71296ms step_avg:53.65ms
+step:1330/1490 train_time:71379ms step_avg:53.67ms
+step:1331/1490 train_time:71458ms step_avg:53.69ms
+step:1332/1490 train_time:71542ms step_avg:53.71ms
+step:1333/1490 train_time:71621ms step_avg:53.73ms
+step:1334/1490 train_time:71707ms step_avg:53.75ms
+step:1335/1490 train_time:71787ms step_avg:53.77ms
+step:1336/1490 train_time:71870ms step_avg:53.80ms
+step:1337/1490 train_time:71950ms step_avg:53.81ms
+step:1338/1490 train_time:72033ms step_avg:53.84ms
+step:1339/1490 train_time:72110ms step_avg:53.85ms
+step:1340/1490 train_time:72194ms step_avg:53.88ms
+step:1341/1490 train_time:72273ms step_avg:53.89ms
+step:1342/1490 train_time:72357ms step_avg:53.92ms
+step:1343/1490 train_time:72436ms step_avg:53.94ms
+step:1344/1490 train_time:72520ms step_avg:53.96ms
+step:1345/1490 train_time:72599ms step_avg:53.98ms
+step:1346/1490 train_time:72685ms step_avg:54.00ms
+step:1347/1490 train_time:72764ms step_avg:54.02ms
+step:1348/1490 train_time:72850ms step_avg:54.04ms
+step:1349/1490 train_time:72929ms step_avg:54.06ms
+step:1350/1490 train_time:73012ms step_avg:54.08ms
+step:1351/1490 train_time:73091ms step_avg:54.10ms
+step:1352/1490 train_time:73175ms step_avg:54.12ms
+step:1353/1490 train_time:73254ms step_avg:54.14ms
+step:1354/1490 train_time:73337ms step_avg:54.16ms
+step:1355/1490 train_time:73416ms step_avg:54.18ms
+step:1356/1490 train_time:73500ms step_avg:54.20ms
+step:1357/1490 train_time:73580ms step_avg:54.22ms
+step:1358/1490 train_time:73665ms step_avg:54.25ms
+step:1359/1490 train_time:73744ms step_avg:54.26ms
+step:1360/1490 train_time:73829ms step_avg:54.29ms
+step:1361/1490 train_time:73909ms step_avg:54.30ms
+step:1362/1490 train_time:73993ms step_avg:54.33ms
+step:1363/1490 train_time:74072ms step_avg:54.35ms
+step:1364/1490 train_time:74156ms step_avg:54.37ms
+step:1365/1490 train_time:74236ms step_avg:54.39ms
+step:1366/1490 train_time:74318ms step_avg:54.41ms
+step:1367/1490 train_time:74398ms step_avg:54.42ms
+step:1368/1490 train_time:74480ms step_avg:54.44ms
+step:1369/1490 train_time:74560ms step_avg:54.46ms
+step:1370/1490 train_time:74646ms step_avg:54.49ms
+step:1371/1490 train_time:74724ms step_avg:54.50ms
+step:1372/1490 train_time:74809ms step_avg:54.53ms
+step:1373/1490 train_time:74890ms step_avg:54.54ms
+step:1374/1490 train_time:74974ms step_avg:54.57ms
+step:1375/1490 train_time:75053ms step_avg:54.58ms
+step:1376/1490 train_time:75136ms step_avg:54.60ms
+step:1377/1490 train_time:75213ms step_avg:54.62ms
+step:1378/1490 train_time:75298ms step_avg:54.64ms
+step:1379/1490 train_time:75377ms step_avg:54.66ms
+step:1380/1490 train_time:75460ms step_avg:54.68ms
+step:1381/1490 train_time:75540ms step_avg:54.70ms
+step:1382/1490 train_time:75625ms step_avg:54.72ms
+step:1383/1490 train_time:75706ms step_avg:54.74ms
+step:1384/1490 train_time:75789ms step_avg:54.76ms
+step:1385/1490 train_time:75868ms step_avg:54.78ms
+step:1386/1490 train_time:75953ms step_avg:54.80ms
+step:1387/1490 train_time:76031ms step_avg:54.82ms
+step:1388/1490 train_time:76116ms step_avg:54.84ms
+step:1389/1490 train_time:76196ms step_avg:54.86ms
+step:1390/1490 train_time:76279ms step_avg:54.88ms
+step:1391/1490 train_time:76357ms step_avg:54.89ms
+step:1392/1490 train_time:76441ms step_avg:54.91ms
+step:1393/1490 train_time:76520ms step_avg:54.93ms
+step:1394/1490 train_time:76605ms step_avg:54.95ms
+step:1395/1490 train_time:76685ms step_avg:54.97ms
+step:1396/1490 train_time:76769ms step_avg:54.99ms
+step:1397/1490 train_time:76849ms step_avg:55.01ms
+step:1398/1490 train_time:76933ms step_avg:55.03ms
+step:1399/1490 train_time:77011ms step_avg:55.05ms
+step:1400/1490 train_time:77095ms step_avg:55.07ms
+step:1401/1490 train_time:77173ms step_avg:55.08ms
+step:1402/1490 train_time:77258ms step_avg:55.11ms
+step:1403/1490 train_time:77337ms step_avg:55.12ms
+step:1404/1490 train_time:77420ms step_avg:55.14ms
+step:1405/1490 train_time:77500ms step_avg:55.16ms
+step:1406/1490 train_time:77584ms step_avg:55.18ms
+step:1407/1490 train_time:77664ms step_avg:55.20ms
+step:1408/1490 train_time:77748ms step_avg:55.22ms
+step:1409/1490 train_time:77828ms step_avg:55.24ms
+step:1410/1490 train_time:77912ms step_avg:55.26ms
+step:1411/1490 train_time:77990ms step_avg:55.27ms
+step:1412/1490 train_time:78075ms step_avg:55.29ms
+step:1413/1490 train_time:78153ms step_avg:55.31ms
+step:1414/1490 train_time:78237ms step_avg:55.33ms
+step:1415/1490 train_time:78316ms step_avg:55.35ms
+step:1416/1490 train_time:78401ms step_avg:55.37ms
+step:1417/1490 train_time:78480ms step_avg:55.38ms
+step:1418/1490 train_time:78564ms step_avg:55.41ms
+step:1419/1490 train_time:78645ms step_avg:55.42ms
+step:1420/1490 train_time:78729ms step_avg:55.44ms
+step:1421/1490 train_time:78809ms step_avg:55.46ms
+step:1422/1490 train_time:78893ms step_avg:55.48ms
+step:1423/1490 train_time:78971ms step_avg:55.50ms
+step:1424/1490 train_time:79056ms step_avg:55.52ms
+step:1425/1490 train_time:79135ms step_avg:55.53ms
+step:1426/1490 train_time:79218ms step_avg:55.55ms
+step:1427/1490 train_time:79297ms step_avg:55.57ms
+step:1428/1490 train_time:79380ms step_avg:55.59ms
+step:1429/1490 train_time:79459ms step_avg:55.60ms
+step:1430/1490 train_time:79544ms step_avg:55.62ms
+step:1431/1490 train_time:79623ms step_avg:55.64ms
+step:1432/1490 train_time:79708ms step_avg:55.66ms
+step:1433/1490 train_time:79786ms step_avg:55.68ms
+step:1434/1490 train_time:79871ms step_avg:55.70ms
+step:1435/1490 train_time:79950ms step_avg:55.71ms
+step:1436/1490 train_time:80033ms step_avg:55.73ms
+step:1437/1490 train_time:80110ms step_avg:55.75ms
+step:1438/1490 train_time:80195ms step_avg:55.77ms
+step:1439/1490 train_time:80273ms step_avg:55.78ms
+step:1440/1490 train_time:80357ms step_avg:55.80ms
+step:1441/1490 train_time:80437ms step_avg:55.82ms
+step:1442/1490 train_time:80522ms step_avg:55.84ms
+step:1443/1490 train_time:80603ms step_avg:55.86ms
+step:1444/1490 train_time:80687ms step_avg:55.88ms
+step:1445/1490 train_time:80765ms step_avg:55.89ms
+step:1446/1490 train_time:80850ms step_avg:55.91ms
+step:1447/1490 train_time:80930ms step_avg:55.93ms
+step:1448/1490 train_time:81013ms step_avg:55.95ms
+step:1449/1490 train_time:81092ms step_avg:55.96ms
+step:1450/1490 train_time:81175ms step_avg:55.98ms
+step:1451/1490 train_time:81256ms step_avg:56.00ms
+step:1452/1490 train_time:81342ms step_avg:56.02ms
+step:1453/1490 train_time:81420ms step_avg:56.04ms
+step:1454/1490 train_time:81506ms step_avg:56.06ms
+step:1455/1490 train_time:81585ms step_avg:56.07ms
+step:1456/1490 train_time:81671ms step_avg:56.09ms
+step:1457/1490 train_time:81751ms step_avg:56.11ms
+step:1458/1490 train_time:81835ms step_avg:56.13ms
+step:1459/1490 train_time:81913ms step_avg:56.14ms
+step:1460/1490 train_time:81999ms step_avg:56.16ms
+step:1461/1490 train_time:82078ms step_avg:56.18ms
+step:1462/1490 train_time:82163ms step_avg:56.20ms
+step:1463/1490 train_time:82242ms step_avg:56.21ms
+step:1464/1490 train_time:82326ms step_avg:56.23ms
+step:1465/1490 train_time:82405ms step_avg:56.25ms
+step:1466/1490 train_time:82489ms step_avg:56.27ms
+step:1467/1490 train_time:82569ms step_avg:56.28ms
+step:1468/1490 train_time:82654ms step_avg:56.30ms
+step:1469/1490 train_time:82732ms step_avg:56.32ms
+step:1470/1490 train_time:82816ms step_avg:56.34ms
+step:1471/1490 train_time:82896ms step_avg:56.35ms
+step:1472/1490 train_time:82980ms step_avg:56.37ms
+step:1473/1490 train_time:83060ms step_avg:56.39ms
+step:1474/1490 train_time:83146ms step_avg:56.41ms
+step:1475/1490 train_time:83225ms step_avg:56.42ms
+step:1476/1490 train_time:83309ms step_avg:56.44ms
+step:1477/1490 train_time:83387ms step_avg:56.46ms
+step:1478/1490 train_time:83471ms step_avg:56.48ms
+step:1479/1490 train_time:83550ms step_avg:56.49ms
+step:1480/1490 train_time:83634ms step_avg:56.51ms
+step:1481/1490 train_time:83714ms step_avg:56.53ms
+step:1482/1490 train_time:83798ms step_avg:56.54ms
+step:1483/1490 train_time:83878ms step_avg:56.56ms
+step:1484/1490 train_time:83962ms step_avg:56.58ms
+step:1485/1490 train_time:84042ms step_avg:56.59ms
+step:1486/1490 train_time:84126ms step_avg:56.61ms
+step:1487/1490 train_time:84205ms step_avg:56.63ms
+step:1488/1490 train_time:84290ms step_avg:56.65ms
+step:1489/1490 train_time:84370ms step_avg:56.66ms
+step:1490/1490 train_time:84453ms step_avg:56.68ms
+step:1490/1490 val_loss:3.2791 train_time:84548ms step_avg:56.74ms
+peak memory allocated: 30949 MiB reserved: 45766 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/e5a3e01d-bb85-4907-82fc-a40b4f876a9a.txt
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/e5a3e01d-bb85-4907-82fc-a40b4f876a9a.txt
@@ -1,0 +1,4804 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128 compiled for CUDA 12.8
+Running Triton version 3.6.0
+Wed Apr  8 22:00:43 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.9     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   31C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   36C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   31C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 481, 482, 483, 484, 965, 966, 967, 968, 1448, 1449, 1450, 1451] for warmup
+Resetting Model
+step:0/1490 val_loss:10.8300 train_time:0ms step_avg:0.03ms
+step:1/1490 train_time:69ms step_avg:69.11ms
+step:2/1490 train_time:91ms step_avg:45.41ms
+step:3/1490 train_time:108ms step_avg:36.03ms
+step:4/1490 train_time:138ms step_avg:34.45ms
+step:5/1490 train_time:164ms step_avg:32.82ms
+step:6/1490 train_time:198ms step_avg:33.06ms
+step:7/1490 train_time:225ms step_avg:32.18ms
+step:8/1490 train_time:259ms step_avg:32.41ms
+step:9/1490 train_time:286ms step_avg:31.80ms
+step:10/1490 train_time:321ms step_avg:32.07ms
+step:11/1490 train_time:348ms step_avg:31.60ms
+step:12/1490 train_time:382ms step_avg:31.80ms
+step:13/1490 train_time:409ms step_avg:31.43ms
+step:14/1490 train_time:443ms step_avg:31.61ms
+step:15/1490 train_time:470ms step_avg:31.31ms
+step:16/1490 train_time:504ms step_avg:31.49ms
+step:17/1490 train_time:531ms step_avg:31.22ms
+step:18/1490 train_time:565ms step_avg:31.37ms
+step:19/1490 train_time:592ms step_avg:31.14ms
+step:20/1490 train_time:625ms step_avg:31.27ms
+step:21/1490 train_time:653ms step_avg:31.08ms
+step:22/1490 train_time:687ms step_avg:31.21ms
+step:23/1490 train_time:714ms step_avg:31.03ms
+step:24/1490 train_time:747ms step_avg:31.14ms
+step:25/1490 train_time:774ms step_avg:30.98ms
+step:26/1490 train_time:808ms step_avg:31.09ms
+step:27/1490 train_time:835ms step_avg:30.93ms
+step:28/1490 train_time:869ms step_avg:31.03ms
+step:29/1490 train_time:896ms step_avg:30.90ms
+step:30/1490 train_time:930ms step_avg:30.99ms
+step:31/1490 train_time:957ms step_avg:30.88ms
+step:32/1490 train_time:991ms step_avg:30.97ms
+step:33/1490 train_time:1018ms step_avg:30.85ms
+step:34/1490 train_time:1052ms step_avg:30.95ms
+step:35/1490 train_time:1079ms step_avg:30.84ms
+step:36/1490 train_time:1113ms step_avg:30.91ms
+step:37/1490 train_time:1140ms step_avg:30.82ms
+step:38/1490 train_time:1174ms step_avg:30.90ms
+step:39/1490 train_time:1202ms step_avg:30.82ms
+step:40/1490 train_time:1235ms step_avg:30.89ms
+step:41/1490 train_time:1263ms step_avg:30.80ms
+step:42/1490 train_time:1297ms step_avg:30.87ms
+step:43/1490 train_time:1324ms step_avg:30.79ms
+step:44/1490 train_time:1358ms step_avg:30.87ms
+step:45/1490 train_time:1386ms step_avg:30.79ms
+step:46/1490 train_time:1420ms step_avg:30.86ms
+step:47/1490 train_time:1447ms step_avg:30.78ms
+step:48/1490 train_time:1481ms step_avg:30.85ms
+step:49/1490 train_time:1508ms step_avg:30.77ms
+step:50/1490 train_time:1542ms step_avg:30.83ms
+step:51/1490 train_time:1568ms step_avg:30.75ms
+step:52/1490 train_time:1603ms step_avg:30.82ms
+step:53/1490 train_time:1630ms step_avg:30.75ms
+step:54/1490 train_time:1663ms step_avg:30.80ms
+step:55/1490 train_time:1690ms step_avg:30.73ms
+step:56/1490 train_time:1724ms step_avg:30.79ms
+step:57/1490 train_time:1751ms step_avg:30.72ms
+step:58/1490 train_time:1785ms step_avg:30.78ms
+step:59/1490 train_time:1813ms step_avg:30.72ms
+step:60/1490 train_time:1846ms step_avg:30.77ms
+step:61/1490 train_time:1874ms step_avg:30.72ms
+step:62/1490 train_time:1908ms step_avg:30.77ms
+step:63/1490 train_time:1935ms step_avg:30.71ms
+step:64/1490 train_time:1969ms step_avg:30.76ms
+step:65/1490 train_time:1996ms step_avg:30.71ms
+step:66/1490 train_time:2030ms step_avg:30.75ms
+step:67/1490 train_time:2057ms step_avg:30.70ms
+step:68/1490 train_time:2091ms step_avg:30.74ms
+step:69/1490 train_time:2118ms step_avg:30.69ms
+step:70/1490 train_time:2151ms step_avg:30.73ms
+step:71/1490 train_time:2178ms step_avg:30.68ms
+step:72/1490 train_time:2212ms step_avg:30.72ms
+step:73/1490 train_time:2239ms step_avg:30.67ms
+step:74/1490 train_time:2272ms step_avg:30.71ms
+step:75/1490 train_time:2300ms step_avg:30.66ms
+step:76/1490 train_time:2333ms step_avg:30.70ms
+step:77/1490 train_time:2360ms step_avg:30.65ms
+step:78/1490 train_time:2394ms step_avg:30.69ms
+step:79/1490 train_time:2421ms step_avg:30.64ms
+step:80/1490 train_time:2455ms step_avg:30.69ms
+step:81/1490 train_time:2482ms step_avg:30.64ms
+step:82/1490 train_time:2516ms step_avg:30.68ms
+step:83/1490 train_time:2543ms step_avg:30.64ms
+step:84/1490 train_time:2577ms step_avg:30.68ms
+step:85/1490 train_time:2604ms step_avg:30.64ms
+step:86/1490 train_time:2637ms step_avg:30.67ms
+step:87/1490 train_time:2665ms step_avg:30.63ms
+step:88/1490 train_time:2699ms step_avg:30.67ms
+step:89/1490 train_time:2726ms step_avg:30.63ms
+step:90/1490 train_time:2760ms step_avg:30.66ms
+step:91/1490 train_time:2787ms step_avg:30.63ms
+step:92/1490 train_time:2821ms step_avg:30.66ms
+step:93/1490 train_time:2848ms step_avg:30.62ms
+step:94/1490 train_time:2882ms step_avg:30.66ms
+step:95/1490 train_time:2909ms step_avg:30.62ms
+step:96/1490 train_time:2943ms step_avg:30.66ms
+step:97/1490 train_time:2970ms step_avg:30.62ms
+step:98/1490 train_time:3005ms step_avg:30.66ms
+step:99/1490 train_time:3032ms step_avg:30.62ms
+step:100/1490 train_time:3065ms step_avg:30.65ms
+step:101/1490 train_time:3093ms step_avg:30.62ms
+step:102/1490 train_time:3127ms step_avg:30.65ms
+step:103/1490 train_time:3154ms step_avg:30.62ms
+step:104/1490 train_time:3188ms step_avg:30.65ms
+step:105/1490 train_time:3215ms step_avg:30.62ms
+step:106/1490 train_time:3248ms step_avg:30.65ms
+step:107/1490 train_time:3275ms step_avg:30.61ms
+step:108/1490 train_time:3309ms step_avg:30.64ms
+step:109/1490 train_time:3336ms step_avg:30.60ms
+step:110/1490 train_time:3370ms step_avg:30.63ms
+step:111/1490 train_time:3397ms step_avg:30.60ms
+step:112/1490 train_time:3430ms step_avg:30.63ms
+step:113/1490 train_time:3457ms step_avg:30.60ms
+step:114/1490 train_time:3491ms step_avg:30.62ms
+step:115/1490 train_time:3518ms step_avg:30.59ms
+step:116/1490 train_time:3551ms step_avg:30.62ms
+step:117/1490 train_time:3579ms step_avg:30.59ms
+step:118/1490 train_time:3612ms step_avg:30.61ms
+step:119/1490 train_time:3640ms step_avg:30.58ms
+step:120/1490 train_time:3673ms step_avg:30.61ms
+step:121/1490 train_time:3700ms step_avg:30.58ms
+step:122/1490 train_time:3734ms step_avg:30.61ms
+step:123/1490 train_time:3761ms step_avg:30.58ms
+step:124/1490 train_time:3795ms step_avg:30.60ms
+step:125/1490 train_time:3822ms step_avg:30.58ms
+step:126/1490 train_time:3856ms step_avg:30.60ms
+step:127/1490 train_time:3883ms step_avg:30.58ms
+step:128/1490 train_time:3917ms step_avg:30.60ms
+step:129/1490 train_time:3944ms step_avg:30.57ms
+step:130/1490 train_time:3977ms step_avg:30.60ms
+step:131/1490 train_time:4006ms step_avg:30.58ms
+step:132/1490 train_time:4039ms step_avg:30.60ms
+step:133/1490 train_time:4066ms step_avg:30.57ms
+step:134/1490 train_time:4100ms step_avg:30.59ms
+step:135/1490 train_time:4127ms step_avg:30.57ms
+step:136/1490 train_time:4161ms step_avg:30.60ms
+step:137/1490 train_time:4188ms step_avg:30.57ms
+step:138/1490 train_time:4222ms step_avg:30.59ms
+step:139/1490 train_time:4249ms step_avg:30.57ms
+step:140/1490 train_time:4283ms step_avg:30.59ms
+step:141/1490 train_time:4310ms step_avg:30.57ms
+step:142/1490 train_time:4344ms step_avg:30.59ms
+step:143/1490 train_time:4371ms step_avg:30.57ms
+step:144/1490 train_time:4405ms step_avg:30.59ms
+step:145/1490 train_time:4432ms step_avg:30.56ms
+step:146/1490 train_time:4466ms step_avg:30.59ms
+step:147/1490 train_time:4493ms step_avg:30.56ms
+step:148/1490 train_time:4527ms step_avg:30.59ms
+step:149/1490 train_time:4554ms step_avg:30.56ms
+step:150/1490 train_time:4588ms step_avg:30.59ms
+step:151/1490 train_time:4615ms step_avg:30.56ms
+step:152/1490 train_time:4649ms step_avg:30.58ms
+step:153/1490 train_time:4676ms step_avg:30.56ms
+step:154/1490 train_time:4710ms step_avg:30.58ms
+step:155/1490 train_time:4737ms step_avg:30.56ms
+step:156/1490 train_time:4770ms step_avg:30.58ms
+step:157/1490 train_time:4798ms step_avg:30.56ms
+step:158/1490 train_time:4831ms step_avg:30.58ms
+step:159/1490 train_time:4858ms step_avg:30.55ms
+step:160/1490 train_time:4892ms step_avg:30.57ms
+step:161/1490 train_time:4918ms step_avg:30.55ms
+step:162/1490 train_time:4952ms step_avg:30.57ms
+step:163/1490 train_time:4979ms step_avg:30.55ms
+step:164/1490 train_time:5012ms step_avg:30.56ms
+step:165/1490 train_time:5040ms step_avg:30.54ms
+step:166/1490 train_time:5073ms step_avg:30.56ms
+step:167/1490 train_time:5100ms step_avg:30.54ms
+step:168/1490 train_time:5134ms step_avg:30.56ms
+step:169/1490 train_time:5161ms step_avg:30.54ms
+step:170/1490 train_time:5194ms step_avg:30.56ms
+step:171/1490 train_time:5222ms step_avg:30.54ms
+step:172/1490 train_time:5255ms step_avg:30.55ms
+step:173/1490 train_time:5283ms step_avg:30.54ms
+step:174/1490 train_time:5316ms step_avg:30.55ms
+step:175/1490 train_time:5343ms step_avg:30.53ms
+step:176/1490 train_time:5377ms step_avg:30.55ms
+step:177/1490 train_time:5404ms step_avg:30.53ms
+step:178/1490 train_time:5438ms step_avg:30.55ms
+step:179/1490 train_time:5465ms step_avg:30.53ms
+step:180/1490 train_time:5499ms step_avg:30.55ms
+step:181/1490 train_time:5527ms step_avg:30.53ms
+step:182/1490 train_time:5560ms step_avg:30.55ms
+step:183/1490 train_time:5587ms step_avg:30.53ms
+step:184/1490 train_time:5621ms step_avg:30.55ms
+step:185/1490 train_time:5648ms step_avg:30.53ms
+step:186/1490 train_time:5682ms step_avg:30.55ms
+step:187/1490 train_time:5709ms step_avg:30.53ms
+step:188/1490 train_time:5743ms step_avg:30.55ms
+step:189/1490 train_time:5770ms step_avg:30.53ms
+step:190/1490 train_time:5804ms step_avg:30.55ms
+step:191/1490 train_time:5831ms step_avg:30.53ms
+step:192/1490 train_time:5865ms step_avg:30.55ms
+step:193/1490 train_time:5892ms step_avg:30.53ms
+step:194/1490 train_time:5926ms step_avg:30.55ms
+step:195/1490 train_time:5953ms step_avg:30.53ms
+step:196/1490 train_time:5986ms step_avg:30.54ms
+step:197/1490 train_time:6013ms step_avg:30.52ms
+step:198/1490 train_time:6047ms step_avg:30.54ms
+step:199/1490 train_time:6074ms step_avg:30.52ms
+step:200/1490 train_time:6108ms step_avg:30.54ms
+step:201/1490 train_time:6134ms step_avg:30.52ms
+step:202/1490 train_time:6168ms step_avg:30.54ms
+step:203/1490 train_time:6195ms step_avg:30.52ms
+step:204/1490 train_time:6229ms step_avg:30.53ms
+step:205/1490 train_time:6256ms step_avg:30.52ms
+step:206/1490 train_time:6289ms step_avg:30.53ms
+step:207/1490 train_time:6317ms step_avg:30.51ms
+step:208/1490 train_time:6350ms step_avg:30.53ms
+step:209/1490 train_time:6377ms step_avg:30.51ms
+step:210/1490 train_time:6411ms step_avg:30.53ms
+step:211/1490 train_time:6438ms step_avg:30.51ms
+step:212/1490 train_time:6472ms step_avg:30.53ms
+step:213/1490 train_time:6499ms step_avg:30.51ms
+step:214/1490 train_time:6532ms step_avg:30.52ms
+step:215/1490 train_time:6560ms step_avg:30.51ms
+step:216/1490 train_time:6593ms step_avg:30.52ms
+step:217/1490 train_time:6621ms step_avg:30.51ms
+step:218/1490 train_time:6654ms step_avg:30.52ms
+step:219/1490 train_time:6682ms step_avg:30.51ms
+step:220/1490 train_time:6716ms step_avg:30.53ms
+step:221/1490 train_time:6743ms step_avg:30.51ms
+step:222/1490 train_time:6777ms step_avg:30.52ms
+step:223/1490 train_time:6804ms step_avg:30.51ms
+step:224/1490 train_time:6838ms step_avg:30.52ms
+step:225/1490 train_time:6865ms step_avg:30.51ms
+step:226/1490 train_time:6898ms step_avg:30.52ms
+step:227/1490 train_time:6926ms step_avg:30.51ms
+step:228/1490 train_time:6960ms step_avg:30.52ms
+step:229/1490 train_time:6987ms step_avg:30.51ms
+step:230/1490 train_time:7020ms step_avg:30.52ms
+step:231/1490 train_time:7048ms step_avg:30.51ms
+step:232/1490 train_time:7082ms step_avg:30.52ms
+step:233/1490 train_time:7109ms step_avg:30.51ms
+step:234/1490 train_time:7143ms step_avg:30.52ms
+step:235/1490 train_time:7169ms step_avg:30.51ms
+step:236/1490 train_time:7203ms step_avg:30.52ms
+step:237/1490 train_time:7230ms step_avg:30.51ms
+step:238/1490 train_time:7265ms step_avg:30.52ms
+step:239/1490 train_time:7291ms step_avg:30.51ms
+step:240/1490 train_time:7325ms step_avg:30.52ms
+step:241/1490 train_time:7352ms step_avg:30.51ms
+step:242/1490 train_time:7386ms step_avg:30.52ms
+step:243/1490 train_time:7413ms step_avg:30.51ms
+step:244/1490 train_time:7447ms step_avg:30.52ms
+step:245/1490 train_time:7474ms step_avg:30.51ms
+step:246/1490 train_time:7508ms step_avg:30.52ms
+step:247/1490 train_time:7535ms step_avg:30.50ms
+step:248/1490 train_time:7569ms step_avg:30.52ms
+step:249/1490 train_time:7595ms step_avg:30.50ms
+step:250/1490 train_time:7629ms step_avg:30.52ms
+step:250/1490 val_loss:4.5280 train_time:7668ms step_avg:30.67ms
+step:251/1490 train_time:7685ms step_avg:30.62ms
+step:252/1490 train_time:7703ms step_avg:30.57ms
+step:253/1490 train_time:7720ms step_avg:30.51ms
+step:254/1490 train_time:7754ms step_avg:30.53ms
+step:255/1490 train_time:7784ms step_avg:30.52ms
+step:256/1490 train_time:7818ms step_avg:30.54ms
+step:257/1490 train_time:7846ms step_avg:30.53ms
+step:258/1490 train_time:7880ms step_avg:30.54ms
+step:259/1490 train_time:7907ms step_avg:30.53ms
+step:260/1490 train_time:7942ms step_avg:30.54ms
+step:261/1490 train_time:7969ms step_avg:30.53ms
+step:262/1490 train_time:8003ms step_avg:30.55ms
+step:263/1490 train_time:8030ms step_avg:30.53ms
+step:264/1490 train_time:8064ms step_avg:30.55ms
+step:265/1490 train_time:8091ms step_avg:30.53ms
+step:266/1490 train_time:8125ms step_avg:30.55ms
+step:267/1490 train_time:8152ms step_avg:30.53ms
+step:268/1490 train_time:8186ms step_avg:30.54ms
+step:269/1490 train_time:8213ms step_avg:30.53ms
+step:270/1490 train_time:8247ms step_avg:30.54ms
+step:271/1490 train_time:8274ms step_avg:30.53ms
+step:272/1490 train_time:8308ms step_avg:30.54ms
+step:273/1490 train_time:8335ms step_avg:30.53ms
+step:274/1490 train_time:8368ms step_avg:30.54ms
+step:275/1490 train_time:8395ms step_avg:30.53ms
+step:276/1490 train_time:8429ms step_avg:30.54ms
+step:277/1490 train_time:8456ms step_avg:30.53ms
+step:278/1490 train_time:8489ms step_avg:30.54ms
+step:279/1490 train_time:8516ms step_avg:30.52ms
+step:280/1490 train_time:8550ms step_avg:30.54ms
+step:281/1490 train_time:8577ms step_avg:30.52ms
+step:282/1490 train_time:8611ms step_avg:30.53ms
+step:283/1490 train_time:8637ms step_avg:30.52ms
+step:284/1490 train_time:8671ms step_avg:30.53ms
+step:285/1490 train_time:8698ms step_avg:30.52ms
+step:286/1490 train_time:8732ms step_avg:30.53ms
+step:287/1490 train_time:8760ms step_avg:30.52ms
+step:288/1490 train_time:8793ms step_avg:30.53ms
+step:289/1490 train_time:8821ms step_avg:30.52ms
+step:290/1490 train_time:8855ms step_avg:30.53ms
+step:291/1490 train_time:8882ms step_avg:30.52ms
+step:292/1490 train_time:8916ms step_avg:30.53ms
+step:293/1490 train_time:8943ms step_avg:30.52ms
+step:294/1490 train_time:8977ms step_avg:30.53ms
+step:295/1490 train_time:9005ms step_avg:30.52ms
+step:296/1490 train_time:9038ms step_avg:30.54ms
+step:297/1490 train_time:9066ms step_avg:30.52ms
+step:298/1490 train_time:9100ms step_avg:30.54ms
+step:299/1490 train_time:9127ms step_avg:30.53ms
+step:300/1490 train_time:9161ms step_avg:30.54ms
+step:301/1490 train_time:9188ms step_avg:30.52ms
+step:302/1490 train_time:9222ms step_avg:30.54ms
+step:303/1490 train_time:9249ms step_avg:30.52ms
+step:304/1490 train_time:9283ms step_avg:30.53ms
+step:305/1490 train_time:9309ms step_avg:30.52ms
+step:306/1490 train_time:9343ms step_avg:30.53ms
+step:307/1490 train_time:9370ms step_avg:30.52ms
+step:308/1490 train_time:9404ms step_avg:30.53ms
+step:309/1490 train_time:9431ms step_avg:30.52ms
+step:310/1490 train_time:9465ms step_avg:30.53ms
+step:311/1490 train_time:9492ms step_avg:30.52ms
+step:312/1490 train_time:9526ms step_avg:30.53ms
+step:313/1490 train_time:9553ms step_avg:30.52ms
+step:314/1490 train_time:9586ms step_avg:30.53ms
+step:315/1490 train_time:9614ms step_avg:30.52ms
+step:316/1490 train_time:9647ms step_avg:30.53ms
+step:317/1490 train_time:9674ms step_avg:30.52ms
+step:318/1490 train_time:9708ms step_avg:30.53ms
+step:319/1490 train_time:9736ms step_avg:30.52ms
+step:320/1490 train_time:9769ms step_avg:30.53ms
+step:321/1490 train_time:9797ms step_avg:30.52ms
+step:322/1490 train_time:9830ms step_avg:30.53ms
+step:323/1490 train_time:9857ms step_avg:30.52ms
+step:324/1490 train_time:9891ms step_avg:30.53ms
+step:325/1490 train_time:9918ms step_avg:30.52ms
+step:326/1490 train_time:9952ms step_avg:30.53ms
+step:327/1490 train_time:9979ms step_avg:30.52ms
+step:328/1490 train_time:10013ms step_avg:30.53ms
+step:329/1490 train_time:10040ms step_avg:30.52ms
+step:330/1490 train_time:10073ms step_avg:30.53ms
+step:331/1490 train_time:10101ms step_avg:30.52ms
+step:332/1490 train_time:10134ms step_avg:30.52ms
+step:333/1490 train_time:10162ms step_avg:30.52ms
+step:334/1490 train_time:10196ms step_avg:30.53ms
+step:335/1490 train_time:10223ms step_avg:30.52ms
+step:336/1490 train_time:10257ms step_avg:30.53ms
+step:337/1490 train_time:10284ms step_avg:30.52ms
+step:338/1490 train_time:10318ms step_avg:30.53ms
+step:339/1490 train_time:10345ms step_avg:30.52ms
+step:340/1490 train_time:10379ms step_avg:30.53ms
+step:341/1490 train_time:10406ms step_avg:30.52ms
+step:342/1490 train_time:10440ms step_avg:30.53ms
+step:343/1490 train_time:10468ms step_avg:30.52ms
+step:344/1490 train_time:10501ms step_avg:30.53ms
+step:345/1490 train_time:10529ms step_avg:30.52ms
+step:346/1490 train_time:10563ms step_avg:30.53ms
+step:347/1490 train_time:10590ms step_avg:30.52ms
+step:348/1490 train_time:10624ms step_avg:30.53ms
+step:349/1490 train_time:10651ms step_avg:30.52ms
+step:350/1490 train_time:10685ms step_avg:30.53ms
+step:351/1490 train_time:10712ms step_avg:30.52ms
+step:352/1490 train_time:10746ms step_avg:30.53ms
+step:353/1490 train_time:10773ms step_avg:30.52ms
+step:354/1490 train_time:10807ms step_avg:30.53ms
+step:355/1490 train_time:10834ms step_avg:30.52ms
+step:356/1490 train_time:10868ms step_avg:30.53ms
+step:357/1490 train_time:10895ms step_avg:30.52ms
+step:358/1490 train_time:10928ms step_avg:30.53ms
+step:359/1490 train_time:10955ms step_avg:30.52ms
+step:360/1490 train_time:10989ms step_avg:30.53ms
+step:361/1490 train_time:11016ms step_avg:30.52ms
+step:362/1490 train_time:11050ms step_avg:30.53ms
+step:363/1490 train_time:11077ms step_avg:30.52ms
+step:364/1490 train_time:11111ms step_avg:30.52ms
+step:365/1490 train_time:11139ms step_avg:30.52ms
+step:366/1490 train_time:11172ms step_avg:30.52ms
+step:367/1490 train_time:11199ms step_avg:30.52ms
+step:368/1490 train_time:11233ms step_avg:30.52ms
+step:369/1490 train_time:11260ms step_avg:30.51ms
+step:370/1490 train_time:11293ms step_avg:30.52ms
+step:371/1490 train_time:11320ms step_avg:30.51ms
+step:372/1490 train_time:11354ms step_avg:30.52ms
+step:373/1490 train_time:11381ms step_avg:30.51ms
+step:374/1490 train_time:11417ms step_avg:30.53ms
+step:375/1490 train_time:11442ms step_avg:30.51ms
+step:376/1490 train_time:11476ms step_avg:30.52ms
+step:377/1490 train_time:11504ms step_avg:30.51ms
+step:378/1490 train_time:11538ms step_avg:30.52ms
+step:379/1490 train_time:11565ms step_avg:30.51ms
+step:380/1490 train_time:11599ms step_avg:30.52ms
+step:381/1490 train_time:11626ms step_avg:30.52ms
+step:382/1490 train_time:11661ms step_avg:30.53ms
+step:383/1490 train_time:11687ms step_avg:30.52ms
+step:384/1490 train_time:11721ms step_avg:30.52ms
+step:385/1490 train_time:11748ms step_avg:30.52ms
+step:386/1490 train_time:11782ms step_avg:30.52ms
+step:387/1490 train_time:11809ms step_avg:30.51ms
+step:388/1490 train_time:11843ms step_avg:30.52ms
+step:389/1490 train_time:11871ms step_avg:30.52ms
+step:390/1490 train_time:11905ms step_avg:30.52ms
+step:391/1490 train_time:11932ms step_avg:30.52ms
+step:392/1490 train_time:11966ms step_avg:30.53ms
+step:393/1490 train_time:11993ms step_avg:30.52ms
+step:394/1490 train_time:12027ms step_avg:30.52ms
+step:395/1490 train_time:12054ms step_avg:30.52ms
+step:396/1490 train_time:12087ms step_avg:30.52ms
+step:397/1490 train_time:12115ms step_avg:30.52ms
+step:398/1490 train_time:12148ms step_avg:30.52ms
+step:399/1490 train_time:12176ms step_avg:30.52ms
+step:400/1490 train_time:12209ms step_avg:30.52ms
+step:401/1490 train_time:12236ms step_avg:30.51ms
+step:402/1490 train_time:12270ms step_avg:30.52ms
+step:403/1490 train_time:12298ms step_avg:30.52ms
+step:404/1490 train_time:12332ms step_avg:30.52ms
+step:405/1490 train_time:12359ms step_avg:30.52ms
+step:406/1490 train_time:12393ms step_avg:30.52ms
+step:407/1490 train_time:12420ms step_avg:30.52ms
+step:408/1490 train_time:12454ms step_avg:30.52ms
+step:409/1490 train_time:12481ms step_avg:30.52ms
+step:410/1490 train_time:12515ms step_avg:30.52ms
+step:411/1490 train_time:12542ms step_avg:30.52ms
+step:412/1490 train_time:12576ms step_avg:30.52ms
+step:413/1490 train_time:12603ms step_avg:30.52ms
+step:414/1490 train_time:12637ms step_avg:30.52ms
+step:415/1490 train_time:12664ms step_avg:30.52ms
+step:416/1490 train_time:12698ms step_avg:30.52ms
+step:417/1490 train_time:12725ms step_avg:30.52ms
+step:418/1490 train_time:12760ms step_avg:30.53ms
+step:419/1490 train_time:12787ms step_avg:30.52ms
+step:420/1490 train_time:12821ms step_avg:30.53ms
+step:421/1490 train_time:12848ms step_avg:30.52ms
+step:422/1490 train_time:12882ms step_avg:30.53ms
+step:423/1490 train_time:12909ms step_avg:30.52ms
+step:424/1490 train_time:12943ms step_avg:30.53ms
+step:425/1490 train_time:12970ms step_avg:30.52ms
+step:426/1490 train_time:13005ms step_avg:30.53ms
+step:427/1490 train_time:13032ms step_avg:30.52ms
+step:428/1490 train_time:13065ms step_avg:30.53ms
+step:429/1490 train_time:13093ms step_avg:30.52ms
+step:430/1490 train_time:13126ms step_avg:30.53ms
+step:431/1490 train_time:13154ms step_avg:30.52ms
+step:432/1490 train_time:13187ms step_avg:30.53ms
+step:433/1490 train_time:13215ms step_avg:30.52ms
+step:434/1490 train_time:13248ms step_avg:30.53ms
+step:435/1490 train_time:13276ms step_avg:30.52ms
+step:436/1490 train_time:13309ms step_avg:30.53ms
+step:437/1490 train_time:13337ms step_avg:30.52ms
+step:438/1490 train_time:13370ms step_avg:30.53ms
+step:439/1490 train_time:13398ms step_avg:30.52ms
+step:440/1490 train_time:13431ms step_avg:30.53ms
+step:441/1490 train_time:13458ms step_avg:30.52ms
+step:442/1490 train_time:13492ms step_avg:30.53ms
+step:443/1490 train_time:13519ms step_avg:30.52ms
+step:444/1490 train_time:13553ms step_avg:30.53ms
+step:445/1490 train_time:13580ms step_avg:30.52ms
+step:446/1490 train_time:13615ms step_avg:30.53ms
+step:447/1490 train_time:13641ms step_avg:30.52ms
+step:448/1490 train_time:13675ms step_avg:30.52ms
+step:449/1490 train_time:13702ms step_avg:30.52ms
+step:450/1490 train_time:13736ms step_avg:30.52ms
+step:451/1490 train_time:13763ms step_avg:30.52ms
+step:452/1490 train_time:13797ms step_avg:30.52ms
+step:453/1490 train_time:13824ms step_avg:30.52ms
+step:454/1490 train_time:13858ms step_avg:30.53ms
+step:455/1490 train_time:13886ms step_avg:30.52ms
+step:456/1490 train_time:13920ms step_avg:30.53ms
+step:457/1490 train_time:13947ms step_avg:30.52ms
+step:458/1490 train_time:13981ms step_avg:30.53ms
+step:459/1490 train_time:14008ms step_avg:30.52ms
+step:460/1490 train_time:14043ms step_avg:30.53ms
+step:461/1490 train_time:14070ms step_avg:30.52ms
+step:462/1490 train_time:14104ms step_avg:30.53ms
+step:463/1490 train_time:14131ms step_avg:30.52ms
+step:464/1490 train_time:14165ms step_avg:30.53ms
+step:465/1490 train_time:14192ms step_avg:30.52ms
+step:466/1490 train_time:14226ms step_avg:30.53ms
+step:467/1490 train_time:14253ms step_avg:30.52ms
+step:468/1490 train_time:14287ms step_avg:30.53ms
+step:469/1490 train_time:14314ms step_avg:30.52ms
+step:470/1490 train_time:14348ms step_avg:30.53ms
+step:471/1490 train_time:14375ms step_avg:30.52ms
+step:472/1490 train_time:14409ms step_avg:30.53ms
+step:473/1490 train_time:14436ms step_avg:30.52ms
+step:474/1490 train_time:14470ms step_avg:30.53ms
+step:475/1490 train_time:14497ms step_avg:30.52ms
+step:476/1490 train_time:14531ms step_avg:30.53ms
+step:477/1490 train_time:14558ms step_avg:30.52ms
+step:478/1490 train_time:14591ms step_avg:30.53ms
+step:479/1490 train_time:14619ms step_avg:30.52ms
+step:480/1490 train_time:14652ms step_avg:30.53ms
+step:481/1490 train_time:14679ms step_avg:30.52ms
+step:482/1490 train_time:14713ms step_avg:30.52ms
+step:483/1490 train_time:14741ms step_avg:30.52ms
+step:484/1490 train_time:14777ms step_avg:30.53ms
+step:485/1490 train_time:14829ms step_avg:30.57ms
+step:486/1490 train_time:14887ms step_avg:30.63ms
+step:487/1490 train_time:14939ms step_avg:30.68ms
+step:488/1490 train_time:14997ms step_avg:30.73ms
+step:489/1490 train_time:15050ms step_avg:30.78ms
+step:490/1490 train_time:15110ms step_avg:30.84ms
+step:491/1490 train_time:15162ms step_avg:30.88ms
+step:492/1490 train_time:15221ms step_avg:30.94ms
+step:493/1490 train_time:15274ms step_avg:30.98ms
+step:494/1490 train_time:15333ms step_avg:31.04ms
+step:495/1490 train_time:15386ms step_avg:31.08ms
+step:496/1490 train_time:15444ms step_avg:31.14ms
+step:497/1490 train_time:15498ms step_avg:31.18ms
+step:498/1490 train_time:15556ms step_avg:31.24ms
+step:499/1490 train_time:15610ms step_avg:31.28ms
+step:500/1490 train_time:15668ms step_avg:31.34ms
+step:500/1490 val_loss:4.2407 train_time:15734ms step_avg:31.47ms
+step:501/1490 train_time:15752ms step_avg:31.44ms
+step:502/1490 train_time:15781ms step_avg:31.44ms
+step:503/1490 train_time:15838ms step_avg:31.49ms
+step:504/1490 train_time:15899ms step_avg:31.55ms
+step:505/1490 train_time:15954ms step_avg:31.59ms
+step:506/1490 train_time:16013ms step_avg:31.65ms
+step:507/1490 train_time:16065ms step_avg:31.69ms
+step:508/1490 train_time:16122ms step_avg:31.74ms
+step:509/1490 train_time:16176ms step_avg:31.78ms
+step:510/1490 train_time:16234ms step_avg:31.83ms
+step:511/1490 train_time:16286ms step_avg:31.87ms
+step:512/1490 train_time:16344ms step_avg:31.92ms
+step:513/1490 train_time:16397ms step_avg:31.96ms
+step:514/1490 train_time:16454ms step_avg:32.01ms
+step:515/1490 train_time:16507ms step_avg:32.05ms
+step:516/1490 train_time:16564ms step_avg:32.10ms
+step:517/1490 train_time:16617ms step_avg:32.14ms
+step:518/1490 train_time:16675ms step_avg:32.19ms
+step:519/1490 train_time:16729ms step_avg:32.23ms
+step:520/1490 train_time:16788ms step_avg:32.28ms
+step:521/1490 train_time:16842ms step_avg:32.33ms
+step:522/1490 train_time:16902ms step_avg:32.38ms
+step:523/1490 train_time:16955ms step_avg:32.42ms
+step:524/1490 train_time:17014ms step_avg:32.47ms
+step:525/1490 train_time:17068ms step_avg:32.51ms
+step:526/1490 train_time:17125ms step_avg:32.56ms
+step:527/1490 train_time:17177ms step_avg:32.59ms
+step:528/1490 train_time:17236ms step_avg:32.64ms
+step:529/1490 train_time:17289ms step_avg:32.68ms
+step:530/1490 train_time:17347ms step_avg:32.73ms
+step:531/1490 train_time:17400ms step_avg:32.77ms
+step:532/1490 train_time:17457ms step_avg:32.81ms
+step:533/1490 train_time:17510ms step_avg:32.85ms
+step:534/1490 train_time:17567ms step_avg:32.90ms
+step:535/1490 train_time:17620ms step_avg:32.94ms
+step:536/1490 train_time:17678ms step_avg:32.98ms
+step:537/1490 train_time:17731ms step_avg:33.02ms
+step:538/1490 train_time:17791ms step_avg:33.07ms
+step:539/1490 train_time:17845ms step_avg:33.11ms
+step:540/1490 train_time:17904ms step_avg:33.16ms
+step:541/1490 train_time:17957ms step_avg:33.19ms
+step:542/1490 train_time:18016ms step_avg:33.24ms
+step:543/1490 train_time:18070ms step_avg:33.28ms
+step:544/1490 train_time:18129ms step_avg:33.33ms
+step:545/1490 train_time:18182ms step_avg:33.36ms
+step:546/1490 train_time:18241ms step_avg:33.41ms
+step:547/1490 train_time:18294ms step_avg:33.44ms
+step:548/1490 train_time:18352ms step_avg:33.49ms
+step:549/1490 train_time:18405ms step_avg:33.52ms
+step:550/1490 train_time:18462ms step_avg:33.57ms
+step:551/1490 train_time:18515ms step_avg:33.60ms
+step:552/1490 train_time:18573ms step_avg:33.65ms
+step:553/1490 train_time:18626ms step_avg:33.68ms
+step:554/1490 train_time:18684ms step_avg:33.73ms
+step:555/1490 train_time:18738ms step_avg:33.76ms
+step:556/1490 train_time:18797ms step_avg:33.81ms
+step:557/1490 train_time:18849ms step_avg:33.84ms
+step:558/1490 train_time:18908ms step_avg:33.89ms
+step:559/1490 train_time:18961ms step_avg:33.92ms
+step:560/1490 train_time:19019ms step_avg:33.96ms
+step:561/1490 train_time:19072ms step_avg:34.00ms
+step:562/1490 train_time:19131ms step_avg:34.04ms
+step:563/1490 train_time:19185ms step_avg:34.08ms
+step:564/1490 train_time:19243ms step_avg:34.12ms
+step:565/1490 train_time:19297ms step_avg:34.15ms
+step:566/1490 train_time:19355ms step_avg:34.20ms
+step:567/1490 train_time:19408ms step_avg:34.23ms
+step:568/1490 train_time:19465ms step_avg:34.27ms
+step:569/1490 train_time:19518ms step_avg:34.30ms
+step:570/1490 train_time:19576ms step_avg:34.34ms
+step:571/1490 train_time:19629ms step_avg:34.38ms
+step:572/1490 train_time:19688ms step_avg:34.42ms
+step:573/1490 train_time:19741ms step_avg:34.45ms
+step:574/1490 train_time:19800ms step_avg:34.49ms
+step:575/1490 train_time:19853ms step_avg:34.53ms
+step:576/1490 train_time:19911ms step_avg:34.57ms
+step:577/1490 train_time:19965ms step_avg:34.60ms
+step:578/1490 train_time:20023ms step_avg:34.64ms
+step:579/1490 train_time:20076ms step_avg:34.67ms
+step:580/1490 train_time:20134ms step_avg:34.71ms
+step:581/1490 train_time:20187ms step_avg:34.75ms
+step:582/1490 train_time:20245ms step_avg:34.79ms
+step:583/1490 train_time:20300ms step_avg:34.82ms
+step:584/1490 train_time:20358ms step_avg:34.86ms
+step:585/1490 train_time:20410ms step_avg:34.89ms
+step:586/1490 train_time:20468ms step_avg:34.93ms
+step:587/1490 train_time:20520ms step_avg:34.96ms
+step:588/1490 train_time:20578ms step_avg:35.00ms
+step:589/1490 train_time:20631ms step_avg:35.03ms
+step:590/1490 train_time:20691ms step_avg:35.07ms
+step:591/1490 train_time:20744ms step_avg:35.10ms
+step:592/1490 train_time:20802ms step_avg:35.14ms
+step:593/1490 train_time:20856ms step_avg:35.17ms
+step:594/1490 train_time:20914ms step_avg:35.21ms
+step:595/1490 train_time:20968ms step_avg:35.24ms
+step:596/1490 train_time:21025ms step_avg:35.28ms
+step:597/1490 train_time:21079ms step_avg:35.31ms
+step:598/1490 train_time:21137ms step_avg:35.35ms
+step:599/1490 train_time:21190ms step_avg:35.38ms
+step:600/1490 train_time:21249ms step_avg:35.42ms
+step:601/1490 train_time:21302ms step_avg:35.44ms
+step:602/1490 train_time:21360ms step_avg:35.48ms
+step:603/1490 train_time:21413ms step_avg:35.51ms
+step:604/1490 train_time:21471ms step_avg:35.55ms
+step:605/1490 train_time:21525ms step_avg:35.58ms
+step:606/1490 train_time:21582ms step_avg:35.61ms
+step:607/1490 train_time:21635ms step_avg:35.64ms
+step:608/1490 train_time:21694ms step_avg:35.68ms
+step:609/1490 train_time:21748ms step_avg:35.71ms
+step:610/1490 train_time:21805ms step_avg:35.75ms
+step:611/1490 train_time:21859ms step_avg:35.78ms
+step:612/1490 train_time:21917ms step_avg:35.81ms
+step:613/1490 train_time:21971ms step_avg:35.84ms
+step:614/1490 train_time:22029ms step_avg:35.88ms
+step:615/1490 train_time:22083ms step_avg:35.91ms
+step:616/1490 train_time:22141ms step_avg:35.94ms
+step:617/1490 train_time:22195ms step_avg:35.97ms
+step:618/1490 train_time:22254ms step_avg:36.01ms
+step:619/1490 train_time:22307ms step_avg:36.04ms
+step:620/1490 train_time:22364ms step_avg:36.07ms
+step:621/1490 train_time:22418ms step_avg:36.10ms
+step:622/1490 train_time:22475ms step_avg:36.13ms
+step:623/1490 train_time:22529ms step_avg:36.16ms
+step:624/1490 train_time:22587ms step_avg:36.20ms
+step:625/1490 train_time:22639ms step_avg:36.22ms
+step:626/1490 train_time:22698ms step_avg:36.26ms
+step:627/1490 train_time:22751ms step_avg:36.29ms
+step:628/1490 train_time:22809ms step_avg:36.32ms
+step:629/1490 train_time:22862ms step_avg:36.35ms
+step:630/1490 train_time:22920ms step_avg:36.38ms
+step:631/1490 train_time:22973ms step_avg:36.41ms
+step:632/1490 train_time:23032ms step_avg:36.44ms
+step:633/1490 train_time:23086ms step_avg:36.47ms
+step:634/1490 train_time:23143ms step_avg:36.50ms
+step:635/1490 train_time:23198ms step_avg:36.53ms
+step:636/1490 train_time:23256ms step_avg:36.57ms
+step:637/1490 train_time:23309ms step_avg:36.59ms
+step:638/1490 train_time:23368ms step_avg:36.63ms
+step:639/1490 train_time:23420ms step_avg:36.65ms
+step:640/1490 train_time:23479ms step_avg:36.69ms
+step:641/1490 train_time:23532ms step_avg:36.71ms
+step:642/1490 train_time:23590ms step_avg:36.74ms
+step:643/1490 train_time:23643ms step_avg:36.77ms
+step:644/1490 train_time:23702ms step_avg:36.80ms
+step:645/1490 train_time:23755ms step_avg:36.83ms
+step:646/1490 train_time:23813ms step_avg:36.86ms
+step:647/1490 train_time:23867ms step_avg:36.89ms
+step:648/1490 train_time:23925ms step_avg:36.92ms
+step:649/1490 train_time:23977ms step_avg:36.94ms
+step:650/1490 train_time:24036ms step_avg:36.98ms
+step:651/1490 train_time:24090ms step_avg:37.00ms
+step:652/1490 train_time:24149ms step_avg:37.04ms
+step:653/1490 train_time:24202ms step_avg:37.06ms
+step:654/1490 train_time:24259ms step_avg:37.09ms
+step:655/1490 train_time:24313ms step_avg:37.12ms
+step:656/1490 train_time:24370ms step_avg:37.15ms
+step:657/1490 train_time:24423ms step_avg:37.17ms
+step:658/1490 train_time:24481ms step_avg:37.21ms
+step:659/1490 train_time:24536ms step_avg:37.23ms
+step:660/1490 train_time:24595ms step_avg:37.26ms
+step:661/1490 train_time:24648ms step_avg:37.29ms
+step:662/1490 train_time:24706ms step_avg:37.32ms
+step:663/1490 train_time:24759ms step_avg:37.34ms
+step:664/1490 train_time:24818ms step_avg:37.38ms
+step:665/1490 train_time:24871ms step_avg:37.40ms
+step:666/1490 train_time:24929ms step_avg:37.43ms
+step:667/1490 train_time:24982ms step_avg:37.45ms
+step:668/1490 train_time:25040ms step_avg:37.49ms
+step:669/1490 train_time:25094ms step_avg:37.51ms
+step:670/1490 train_time:25152ms step_avg:37.54ms
+step:671/1490 train_time:25205ms step_avg:37.56ms
+step:672/1490 train_time:25263ms step_avg:37.59ms
+step:673/1490 train_time:25317ms step_avg:37.62ms
+step:674/1490 train_time:25375ms step_avg:37.65ms
+step:675/1490 train_time:25428ms step_avg:37.67ms
+step:676/1490 train_time:25486ms step_avg:37.70ms
+step:677/1490 train_time:25540ms step_avg:37.73ms
+step:678/1490 train_time:25599ms step_avg:37.76ms
+step:679/1490 train_time:25652ms step_avg:37.78ms
+step:680/1490 train_time:25711ms step_avg:37.81ms
+step:681/1490 train_time:25764ms step_avg:37.83ms
+step:682/1490 train_time:25821ms step_avg:37.86ms
+step:683/1490 train_time:25873ms step_avg:37.88ms
+step:684/1490 train_time:25932ms step_avg:37.91ms
+step:685/1490 train_time:25986ms step_avg:37.94ms
+step:686/1490 train_time:26045ms step_avg:37.97ms
+step:687/1490 train_time:26098ms step_avg:37.99ms
+step:688/1490 train_time:26156ms step_avg:38.02ms
+step:689/1490 train_time:26209ms step_avg:38.04ms
+step:690/1490 train_time:26268ms step_avg:38.07ms
+step:691/1490 train_time:26320ms step_avg:38.09ms
+step:692/1490 train_time:26378ms step_avg:38.12ms
+step:693/1490 train_time:26433ms step_avg:38.14ms
+step:694/1490 train_time:26492ms step_avg:38.17ms
+step:695/1490 train_time:26544ms step_avg:38.19ms
+step:696/1490 train_time:26602ms step_avg:38.22ms
+step:697/1490 train_time:26655ms step_avg:38.24ms
+step:698/1490 train_time:26714ms step_avg:38.27ms
+step:699/1490 train_time:26767ms step_avg:38.29ms
+step:700/1490 train_time:26825ms step_avg:38.32ms
+step:701/1490 train_time:26877ms step_avg:38.34ms
+step:702/1490 train_time:26937ms step_avg:38.37ms
+step:703/1490 train_time:26990ms step_avg:38.39ms
+step:704/1490 train_time:27048ms step_avg:38.42ms
+step:705/1490 train_time:27101ms step_avg:38.44ms
+step:706/1490 train_time:27159ms step_avg:38.47ms
+step:707/1490 train_time:27212ms step_avg:38.49ms
+step:708/1490 train_time:27271ms step_avg:38.52ms
+step:709/1490 train_time:27324ms step_avg:38.54ms
+step:710/1490 train_time:27382ms step_avg:38.57ms
+step:711/1490 train_time:27436ms step_avg:38.59ms
+step:712/1490 train_time:27495ms step_avg:38.62ms
+step:713/1490 train_time:27548ms step_avg:38.64ms
+step:714/1490 train_time:27606ms step_avg:38.66ms
+step:715/1490 train_time:27659ms step_avg:38.68ms
+step:716/1490 train_time:27717ms step_avg:38.71ms
+step:717/1490 train_time:27770ms step_avg:38.73ms
+step:718/1490 train_time:27828ms step_avg:38.76ms
+step:719/1490 train_time:27882ms step_avg:38.78ms
+step:720/1490 train_time:27940ms step_avg:38.81ms
+step:721/1490 train_time:27993ms step_avg:38.83ms
+step:722/1490 train_time:28052ms step_avg:38.85ms
+step:723/1490 train_time:28105ms step_avg:38.87ms
+step:724/1490 train_time:28163ms step_avg:38.90ms
+step:725/1490 train_time:28216ms step_avg:38.92ms
+step:726/1490 train_time:28275ms step_avg:38.95ms
+step:727/1490 train_time:28328ms step_avg:38.97ms
+step:728/1490 train_time:28386ms step_avg:38.99ms
+step:729/1490 train_time:28439ms step_avg:39.01ms
+step:730/1490 train_time:28498ms step_avg:39.04ms
+step:731/1490 train_time:28550ms step_avg:39.06ms
+step:732/1490 train_time:28609ms step_avg:39.08ms
+step:733/1490 train_time:28662ms step_avg:39.10ms
+step:734/1490 train_time:28720ms step_avg:39.13ms
+step:735/1490 train_time:28773ms step_avg:39.15ms
+step:736/1490 train_time:28832ms step_avg:39.17ms
+step:737/1490 train_time:28885ms step_avg:39.19ms
+step:738/1490 train_time:28943ms step_avg:39.22ms
+step:739/1490 train_time:28997ms step_avg:39.24ms
+step:740/1490 train_time:29055ms step_avg:39.26ms
+step:741/1490 train_time:29108ms step_avg:39.28ms
+step:742/1490 train_time:29166ms step_avg:39.31ms
+step:743/1490 train_time:29219ms step_avg:39.33ms
+step:744/1490 train_time:29278ms step_avg:39.35ms
+step:745/1490 train_time:29331ms step_avg:39.37ms
+step:746/1490 train_time:29390ms step_avg:39.40ms
+step:747/1490 train_time:29444ms step_avg:39.42ms
+step:748/1490 train_time:29502ms step_avg:39.44ms
+step:749/1490 train_time:29555ms step_avg:39.46ms
+step:750/1490 train_time:29614ms step_avg:39.48ms
+step:750/1490 val_loss:3.8016 train_time:29680ms step_avg:39.57ms
+step:751/1490 train_time:29697ms step_avg:39.54ms
+step:752/1490 train_time:29727ms step_avg:39.53ms
+step:753/1490 train_time:29783ms step_avg:39.55ms
+step:754/1490 train_time:29847ms step_avg:39.58ms
+step:755/1490 train_time:29899ms step_avg:39.60ms
+step:756/1490 train_time:29958ms step_avg:39.63ms
+step:757/1490 train_time:30011ms step_avg:39.65ms
+step:758/1490 train_time:30069ms step_avg:39.67ms
+step:759/1490 train_time:30123ms step_avg:39.69ms
+step:760/1490 train_time:30180ms step_avg:39.71ms
+step:761/1490 train_time:30233ms step_avg:39.73ms
+step:762/1490 train_time:30291ms step_avg:39.75ms
+step:763/1490 train_time:30344ms step_avg:39.77ms
+step:764/1490 train_time:30401ms step_avg:39.79ms
+step:765/1490 train_time:30454ms step_avg:39.81ms
+step:766/1490 train_time:30511ms step_avg:39.83ms
+step:767/1490 train_time:30564ms step_avg:39.85ms
+step:768/1490 train_time:30622ms step_avg:39.87ms
+step:769/1490 train_time:30675ms step_avg:39.89ms
+step:770/1490 train_time:30735ms step_avg:39.92ms
+step:771/1490 train_time:30789ms step_avg:39.93ms
+step:772/1490 train_time:30848ms step_avg:39.96ms
+step:773/1490 train_time:30902ms step_avg:39.98ms
+step:774/1490 train_time:30961ms step_avg:40.00ms
+step:775/1490 train_time:31015ms step_avg:40.02ms
+step:776/1490 train_time:31073ms step_avg:40.04ms
+step:777/1490 train_time:31126ms step_avg:40.06ms
+step:778/1490 train_time:31184ms step_avg:40.08ms
+step:779/1490 train_time:31237ms step_avg:40.10ms
+step:780/1490 train_time:31295ms step_avg:40.12ms
+step:781/1490 train_time:31348ms step_avg:40.14ms
+step:782/1490 train_time:31406ms step_avg:40.16ms
+step:783/1490 train_time:31459ms step_avg:40.18ms
+step:784/1490 train_time:31518ms step_avg:40.20ms
+step:785/1490 train_time:31571ms step_avg:40.22ms
+step:786/1490 train_time:31628ms step_avg:40.24ms
+step:787/1490 train_time:31681ms step_avg:40.26ms
+step:788/1490 train_time:31741ms step_avg:40.28ms
+step:789/1490 train_time:31795ms step_avg:40.30ms
+step:790/1490 train_time:31854ms step_avg:40.32ms
+step:791/1490 train_time:31907ms step_avg:40.34ms
+step:792/1490 train_time:31966ms step_avg:40.36ms
+step:793/1490 train_time:32021ms step_avg:40.38ms
+step:794/1490 train_time:32079ms step_avg:40.40ms
+step:795/1490 train_time:32132ms step_avg:40.42ms
+step:796/1490 train_time:32189ms step_avg:40.44ms
+step:797/1490 train_time:32243ms step_avg:40.46ms
+step:798/1490 train_time:32301ms step_avg:40.48ms
+step:799/1490 train_time:32354ms step_avg:40.49ms
+step:800/1490 train_time:32412ms step_avg:40.51ms
+step:801/1490 train_time:32465ms step_avg:40.53ms
+step:802/1490 train_time:32524ms step_avg:40.55ms
+step:803/1490 train_time:32577ms step_avg:40.57ms
+step:804/1490 train_time:32635ms step_avg:40.59ms
+step:805/1490 train_time:32689ms step_avg:40.61ms
+step:806/1490 train_time:32746ms step_avg:40.63ms
+step:807/1490 train_time:32800ms step_avg:40.64ms
+step:808/1490 train_time:32859ms step_avg:40.67ms
+step:809/1490 train_time:32913ms step_avg:40.68ms
+step:810/1490 train_time:32971ms step_avg:40.70ms
+step:811/1490 train_time:33024ms step_avg:40.72ms
+step:812/1490 train_time:33083ms step_avg:40.74ms
+step:813/1490 train_time:33136ms step_avg:40.76ms
+step:814/1490 train_time:33195ms step_avg:40.78ms
+step:815/1490 train_time:33248ms step_avg:40.80ms
+step:816/1490 train_time:33305ms step_avg:40.82ms
+step:817/1490 train_time:33359ms step_avg:40.83ms
+step:818/1490 train_time:33418ms step_avg:40.85ms
+step:819/1490 train_time:33471ms step_avg:40.87ms
+step:820/1490 train_time:33529ms step_avg:40.89ms
+step:821/1490 train_time:33582ms step_avg:40.90ms
+step:822/1490 train_time:33640ms step_avg:40.92ms
+step:823/1490 train_time:33694ms step_avg:40.94ms
+step:824/1490 train_time:33751ms step_avg:40.96ms
+step:825/1490 train_time:33804ms step_avg:40.97ms
+step:826/1490 train_time:33863ms step_avg:41.00ms
+step:827/1490 train_time:33917ms step_avg:41.01ms
+step:828/1490 train_time:33975ms step_avg:41.03ms
+step:829/1490 train_time:34029ms step_avg:41.05ms
+step:830/1490 train_time:34086ms step_avg:41.07ms
+step:831/1490 train_time:34140ms step_avg:41.08ms
+step:832/1490 train_time:34198ms step_avg:41.10ms
+step:833/1490 train_time:34251ms step_avg:41.12ms
+step:834/1490 train_time:34310ms step_avg:41.14ms
+step:835/1490 train_time:34363ms step_avg:41.15ms
+step:836/1490 train_time:34422ms step_avg:41.17ms
+step:837/1490 train_time:34474ms step_avg:41.19ms
+step:838/1490 train_time:34532ms step_avg:41.21ms
+step:839/1490 train_time:34585ms step_avg:41.22ms
+step:840/1490 train_time:34643ms step_avg:41.24ms
+step:841/1490 train_time:34697ms step_avg:41.26ms
+step:842/1490 train_time:34755ms step_avg:41.28ms
+step:843/1490 train_time:34809ms step_avg:41.29ms
+step:844/1490 train_time:34867ms step_avg:41.31ms
+step:845/1490 train_time:34922ms step_avg:41.33ms
+step:846/1490 train_time:34980ms step_avg:41.35ms
+step:847/1490 train_time:35034ms step_avg:41.36ms
+step:848/1490 train_time:35092ms step_avg:41.38ms
+step:849/1490 train_time:35144ms step_avg:41.39ms
+step:850/1490 train_time:35202ms step_avg:41.41ms
+step:851/1490 train_time:35255ms step_avg:41.43ms
+step:852/1490 train_time:35314ms step_avg:41.45ms
+step:853/1490 train_time:35368ms step_avg:41.46ms
+step:854/1490 train_time:35425ms step_avg:41.48ms
+step:855/1490 train_time:35478ms step_avg:41.49ms
+step:856/1490 train_time:35536ms step_avg:41.51ms
+step:857/1490 train_time:35590ms step_avg:41.53ms
+step:858/1490 train_time:35647ms step_avg:41.55ms
+step:859/1490 train_time:35700ms step_avg:41.56ms
+step:860/1490 train_time:35759ms step_avg:41.58ms
+step:861/1490 train_time:35812ms step_avg:41.59ms
+step:862/1490 train_time:35870ms step_avg:41.61ms
+step:863/1490 train_time:35924ms step_avg:41.63ms
+step:864/1490 train_time:35983ms step_avg:41.65ms
+step:865/1490 train_time:36036ms step_avg:41.66ms
+step:866/1490 train_time:36095ms step_avg:41.68ms
+step:867/1490 train_time:36147ms step_avg:41.69ms
+step:868/1490 train_time:36205ms step_avg:41.71ms
+step:869/1490 train_time:36259ms step_avg:41.73ms
+step:870/1490 train_time:36317ms step_avg:41.74ms
+step:871/1490 train_time:36370ms step_avg:41.76ms
+step:872/1490 train_time:36429ms step_avg:41.78ms
+step:873/1490 train_time:36483ms step_avg:41.79ms
+step:874/1490 train_time:36541ms step_avg:41.81ms
+step:875/1490 train_time:36594ms step_avg:41.82ms
+step:876/1490 train_time:36653ms step_avg:41.84ms
+step:877/1490 train_time:36706ms step_avg:41.85ms
+step:878/1490 train_time:36765ms step_avg:41.87ms
+step:879/1490 train_time:36819ms step_avg:41.89ms
+step:880/1490 train_time:36876ms step_avg:41.91ms
+step:881/1490 train_time:36930ms step_avg:41.92ms
+step:882/1490 train_time:36987ms step_avg:41.94ms
+step:883/1490 train_time:37041ms step_avg:41.95ms
+step:884/1490 train_time:37100ms step_avg:41.97ms
+step:885/1490 train_time:37153ms step_avg:41.98ms
+step:886/1490 train_time:37211ms step_avg:42.00ms
+step:887/1490 train_time:37265ms step_avg:42.01ms
+step:888/1490 train_time:37324ms step_avg:42.03ms
+step:889/1490 train_time:37377ms step_avg:42.04ms
+step:890/1490 train_time:37435ms step_avg:42.06ms
+step:891/1490 train_time:37488ms step_avg:42.07ms
+step:892/1490 train_time:37546ms step_avg:42.09ms
+step:893/1490 train_time:37599ms step_avg:42.10ms
+step:894/1490 train_time:37657ms step_avg:42.12ms
+step:895/1490 train_time:37711ms step_avg:42.14ms
+step:896/1490 train_time:37769ms step_avg:42.15ms
+step:897/1490 train_time:37823ms step_avg:42.17ms
+step:898/1490 train_time:37882ms step_avg:42.19ms
+step:899/1490 train_time:37936ms step_avg:42.20ms
+step:900/1490 train_time:37994ms step_avg:42.22ms
+step:901/1490 train_time:38048ms step_avg:42.23ms
+step:902/1490 train_time:38105ms step_avg:42.25ms
+step:903/1490 train_time:38159ms step_avg:42.26ms
+step:904/1490 train_time:38218ms step_avg:42.28ms
+step:905/1490 train_time:38272ms step_avg:42.29ms
+step:906/1490 train_time:38330ms step_avg:42.31ms
+step:907/1490 train_time:38382ms step_avg:42.32ms
+step:908/1490 train_time:38441ms step_avg:42.34ms
+step:909/1490 train_time:38494ms step_avg:42.35ms
+step:910/1490 train_time:38553ms step_avg:42.37ms
+step:911/1490 train_time:38605ms step_avg:42.38ms
+step:912/1490 train_time:38663ms step_avg:42.39ms
+step:913/1490 train_time:38717ms step_avg:42.41ms
+step:914/1490 train_time:38775ms step_avg:42.42ms
+step:915/1490 train_time:38829ms step_avg:42.44ms
+step:916/1490 train_time:38886ms step_avg:42.45ms
+step:917/1490 train_time:38940ms step_avg:42.47ms
+step:918/1490 train_time:38999ms step_avg:42.48ms
+step:919/1490 train_time:39051ms step_avg:42.49ms
+step:920/1490 train_time:39109ms step_avg:42.51ms
+step:921/1490 train_time:39163ms step_avg:42.52ms
+step:922/1490 train_time:39221ms step_avg:42.54ms
+step:923/1490 train_time:39275ms step_avg:42.55ms
+step:924/1490 train_time:39333ms step_avg:42.57ms
+step:925/1490 train_time:39386ms step_avg:42.58ms
+step:926/1490 train_time:39444ms step_avg:42.60ms
+step:927/1490 train_time:39497ms step_avg:42.61ms
+step:928/1490 train_time:39556ms step_avg:42.62ms
+step:929/1490 train_time:39609ms step_avg:42.64ms
+step:930/1490 train_time:39666ms step_avg:42.65ms
+step:931/1490 train_time:39721ms step_avg:42.66ms
+step:932/1490 train_time:39779ms step_avg:42.68ms
+step:933/1490 train_time:39832ms step_avg:42.69ms
+step:934/1490 train_time:39890ms step_avg:42.71ms
+step:935/1490 train_time:39943ms step_avg:42.72ms
+step:936/1490 train_time:40002ms step_avg:42.74ms
+step:937/1490 train_time:40056ms step_avg:42.75ms
+step:938/1490 train_time:40115ms step_avg:42.77ms
+step:939/1490 train_time:40168ms step_avg:42.78ms
+step:940/1490 train_time:40227ms step_avg:42.79ms
+step:941/1490 train_time:40281ms step_avg:42.81ms
+step:942/1490 train_time:40339ms step_avg:42.82ms
+step:943/1490 train_time:40391ms step_avg:42.83ms
+step:944/1490 train_time:40450ms step_avg:42.85ms
+step:945/1490 train_time:40502ms step_avg:42.86ms
+step:946/1490 train_time:40561ms step_avg:42.88ms
+step:947/1490 train_time:40614ms step_avg:42.89ms
+step:948/1490 train_time:40673ms step_avg:42.90ms
+step:949/1490 train_time:40726ms step_avg:42.91ms
+step:950/1490 train_time:40783ms step_avg:42.93ms
+step:951/1490 train_time:40837ms step_avg:42.94ms
+step:952/1490 train_time:40895ms step_avg:42.96ms
+step:953/1490 train_time:40948ms step_avg:42.97ms
+step:954/1490 train_time:41006ms step_avg:42.98ms
+step:955/1490 train_time:41060ms step_avg:42.99ms
+step:956/1490 train_time:41119ms step_avg:43.01ms
+step:957/1490 train_time:41172ms step_avg:43.02ms
+step:958/1490 train_time:41230ms step_avg:43.04ms
+step:959/1490 train_time:41283ms step_avg:43.05ms
+step:960/1490 train_time:41342ms step_avg:43.06ms
+step:961/1490 train_time:41395ms step_avg:43.07ms
+step:962/1490 train_time:41453ms step_avg:43.09ms
+step:963/1490 train_time:41506ms step_avg:43.10ms
+step:964/1490 train_time:41563ms step_avg:43.12ms
+step:965/1490 train_time:41617ms step_avg:43.13ms
+step:966/1490 train_time:41674ms step_avg:43.14ms
+step:967/1490 train_time:41727ms step_avg:43.15ms
+step:968/1490 train_time:41789ms step_avg:43.17ms
+step:969/1490 train_time:41869ms step_avg:43.21ms
+step:970/1490 train_time:41952ms step_avg:43.25ms
+step:971/1490 train_time:42031ms step_avg:43.29ms
+step:972/1490 train_time:42115ms step_avg:43.33ms
+step:973/1490 train_time:42195ms step_avg:43.37ms
+step:974/1490 train_time:42279ms step_avg:43.41ms
+step:975/1490 train_time:42358ms step_avg:43.44ms
+step:976/1490 train_time:42442ms step_avg:43.49ms
+step:977/1490 train_time:42520ms step_avg:43.52ms
+step:978/1490 train_time:42606ms step_avg:43.56ms
+step:979/1490 train_time:42684ms step_avg:43.60ms
+step:980/1490 train_time:42768ms step_avg:43.64ms
+step:981/1490 train_time:42847ms step_avg:43.68ms
+step:982/1490 train_time:42931ms step_avg:43.72ms
+step:983/1490 train_time:43010ms step_avg:43.75ms
+step:984/1490 train_time:43093ms step_avg:43.79ms
+step:985/1490 train_time:43172ms step_avg:43.83ms
+step:986/1490 train_time:43258ms step_avg:43.87ms
+step:987/1490 train_time:43336ms step_avg:43.91ms
+step:988/1490 train_time:43421ms step_avg:43.95ms
+step:989/1490 train_time:43500ms step_avg:43.98ms
+step:990/1490 train_time:43584ms step_avg:44.02ms
+step:991/1490 train_time:43664ms step_avg:44.06ms
+step:992/1490 train_time:43748ms step_avg:44.10ms
+step:993/1490 train_time:43826ms step_avg:44.13ms
+step:994/1490 train_time:43909ms step_avg:44.17ms
+step:995/1490 train_time:43989ms step_avg:44.21ms
+step:996/1490 train_time:44073ms step_avg:44.25ms
+step:997/1490 train_time:44153ms step_avg:44.29ms
+step:998/1490 train_time:44237ms step_avg:44.33ms
+step:999/1490 train_time:44315ms step_avg:44.36ms
+step:1000/1490 train_time:44400ms step_avg:44.40ms
+step:1000/1490 val_loss:3.5159 train_time:44495ms step_avg:44.50ms
+step:1001/1490 train_time:44512ms step_avg:44.47ms
+step:1002/1490 train_time:44569ms step_avg:44.48ms
+step:1003/1490 train_time:44652ms step_avg:44.52ms
+step:1004/1490 train_time:44736ms step_avg:44.56ms
+step:1005/1490 train_time:44814ms step_avg:44.59ms
+step:1006/1490 train_time:44898ms step_avg:44.63ms
+step:1007/1490 train_time:44976ms step_avg:44.66ms
+step:1008/1490 train_time:45060ms step_avg:44.70ms
+step:1009/1490 train_time:45138ms step_avg:44.74ms
+step:1010/1490 train_time:45220ms step_avg:44.77ms
+step:1011/1490 train_time:45297ms step_avg:44.80ms
+step:1012/1490 train_time:45380ms step_avg:44.84ms
+step:1013/1490 train_time:45459ms step_avg:44.88ms
+step:1014/1490 train_time:45543ms step_avg:44.91ms
+step:1015/1490 train_time:45622ms step_avg:44.95ms
+step:1016/1490 train_time:45708ms step_avg:44.99ms
+step:1017/1490 train_time:45788ms step_avg:45.02ms
+step:1018/1490 train_time:45874ms step_avg:45.06ms
+step:1019/1490 train_time:45953ms step_avg:45.10ms
+step:1020/1490 train_time:46038ms step_avg:45.14ms
+step:1021/1490 train_time:46117ms step_avg:45.17ms
+step:1022/1490 train_time:46200ms step_avg:45.21ms
+step:1023/1490 train_time:46277ms step_avg:45.24ms
+step:1024/1490 train_time:46361ms step_avg:45.27ms
+step:1025/1490 train_time:46438ms step_avg:45.31ms
+step:1026/1490 train_time:46522ms step_avg:45.34ms
+step:1027/1490 train_time:46604ms step_avg:45.38ms
+step:1028/1490 train_time:46689ms step_avg:45.42ms
+step:1029/1490 train_time:46768ms step_avg:45.45ms
+step:1030/1490 train_time:46854ms step_avg:45.49ms
+step:1031/1490 train_time:46933ms step_avg:45.52ms
+step:1032/1490 train_time:47017ms step_avg:45.56ms
+step:1033/1490 train_time:47095ms step_avg:45.59ms
+step:1034/1490 train_time:47179ms step_avg:45.63ms
+step:1035/1490 train_time:47257ms step_avg:45.66ms
+step:1036/1490 train_time:47340ms step_avg:45.69ms
+step:1037/1490 train_time:47418ms step_avg:45.73ms
+step:1038/1490 train_time:47503ms step_avg:45.76ms
+step:1039/1490 train_time:47582ms step_avg:45.80ms
+step:1040/1490 train_time:47667ms step_avg:45.83ms
+step:1041/1490 train_time:47747ms step_avg:45.87ms
+step:1042/1490 train_time:47831ms step_avg:45.90ms
+step:1043/1490 train_time:47910ms step_avg:45.94ms
+step:1044/1490 train_time:47995ms step_avg:45.97ms
+step:1045/1490 train_time:48074ms step_avg:46.00ms
+step:1046/1490 train_time:48159ms step_avg:46.04ms
+step:1047/1490 train_time:48236ms step_avg:46.07ms
+step:1048/1490 train_time:48320ms step_avg:46.11ms
+step:1049/1490 train_time:48398ms step_avg:46.14ms
+step:1050/1490 train_time:48482ms step_avg:46.17ms
+step:1051/1490 train_time:48562ms step_avg:46.21ms
+step:1052/1490 train_time:48644ms step_avg:46.24ms
+step:1053/1490 train_time:48723ms step_avg:46.27ms
+step:1054/1490 train_time:48808ms step_avg:46.31ms
+step:1055/1490 train_time:48888ms step_avg:46.34ms
+step:1056/1490 train_time:48973ms step_avg:46.38ms
+step:1057/1490 train_time:49053ms step_avg:46.41ms
+step:1058/1490 train_time:49136ms step_avg:46.44ms
+step:1059/1490 train_time:49214ms step_avg:46.47ms
+step:1060/1490 train_time:49299ms step_avg:46.51ms
+step:1061/1490 train_time:49378ms step_avg:46.54ms
+step:1062/1490 train_time:49462ms step_avg:46.57ms
+step:1063/1490 train_time:49540ms step_avg:46.60ms
+step:1064/1490 train_time:49625ms step_avg:46.64ms
+step:1065/1490 train_time:49704ms step_avg:46.67ms
+step:1066/1490 train_time:49789ms step_avg:46.71ms
+step:1067/1490 train_time:49868ms step_avg:46.74ms
+step:1068/1490 train_time:49953ms step_avg:46.77ms
+step:1069/1490 train_time:50032ms step_avg:46.80ms
+step:1070/1490 train_time:50115ms step_avg:46.84ms
+step:1071/1490 train_time:50194ms step_avg:46.87ms
+step:1072/1490 train_time:50278ms step_avg:46.90ms
+step:1073/1490 train_time:50358ms step_avg:46.93ms
+step:1074/1490 train_time:50441ms step_avg:46.97ms
+step:1075/1490 train_time:50519ms step_avg:46.99ms
+step:1076/1490 train_time:50603ms step_avg:47.03ms
+step:1077/1490 train_time:50682ms step_avg:47.06ms
+step:1078/1490 train_time:50767ms step_avg:47.09ms
+step:1079/1490 train_time:50845ms step_avg:47.12ms
+step:1080/1490 train_time:50929ms step_avg:47.16ms
+step:1081/1490 train_time:51009ms step_avg:47.19ms
+step:1082/1490 train_time:51094ms step_avg:47.22ms
+step:1083/1490 train_time:51173ms step_avg:47.25ms
+step:1084/1490 train_time:51259ms step_avg:47.29ms
+step:1085/1490 train_time:51338ms step_avg:47.32ms
+step:1086/1490 train_time:51422ms step_avg:47.35ms
+step:1087/1490 train_time:51501ms step_avg:47.38ms
+step:1088/1490 train_time:51587ms step_avg:47.41ms
+step:1089/1490 train_time:51665ms step_avg:47.44ms
+step:1090/1490 train_time:51748ms step_avg:47.48ms
+step:1091/1490 train_time:51827ms step_avg:47.50ms
+step:1092/1490 train_time:51911ms step_avg:47.54ms
+step:1093/1490 train_time:51989ms step_avg:47.57ms
+step:1094/1490 train_time:52073ms step_avg:47.60ms
+step:1095/1490 train_time:52153ms step_avg:47.63ms
+step:1096/1490 train_time:52237ms step_avg:47.66ms
+step:1097/1490 train_time:52316ms step_avg:47.69ms
+step:1098/1490 train_time:52401ms step_avg:47.72ms
+step:1099/1490 train_time:52479ms step_avg:47.75ms
+step:1100/1490 train_time:52564ms step_avg:47.79ms
+step:1101/1490 train_time:52642ms step_avg:47.81ms
+step:1102/1490 train_time:52725ms step_avg:47.85ms
+step:1103/1490 train_time:52804ms step_avg:47.87ms
+step:1104/1490 train_time:52888ms step_avg:47.91ms
+step:1105/1490 train_time:52968ms step_avg:47.93ms
+step:1106/1490 train_time:53053ms step_avg:47.97ms
+step:1107/1490 train_time:53133ms step_avg:48.00ms
+step:1108/1490 train_time:53218ms step_avg:48.03ms
+step:1109/1490 train_time:53298ms step_avg:48.06ms
+step:1110/1490 train_time:53381ms step_avg:48.09ms
+step:1111/1490 train_time:53460ms step_avg:48.12ms
+step:1112/1490 train_time:53543ms step_avg:48.15ms
+step:1113/1490 train_time:53620ms step_avg:48.18ms
+step:1114/1490 train_time:53705ms step_avg:48.21ms
+step:1115/1490 train_time:53783ms step_avg:48.24ms
+step:1116/1490 train_time:53867ms step_avg:48.27ms
+step:1117/1490 train_time:53947ms step_avg:48.30ms
+step:1118/1490 train_time:54033ms step_avg:48.33ms
+step:1119/1490 train_time:54112ms step_avg:48.36ms
+step:1120/1490 train_time:54197ms step_avg:48.39ms
+step:1121/1490 train_time:54275ms step_avg:48.42ms
+step:1122/1490 train_time:54360ms step_avg:48.45ms
+step:1123/1490 train_time:54439ms step_avg:48.48ms
+step:1124/1490 train_time:54522ms step_avg:48.51ms
+step:1125/1490 train_time:54601ms step_avg:48.53ms
+step:1126/1490 train_time:54685ms step_avg:48.57ms
+step:1127/1490 train_time:54764ms step_avg:48.59ms
+step:1128/1490 train_time:54847ms step_avg:48.62ms
+step:1129/1490 train_time:54925ms step_avg:48.65ms
+step:1130/1490 train_time:55010ms step_avg:48.68ms
+step:1131/1490 train_time:55092ms step_avg:48.71ms
+step:1132/1490 train_time:55176ms step_avg:48.74ms
+step:1133/1490 train_time:55255ms step_avg:48.77ms
+step:1134/1490 train_time:55341ms step_avg:48.80ms
+step:1135/1490 train_time:55419ms step_avg:48.83ms
+step:1136/1490 train_time:55504ms step_avg:48.86ms
+step:1137/1490 train_time:55584ms step_avg:48.89ms
+step:1138/1490 train_time:55668ms step_avg:48.92ms
+step:1139/1490 train_time:55746ms step_avg:48.94ms
+step:1140/1490 train_time:55829ms step_avg:48.97ms
+step:1141/1490 train_time:55907ms step_avg:49.00ms
+step:1142/1490 train_time:55992ms step_avg:49.03ms
+step:1143/1490 train_time:56072ms step_avg:49.06ms
+step:1144/1490 train_time:56157ms step_avg:49.09ms
+step:1145/1490 train_time:56235ms step_avg:49.11ms
+step:1146/1490 train_time:56319ms step_avg:49.14ms
+step:1147/1490 train_time:56398ms step_avg:49.17ms
+step:1148/1490 train_time:56481ms step_avg:49.20ms
+step:1149/1490 train_time:56560ms step_avg:49.23ms
+step:1150/1490 train_time:56644ms step_avg:49.26ms
+step:1151/1490 train_time:56720ms step_avg:49.28ms
+step:1152/1490 train_time:56805ms step_avg:49.31ms
+step:1153/1490 train_time:56884ms step_avg:49.34ms
+step:1154/1490 train_time:56968ms step_avg:49.37ms
+step:1155/1490 train_time:57048ms step_avg:49.39ms
+step:1156/1490 train_time:57132ms step_avg:49.42ms
+step:1157/1490 train_time:57212ms step_avg:49.45ms
+step:1158/1490 train_time:57296ms step_avg:49.48ms
+step:1159/1490 train_time:57375ms step_avg:49.50ms
+step:1160/1490 train_time:57460ms step_avg:49.53ms
+step:1161/1490 train_time:57538ms step_avg:49.56ms
+step:1162/1490 train_time:57621ms step_avg:49.59ms
+step:1163/1490 train_time:57700ms step_avg:49.61ms
+step:1164/1490 train_time:57782ms step_avg:49.64ms
+step:1165/1490 train_time:57860ms step_avg:49.67ms
+step:1166/1490 train_time:57945ms step_avg:49.70ms
+step:1167/1490 train_time:58023ms step_avg:49.72ms
+step:1168/1490 train_time:58108ms step_avg:49.75ms
+step:1169/1490 train_time:58188ms step_avg:49.78ms
+step:1170/1490 train_time:58273ms step_avg:49.81ms
+step:1171/1490 train_time:58353ms step_avg:49.83ms
+step:1172/1490 train_time:58437ms step_avg:49.86ms
+step:1173/1490 train_time:58515ms step_avg:49.89ms
+step:1174/1490 train_time:58601ms step_avg:49.92ms
+step:1175/1490 train_time:58679ms step_avg:49.94ms
+step:1176/1490 train_time:58764ms step_avg:49.97ms
+step:1177/1490 train_time:58842ms step_avg:49.99ms
+step:1178/1490 train_time:58925ms step_avg:50.02ms
+step:1179/1490 train_time:59003ms step_avg:50.05ms
+step:1180/1490 train_time:59088ms step_avg:50.07ms
+step:1181/1490 train_time:59167ms step_avg:50.10ms
+step:1182/1490 train_time:59253ms step_avg:50.13ms
+step:1183/1490 train_time:59332ms step_avg:50.15ms
+step:1184/1490 train_time:59416ms step_avg:50.18ms
+step:1185/1490 train_time:59495ms step_avg:50.21ms
+step:1186/1490 train_time:59580ms step_avg:50.24ms
+step:1187/1490 train_time:59660ms step_avg:50.26ms
+step:1188/1490 train_time:59743ms step_avg:50.29ms
+step:1189/1490 train_time:59820ms step_avg:50.31ms
+step:1190/1490 train_time:59904ms step_avg:50.34ms
+step:1191/1490 train_time:59983ms step_avg:50.36ms
+step:1192/1490 train_time:60067ms step_avg:50.39ms
+step:1193/1490 train_time:60146ms step_avg:50.42ms
+step:1194/1490 train_time:60231ms step_avg:50.45ms
+step:1195/1490 train_time:60312ms step_avg:50.47ms
+step:1196/1490 train_time:60397ms step_avg:50.50ms
+step:1197/1490 train_time:60476ms step_avg:50.52ms
+step:1198/1490 train_time:60562ms step_avg:50.55ms
+step:1199/1490 train_time:60640ms step_avg:50.58ms
+step:1200/1490 train_time:60724ms step_avg:50.60ms
+step:1201/1490 train_time:60802ms step_avg:50.63ms
+step:1202/1490 train_time:60886ms step_avg:50.65ms
+step:1203/1490 train_time:60964ms step_avg:50.68ms
+step:1204/1490 train_time:61048ms step_avg:50.70ms
+step:1205/1490 train_time:61127ms step_avg:50.73ms
+step:1206/1490 train_time:61212ms step_avg:50.76ms
+step:1207/1490 train_time:61291ms step_avg:50.78ms
+step:1208/1490 train_time:61376ms step_avg:50.81ms
+step:1209/1490 train_time:61455ms step_avg:50.83ms
+step:1210/1490 train_time:61539ms step_avg:50.86ms
+step:1211/1490 train_time:61619ms step_avg:50.88ms
+step:1212/1490 train_time:61703ms step_avg:50.91ms
+step:1213/1490 train_time:61781ms step_avg:50.93ms
+step:1214/1490 train_time:61865ms step_avg:50.96ms
+step:1215/1490 train_time:61943ms step_avg:50.98ms
+step:1216/1490 train_time:62027ms step_avg:51.01ms
+step:1217/1490 train_time:62106ms step_avg:51.03ms
+step:1218/1490 train_time:62191ms step_avg:51.06ms
+step:1219/1490 train_time:62271ms step_avg:51.08ms
+step:1220/1490 train_time:62356ms step_avg:51.11ms
+step:1221/1490 train_time:62435ms step_avg:51.13ms
+step:1222/1490 train_time:62518ms step_avg:51.16ms
+step:1223/1490 train_time:62597ms step_avg:51.18ms
+step:1224/1490 train_time:62681ms step_avg:51.21ms
+step:1225/1490 train_time:62758ms step_avg:51.23ms
+step:1226/1490 train_time:62843ms step_avg:51.26ms
+step:1227/1490 train_time:62920ms step_avg:51.28ms
+step:1228/1490 train_time:63005ms step_avg:51.31ms
+step:1229/1490 train_time:63084ms step_avg:51.33ms
+step:1230/1490 train_time:63167ms step_avg:51.36ms
+step:1231/1490 train_time:63248ms step_avg:51.38ms
+step:1232/1490 train_time:63333ms step_avg:51.41ms
+step:1233/1490 train_time:63413ms step_avg:51.43ms
+step:1234/1490 train_time:63497ms step_avg:51.46ms
+step:1235/1490 train_time:63577ms step_avg:51.48ms
+step:1236/1490 train_time:63662ms step_avg:51.51ms
+step:1237/1490 train_time:63740ms step_avg:51.53ms
+step:1238/1490 train_time:63822ms step_avg:51.55ms
+step:1239/1490 train_time:63901ms step_avg:51.58ms
+step:1240/1490 train_time:63985ms step_avg:51.60ms
+step:1241/1490 train_time:64064ms step_avg:51.62ms
+step:1242/1490 train_time:64147ms step_avg:51.65ms
+step:1243/1490 train_time:64226ms step_avg:51.67ms
+step:1244/1490 train_time:64311ms step_avg:51.70ms
+step:1245/1490 train_time:64391ms step_avg:51.72ms
+step:1246/1490 train_time:64476ms step_avg:51.75ms
+step:1247/1490 train_time:64555ms step_avg:51.77ms
+step:1248/1490 train_time:64640ms step_avg:51.79ms
+step:1249/1490 train_time:64719ms step_avg:51.82ms
+step:1250/1490 train_time:64801ms step_avg:51.84ms
+step:1250/1490 val_loss:3.3705 train_time:64896ms step_avg:51.92ms
+step:1251/1490 train_time:64914ms step_avg:51.89ms
+step:1252/1490 train_time:64970ms step_avg:51.89ms
+step:1253/1490 train_time:65051ms step_avg:51.92ms
+step:1254/1490 train_time:65136ms step_avg:51.94ms
+step:1255/1490 train_time:65214ms step_avg:51.96ms
+step:1256/1490 train_time:65299ms step_avg:51.99ms
+step:1257/1490 train_time:65376ms step_avg:52.01ms
+step:1258/1490 train_time:65459ms step_avg:52.03ms
+step:1259/1490 train_time:65536ms step_avg:52.05ms
+step:1260/1490 train_time:65619ms step_avg:52.08ms
+step:1261/1490 train_time:65696ms step_avg:52.10ms
+step:1262/1490 train_time:65780ms step_avg:52.12ms
+step:1263/1490 train_time:65860ms step_avg:52.15ms
+step:1264/1490 train_time:65946ms step_avg:52.17ms
+step:1265/1490 train_time:66027ms step_avg:52.20ms
+step:1266/1490 train_time:66112ms step_avg:52.22ms
+step:1267/1490 train_time:66191ms step_avg:52.24ms
+step:1268/1490 train_time:66276ms step_avg:52.27ms
+step:1269/1490 train_time:66354ms step_avg:52.29ms
+step:1270/1490 train_time:66436ms step_avg:52.31ms
+step:1271/1490 train_time:66514ms step_avg:52.33ms
+step:1272/1490 train_time:66598ms step_avg:52.36ms
+step:1273/1490 train_time:66675ms step_avg:52.38ms
+step:1274/1490 train_time:66759ms step_avg:52.40ms
+step:1275/1490 train_time:66837ms step_avg:52.42ms
+step:1276/1490 train_time:66923ms step_avg:52.45ms
+step:1277/1490 train_time:67004ms step_avg:52.47ms
+step:1278/1490 train_time:67089ms step_avg:52.49ms
+step:1279/1490 train_time:67169ms step_avg:52.52ms
+step:1280/1490 train_time:67253ms step_avg:52.54ms
+step:1281/1490 train_time:67331ms step_avg:52.56ms
+step:1282/1490 train_time:67415ms step_avg:52.59ms
+step:1283/1490 train_time:67493ms step_avg:52.61ms
+step:1284/1490 train_time:67577ms step_avg:52.63ms
+step:1285/1490 train_time:67654ms step_avg:52.65ms
+step:1286/1490 train_time:67737ms step_avg:52.67ms
+step:1287/1490 train_time:67816ms step_avg:52.69ms
+step:1288/1490 train_time:67902ms step_avg:52.72ms
+step:1289/1490 train_time:67982ms step_avg:52.74ms
+step:1290/1490 train_time:68067ms step_avg:52.77ms
+step:1291/1490 train_time:68146ms step_avg:52.79ms
+step:1292/1490 train_time:68231ms step_avg:52.81ms
+step:1293/1490 train_time:68311ms step_avg:52.83ms
+step:1294/1490 train_time:68394ms step_avg:52.85ms
+step:1295/1490 train_time:68472ms step_avg:52.87ms
+step:1296/1490 train_time:68556ms step_avg:52.90ms
+step:1297/1490 train_time:68634ms step_avg:52.92ms
+step:1298/1490 train_time:68719ms step_avg:52.94ms
+step:1299/1490 train_time:68797ms step_avg:52.96ms
+step:1300/1490 train_time:68882ms step_avg:52.99ms
+step:1301/1490 train_time:68962ms step_avg:53.01ms
+step:1302/1490 train_time:69047ms step_avg:53.03ms
+step:1303/1490 train_time:69127ms step_avg:53.05ms
+step:1304/1490 train_time:69212ms step_avg:53.08ms
+step:1305/1490 train_time:69291ms step_avg:53.10ms
+step:1306/1490 train_time:69376ms step_avg:53.12ms
+step:1307/1490 train_time:69454ms step_avg:53.14ms
+step:1308/1490 train_time:69537ms step_avg:53.16ms
+step:1309/1490 train_time:69616ms step_avg:53.18ms
+step:1310/1490 train_time:69698ms step_avg:53.20ms
+step:1311/1490 train_time:69777ms step_avg:53.22ms
+step:1312/1490 train_time:69861ms step_avg:53.25ms
+step:1313/1490 train_time:69940ms step_avg:53.27ms
+step:1314/1490 train_time:70023ms step_avg:53.29ms
+step:1315/1490 train_time:70104ms step_avg:53.31ms
+step:1316/1490 train_time:70189ms step_avg:53.33ms
+step:1317/1490 train_time:70268ms step_avg:53.35ms
+step:1318/1490 train_time:70354ms step_avg:53.38ms
+step:1319/1490 train_time:70432ms step_avg:53.40ms
+step:1320/1490 train_time:70516ms step_avg:53.42ms
+step:1321/1490 train_time:70593ms step_avg:53.44ms
+step:1322/1490 train_time:70677ms step_avg:53.46ms
+step:1323/1490 train_time:70756ms step_avg:53.48ms
+step:1324/1490 train_time:70841ms step_avg:53.51ms
+step:1325/1490 train_time:70922ms step_avg:53.53ms
+step:1326/1490 train_time:71005ms step_avg:53.55ms
+step:1327/1490 train_time:71083ms step_avg:53.57ms
+step:1328/1490 train_time:71169ms step_avg:53.59ms
+step:1329/1490 train_time:71249ms step_avg:53.61ms
+step:1330/1490 train_time:71333ms step_avg:53.63ms
+step:1331/1490 train_time:71412ms step_avg:53.65ms
+step:1332/1490 train_time:71494ms step_avg:53.67ms
+step:1333/1490 train_time:71574ms step_avg:53.69ms
+step:1334/1490 train_time:71658ms step_avg:53.72ms
+step:1335/1490 train_time:71735ms step_avg:53.73ms
+step:1336/1490 train_time:71820ms step_avg:53.76ms
+step:1337/1490 train_time:71900ms step_avg:53.78ms
+step:1338/1490 train_time:71984ms step_avg:53.80ms
+step:1339/1490 train_time:72065ms step_avg:53.82ms
+step:1340/1490 train_time:72150ms step_avg:53.84ms
+step:1341/1490 train_time:72230ms step_avg:53.86ms
+step:1342/1490 train_time:72314ms step_avg:53.89ms
+step:1343/1490 train_time:72393ms step_avg:53.90ms
+step:1344/1490 train_time:72477ms step_avg:53.93ms
+step:1345/1490 train_time:72556ms step_avg:53.94ms
+step:1346/1490 train_time:72639ms step_avg:53.97ms
+step:1347/1490 train_time:72718ms step_avg:53.98ms
+step:1348/1490 train_time:72801ms step_avg:54.01ms
+step:1349/1490 train_time:72879ms step_avg:54.02ms
+step:1350/1490 train_time:72964ms step_avg:54.05ms
+step:1351/1490 train_time:73043ms step_avg:54.07ms
+step:1352/1490 train_time:73126ms step_avg:54.09ms
+step:1353/1490 train_time:73206ms step_avg:54.11ms
+step:1354/1490 train_time:73292ms step_avg:54.13ms
+step:1355/1490 train_time:73372ms step_avg:54.15ms
+step:1356/1490 train_time:73456ms step_avg:54.17ms
+step:1357/1490 train_time:73534ms step_avg:54.19ms
+step:1358/1490 train_time:73618ms step_avg:54.21ms
+step:1359/1490 train_time:73696ms step_avg:54.23ms
+step:1360/1490 train_time:73780ms step_avg:54.25ms
+step:1361/1490 train_time:73859ms step_avg:54.27ms
+step:1362/1490 train_time:73943ms step_avg:54.29ms
+step:1363/1490 train_time:74023ms step_avg:54.31ms
+step:1364/1490 train_time:74109ms step_avg:54.33ms
+step:1365/1490 train_time:74188ms step_avg:54.35ms
+step:1366/1490 train_time:74272ms step_avg:54.37ms
+step:1367/1490 train_time:74352ms step_avg:54.39ms
+step:1368/1490 train_time:74436ms step_avg:54.41ms
+step:1369/1490 train_time:74515ms step_avg:54.43ms
+step:1370/1490 train_time:74599ms step_avg:54.45ms
+step:1371/1490 train_time:74677ms step_avg:54.47ms
+step:1372/1490 train_time:74760ms step_avg:54.49ms
+step:1373/1490 train_time:74838ms step_avg:54.51ms
+step:1374/1490 train_time:74921ms step_avg:54.53ms
+step:1375/1490 train_time:75001ms step_avg:54.55ms
+step:1376/1490 train_time:75086ms step_avg:54.57ms
+step:1377/1490 train_time:75165ms step_avg:54.59ms
+step:1378/1490 train_time:75251ms step_avg:54.61ms
+step:1379/1490 train_time:75330ms step_avg:54.63ms
+step:1380/1490 train_time:75414ms step_avg:54.65ms
+step:1381/1490 train_time:75493ms step_avg:54.67ms
+step:1382/1490 train_time:75577ms step_avg:54.69ms
+step:1383/1490 train_time:75655ms step_avg:54.70ms
+step:1384/1490 train_time:75737ms step_avg:54.72ms
+step:1385/1490 train_time:75816ms step_avg:54.74ms
+step:1386/1490 train_time:75901ms step_avg:54.76ms
+step:1387/1490 train_time:75980ms step_avg:54.78ms
+step:1388/1490 train_time:76065ms step_avg:54.80ms
+step:1389/1490 train_time:76144ms step_avg:54.82ms
+step:1390/1490 train_time:76229ms step_avg:54.84ms
+step:1391/1490 train_time:76308ms step_avg:54.86ms
+step:1392/1490 train_time:76393ms step_avg:54.88ms
+step:1393/1490 train_time:76473ms step_avg:54.90ms
+step:1394/1490 train_time:76556ms step_avg:54.92ms
+step:1395/1490 train_time:76634ms step_avg:54.93ms
+step:1396/1490 train_time:76718ms step_avg:54.96ms
+step:1397/1490 train_time:76796ms step_avg:54.97ms
+step:1398/1490 train_time:76880ms step_avg:54.99ms
+step:1399/1490 train_time:76959ms step_avg:55.01ms
+step:1400/1490 train_time:77042ms step_avg:55.03ms
+step:1401/1490 train_time:77121ms step_avg:55.05ms
+step:1402/1490 train_time:77208ms step_avg:55.07ms
+step:1403/1490 train_time:77287ms step_avg:55.09ms
+step:1404/1490 train_time:77373ms step_avg:55.11ms
+step:1405/1490 train_time:77453ms step_avg:55.13ms
+step:1406/1490 train_time:77536ms step_avg:55.15ms
+step:1407/1490 train_time:77614ms step_avg:55.16ms
+step:1408/1490 train_time:77697ms step_avg:55.18ms
+step:1409/1490 train_time:77775ms step_avg:55.20ms
+step:1410/1490 train_time:77859ms step_avg:55.22ms
+step:1411/1490 train_time:77937ms step_avg:55.24ms
+step:1412/1490 train_time:78022ms step_avg:55.26ms
+step:1413/1490 train_time:78103ms step_avg:55.27ms
+step:1414/1490 train_time:78188ms step_avg:55.30ms
+step:1415/1490 train_time:78268ms step_avg:55.31ms
+step:1416/1490 train_time:78352ms step_avg:55.33ms
+step:1417/1490 train_time:78431ms step_avg:55.35ms
+step:1418/1490 train_time:78515ms step_avg:55.37ms
+step:1419/1490 train_time:78593ms step_avg:55.39ms
+step:1420/1490 train_time:78677ms step_avg:55.41ms
+step:1421/1490 train_time:78755ms step_avg:55.42ms
+step:1422/1490 train_time:78838ms step_avg:55.44ms
+step:1423/1490 train_time:78916ms step_avg:55.46ms
+step:1424/1490 train_time:79002ms step_avg:55.48ms
+step:1425/1490 train_time:79081ms step_avg:55.50ms
+step:1426/1490 train_time:79166ms step_avg:55.52ms
+step:1427/1490 train_time:79247ms step_avg:55.53ms
+step:1428/1490 train_time:79331ms step_avg:55.55ms
+step:1429/1490 train_time:79409ms step_avg:55.57ms
+step:1430/1490 train_time:79493ms step_avg:55.59ms
+step:1431/1490 train_time:79573ms step_avg:55.61ms
+step:1432/1490 train_time:79655ms step_avg:55.63ms
+step:1433/1490 train_time:79733ms step_avg:55.64ms
+step:1434/1490 train_time:79818ms step_avg:55.66ms
+step:1435/1490 train_time:79895ms step_avg:55.68ms
+step:1436/1490 train_time:79980ms step_avg:55.70ms
+step:1437/1490 train_time:80059ms step_avg:55.71ms
+step:1438/1490 train_time:80145ms step_avg:55.73ms
+step:1439/1490 train_time:80226ms step_avg:55.75ms
+step:1440/1490 train_time:80310ms step_avg:55.77ms
+step:1441/1490 train_time:80389ms step_avg:55.79ms
+step:1442/1490 train_time:80474ms step_avg:55.81ms
+step:1443/1490 train_time:80552ms step_avg:55.82ms
+step:1444/1490 train_time:80634ms step_avg:55.84ms
+step:1445/1490 train_time:80714ms step_avg:55.86ms
+step:1446/1490 train_time:80798ms step_avg:55.88ms
+step:1447/1490 train_time:80876ms step_avg:55.89ms
+step:1448/1490 train_time:80959ms step_avg:55.91ms
+step:1449/1490 train_time:81039ms step_avg:55.93ms
+step:1450/1490 train_time:81123ms step_avg:55.95ms
+step:1451/1490 train_time:81209ms step_avg:55.97ms
+step:1452/1490 train_time:81296ms step_avg:55.99ms
+step:1453/1490 train_time:81374ms step_avg:56.00ms
+step:1454/1490 train_time:81459ms step_avg:56.02ms
+step:1455/1490 train_time:81538ms step_avg:56.04ms
+step:1456/1490 train_time:81622ms step_avg:56.06ms
+step:1457/1490 train_time:81702ms step_avg:56.08ms
+step:1458/1490 train_time:81786ms step_avg:56.09ms
+step:1459/1490 train_time:81865ms step_avg:56.11ms
+step:1460/1490 train_time:81949ms step_avg:56.13ms
+step:1461/1490 train_time:82027ms step_avg:56.14ms
+step:1462/1490 train_time:82113ms step_avg:56.16ms
+step:1463/1490 train_time:82193ms step_avg:56.18ms
+step:1464/1490 train_time:82277ms step_avg:56.20ms
+step:1465/1490 train_time:82357ms step_avg:56.22ms
+step:1466/1490 train_time:82441ms step_avg:56.24ms
+step:1467/1490 train_time:82521ms step_avg:56.25ms
+step:1468/1490 train_time:82606ms step_avg:56.27ms
+step:1469/1490 train_time:82686ms step_avg:56.29ms
+step:1470/1490 train_time:82770ms step_avg:56.31ms
+step:1471/1490 train_time:82849ms step_avg:56.32ms
+step:1472/1490 train_time:82932ms step_avg:56.34ms
+step:1473/1490 train_time:83011ms step_avg:56.36ms
+step:1474/1490 train_time:83095ms step_avg:56.37ms
+step:1475/1490 train_time:83174ms step_avg:56.39ms
+step:1476/1490 train_time:83258ms step_avg:56.41ms
+step:1477/1490 train_time:83337ms step_avg:56.42ms
+step:1478/1490 train_time:83422ms step_avg:56.44ms
+step:1479/1490 train_time:83502ms step_avg:56.46ms
+step:1480/1490 train_time:83587ms step_avg:56.48ms
+step:1481/1490 train_time:83667ms step_avg:56.49ms
+step:1482/1490 train_time:83751ms step_avg:56.51ms
+step:1483/1490 train_time:83830ms step_avg:56.53ms
+step:1484/1490 train_time:83913ms step_avg:56.55ms
+step:1485/1490 train_time:83992ms step_avg:56.56ms
+step:1486/1490 train_time:84077ms step_avg:56.58ms
+step:1487/1490 train_time:84154ms step_avg:56.59ms
+step:1488/1490 train_time:84239ms step_avg:56.61ms
+step:1489/1490 train_time:84319ms step_avg:56.63ms
+step:1490/1490 train_time:84403ms step_avg:56.65ms
+step:1490/1490 val_loss:3.2785 train_time:84498ms step_avg:56.71ms
+peak memory allocated: 30949 MiB reserved: 46026 MiB

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/train_gpt.py
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/train_gpt.py
@@ -1,0 +1,2238 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f:
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n"
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+import numpy as np
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, XTX, ba_plus_cAA, ba_plus_cAA_kernel, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy, transpose_add, transpose_copy
+# Fused triton kernel: relu(x @ W1.T)^2 @ W2.T
+# https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+ReLUSqrdMLP = FusedLinearReLUSquareFunction.apply
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Distributed training setup
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+grad_scale = 1 / grad_accum_steps # consistent grad magnitudes between different num_devices
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="cuda:nccl,cpu:gloo", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+def ba_plus_cAA_f32(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """ba_plus_cAA with num_stages=2 for FP32 tensors (avoids shared memory overflow)."""
+    M, K = A.shape[-2:]
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A, C_ptr=out, M=M,
+        a_stride_b=input_batch_stride, a_stride_r=A.stride(-2), a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride, c_stride_r=out.stride(-2), c_stride_c=out.stride(-1),
+        alpha=alpha, beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8, LOWER_UPPER=1, num_stages=2, num_warps=8,
+    )
+    return out
+
+# Full 5-step polynomial coefficients (computed for num_iters=5, safety_factor=2e-2, cushion=2).
+polar_express_coeffs = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+_P0A, _P0B, _P0C = polar_express_coeffs[0]
+_P1A, _P1B, _P1C = polar_express_coeffs[1]
+_P2A, _P2B, _P2C = polar_express_coeffs[2]
+_P3A, _P3B, _P3C = polar_express_coeffs[3]
+_P4A, _P4B, _P4C = polar_express_coeffs[4]
+
+_POLAR_SAFETY_SCALE = 1.02
+_POLAR_EPS = 1e-6
+_INV_WORLD = 1.0 / world_size
+
+_current_training_step = 0
+_POLAR_SWITCH_STEP = 500
+
+# Sparse communication partition boundaries depend only on (N, world).
+_SPARSE_BOUNDARY_CACHE = {}
+
+
+def _sparse_partition_boundaries(N: int, world: int):
+    key = (N, world)
+    boundaries = _SPARSE_BOUNDARY_CACHE.get(key)
+    if boundaries is None:
+        rows_per_rank = N // world
+        boundaries = np.arange(
+            0,
+            rows_per_rank * (world + 1),
+            rows_per_rank,
+            dtype=np.int32,
+        )
+        _SPARSE_BOUNDARY_CACHE[key] = boundaries
+    return boundaries
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_right_fast_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_transform_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    3-step accumulated transform for tall matrices (proven stable).
+    Propagates the Gram and accumulated transform on the small n x n factor,
+    touching the tall m x n matrix only twice (initial XTX, final bmm).
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    F = torch.empty_like(A)
+    T = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    F, B = B, F
+
+    ba_plus_cAA(F, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(F, B, out=T)
+    F, T = T, F
+
+    ba_plus_cAA(B, alpha=1.0, beta=0.0, out=T)
+    torch.bmm(A, T, out=B)
+    A, B = B, A
+
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(F, B, out=T)
+    T.mul_(scale[..., None].to(dtype=T.dtype))
+
+    torch.bmm(X, T, out=C)
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_tall_standard_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    """
+    5-step self-correcting path for tall matrices.
+    Uses XTX (small n x n) with Gram-trace normalization and diagonal-fold.
+    More expensive than accumulated (5 XTX + 5 tall bmm) but higher quality.
+    """
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    n = X.size(-1)
+    A = torch.empty((*X.shape[:-2], n, n), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XTX(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    ba_plus_cAA(A, alpha=_P0C, beta=_P0B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P0A)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P1C, beta=_P1B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P1A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P2C, beta=_P2B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P2A)
+    torch.bmm(X, B, out=C)
+
+    XTX(C, out=A)
+    ba_plus_cAA(A, alpha=_P3C, beta=_P3B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P3A)
+    torch.bmm(C, B, out=X)
+
+    XTX(X, out=A)
+    ba_plus_cAA(A, alpha=_P4C, beta=_P4B, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(_P4A)
+    torch.bmm(X, B, out=C)
+
+    return C
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def _polar_express_left_fallback_batched(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+):
+    momentum = momentum_t.to(dtype=grad_chunk.dtype)
+
+    momentum_buffer.lerp_(grad_chunk, 1 - momentum)
+    X = grad_chunk.lerp(momentum_buffer, momentum).to(dtype=torch.bfloat16).contiguous()
+
+    m = X.size(-2)
+    A = torch.empty((*X.shape[:-2], m, m), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    XXT(X, out=A)
+    scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
+    scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
+    A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
+
+    a, b, c = polar_express_coeffs[0]
+    ba_plus_cAA(A, alpha=c, beta=b, out=B)
+    B.diagonal(dim1=-2, dim2=-1).add_(a)
+    B.mul_(scale[..., None].to(dtype=B.dtype))
+    torch.bmm(B, X, out=C)
+    X, C = C, X
+
+    for a, b, c in polar_express_coeffs[1:]:
+        XXT(X, out=A)
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)
+        B.diagonal(dim1=-2, dim2=-1).add_(a)
+        torch.bmm(B, X, out=C)
+        X, C = C, X
+
+    return X
+
+
+def polar_express(
+    grad_chunk: torch.Tensor,
+    momentum_buffer: torch.Tensor,
+    momentum_t: torch.Tensor,
+    split_baddbmm: bool = False,
+):
+    """
+    Fused Nesterov momentum + Polar Express orthogonalization.
+
+    - square / right (m >= n): 5-step Gram-trace, diagonal-fold, self-correcting
+    - large tall (split_baddbmm, m > n): staged -- 3-step accumulated early,
+      5-step standard after _POLAR_SWITCH_STEP
+    - wide (m < n): 5-step Gram-trace fallback (unused in current model)
+    """
+    m = grad_chunk.size(-2)
+    n = grad_chunk.size(-1)
+
+    if grad_chunk.ndim == 2:
+        grad_chunk = grad_chunk.unsqueeze(0)
+        momentum_buffer = momentum_buffer.unsqueeze(0)
+        squeeze = True
+    else:
+        squeeze = False
+
+    if split_baddbmm and m > n:
+        if _current_training_step < _POLAR_SWITCH_STEP:
+            out = _polar_express_tall_transform_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+        else:
+            out = _polar_express_tall_standard_batched(
+                grad_chunk,
+                momentum_buffer,
+                momentum_t,
+            )
+    elif m >= n:
+        out = _polar_express_right_fast_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+    else:
+        out = _polar_express_left_fallback_batched(
+            grad_chunk,
+            momentum_buffer,
+            momentum_t,
+        )
+
+    return out.squeeze(0) if squeeze else out
+
+
+# -----------------------------------------------------------------------------
+# Sparse Comms for bigram embedding gradient reduce-scatter
+
+
+def _sparse_comms_active():
+    # we count on this in order for sparse communication to be worthwhile
+    return world_size == 8 and grad_accum_steps == 1
+
+
+@torch.no_grad()
+def sparse_comms_start(idxes_np, N, rank, world, send_idxes_buffer):
+    insertion_points = np.searchsorted(
+        idxes_np,
+        _sparse_partition_boundaries(N, world),
+    )
+    send_counts = torch.from_numpy(insertion_points[1:] - insertion_points[:-1])
+
+    # Keep rows owned by this rank local; only transmit rows for remote owners.
+    local_start = int(insertion_points[rank])
+    local_end = int(insertion_points[rank + 1])
+    send_counts[rank] = 0
+
+    kept = idxes_np.shape[0] - (local_end - local_start)
+    send_idxes_cpu = send_idxes_buffer.narrow(0, 0, kept)
+
+    if kept:
+        idxes_t = torch.from_numpy(idxes_np)
+        if local_start == 0:
+            send_idxes_cpu.copy_(idxes_t[local_end:])
+        elif local_end == idxes_np.shape[0]:
+            send_idxes_cpu.copy_(idxes_t[:local_start])
+        else:
+            send_idxes_cpu[:local_start].copy_(idxes_t[:local_start])
+            send_idxes_cpu[local_start:].copy_(idxes_t[local_end:])
+
+    send_idxes = send_idxes_cpu.to(device, non_blocking=True)
+
+    recv_counts = torch.empty_like(send_counts)
+    recv_counts_fut = dist.all_to_all_single(
+        recv_counts,
+        send_counts,
+        async_op=True,
+    ).get_future()
+    return send_idxes, send_counts, recv_counts, recv_counts_fut
+
+
+@torch.no_grad()
+def sparse_comms_share_indexes(send_idxes, send_counts, recv_counts):
+    total_recv_count = int(recv_counts.sum().item())
+    recv_counts = recv_counts.tolist()
+    send_counts = send_counts.tolist()
+
+    recv_idxes = torch.empty(total_recv_count, dtype=torch.int32, device=device)
+    idxes_fut = dist.all_to_all_single(
+        recv_idxes,
+        send_idxes,
+        output_split_sizes=recv_counts,
+        input_split_sizes=send_counts,
+        async_op=True,
+    ).get_future()
+
+    sparse_state = {
+        "send_idxes": send_idxes,
+        "send_counts": send_counts,
+        "recv_counts": recv_counts,
+    }
+    return recv_idxes, sparse_state, idxes_fut
+
+
+@torch.compile
+@torch.no_grad()
+def sparse_comms_share_gradients(grad, idxes, send_counts, recv_counts):
+    send_vals = torch.index_select(grad, 0, idxes)
+
+    d = grad.shape[1]
+    total_recv_count = sum(recv_counts)
+    send_sizes = [count * d for count in send_counts]
+    recv_sizes = [count * d for count in recv_counts]
+
+    recv_vals = torch.empty(total_recv_count * d, device=send_vals.device, dtype=grad.dtype)
+
+    val_fut = dist.all_to_all_single(
+        recv_vals,
+        send_vals.view(-1),
+        input_split_sizes=send_sizes,
+        output_split_sizes=recv_sizes,
+        async_op=True,
+    ).get_future()
+
+    return recv_vals, val_fut
+
+
+@torch.no_grad()
+def sparse_comms_merge_gradients(grad, recv_idx, recv_vals, rank, world):
+    d = grad.shape[1]
+    rows_per_rank = grad.shape[0] // world
+    start = rows_per_rank * rank
+    local_grad = grad.narrow(0, start, rows_per_rank)
+
+    if recv_idx.numel():
+        local_grad.index_add_(0, recv_idx.sub(start), recv_vals.view(-1, d))
+
+    return local_grad.mul_(_INV_WORLD)
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", "sharded" or "sharded_sparse"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+
+        # Initialize state for all params
+        self._init_state()
+
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._momentum_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        self._sparse_async_data: dict[nn.Parameter, list] = {}
+
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        if comms == "sharded_sparse" and not _sparse_comms_active():
+            comms = "sharded"
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms.startswith("sharded") else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp_bank":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+
+        self.param_cfgs[param] = p_cfg
+
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms.startswith("sharded"):
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+        elif p_cfg.comms == "sharded_sparse":
+            sparse_state = self._sparse_async_data[param]
+            send_idxes = sparse_state["send_idxes"]
+            send_counts = sparse_state["send_counts"]
+            recv_counts = sparse_state["recv_counts"]
+            recv_vals, val_fut = sparse_comms_share_gradients(
+                grad, send_idxes, send_counts, recv_counts
+            )
+            self._reduce_futures[param].extend((val_fut, recv_vals))
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction
+
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+
+        # Mark as split
+        self.split_embed = True
+
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+
+            # lm_head when tied: aggregate embed.grad.T (tiled Triton transpose-add)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    transpose_add(embed_param.grad, param.grad)
+
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+
+            self._launch_reduce(param, param.grad)
+
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            if p_cfg.comms != "sharded_sparse":
+                future, grad_chunk = self._reduce_futures[param]
+                if future is not None:
+                    future.wait()
+            else:
+                idxes_fut, recv_idxes, recv_fut, recv_vals = self._reduce_futures[param]
+                idxes_fut.wait()
+                recv_fut.wait()
+
+                grad_chunk = sparse_comms_merge_gradients(param.grad, recv_idxes, recv_vals, rank, world_size)
+
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms.startswith("sharded") and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+
+        # When tied: copy lm_head.T to embed (tiled Triton transpose for coalesced writes)
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            transpose_copy(lm_param.data, embed_param.data)
+
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+
+        self._reduce_futures.clear()
+        self._sparse_async_data.clear()
+
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+
+        # Get parameter slice
+        if p_cfg.comms.startswith("sharded"):
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+
+        self._momentum_t.fill_(p_cfg.momentum)
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+
+        # Fused Nesterov momentum + Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(
+            grad_chunk, p_state["momentum_buffer"], self._momentum_t,
+            split_baddbmm=is_large_matrix,
+        )
+
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len, paired=False):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.paired = paired
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        if not self.paired:
+            theta = torch.outer(t, angular_freq)
+            self.factor1 = nn.Buffer(
+                theta.cos().to(torch.bfloat16), persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                theta.sin().to(torch.bfloat16), persistent=False
+            )
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, angular_freq)
+            theta2 = torch.outer(t_odd, angular_freq)
+            self.factor1 = nn.Buffer(
+                torch.cat((theta1.cos(), theta2.cos()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+            self.factor2 = nn.Buffer(
+                torch.cat((theta1.sin(), theta2.sin()), dim=-1).to(torch.bfloat16),
+                persistent=False
+            )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        if not self.paired:
+            theta = torch.outer(t, self.angular_freq)
+            self.factor1.copy_(theta.cos())
+            self.factor2.copy_(theta.sin())
+        else:
+            t_even = 2 * t
+            t_odd = 2 * t + 1
+            theta1 = torch.outer(t_even, self.angular_freq)
+            theta2 = torch.outer(t_odd, self.angular_freq)
+            self.factor1.copy_(torch.cat((theta1.cos(), theta2.cos()), dim=-1))
+            self.factor2.copy_(torch.cat((theta1.sin(), theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+    train_max_seq_len: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, paired: bool = False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        self.paired = paired
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+        train_max_seq_len = attn_args.train_max_seq_len
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        max_len = train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+
+        if not self.paired:
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            if key_offset:
+                # shift keys forward for the stationary head dims. Enables 1-layer induction.
+                k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+
+            if ve is not None:
+                # gate pattern g(x[:6] + ve[:6]) by @photomz
+                ve_gate_out = 2 * torch.sigmoid(F.linear(torch.cat([x[..., :6], ve[None, ..., :6]], dim=-1), ve_gate_w)).view(B, T, self.num_heads, 1)
+                v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        else:
+            # Paired heads: adjacent heads' queries attend to each other's keys.
+            # Two copies of the input stream are interleaved to achieve this, which:
+            # - doubles the length of each sequence
+            # - halves the effective window size
+            q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+            v = v.reshape(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            q, k = yarn.rotary(q), yarn.rotary(k)
+
+            q = q.view(B, T * 2, self.num_heads // 2, self.head_dim)
+            k = k.view(B, T * 2, self.num_heads // 2, self.head_dim)
+
+            if ve is not None:
+                ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T * 2, self.num_heads // 2, 1)
+                v = v + ve_gate_out * ve.view_as(v)
+
+            seqlens = 2 * seqlens
+            max_len = 2 * max_len
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+    train_max_seq_len: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        self.vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        # spherical gaussian init by @photomz
+        self.value_embeds = nn.Parameter(0.01 * torch.randn(5 * self.vocab_size, model_dim, dtype=torch.bfloat16))
+
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        num_attn_layers = num_layers - 1
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        num_mlp_layers = num_layers
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.attn_bank = nn.Parameter(torch.empty(num_attn_layers, 4 * model_dim, hdim)) # (10, 3072, 768)
+        self.attn_bank.reshape = (num_attn_layers * 4, hdim, hdim)   # Shape for sharding: (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        self.mlp_bank = nn.Parameter(torch.empty(12, 2, mlp_hdim, model_dim))  # (12, 2, 3072, 768)
+        self.mlp_bank.reshape = (24, mlp_hdim, model_dim)  # Shape for sharding: (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng and @srashedll
+        std = 0.5 * model_dim ** -0.5
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.attn_bank.uniform_(-bound, bound)
+            self.mlp_bank[:, 0, :, :].uniform_(-bound, bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Attention modules (no learned params -- weights come from attn_bank)
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.attn = CausalSelfAttention(model_dim, head_dim, num_heads, paired=False)
+        self.attn_paired = CausalSelfAttention(model_dim, head_dim, num_heads, paired=True)
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = Yarn(head_dim, max_seq_len, paired=True)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, self.vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=grad_scale * 0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+
+        self.embed = nn.Embedding(self.vocab_size, model_dim)
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        self.post_lambdas = nn.Parameter(torch.ones(num_layers, 2))
+
+        # Per-layer injection coefficients for x0 and bigram
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(num_layers))
+
+        # Per-sublayer residual scaling: [num_layers, 2] where [:,0]=attn, [:,1]=mlp
+        # sqrt(1.1) per sublayer so cumulative per-layer scaling is 1.1
+        self.resid_lambdas = nn.Parameter(torch.full((num_layers, 2), 1.1**0.5))
+
+        pad = (-num_layers * 2 - 3) % dist.get_world_size()
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        # Auto-label parameters
+        for name, param in self.named_parameters():
+            param.label = name.replace('.weight', '')
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # ---- Schedule and layer topology ----
+        mtp_weights, train_max_seq_len = schedule_cfg.mtp_weights, schedule_cfg.train_max_seq_len
+        ws_short, ws_long = schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set block masks and key shift
+        bm_sizes = [ws_short, ws_short, ws_short, ws_long, ws_short, ws_short, None, ws_short, ws_short, ws_short, ws_long]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==ws_long for b in bm_sizes] # apply partial key offset to long windows
+
+        # ---- Unbind parameters (avoid select_backward kernels) ----
+        sa_lambdas = self.scalars[: 2 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[2 * self.num_layers]
+        backout_lambda = self.scalars[2 * self.num_layers + 1]
+        skip_lambda = self.scalars[2 * self.num_layers + 2]
+        resid_lambdas_attn = self.resid_lambdas[:, 0].bfloat16().unbind(0)
+        resid_lambdas_mlp  = self.resid_lambdas[:, 1].bfloat16().unbind(0)
+        post_lambdas_attn = self.post_lambdas[:, 0].bfloat16().unbind(0)
+        post_lambdas_mlp  = self.post_lambdas[:, 1].bfloat16().unbind(0)
+        x0_lambdas = self.x0_lambdas.bfloat16().unbind(0)
+        bigram_lambdas = self.bigram_lambdas.bfloat16().unbind(0)
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)]
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [None] + [veg[0], veg[1]] + [None] * (self.num_layers - 6) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_all = self.mlp_bank.flatten(0, 1).unbind(0)  # 24 tensors of [mlp_hdim, dim]
+        mlp_fcs = mlp_all[0::2]    # even indices: c_fc
+        mlp_projs = mlp_all[1::2]  # odd indices: c_proj
+
+        # ---- Embeddings and input preparation ----
+        x = self.embed(input_seq) # embed is synced from lm_head during tied phase by optimizer
+        
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+
+        # Value embeddings - always computed (not precomputed)
+        ve = self.value_embeds.view(5, self.vocab_size, -1)[:, input_seq]
+        # Shifted .01 ... 234 structure on token value embeddings by @photomz
+        ve = [None, ve[0], ve[1]] + [None] * (self.num_layers - 6) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # Initialize residual stream with pre-layer-0 bigram injection
+        x = x + x0_bigram * bigram_lambdas[0]
+
+        # Precompute x0/bigram injection (added to attention output each layer)
+        # Layer 0: bigram already injected above, so only x0 component
+        x0_inject = (x0 * x0_lambdas[0],) + tuple(x0 * x0_lambdas[i] + x0_bigram * bigram_lambdas[i] for i in range(1, self.num_layers))
+        skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+        
+        # ---- Transformer layers ----
+        x_backout = None
+        skip_connection = None
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i],
+                train_max_seq_len=train_max_seq_len
+            )
+            # Select weights from banks
+            qkvo_w = attn_weights[i - (i > 6)] if i != 6 else None
+            c_fc = mlp_fcs[i]
+            c_proj = mlp_projs[i]
+
+            # Select attention variant for this layer
+            attn = self.attn_paired if i in self.paired_head_layers else self.attn
+
+            # Skip attention on layer 6 @YouJiacheng. Instead pull skip connection from prior long window
+            if i == 6:
+                x = x + skip_gate_out * skip_connection
+            else:
+                attn_in = x_backout if x_backout is not None else x
+                attn_out = attn(norm(attn_in), attn_args, qkvo_w)
+                x = resid_lambdas_attn[i] * x + post_lambdas_attn[i] * attn_out + x0_inject[i]
+            x = resid_lambdas_mlp[i] * x + post_lambdas_mlp[i] * ReLUSqrdMLP(norm(x), c_fc, c_proj)
+            if i == 3:
+                skip_connection = x
+            if i == 7:
+                x_backout = x
+
+        # back out contributions from first 7 layers
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            loss_per_token = FusedSoftcappedCrossEntropy.apply(x.view(-1, x.size(-1)), target_seq, mtp_weights, self.lm_head.weight, self.lm_head.x_s, self.lm_head.w_s, self.lm_head.grad_s, grad_scale)
+        else:
+            logits = self.lm_head(x)
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss_per_token = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="none")
+        return loss_per_token
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+TRAIN_MAX_NUM_DOCS = {16384: 64, 32768: 96, 49152: 128}
+
+class Shard:
+    def __init__(self, tokens: Tensor, world_size: int = 1):
+        self.tokens = tokens
+        self.size = tokens.numel()
+        self.world_size = world_size
+        self.i = 0
+
+        # Partial index now, full index async
+        self.bos_idx = (tokens[:6_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._full_idx = None
+        self._loader_thread = None
+        self._ready = threading.Event()
+        self._loader_thread = threading.Thread(target=self._scan)
+        self._loader_thread.start()
+
+    def _scan(self):
+        self._full_idx = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self._ready.set()
+
+    def _maybe_switch(self):
+        # Switch to full index as soon as async scan completes
+        if self.bos_idx is not self._full_idx and self._ready.is_set():
+            self._loader_thread.join()
+            self.bos_idx = self._full_idx
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        self._maybe_switch()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        return starts, ends
+
+    @staticmethod
+    def load_async(file: Path, world_size: int = 1):
+        """Returns getter function for async shard loading"""
+        result = {}
+        ready = threading.Event()
+        def load():
+            tokens = _load_data_shard(file)
+            result['shard'] = Shard(tokens, world_size)
+            ready.set()
+        thread = threading.Thread(target=load)
+        thread.start()
+        def get():
+            ready.wait()
+            thread.join()
+            return result['shard']
+        return get
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32)
+    out = torch.empty_like(x, pin_memory=True)
+    out.copy_(x)
+    out[0] = mod
+    out[1:] = torch.bitwise_xor(rand_int_1 * out[1:], rand_int_2 * out[:-1]) % mod
+    return out
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        shard = Shard(tokens, world_size)
+        next_shard_getter = Shard.load_async(next(file_iter), world_size)
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = TRAIN_MAX_NUM_DOCS.get(num_tokens_local, next_multiple_of_n(num_tokens_local // 300, n=128))
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = shard.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                shard = next_shard_getter()
+                tokens = shard.tokens
+                try:
+                    next_shard_getter = Shard.load_async(next(file_iter), world_size)
+                except StopIteration:
+                    next_shard_getter = None  # no more shards to preload
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True),
+            _bigram_inputs.numpy(),
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+@dataclass
+class Hyperparameters:
+    # data
+    data_path = os.environ.get("DATA_PATH", ".")
+    train_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_train_*.bin") # input .bin to train on
+    val_files: str = os.path.join(data_path, "data/fineweb10B/fineweb_val_*.bin") # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # schedule
+    num_scheduled_iterations: int = 1450  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    run_evals: bool = False  # run additional evaluations after training is completed
+    # bigram hash embedding
+    bigram_vocab_size: int = 50304 * 5
+
+args = Hyperparameters()
+
+@dataclass
+class TrainingStage:
+    lr_mul: float
+    batch_size: int
+    window_sizes: tuple[int, int]  # (short, long) in block units
+    mtp_weights_start: list[float]
+    mtp_weights_end: list[float]
+    train_max_seq_len: int
+    duration: float = None
+
+class TrainingSchedule:
+    """
+    Training schedule initialized via TRAINING_STAGES
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+        7. Seq len updates from 896 to 2048 at 1/3 of training
+    """
+
+    def __init__(self, stages: list[TrainingStage], scheduled_iterations: int, extension_iterations: int,
+                 cooldown_frac: float = 0.5, split_embed_stage: int = 2, ws_post_yarn_ext: int = 20):
+        self.stages = stages
+        self.scheduled_iterations = scheduled_iterations
+        self.cooldown_frac = cooldown_frac
+        # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+        self.ws_post_yarn_ext = ws_post_yarn_ext
+
+        self.total_steps = self.scheduled_iterations + extension_iterations
+
+        # Build stage boundaries (last is extension stage)
+        ends = [0] + [round(c * scheduled_iterations) for c in accumulate(s.duration for s in stages[:-1])] + [self.total_steps]
+        assert self.scheduled_iterations == ends[-2]
+        self.boundaries = list(pairwise(ends))
+
+        # Split embed at specified stage (ensure odd step for Adam)
+        self.split_step = self.boundaries[split_embed_stage][0] | 1
+
+        # Precompute MTP weights for all steps
+        self.mtp_weights = []
+        for step in range(self.total_steps + 1):
+            stage, t = self.lookup(step)
+            w = [a + (b - a) * t for a, b in zip(stage.mtp_weights_start, stage.mtp_weights_end)]
+            self.mtp_weights.append(torch.tensor(w, device=device))
+
+    def lookup(self, step: int) -> tuple[TrainingStage, float]:
+        # Returns stage and % of the way through that stage
+        for i, (start, end) in enumerate(self.boundaries):
+            if step < end:
+                t = (step - start) / (end - start)
+                return self.stages[i], t
+        return self.stages[-1], 1.0
+
+    def get_lr(self, step: int) -> float:
+        # learning rate schedule: tied to batch size schedule, with cooldown at the end
+        stage, _ = self.lookup(step)
+        lr = stage.lr_mul
+        cd_start = int(self.scheduled_iterations * (1 - self.cooldown_frac))
+        if step >= cd_start:
+            t = min(1.0, (step - cd_start) / (self.scheduled_iterations - cd_start))
+            lr = lr * (1 - t) + 0.15 * t
+        return lr
+
+# window_sizes are in units of `block_size` tokens (defined in TrainingManager)
+TRAINING_STAGES = [
+    TrainingStage(duration=1/3, train_max_seq_len=896, batch_size=8 * 2048 * 8, window_sizes=(1, 3), lr_mul=1.0,
+                  mtp_weights_start=[1.0, 0.5, 0.25], mtp_weights_end=[1.0, 0.5, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=16 * 2048 * 8, window_sizes=(3, 7), lr_mul=1.52,  # (16/8)**0.6
+                  mtp_weights_start=[1.0, 0.5], mtp_weights_end=[1.0, 0.0]),
+    TrainingStage(duration=1/3, train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(5, 11), lr_mul=1.73,  # (24/8)**0.5
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+    # extension stage
+    TrainingStage(train_max_seq_len=2048, batch_size=24 * 2048 * 8, window_sizes=(6, 13), lr_mul=1.0,  # lr_mul is not used
+                  mtp_weights_start=[1.0], mtp_weights_end=[1.0]),
+]
+
+# TODO - Confirm.
+training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.60)
+#training_schedule = TrainingSchedule(TRAINING_STAGES, args.num_scheduled_iterations, args.num_extension_iterations, cooldown_frac=0.55)
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = training_schedule.total_steps - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+    """
+    def __init__(self, model):
+        self.model = model
+        self.block_size = 128
+
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn_bank":      {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp_bank":       {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded_sparse", "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "post_lambdas":   {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "bigram_lambdas": {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 1.0,  "wd_mul": 0.0},
+            "resid_lambdas":  {"optim": "adam",    "comms": "replicated",     "adam_betas": [0.9,  0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "value_embeds":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "post_lambdas", "x0_lambdas", "bigram_lambdas", "resid_lambdas",  # Small, fast
+            "value_embeds", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn_bank", "mlp_bank",  # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.9,
+            weight_decay=1.2,
+        )
+
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = training_schedule.split_step
+
+        self.reset()
+
+    def apply_final_ws_ext(self):
+        self.ws_long = training_schedule.ws_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short * self.block_size,
+            ws_long = self.ws_long * self.block_size,
+            train_max_seq_len = self.train_max_seq_len
+        )
+
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        return [start for start, _ in training_schedule.boundaries[1:]]
+
+    def advance_schedule(self, step: int):
+        stage, _ = training_schedule.lookup(step)
+        self.ws_short, new_ws_long = stage.window_sizes
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+            self.model.yarn_paired_head.apply(self.ws_long * self.block_size, new_ws_long * self.block_size)
+
+        new_batch_size = stage.batch_size
+        new_train_max_seq_len = stage.train_max_seq_len
+        if new_batch_size != self.batch_size or new_train_max_seq_len != self.train_max_seq_len:
+            self.train_loader_send_args = (new_batch_size, new_train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+            self.train_max_seq_len = new_train_max_seq_len
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = training_schedule.mtp_weights[step]
+
+    def step_optimizers(self, step: int):
+        step_lr = training_schedule.get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        stage, _ = training_schedule.lookup(0)
+        self.ws_short, self.ws_long = stage.window_sizes
+        self.batch_size = stage.batch_size
+        self.train_max_seq_len = stage.train_max_seq_len
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+        if _sparse_comms_active():
+            self.row_update_mask = np.zeros(args.bigram_vocab_size, dtype=np.uint8)
+            self.sparse_counts_state = None
+            # buffer we use for fast GPU uploads of send indexes
+            self.send_idxes_buffer = torch.empty(args.bigram_vocab_size, dtype=torch.int32, pin_memory=True)
+
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+    def sparse_index_update(self, step, bigram_indexes):
+        if not _sparse_comms_active():
+            return
+
+        self.row_update_mask[bigram_indexes] = 1
+
+        if self._is_adam_step(step):
+            with torch.no_grad():
+                bigram_idx_np = np.flatnonzero(self.row_update_mask).astype(np.int32)
+                send_idxes, send_counts, recv_counts, recv_counts_fut = sparse_comms_start(
+                    bigram_idx_np, args.bigram_vocab_size, rank, world_size, self.send_idxes_buffer
+                )
+                self.sparse_counts_state = (send_idxes, send_counts, recv_counts, recv_counts_fut)
+
+    def sparse_index_share(self, step):
+        if not _sparse_comms_active() or not self._is_adam_step(step):
+            return
+
+        send_idxes, send_counts, recv_counts, recv_counts_fut = self.sparse_counts_state
+        self.sparse_counts_state = None
+
+        recv_counts_fut.wait()
+        recv_idxes, sparse_state, idxes_fut = sparse_comms_share_indexes(send_idxes, send_counts, recv_counts)
+        self.optimizer._reduce_futures[model.bigram_embed.weight] = [idxes_fut, recv_idxes]
+        self.optimizer._sparse_async_data[model.bigram_embed.weight] = sparse_state
+
+        self.row_update_mask.fill(0)
+
+
+        
+
+# -----------------------------------------------------------------------------
+# int main
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first and last pair of steps in each transition
+warmup_steps = sorted({0, 1 } | set(s + offset for s in transition_steps for offset in [-2, -1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, TRAINING_STAGES[0].batch_size, TRAINING_STAGES[0].train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = training_schedule.total_steps
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs, _ = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).mean()
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs, bigram_cpu = train_loader.send(training_manager.train_loader_send_args)
+        training_manager.sparse_index_update(step, bigram_cpu)
+        loss = model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()).sum() * grad_scale
+        training_manager.sparse_index_share(step)
+        loss.backward()
+        del loss
+    _current_training_step = step
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+if args.run_evals:
+    model.eval()
+    from evals import hellaswag
+    hellaswag.evaluate(model=model, 
+                       schedule_cfg=training_manager.get_forward_args(), 
+                       seq_len=args.val_batch_size // (grad_accum_steps * world_size),
+                       get_bigram_hash=get_bigram_hash, 
+                       print0=print0)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()

--- a/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/triton_kernels.py
+++ b/records/track_1_short/2026-04-09_Polar_Express_Optimization/pr251_plus_polar/triton_kernels.py
@@ -1,0 +1,1006 @@
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Load A blocks for C[m,n] = A[m,:] @ A[n,:].T
+    # Load A[m, k] -> shape (BM, BK)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # Load A[n, k] -> shape (BN, BK). Transpose to get (BK, BN) for accumulation.
+    # Loading (BN, BK) is coalesced because stride_c is 1 (contiguous dim is k).
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for X.T @ X (tall matrices)
+# Computes C = A.T @ A where A is (M, K) and output C is (K, K)
+
+@triton.jit
+def XTX_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    """
+    Compute C = A.T @ A where A is (M, K) and C is (K, K).
+    This is the transpose variant of XXT for tall matrices.
+    
+    The output matrix C is symmetric, so we compute upper triangle and mirror.
+    We iterate over blocks of M (the reduction dimension after transpose).
+    """
+    pid = tl.program_id(axis=0)
+    # Note: Output is (K, K), so we use K for the output grid
+    batch_idx, k_idx, n_idx = _pid_to_block(
+        pid, K, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed (symmetry optimization)
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= k_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (k_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # For A.T @ A:
+    # - A.T has shape (K, M), so A.T[k, m] = A[m, k]
+    # - We load blocks from columns k_idx and n_idx of A (which are rows of A.T)
+    # - We reduce over M (the shared dimension)
+    offs_k = (k_idx + tl.arange(0, BLOCK_SIZE_M)) % K  # Output row indices (columns of A)
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % K  # Output col indices (columns of A)
+    offs_m = tl.arange(0, BLOCK_SIZE_K)  # Reduction dimension (rows of A)
+
+    # Pointers for loading A[:, k_idx:k_idx+BLOCK] (transposed view is A.T[k_idx:, :])
+    # at_ptrs loads A.T block: A.T[offs_k, offs_m] = A[offs_m, offs_k]
+    at_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    # a_ptrs loads A block for the other factor: A.T[offs_m, offs_n].T = A[offs_m, offs_n]
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_n[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of M (the reduction dimension)
+    for m in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        m_remaining = M - m * BLOCK_SIZE_K
+        # Load A.T[offs_k, offs_m] = A[offs_m, offs_k] -> shape (BLOCK_K, BLOCK_M)
+        at = tl.load(at_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # Load A[offs_m, offs_n] -> shape (BLOCK_K, BLOCK_N)
+        a = tl.load(a_ptrs, mask=offs_m[:, None] < m_remaining, other=0.0)
+        # C[k, n] = sum_m A.T[k, m] * A[m, n] = sum_m A[m, k] * A[m, n]
+        # at.T @ a: (BLOCK_M, BLOCK_K) @ (BLOCK_K, BLOCK_N) = (BLOCK_M, BLOCK_N)
+        accumulator = tl.dot(at.T, a, accumulator)
+        at_ptrs += BLOCK_SIZE_K * a_stride_r
+        a_ptrs += BLOCK_SIZE_K * a_stride_r
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_ck = k_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_ck[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_ck[:, None] < K) & (offs_cn[None, :] < K)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal (symmetry)
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_ck[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < K) & (offs_ck[None, :] < K)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+
+def XTX(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A.T @ A
+    
+    For tall matrices (M > K), this is more efficient than transposing
+    and using XXT because the intermediate products are smaller (K x K vs M x M).
+    
+    Args:
+        A: Input tensor of shape (M, K) or (batch, M, K)
+        out: Output tensor of shape (K, K) or (batch, K, K)
+    
+    Returns:
+        out: The same output tensor, filled with A.T @ A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+    assert out.size(-1) == K, f"Output matrix has incorrect shape: expected ({K}, {K}), got {tuple(out.shape[-2:])}"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded configs based on H100 autotuning
+    if K == 768:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+        num_stages, num_warps = 4, 8
+    else:
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 64, 128, 128
+        num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(K, BLOCK_SIZE_M) * triton.cdiv(K, BLOCK_SIZE_N),)
+    XTX_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    
+    # Coalesced loads similar to XXT_kernel
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_n[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        k_remaining = M - k * BLOCK_SIZE_K
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at_temp = tl.load(at_ptrs, mask=offs_k[None, :] < k_remaining, other=0.0)
+        at = tl.trans(at_temp)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    # Hardcoded config based on H100 autotuning (M=768)
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    num_stages, num_warps = 4, 8
+
+    grid = (batch_size * triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(M, BLOCK_SIZE_N),)
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        LOWER_UPPER=1,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose copy kernel: dst (N, M) = src (M, N).T
+# Uses coalesced reads from src and coalesced writes to dst via tl.trans().
+# Replaces PyTorch's elementwise copy_ which uses a naive 75k-block kernel
+# with non-coalesced writes, saturating all SMs and blocking NCCL.
+
+@triton.jit
+def _transpose_copy_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced write to dst (N, M): dst[n, m] = src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    tl.store(
+        dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1,
+        tl.trans(tile), mask=mask_T,
+    )
+
+
+def transpose_copy(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose copy: dst = src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 64x128 tiled Triton kernel with coalesced reads AND writes,
+    achieving near memory-bandwidth-limited performance.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 64, 128
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_copy_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiled transpose-add kernel: dst (M, N) += src (N, M).T
+# Same tiling strategy as transpose_copy but with a fused read-add-write.
+# Replaces PyTorch's .add_(src.T) which uses the same 75k-block elementwise
+# kernel with non-coalesced reads from the transposed operand.
+
+@triton.jit
+def _transpose_add_kernel(
+    src_ptr, dst_ptr,
+    M, N,
+    src_stride_m, src_stride_n,
+    dst_stride_0, dst_stride_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    # Coalesced read from src (M, N)
+    src_tile = tl.load(
+        src_ptr + offs_m[:, None] * src_stride_m + offs_n[None, :] * src_stride_n,
+        mask=mask, other=0.0,
+    )
+
+    # Coalesced read-add-write on dst (N, M): dst[n, m] += src[m, n]
+    mask_T = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+    dst_ptrs = dst_ptr + offs_n[:, None] * dst_stride_0 + offs_m[None, :] * dst_stride_1
+    dst_tile = tl.load(dst_ptrs, mask=mask_T, other=0.0)
+    tl.store(dst_ptrs, dst_tile + tl.trans(src_tile), mask=mask_T)
+
+
+def transpose_add(src: torch.Tensor, dst: torch.Tensor):
+    """Tiled transpose-add: dst += src.T where src is (M, N) and dst is (N, M).
+
+    Uses a 32x32 tiled Triton kernel with coalesced access on both src and dst,
+    replacing PyTorch's .add_(src.T) which has non-coalesced reads from the
+    transposed operand.
+    """
+    assert src.ndim == 2 and dst.ndim == 2
+    M, N = src.shape
+    assert dst.shape == (N, M), f"Expected dst shape ({N}, {M}), got {dst.shape}"
+
+    BLOCK_M, BLOCK_N = 32, 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+
+    _transpose_add_kernel[grid](
+        src, dst,
+        M, N,
+        src.stride(0), src.stride(1),
+        dst.stride(0), dst.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+CE_KERNEL_BLOCK_SIZE = 256
+CE_KERNEL_VOCAB_SIZE = 50304
+
+CE_KERNEL_DECLS = f"""
+constexpr int VOCAB_SIZE = {CE_KERNEL_VOCAB_SIZE};
+constexpr int BLOCK_SIZE = {CE_KERNEL_BLOCK_SIZE};
+"""
+
+CE_KERNEL_SOURCE = """
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+#define __nv_fp8_e5m2 char
+#define uint16_t unsigned short
+#define uint8_t unsigned char
+#define int64_t long long
+
+__device__ __forceinline__ __nv_fp8_e5m2 f32_to_fp8_e5m2(float x) {
+    uint16_t packed;
+    asm volatile(
+        "cvt.rn.satfinite.e5m2x2.f32 %0, %1, %2;"
+        : "=h"(packed)
+        : "f"(x), "f"(0.0f)
+    );
+    __nv_fp8_e5m2 result;
+    *reinterpret_cast<uint8_t*>(&result) = (packed & (0xFF << 8)) >> 8;
+    return result;
+}
+
+struct __align__(16) __nv_bfloat168 {
+    __nv_bfloat16 data[8];
+    __device__ __nv_bfloat16& operator[](int i) { return data[i]; }
+    __device__ const __nv_bfloat16& operator[](int i) const { return data[i]; }
+};
+
+struct __align__(8) __nv_fp8_e5m28 {
+    __nv_fp8_e5m2 data[8];
+    __device__ __nv_fp8_e5m2& operator[](int i) { return data[i]; }
+    __device__ const __nv_fp8_e5m2& operator[](int i) const { return data[i]; }
+};
+
+template<typename T> __device__ constexpr T CEIL_DIV(T a, T b) { return (a + b - 1) / b; }
+
+//__device__ float sigmoid(float x) {
+//  return 1.0f / (1.0f + __expf(-x));
+//}
+__device__ float sigmoid(float x) {
+  return 0.5f + __tanhf(x * 0.5f) * 0.5f;
+}
+
+extern "C"
+__launch_bounds__(BLOCK_SIZE, 2)
+__global__ void ce_fwd_bwd_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    const int64_t* __restrict__ targets,
+    const float* __restrict__ mtp_weights,
+    float* __restrict__ losses,
+    __nv_fp8_e5m2* grad_input,
+    int batch_size,
+    int n_predict,
+    double A_param,
+    double B_param,
+    double C_param,
+    double grad_s_param,
+    double grad_scale_param)
+{
+  constexpr int VEC_WIDTH = 8;
+  constexpr int NUM_FULL_LOADS = VOCAB_SIZE / (BLOCK_SIZE * VEC_WIDTH);
+  constexpr int NUM_LOADS = CEIL_DIV(VOCAB_SIZE, BLOCK_SIZE * VEC_WIDTH);
+
+  float A = (float)A_param;
+  float B = (float)B_param;
+  float C = (float)C_param;
+  float grad_s = (float)grad_s_param;
+  float grad_scale = (float)grad_scale_param;
+
+  extern __shared__ __nv_bfloat16 smem[];
+
+  static_assert(VEC_WIDTH == 8);
+
+  const __nv_bfloat16 *block_logit_ptr = logits + VOCAB_SIZE * blockIdx.x;
+
+  float inv_C = 1 / C;
+  float B_div_C = B * inv_C;
+  float thread_max = -CUDART_INF_F;
+
+  #pragma unroll 25
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 result = *(__nv_bfloat168*)(&block_logit_ptr[idx]);
+      __nv_bfloat168 result_sigmoid;
+      #pragma unroll
+      for (int k = 0; k < VEC_WIDTH; k++) {
+        float tmp = __bfloat162float(result[k]);
+        tmp = sigmoid(tmp * inv_C + B_div_C);
+        result_sigmoid[k] = __float2bfloat16(tmp);
+        tmp = A * tmp;
+        thread_max = max(tmp, thread_max);
+      }
+      *(__nv_bfloat168*)(&smem[idx]) = result_sigmoid;
+    }
+  }
+
+  constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+  int warp_id = threadIdx.x / 32;
+  __shared__ float block_maxs[NUM_WARPS];
+  __shared__ float block_sums[NUM_WARPS];
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_max = fmaxf(thread_max, __shfl_down_sync(0xFFFFFFFF, thread_max, offset));
+
+  if (threadIdx.x % 32 == 0) {
+    block_maxs[warp_id] = thread_max;
+  }
+
+  __syncthreads();
+
+  float block_max = -CUDART_INF_F;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_max = fmaxf(block_max, block_maxs[i]);
+  }
+
+  float thread_sum = 0.0f;
+  #pragma unroll 2
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_bfloat168 l;
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      l = *(__nv_bfloat168*)(&smem[idx]);
+    }
+    #pragma unroll
+    for (int k = 0; k < VEC_WIDTH; k++) {
+      float tmp = A * __bfloat162float(l[k]);
+      tmp = __expf(tmp - block_max);
+      if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+        thread_sum += tmp;
+      }
+    }
+  }
+
+  for (int offset = 16; offset > 0; offset >>= 1)
+    thread_sum += __shfl_down_sync(0xFFFFFFFF, thread_sum, offset);
+
+  if (threadIdx.x % 32 == 0) {
+    block_sums[warp_id] = thread_sum;
+  }
+
+  __syncthreads();
+
+  float block_sum = 0.0f;
+  for (int i = 0; i < NUM_WARPS; i++) {
+    block_sum += block_sums[i];
+  }
+
+  float lse = block_max + __logf(block_sum);
+
+  if (threadIdx.x == 0) {
+    float total_loss = 0.0f;
+    for (int k = 0; k < n_predict; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size) {
+        float weight = mtp_weights[k];
+        int64_t target = targets[target_idx];
+        if (target >= 0 && target < VOCAB_SIZE) {
+          float z_target = A * __bfloat162float(smem[target]);
+          total_loss += weight * (lse - z_target);
+        }
+      }
+    }
+    losses[blockIdx.x] = total_loss;
+  }
+
+  float S_w = 0.0f;
+
+  for (int i = 0; i < n_predict; i++) {
+    S_w += mtp_weights[i];
+  }
+
+  #pragma unroll 4
+  for (int i = 0; i < NUM_LOADS; i++) {
+    int idx = i * BLOCK_SIZE * VEC_WIDTH + threadIdx.x * VEC_WIDTH;
+    __nv_fp8_e5m28 result;
+
+    if (i < NUM_FULL_LOADS || idx < VOCAB_SIZE) {
+      __nv_bfloat168 sigmoid_us = *(__nv_bfloat168*)(&smem[idx]);
+      #pragma unroll
+      for (int j = 0; j < VEC_WIDTH; j++) {
+        float sigmoid_u = __bfloat162float(sigmoid_us[j]);
+        float z = A * sigmoid_u;
+        float p = __expf(z - lse);
+
+        float term1 = S_w * p;
+        float term2 = 0.0f;
+
+        float grad_z = term1 - term2;
+        float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+        auto result_tmp = f32_to_fp8_e5m2(grad_x);
+        result[j] = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+      }
+      *(__nv_fp8_e5m28*)(&grad_input[blockIdx.x * VOCAB_SIZE + idx]) = result;
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < n_predict && blockIdx.x + threadIdx.x < batch_size) {
+    int i = threadIdx.x;
+    int64_t target = targets[blockIdx.x + i];
+
+    float sigmoid_u = __bfloat162float(smem[target]);
+    float z = A * sigmoid_u;
+    float p = __expf(z - lse);
+
+    float term1 = S_w * p;
+    float term2 = 0.0f;
+
+    #pragma unroll
+    for (int k = 0; k < 3; k++) {
+      int64_t target_idx = blockIdx.x + k;
+      if (target_idx < batch_size && k < n_predict) {
+        if (targets[target_idx] == target) {
+          term2 += mtp_weights[k];
+        }
+      }
+    }
+
+    float grad_z = term1 - term2;
+    float grad_x = grad_scale * (1.0f / C * A) * (1.0f / grad_s) * grad_z * sigmoid_u * (1.0f - sigmoid_u);
+    auto result_tmp = f32_to_fp8_e5m2(grad_x);
+    auto result = *reinterpret_cast<__nv_fp8_e5m2*>(&result_tmp);
+    grad_input[blockIdx.x * VOCAB_SIZE + target] = result;
+  }
+}
+"""
+
+ce_fwd_bwd_kernel = torch.cuda._compile_kernel(
+    CE_KERNEL_DECLS + CE_KERNEL_SOURCE,
+    "ce_fwd_bwd_kernel",
+    compute_capability="90",
+    cuda_include_dirs=["/usr/local/cuda/include/"],
+    nvcc_options=["-lineinfo", "--use_fast_math"],
+)
+ce_fwd_bwd_kernel.set_shared_memory_config(CE_KERNEL_VOCAB_SIZE * 2)
+
+@torch.library.custom_op("nanogpt::ce_fwd_bwd", mutates_args={"losses", "grad_input"})
+def ce_fwd_bwd(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    mtp_weights: torch.Tensor,
+    losses: torch.Tensor,
+    grad_input: torch.Tensor,
+    n_rows: int,
+    n_predict: int,
+    A: float,
+    B: float,
+    C: float,
+    grad_s: float,
+    grad_scale: float,
+) -> None:
+    grid = (n_rows, 1, 1)
+    ce_fwd_bwd_kernel(
+        grid,
+        (CE_KERNEL_BLOCK_SIZE, 1, 1),
+        (logits, targets, mtp_weights, losses, grad_input,
+         n_rows, n_predict, A, B, C, grad_s, grad_scale),
+        shared_mem=CE_KERNEL_VOCAB_SIZE * 2,
+    )
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, targets, mtp_weights, lm_head_weight, x_s, w_s, grad_s, grad_scale, A=23.0, B=5.0, C=7.5):
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = lm_head_weight.div(w_s).to(torch.float8_e4m3fn)
+
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        logits = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.float8_e5m2, device=logits.device)
+
+        ce_fwd_bwd(logits, targets, mtp_weights, losses, grad_input,
+             n_rows, n_predict, A, B, C, grad_s, grad_scale)
+
+        ctx.save_for_backward(logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input)
+        ctx.params = (A, B, C, x_s, w_s, grad_s)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse, x, lm_head_weight, x_f8, w_f8, grad_input = ctx.saved_tensors
+        A, B, C, x_s, w_s, grad_s = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+
+        grad_output = grad_output.contiguous()
+
+        x_scale = grad_input.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad_input.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad_input.new_tensor(grad_s, dtype=torch.float32)
+
+        grad_x = torch._scaled_mm(
+            grad_input,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+
+        x_f8_T = torch.empty((x_f8.shape[1], x_f8.shape[0]), dtype=x_f8.dtype, device=x_f8.device)
+        transpose_copy(x_f8, x_f8_T)  # (768, n_rows) row-major
+
+        grad_input_T = torch.empty((n_cols, n_rows), dtype=grad_input.dtype, device=grad_input.device)
+        transpose_copy(grad_input, grad_input_T)  # (50304, n_rows) row-major
+
+        grad_w = torch._scaled_mm(
+            x_f8_T,            # (768, n_rows) row-major
+            grad_input_T.T,    # (n_rows, 50304) column-major view
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+
+        return grad_x, None, None, grad_w, None, None, None


### PR DESCRIPTION
All changes are confined to the **Polar Express orthogonalization** step and the **sparse communication** routines used during distributed training. The model architecture, hyperparameters, training schedule, and all other code remain identical.

## Optimizations

### 1. Gram-Trace Normalization with Diagonal Fold

**Before:** The spectral norm of the input matrix is bounded by dividing by the Frobenius norm — a full-matrix operation that materializes a normalized copy every iteration.

```python
X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
```

**After:** Normalization uses the Gram matrix diagonal (trace of X^T X), which is already computed for the iteration. The scale factor is folded into the first polynomial coefficient via diagonal addition, avoiding a separate full-matrix division.

```python
scale = A.diagonal(dim1=-2, dim2=-1).sum(dim=-1, keepdim=True, dtype=torch.float32)
scale.sqrt_().mul_(_POLAR_SAFETY_SCALE).add_(_POLAR_EPS).reciprocal_()
A.mul_((scale * scale)[..., None].to(dtype=A.dtype))
# ... first iteration ...
B.diagonal(dim1=-2, dim2=-1).add_(_P0A)  # fold aI into polynomial
B.mul_(scale[..., None].to(dtype=B.dtype))
```

This eliminates the `aX + X @ B` fused addmm/baddbmm pattern (which required referencing X twice and triggered defensive copies in PyTorch) and replaces it with a single `bmm` per iteration.

### 2. Specialized Tall-Matrix Paths (MLP Weights)

The MLP weight bank has shape (3072, 768) per matrix — a 4:1 tall aspect ratio. The baseline uses the same iteration loop for all shapes, performing 5 tall-matrix multiplications per step.

**After:** Two dedicated tall-matrix paths are introduced:

- **3-step accumulated transform** (`_polar_express_tall_transform_batched`, used for steps < 500): Propagates the Gram and accumulated transform entirely on the small n×n factor, touching the tall m×n matrix only twice (initial XTX, final bmm). This cuts 3 expensive tall-matrix bmm operations per step.

- **5-step standard path** (`_polar_express_tall_standard_batched`, used for steps ≥ 500): Uses the full 5-step self-correcting iteration with Gram-trace normalization for higher quality convergence in later training.

The transition at step 500 (`_POLAR_SWITCH_STEP`) balances speed in early training against quality in later training.

### 3. Fully Unrolled Iterations

**Before:** Polar Express iterations are written as a Python `for` loop over the coefficient list, which prevents `torch.compile` from fully optimizing memory reuse across iterations.

**After:** Each specialized function has all 5 (or 3) iterations fully unrolled with pre-extracted scalar coefficients (`_P0A`, `_P0B`, ..., `_P4C`). Combined with `fullgraph=True`, this allows the compiler to fuse operations across iteration boundaries and optimize buffer reuse.

### 4. Sparse Communication Improvements

Several micro-optimizations to the distributed sparse gradient communication:

- **Cached partition boundaries** (`_sparse_partition_boundaries`): The `searchsorted` boundary array is computed once per (N, world_size) pair and reused, avoiding repeated allocation.
- **In-place index slicing**: Local rank's rows are excluded via `narrow` + conditional `copy_` instead of `torch.cat` with two slices, reducing CPU-side allocations.
- **Local gradient merge**: `sparse_comms_merge_gradients` now operates on a `narrow`ed local slice with adjusted indices (`recv_idx.sub(start)`), avoiding the final full-tensor slice.

## Results

All experiments run on 8×H100 GPUs with identical seeds, hyperparameters, and training schedule. Each configuration was run multiple times to assess variance.

| Configuration | Runs | Mean Time (ms) | Mean Val Loss | Time Saved |
|---|---|---|---|---|
| **Baseline (03/22/26)** | 5 | 85,658 | 3.2786 | — |
| **Baseline + Polar Express Optimization** | 5 | 85,219 | 3.2777 | **439 ms (0.51%)** |
| **PR#251** | 4 | 84,930 | 3.2788 | — |
| **PR#251 + Polar Express Optimization** | 5 | 84,545 | 3.2795 | **385 ms (0.45%)** |

All configurations achieve val_loss < 3.28.