### PR TITLE
Implemented recently proposed Exclusive Self Attention in train_gpt.py

### DIFF
--- a/train_gpt.py
+++ b/train_gpt.py
@@ -1127,7 +1127,13 @@ class CausalSelfAttention(nn.Module):
         y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
                                                         max_seqlen_q=max_len, max_seqlen_k=max_len,
                                                         causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        
         y = y.view(B, T, self.num_heads, self.head_dim)
+
+        # XSA ( Exclusive Self Attention implementation)
+        Vn=torch.nn.functional.normalize(v,dim=-1)     
+        y=y-(y*Vn).sum(dim=-1,keepdim=True)*Vn  
+        
         y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
         y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
         y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg


### PR DESCRIPTION
Implements XSA by removing the component of the attention output aligned with the token’s own value vector, encouraging attention to focus on contextual information rather than self-copying. This is a 2 line addition to the Causal Attention block . 